### PR TITLE
WIP - Use the unsafe package to perform direct memory copies during conversion

### DIFF
--- a/cmd/libs/go2idl/args/args.go
+++ b/cmd/libs/go2idl/args/args.go
@@ -66,6 +66,9 @@ type GeneratorArgs struct {
 	// If true, only verify, don't write anything.
 	VerifyOnly bool
 
+	// If true, use of the "unsafe" package is allowed for better performance
+	Unsafe bool
+
 	// Any custom arguments go here
 	CustomArgs interface{}
 }
@@ -75,6 +78,7 @@ func (g *GeneratorArgs) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&g.OutputBase, "output-base", "o", g.OutputBase, "Output base; defaults to $GOPATH/src/ or ./ if $GOPATH is not set.")
 	fs.StringVarP(&g.OutputPackagePath, "output-package", "p", g.OutputPackagePath, "Base package path.")
 	fs.StringVarP(&g.GoHeaderFilePath, "go-header-file", "h", g.GoHeaderFilePath, "File containing boilerplate header text. The string YEAR will be replaced with the current 4-digit year.")
+	fs.BoolVar(&g.Unsafe, "unsafe", g.Unsafe, "If true, the unsafe package may be used for better performance.")
 	fs.BoolVar(&g.VerifyOnly, "verify-only", g.VerifyOnly, "If true, only verify existing output, do not write anything.")
 	fs.BoolVar(&g.Recursive, "recursive", g.VerifyOnly, "If true, recurse into all children of input directories.")
 }

--- a/cmd/libs/go2idl/deepcopy-gen/main.go
+++ b/cmd/libs/go2idl/deepcopy-gen/main.go
@@ -38,6 +38,19 @@ func main() {
 
 	// Override defaults. These are Kubernetes specific input locations.
 	arguments.InputDirs = []string{
+		// generate all types, but do not register them
+		"+k8s.io/kubernetes/pkg/api/unversioned",
+
+		"-k8s.io/kubernetes/pkg/api/meta",
+		"-k8s.io/kubernetes/pkg/api/meta/metatypes",
+		"-k8s.io/kubernetes/pkg/api/resource",
+		"-k8s.io/kubernetes/pkg/conversion",
+		"-k8s.io/kubernetes/pkg/labels",
+		"-k8s.io/kubernetes/pkg/runtime",
+		"-k8s.io/kubernetes/pkg/runtime/serializer",
+		"-k8s.io/kubernetes/pkg/util/intstr",
+		"-k8s.io/kubernetes/pkg/util/sets",
+
 		"k8s.io/kubernetes/pkg/api",
 		"k8s.io/kubernetes/pkg/api/v1",
 		"k8s.io/kubernetes/pkg/apis/authentication.k8s.io",
@@ -61,19 +74,6 @@ func main() {
 		"k8s.io/kubernetes/pkg/apis/rbac/v1alpha1",
 		"k8s.io/kubernetes/federation/apis/federation",
 		"k8s.io/kubernetes/federation/apis/federation/v1alpha1",
-
-		// generate all types, but do not register them
-		"+k8s.io/kubernetes/pkg/api/unversioned",
-
-		"-k8s.io/kubernetes/pkg/api/meta",
-		"-k8s.io/kubernetes/pkg/api/meta/metatypes",
-		"-k8s.io/kubernetes/pkg/api/resource",
-		"-k8s.io/kubernetes/pkg/conversion",
-		"-k8s.io/kubernetes/pkg/labels",
-		"-k8s.io/kubernetes/pkg/runtime",
-		"-k8s.io/kubernetes/pkg/runtime/serializer",
-		"-k8s.io/kubernetes/pkg/util/intstr",
-		"-k8s.io/kubernetes/pkg/util/sets",
 	}
 
 	if err := arguments.Execute(

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
@@ -124,6 +124,9 @@ func Run(g *Generator) {
 	protobufNames := NewProtobufNamer()
 	outputPackages := generator.Packages{}
 	for _, d := range strings.Split(g.Packages, ",") {
+		if strings.Contains(d, "-") {
+			log.Fatalf("Package names must be valid protobuf package identifiers, which allow only [a-z0-9_]: %s", d)
+		}
 		generateAllTypes, outputPackage := true, true
 		switch {
 		case strings.HasPrefix(d, "+"):
@@ -235,7 +238,7 @@ func Run(g *Generator) {
 
 		// alter the generated protobuf file to remove the generated types (but leave the serializers) and rewrite the
 		// package statement to match the desired package name
-		if err := RewriteGeneratedGogoProtobufFile(outputPath, p.ExtractGeneratedType, buf.Bytes()); err != nil {
+		if err := RewriteGeneratedGogoProtobufFile(outputPath, p.ExtractGeneratedType, p.OptionalTypeName, buf.Bytes()); err != nil {
 			log.Fatalf("Unable to rewrite generated %s: %v", outputPath, err)
 		}
 

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
@@ -101,7 +101,7 @@ type typeNameSet map[types.Name]*protobufPackage
 
 // assignGoTypeToProtoPackage looks for Go and Protobuf types that are referenced by a type in
 // a package. It will not recurse into protobuf types.
-func assignGoTypeToProtoPackage(p *protobufPackage, t *types.Type, local, global typeNameSet) {
+func assignGoTypeToProtoPackage(p *protobufPackage, t *types.Type, local, global typeNameSet, optional map[types.Name]struct{}) {
 	newT, isProto := isFundamentalProtoType(t)
 	if isProto {
 		t = newT
@@ -136,20 +136,23 @@ func assignGoTypeToProtoPackage(p *protobufPackage, t *types.Type, local, global
 			continue
 		}
 		if err := protobufTagToField(tag, field, m, t, p.ProtoTypeName()); err == nil && field.Type != nil {
-			assignGoTypeToProtoPackage(p, field.Type, local, global)
+			assignGoTypeToProtoPackage(p, field.Type, local, global, optional)
 			continue
 		}
-		assignGoTypeToProtoPackage(p, m.Type, local, global)
+		assignGoTypeToProtoPackage(p, m.Type, local, global, optional)
 	}
 	// TODO: should methods be walked?
 	if t.Elem != nil {
-		assignGoTypeToProtoPackage(p, t.Elem, local, global)
+		assignGoTypeToProtoPackage(p, t.Elem, local, global, optional)
 	}
 	if t.Key != nil {
-		assignGoTypeToProtoPackage(p, t.Key, local, global)
+		assignGoTypeToProtoPackage(p, t.Key, local, global, optional)
 	}
 	if t.Underlying != nil {
-		assignGoTypeToProtoPackage(p, t.Underlying, local, global)
+		if t.Kind == types.Alias && isOptionalAlias(t) {
+			optional[t.Name] = struct{}{}
+		}
+		assignGoTypeToProtoPackage(p, t.Underlying, local, global, optional)
 	}
 }
 
@@ -157,19 +160,24 @@ func (n *protobufNamer) AssignTypesToPackages(c *generator.Context) error {
 	global := make(typeNameSet)
 	for _, p := range n.packages {
 		local := make(typeNameSet)
+		optional := make(map[types.Name]struct{})
 		p.Imports = NewImportTracker(p.ProtoTypeName())
 		for _, t := range c.Order {
 			if t.Name.Package != p.PackagePath {
 				continue
 			}
-			assignGoTypeToProtoPackage(p, t, local, global)
+			assignGoTypeToProtoPackage(p, t, local, global, optional)
 		}
 		p.FilterTypes = make(map[types.Name]struct{})
 		p.LocalNames = make(map[string]struct{})
+		p.OptionalTypeNames = make(map[string]struct{})
 		for k, v := range local {
 			if v == p {
 				p.FilterTypes[k] = struct{}{}
 				p.LocalNames[k.Name] = struct{}{}
+				if _, ok := optional[k]; ok {
+					p.OptionalTypeNames[k.Name] = struct{}{}
+				}
 			}
 		}
 	}

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/package.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/package.go
@@ -75,6 +75,10 @@ type protobufPackage struct {
 	// A list of names that this package exports
 	LocalNames map[string]struct{}
 
+	// A list of type names in this package that will need marshaller rewriting
+	// to remove synthetic protobuf fields.
+	OptionalTypeNames map[string]struct{}
+
 	// A list of struct tags to generate onto named struct fields
 	StructTags map[string]map[string]string
 
@@ -110,7 +114,9 @@ func (p *protobufPackage) filterFunc(c *generator.Context, t *types.Type) bool {
 	case types.Builtin:
 		return false
 	case types.Alias:
-		return false
+		if !isOptionalAlias(t) {
+			return false
+		}
 	case types.Slice, types.Array, types.Map:
 		return false
 	case types.Pointer:
@@ -125,6 +131,11 @@ func (p *protobufPackage) filterFunc(c *generator.Context, t *types.Type) bool {
 
 func (p *protobufPackage) HasGoType(name string) bool {
 	_, ok := p.LocalNames[name]
+	return ok
+}
+
+func (p *protobufPackage) OptionalTypeName(name string) bool {
+	_, ok := p.OptionalTypeNames[name]
 	return ok
 }
 

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/parser.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/parser.go
@@ -74,9 +74,18 @@ func rewriteFile(name string, header []byte, rewriteFn func(*token.FileSet, *ast
 // removed from the destination file.
 type ExtractFunc func(*ast.TypeSpec) bool
 
-func RewriteGeneratedGogoProtobufFile(name string, extractFn ExtractFunc, header []byte) error {
+// OptionalFunc returns true if the provided local name is a type that has protobuf.nullable=true
+// and should have its marshal functions adjusted to remove the 'Items' accessor.
+type OptionalFunc func(name string) bool
+
+func RewriteGeneratedGogoProtobufFile(name string, extractFn ExtractFunc, optionalFn OptionalFunc, header []byte) error {
 	return rewriteFile(name, header, func(fset *token.FileSet, file *ast.File) error {
 		cmap := ast.NewCommentMap(fset, file, file.Comments)
+
+		// transform methods that point to optional maps or slices
+		for _, d := range file.Decls {
+			rewriteOptionalMethods(d, optionalFn)
+		}
 
 		// remove types that are already declared
 		decls := []ast.Decl{}
@@ -95,6 +104,168 @@ func RewriteGeneratedGogoProtobufFile(name string, extractFn ExtractFunc, header
 		file.Comments = cmap.Filter(file).Comments()
 		return nil
 	})
+}
+
+// rewriteOptionalMethods makes specific mutations to marshaller methods that belong to types identified
+// as being "optional" (they may be nil on the wire). This allows protobuf to serialize a map or slice and
+// properly discriminate between empty and nil (which is not possible in protobuf).
+// TODO: move into upstream gogo-protobuf once https://github.com/gogo/protobuf/issues/181
+//   has agreement
+func rewriteOptionalMethods(decl ast.Decl, isOptional OptionalFunc) {
+	switch t := decl.(type) {
+	case *ast.FuncDecl:
+		ident, ptr, ok := receiver(t)
+		if !ok {
+			return
+		}
+
+		// correct initialization of the form `m.Field = &OptionalType{}` to
+		// `m.Field = OptionalType{}`
+		if t.Name.Name == "Unmarshal" {
+			ast.Walk(optionalAssignmentVisitor{fn: isOptional}, t.Body)
+		}
+
+		if !isOptional(ident.Name) {
+			return
+		}
+
+		switch t.Name.Name {
+		case "Unmarshal":
+			ast.Walk(&optionalItemsVisitor{}, t.Body)
+		case "MarshalTo", "Size":
+			ast.Walk(&optionalItemsVisitor{}, t.Body)
+			fallthrough
+		case "Marshal":
+			// if the method has a pointer receiver, set it back to a normal receiver
+			if ptr {
+				t.Recv.List[0].Type = ident
+			}
+		}
+	}
+}
+
+type optionalAssignmentVisitor struct {
+	fn OptionalFunc
+}
+
+// Visit walks the provided node, transforming field initializations of the form
+// m.Field = &OptionalType{} -> m.Field = OptionalType{}
+func (v optionalAssignmentVisitor) Visit(n ast.Node) ast.Visitor {
+	switch t := n.(type) {
+	case *ast.AssignStmt:
+		if len(t.Lhs) == 1 && len(t.Rhs) == 1 {
+			if !isFieldSelector(t.Lhs[0], "m", "") {
+				return nil
+			}
+			unary, ok := t.Rhs[0].(*ast.UnaryExpr)
+			if !ok || unary.Op != token.AND {
+				return nil
+			}
+			composite, ok := unary.X.(*ast.CompositeLit)
+			if !ok || composite.Type == nil || len(composite.Elts) != 0 {
+				return nil
+			}
+			if ident, ok := composite.Type.(*ast.Ident); ok && v.fn(ident.Name) {
+				t.Rhs[0] = composite
+			}
+		}
+		return nil
+	}
+	return v
+}
+
+type optionalItemsVisitor struct{}
+
+// Visit walks the provided node, looking for specific patterns to transform that match
+// the effective outcome of turning struct{ map[x]y || []x } into map[x]y or []x.
+func (v *optionalItemsVisitor) Visit(n ast.Node) ast.Visitor {
+	switch t := n.(type) {
+	case *ast.RangeStmt:
+		if isFieldSelector(t.X, "m", "Items") {
+			t.X = &ast.Ident{Name: "m"}
+		}
+	case *ast.AssignStmt:
+		if len(t.Lhs) == 1 && len(t.Rhs) == 1 {
+			switch lhs := t.Lhs[0].(type) {
+			case *ast.IndexExpr:
+				if isFieldSelector(lhs.X, "m", "Items") {
+					lhs.X = &ast.StarExpr{X: &ast.Ident{Name: "m"}}
+				}
+			default:
+				if isFieldSelector(t.Lhs[0], "m", "Items") {
+					t.Lhs[0] = &ast.StarExpr{X: &ast.Ident{Name: "m"}}
+				}
+			}
+			switch rhs := t.Rhs[0].(type) {
+			case *ast.CallExpr:
+				if ident, ok := rhs.Fun.(*ast.Ident); ok && ident.Name == "append" {
+					ast.Walk(v, rhs)
+					if len(rhs.Args) > 0 {
+						switch arg := rhs.Args[0].(type) {
+						case *ast.Ident:
+							if arg.Name == "m" {
+								rhs.Args[0] = &ast.StarExpr{X: &ast.Ident{Name: "m"}}
+							}
+						}
+					}
+					return nil
+				}
+			}
+		}
+	case *ast.IfStmt:
+		if b, ok := t.Cond.(*ast.BinaryExpr); ok && b.Op == token.EQL {
+			if isFieldSelector(b.X, "m", "Items") && isIdent(b.Y, "nil") {
+				b.X = &ast.StarExpr{X: &ast.Ident{Name: "m"}}
+			}
+		}
+	case *ast.IndexExpr:
+		if isFieldSelector(t.X, "m", "Items") {
+			t.X = &ast.Ident{Name: "m"}
+			return nil
+		}
+	case *ast.CallExpr:
+		changed := false
+		for i := range t.Args {
+			if isFieldSelector(t.Args[i], "m", "Items") {
+				t.Args[i] = &ast.Ident{Name: "m"}
+				changed = true
+			}
+		}
+		if changed {
+			return nil
+		}
+	}
+	return v
+}
+
+func isFieldSelector(n ast.Expr, name, field string) bool {
+	s, ok := n.(*ast.SelectorExpr)
+	if !ok || s.Sel == nil || (field != "" && s.Sel.Name != field) {
+		return false
+	}
+	return isIdent(s.X, name)
+}
+
+func isIdent(n ast.Expr, value string) bool {
+	ident, ok := n.(*ast.Ident)
+	return ok && ident.Name == value
+}
+
+func receiver(f *ast.FuncDecl) (ident *ast.Ident, pointer bool, ok bool) {
+	if f.Recv == nil || len(f.Recv.List) != 1 {
+		return nil, false, false
+	}
+	switch t := f.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		identity, ok := t.X.(*ast.Ident)
+		if !ok {
+			return nil, false, false
+		}
+		return identity, true, true
+	case *ast.Ident:
+		return t, false, true
+	}
+	return nil, false, false
 }
 
 // dropExistingTypeDeclarations removes any type declaration for which extractFn returns true. The function

--- a/cmd/libs/go2idl/parser/parse.go
+++ b/cmd/libs/go2idl/parser/parse.go
@@ -591,9 +591,6 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 			// "feature" for users. This flattens those types
 			// together.
 			name := tcNameToName(t.String())
-			if name.Name == "OptionalMap" {
-				fmt.Printf("DEBUG: flattening %T -> %T\n", t, t.Underlying())
-			}
 			if out := u.Type(name); out.Kind != types.Unknown {
 				return out // short circuit if we've already made this.
 			}

--- a/cmd/libs/go2idl/parser/parse.go
+++ b/cmd/libs/go2idl/parser/parse.go
@@ -576,7 +576,7 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 		return out
 	case *tc.Named:
 		switch t.Underlying().(type) {
-		case *tc.Named, *tc.Basic:
+		case *tc.Named, *tc.Basic, *tc.Map, *tc.Slice:
 			name := tcNameToName(t.String())
 			out := u.Type(name)
 			if out.Kind != types.Unknown {
@@ -591,6 +591,9 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 			// "feature" for users. This flattens those types
 			// together.
 			name := tcNameToName(t.String())
+			if name.Name == "OptionalMap" {
+				fmt.Printf("DEBUG: flattening %T -> %T\n", t, t.Underlying())
+			}
 			if out := u.Type(name); out.Kind != types.Unknown {
 				return out // short circuit if we've already made this.
 			}

--- a/cmd/libs/go2idl/parser/parse_test.go
+++ b/cmd/libs/go2idl/parser/parse_test.go
@@ -391,8 +391,16 @@ type Interface interface{Method(a, b string) (c, d string)}
 				t.Errorf("type %s not found", n)
 				continue
 			}
-			if e, a := item.k, thisType.Kind; e != a {
-				t.Errorf("%v-%s: type kind wrong, wanted %v, got %v (%#v)", nameIndex, n, e, a, thisType)
+			underlyingType := thisType
+			if item.k != types.Alias && thisType.Kind == types.Alias {
+				underlyingType = thisType.Underlying
+				if underlyingType == nil {
+					t.Errorf("underlying type %s not found", n)
+					continue
+				}
+			}
+			if e, a := item.k, underlyingType.Kind; e != a {
+				t.Errorf("%v-%s: type kind wrong, wanted %v, got %v (%#v)", nameIndex, n, e, a, underlyingType)
 			}
 			if e, a := item.names[nameIndex], namer.Name(thisType); e != a {
 				t.Errorf("%v-%s: Expected %q, got %q", nameIndex, n, e, a)

--- a/federation/apis/federation/v1alpha1/conversion_generated.go
+++ b/federation/apis/federation/v1alpha1/conversion_generated.go
@@ -23,9 +23,10 @@ package v1alpha1
 import (
 	federation "k8s.io/kubernetes/federation/apis/federation"
 	api "k8s.io/kubernetes/pkg/api"
-	resource "k8s.io/kubernetes/pkg/api/resource"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -135,16 +136,10 @@ func autoConvert_v1alpha1_ClusterList_To_federation_ClusterList(in *ClusterList,
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]federation.Cluster, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_Cluster_To_federation_Cluster(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -160,16 +155,10 @@ func autoConvert_federation_ClusterList_To_v1alpha1_ClusterList(in *federation.C
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Cluster, len(*in))
-		for i := range *in {
-			if err := Convert_federation_Cluster_To_v1alpha1_Cluster(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -197,27 +186,12 @@ func Convert_federation_ClusterMeta_To_v1alpha1_ClusterMeta(in *federation.Clust
 }
 
 func autoConvert_v1alpha1_ClusterSpec_To_federation_ClusterSpec(in *ClusterSpec, out *federation.ClusterSpec, s conversion.Scope) error {
-	if in.ServerAddressByClientCIDRs != nil {
-		in, out := &in.ServerAddressByClientCIDRs, &out.ServerAddressByClientCIDRs
-		*out = make([]federation.ServerAddressByClientCIDR, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_ServerAddressByClientCIDR_To_federation_ServerAddressByClientCIDR(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ServerAddressByClientCIDRs = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ServerAddressByClientCIDRs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(api.LocalObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*api.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	return nil
 }
 
@@ -226,27 +200,12 @@ func Convert_v1alpha1_ClusterSpec_To_federation_ClusterSpec(in *ClusterSpec, out
 }
 
 func autoConvert_federation_ClusterSpec_To_v1alpha1_ClusterSpec(in *federation.ClusterSpec, out *ClusterSpec, s conversion.Scope) error {
-	if in.ServerAddressByClientCIDRs != nil {
-		in, out := &in.ServerAddressByClientCIDRs, &out.ServerAddressByClientCIDRs
-		*out = make([]ServerAddressByClientCIDR, len(*in))
-		for i := range *in {
-			if err := Convert_federation_ServerAddressByClientCIDR_To_v1alpha1_ServerAddressByClientCIDR(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ServerAddressByClientCIDRs = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ServerAddressByClientCIDRs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(v1.LocalObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	return nil
 }
 
@@ -255,16 +214,10 @@ func Convert_federation_ClusterSpec_To_v1alpha1_ClusterSpec(in *federation.Clust
 }
 
 func autoConvert_v1alpha1_ClusterStatus_To_federation_ClusterStatus(in *ClusterStatus, out *federation.ClusterStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]federation.ClusterCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_ClusterCondition_To_federation_ClusterCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := v1.Convert_v1_ResourceList_To_api_ResourceList(&in.Capacity, &out.Capacity, s); err != nil {
 		return err
@@ -275,7 +228,11 @@ func autoConvert_v1alpha1_ClusterStatus_To_federation_ClusterStatus(in *ClusterS
 	if err := Convert_v1alpha1_ClusterMeta_To_federation_ClusterMeta(&in.ClusterMeta, &out.ClusterMeta, s); err != nil {
 		return err
 	}
-	out.Zones = in.Zones
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Zones))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Zones))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.Region = in.Region
 	return nil
 }
@@ -285,47 +242,27 @@ func Convert_v1alpha1_ClusterStatus_To_federation_ClusterStatus(in *ClusterStatu
 }
 
 func autoConvert_federation_ClusterStatus_To_v1alpha1_ClusterStatus(in *federation.ClusterStatus, out *ClusterStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]ClusterCondition, len(*in))
-		for i := range *in {
-			if err := Convert_federation_ClusterCondition_To_v1alpha1_ClusterCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Capacity != nil {
-		in, out := &in.Capacity, &out.Capacity
-		*out = make(v1.ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[v1.ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Capacity = nil
+	{
+		m := (*v1.ResourceList)(unsafe.Pointer(&in.Capacity))
+		out.Capacity = *m
 	}
-	if in.Allocatable != nil {
-		in, out := &in.Allocatable, &out.Allocatable
-		*out = make(v1.ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[v1.ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Allocatable = nil
+	{
+		m := (*v1.ResourceList)(unsafe.Pointer(&in.Allocatable))
+		out.Allocatable = *m
 	}
 	if err := Convert_federation_ClusterMeta_To_v1alpha1_ClusterMeta(&in.ClusterMeta, &out.ClusterMeta, s); err != nil {
 		return err
 	}
-	out.Zones = in.Zones
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Zones))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Zones))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.Region = in.Region
 	return nil
 }

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -47,7 +47,7 @@ ${clientgen} --clientset-name="release_1_3" --input="api/v1,extensions/v1beta1,a
 # Clientgen for federation clientset.
 ${clientgen} --clientset-name=federation_internalclientset --clientset-path=k8s.io/kubernetes/federation/client/clientset_generated --input="../../federation/apis/federation/","api/" --included-types-overrides="api/Service"   "$@"
 ${clientgen} --clientset-name=federation_release_1_3 --clientset-path=k8s.io/kubernetes/federation/client/clientset_generated --input="../../federation/apis/federation/v1alpha1","api/v1" --included-types-overrides="api/v1/Service"   "$@"
-${conversiongen} "$@"
+${conversiongen} --unsafe "$@"
 ${deepcopygen} "$@"
 ${setgen} "$@"
 

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -43,4 +43,5 @@ gotoprotobuf=$(kube::util::find-binary "go-to-protobuf")
 PATH="${KUBE_ROOT}/_output/local/go/bin:${PATH}" \
   "${gotoprotobuf}" \
   --proto-import="${KUBE_ROOT}/vendor" \
-  --proto-import="${KUBE_ROOT}/third_party/protobuf"
+  --proto-import="${KUBE_ROOT}/third_party/protobuf" \
+  $@

--- a/pkg/api/copy_test.go
+++ b/pkg/api/copy_test.go
@@ -54,7 +54,7 @@ func doDeepCopyTest(t *testing.T, kind unversioned.GroupVersionKind, f *fuzz.Fuz
 	}
 
 	if !reflect.DeepEqual(item, itemCopy) {
-		t.Errorf("\nexpected: %#v\n\ngot:      %#v\n\ndiff:      %v", item, itemCopy, diff.ObjectGoPrintSideBySide(item, itemCopy))
+		t.Errorf("\nexpected: %#v\n\ngot:      %#v\n\ndiff:      %v", item, itemCopy, diff.ObjectReflectDiff(item, itemCopy))
 	}
 }
 

--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -487,6 +487,14 @@ func (q *Quantity) Sign() int {
 	return q.i.Sign()
 }
 
+// Scale returns the scale of the quantity.
+func (q *Quantity) Scale() Scale {
+	if q.d.Dec != nil {
+		return Scale(-q.d.Scale())
+	}
+	return q.i.scale
+}
+
 // AsScaled returns the current value, rounded up to the provided scale, and returns
 // false if the scale resulted in a loss of precision.
 func (q *Quantity) AsScale(scale Scale) (CanonicalValue, bool) {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -25,6 +25,7 @@ import (
 	resource "k8s.io/kubernetes/pkg/api/resource"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
+	types "k8s.io/kubernetes/pkg/types"
 )
 
 func init() {
@@ -3549,7 +3550,7 @@ func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	out.GenerateName = in.GenerateName
 	out.Namespace = in.Namespace
 	out.SelfLink = in.SelfLink
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
@@ -3583,7 +3584,7 @@ func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	out.GenerateName = in.GenerateName
 	out.Namespace = in.Namespace
 	out.SelfLink = in.SelfLink
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
@@ -3616,7 +3617,7 @@ func autoConvert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, 
 	out.Kind = in.Kind
 	out.Namespace = in.Namespace
 	out.Name = in.Name
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.APIVersion = in.APIVersion
 	out.ResourceVersion = in.ResourceVersion
 	out.FieldPath = in.FieldPath
@@ -3631,7 +3632,7 @@ func autoConvert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReferen
 	out.Kind = in.Kind
 	out.Namespace = in.Namespace
 	out.Name = in.Name
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.APIVersion = in.APIVersion
 	out.ResourceVersion = in.ResourceVersion
 	out.FieldPath = in.FieldPath
@@ -3646,7 +3647,7 @@ func autoConvert_v1_OwnerReference_To_api_OwnerReference(in *OwnerReference, out
 	out.APIVersion = in.APIVersion
 	out.Kind = in.Kind
 	out.Name = in.Name
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.Controller = in.Controller
 	return nil
 }
@@ -3659,7 +3660,7 @@ func autoConvert_api_OwnerReference_To_v1_OwnerReference(in *api.OwnerReference,
 	out.APIVersion = in.APIVersion
 	out.Kind = in.Kind
 	out.Name = in.Name
-	out.UID = in.UID
+	out.UID = types.UID(in.UID)
 	out.Controller = in.Controller
 	return nil
 }

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -22,10 +22,12 @@ package v1
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
-	resource "k8s.io/kubernetes/pkg/api/resource"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
 	types "k8s.io/kubernetes/pkg/types"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -357,15 +359,7 @@ func Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolu
 }
 
 func autoConvert_v1_Affinity_To_api_Affinity(in *Affinity, out *api.Affinity, s conversion.Scope) error {
-	if in.NodeAffinity != nil {
-		in, out := &in.NodeAffinity, &out.NodeAffinity
-		*out = new(api.NodeAffinity)
-		if err := Convert_v1_NodeAffinity_To_api_NodeAffinity(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NodeAffinity = nil
-	}
+	out.NodeAffinity = (*api.NodeAffinity)(unsafe.Pointer(in.NodeAffinity))
 	if in.PodAffinity != nil {
 		in, out := &in.PodAffinity, &out.PodAffinity
 		*out = new(api.PodAffinity)
@@ -392,15 +386,7 @@ func Convert_v1_Affinity_To_api_Affinity(in *Affinity, out *api.Affinity, s conv
 }
 
 func autoConvert_api_Affinity_To_v1_Affinity(in *api.Affinity, out *Affinity, s conversion.Scope) error {
-	if in.NodeAffinity != nil {
-		in, out := &in.NodeAffinity, &out.NodeAffinity
-		*out = new(NodeAffinity)
-		if err := Convert_api_NodeAffinity_To_v1_NodeAffinity(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NodeAffinity = nil
-	}
+	out.NodeAffinity = (*NodeAffinity)(unsafe.Pointer(in.NodeAffinity))
 	if in.PodAffinity != nil {
 		in, out := &in.PodAffinity, &out.PodAffinity
 		*out = new(PodAffinity)
@@ -483,23 +469,15 @@ func Convert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversi
 }
 
 func autoConvert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capabilities, s conversion.Scope) error {
-	if in.Add != nil {
-		in, out := &in.Add, &out.Add
-		*out = make([]api.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = api.Capability((*in)[i])
-		}
-	} else {
-		out.Add = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Add))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Add))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Drop != nil {
-		in, out := &in.Drop, &out.Drop
-		*out = make([]api.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = api.Capability((*in)[i])
-		}
-	} else {
-		out.Drop = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Drop))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Drop))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -509,23 +487,15 @@ func Convert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capa
 }
 
 func autoConvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capabilities, s conversion.Scope) error {
-	if in.Add != nil {
-		in, out := &in.Add, &out.Add
-		*out = make([]Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = Capability((*in)[i])
-		}
-	} else {
-		out.Add = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Add))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Add))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Drop != nil {
-		in, out := &in.Drop, &out.Drop
-		*out = make([]Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = Capability((*in)[i])
-		}
-	} else {
-		out.Drop = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Drop))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Drop))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -535,19 +505,15 @@ func Convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capa
 }
 
 func autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = in.Monitors
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Monitors))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Monitors))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(api.LocalObjectReference)
-		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*api.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -557,19 +523,15 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSou
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = in.Monitors
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Monitors))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Monitors))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(LocalObjectReference)
-		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -631,16 +593,10 @@ func autoConvert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, 
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]api.ComponentCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ComponentCondition_To_api_ComponentCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -656,16 +612,10 @@ func autoConvert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStat
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]ComponentCondition, len(*in))
-		for i := range *in {
-			if err := Convert_api_ComponentCondition_To_v1_ComponentCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -681,16 +631,10 @@ func autoConvert_v1_ComponentStatusList_To_api_ComponentStatusList(in *Component
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.ComponentStatus, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ComponentStatus_To_api_ComponentStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -706,16 +650,10 @@ func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.Compo
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ComponentStatus, len(*in))
-		for i := range *in {
-			if err := Convert_api_ComponentStatus_To_v1_ComponentStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -732,7 +670,10 @@ func autoConvert_v1_ConfigMap_To_api_ConfigMap(in *ConfigMap, out *api.ConfigMap
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	out.Data = in.Data
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Data))
+		out.Data = *m
+	}
 	return nil
 }
 
@@ -747,7 +688,10 @@ func autoConvert_api_ConfigMap_To_v1_ConfigMap(in *api.ConfigMap, out *ConfigMap
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	out.Data = in.Data
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Data))
+		out.Data = *m
+	}
 	return nil
 }
 
@@ -786,16 +730,10 @@ func autoConvert_v1_ConfigMapList_To_api_ConfigMapList(in *ConfigMapList, out *a
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.ConfigMap, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ConfigMap_To_api_ConfigMap(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -811,16 +749,10 @@ func autoConvert_api_ConfigMapList_To_v1_ConfigMapList(in *api.ConfigMapList, ou
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ConfigMap, len(*in))
-		for i := range *in {
-			if err := Convert_api_ConfigMap_To_v1_ConfigMap(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -833,16 +765,10 @@ func autoConvert_v1_ConfigMapVolumeSource_To_api_ConfigMapVolumeSource(in *Confi
 	if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.KeyToPath, len(*in))
-		for i := range *in {
-			if err := Convert_v1_KeyToPath_To_api_KeyToPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -855,16 +781,10 @@ func autoConvert_api_ConfigMapVolumeSource_To_v1_ConfigMapVolumeSource(in *api.C
 	if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]KeyToPath, len(*in))
-		for i := range *in {
-			if err := Convert_api_KeyToPath_To_v1_KeyToPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -877,83 +797,41 @@ func autoConvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	SetDefaults_Container(in)
 	out.Name = in.Name
 	out.Image = in.Image
-	out.Command = in.Command
-	out.Args = in.Args
-	out.WorkingDir = in.WorkingDir
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]api.ContainerPort, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ContainerPort_To_api_ContainerPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Env != nil {
-		in, out := &in.Env, &out.Env
-		*out = make([]api.EnvVar, len(*in))
-		for i := range *in {
-			if err := Convert_v1_EnvVar_To_api_EnvVar(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Env = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Args))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Args))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	out.WorkingDir = in.WorkingDir
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Env))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Env))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
-	if in.VolumeMounts != nil {
-		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]api.VolumeMount, len(*in))
-		for i := range *in {
-			if err := Convert_v1_VolumeMount_To_api_VolumeMount(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.VolumeMounts = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.VolumeMounts))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.VolumeMounts))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.LivenessProbe != nil {
-		in, out := &in.LivenessProbe, &out.LivenessProbe
-		*out = new(api.Probe)
-		if err := Convert_v1_Probe_To_api_Probe(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LivenessProbe = nil
-	}
-	if in.ReadinessProbe != nil {
-		in, out := &in.ReadinessProbe, &out.ReadinessProbe
-		*out = new(api.Probe)
-		if err := Convert_v1_Probe_To_api_Probe(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ReadinessProbe = nil
-	}
-	if in.Lifecycle != nil {
-		in, out := &in.Lifecycle, &out.Lifecycle
-		*out = new(api.Lifecycle)
-		if err := Convert_v1_Lifecycle_To_api_Lifecycle(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Lifecycle = nil
-	}
+	out.LivenessProbe = (*api.Probe)(unsafe.Pointer(in.LivenessProbe))
+	out.ReadinessProbe = (*api.Probe)(unsafe.Pointer(in.ReadinessProbe))
+	out.Lifecycle = (*api.Lifecycle)(unsafe.Pointer(in.Lifecycle))
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = api.PullPolicy(in.ImagePullPolicy)
-	if in.SecurityContext != nil {
-		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(api.SecurityContext)
-		if err := Convert_v1_SecurityContext_To_api_SecurityContext(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecurityContext = nil
-	}
+	out.SecurityContext = (*api.SecurityContext)(unsafe.Pointer(in.SecurityContext))
 	out.Stdin = in.Stdin
 	out.StdinOnce = in.StdinOnce
 	out.TTY = in.TTY
@@ -967,83 +845,41 @@ func Convert_v1_Container_To_api_Container(in *Container, out *api.Container, s 
 func autoConvert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Image = in.Image
-	out.Command = in.Command
-	out.Args = in.Args
-	out.WorkingDir = in.WorkingDir
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]ContainerPort, len(*in))
-		for i := range *in {
-			if err := Convert_api_ContainerPort_To_v1_ContainerPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Env != nil {
-		in, out := &in.Env, &out.Env
-		*out = make([]EnvVar, len(*in))
-		for i := range *in {
-			if err := Convert_api_EnvVar_To_v1_EnvVar(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Env = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Args))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Args))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	out.WorkingDir = in.WorkingDir
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Env))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Env))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
-	if in.VolumeMounts != nil {
-		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]VolumeMount, len(*in))
-		for i := range *in {
-			if err := Convert_api_VolumeMount_To_v1_VolumeMount(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.VolumeMounts = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.VolumeMounts))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.VolumeMounts))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.LivenessProbe != nil {
-		in, out := &in.LivenessProbe, &out.LivenessProbe
-		*out = new(Probe)
-		if err := Convert_api_Probe_To_v1_Probe(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LivenessProbe = nil
-	}
-	if in.ReadinessProbe != nil {
-		in, out := &in.ReadinessProbe, &out.ReadinessProbe
-		*out = new(Probe)
-		if err := Convert_api_Probe_To_v1_Probe(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ReadinessProbe = nil
-	}
-	if in.Lifecycle != nil {
-		in, out := &in.Lifecycle, &out.Lifecycle
-		*out = new(Lifecycle)
-		if err := Convert_api_Lifecycle_To_v1_Lifecycle(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Lifecycle = nil
-	}
+	out.LivenessProbe = (*Probe)(unsafe.Pointer(in.LivenessProbe))
+	out.ReadinessProbe = (*Probe)(unsafe.Pointer(in.ReadinessProbe))
+	out.Lifecycle = (*Lifecycle)(unsafe.Pointer(in.Lifecycle))
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = PullPolicy(in.ImagePullPolicy)
-	if in.SecurityContext != nil {
-		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(SecurityContext)
-		if err := Convert_api_SecurityContext_To_v1_SecurityContext(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecurityContext = nil
-	}
+	out.SecurityContext = (*SecurityContext)(unsafe.Pointer(in.SecurityContext))
 	out.Stdin = in.Stdin
 	out.StdinOnce = in.StdinOnce
 	out.TTY = in.TTY
@@ -1055,7 +891,11 @@ func Convert_api_Container_To_v1_Container(in *api.Container, out *Container, s 
 }
 
 func autoConvert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *api.ContainerImage, s conversion.Scope) error {
-	out.Names = in.Names
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Names))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Names))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1065,7 +905,11 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *ap
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *ContainerImage, s conversion.Scope) error {
-	out.Names = in.Names
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Names))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Names))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1102,33 +946,9 @@ func Convert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *C
 }
 
 func autoConvert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *api.ContainerState, s conversion.Scope) error {
-	if in.Waiting != nil {
-		in, out := &in.Waiting, &out.Waiting
-		*out = new(api.ContainerStateWaiting)
-		if err := Convert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Waiting = nil
-	}
-	if in.Running != nil {
-		in, out := &in.Running, &out.Running
-		*out = new(api.ContainerStateRunning)
-		if err := Convert_v1_ContainerStateRunning_To_api_ContainerStateRunning(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Running = nil
-	}
-	if in.Terminated != nil {
-		in, out := &in.Terminated, &out.Terminated
-		*out = new(api.ContainerStateTerminated)
-		if err := Convert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Terminated = nil
-	}
+	out.Waiting = (*api.ContainerStateWaiting)(unsafe.Pointer(in.Waiting))
+	out.Running = (*api.ContainerStateRunning)(unsafe.Pointer(in.Running))
+	out.Terminated = (*api.ContainerStateTerminated)(unsafe.Pointer(in.Terminated))
 	return nil
 }
 
@@ -1137,33 +957,9 @@ func Convert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *ap
 }
 
 func autoConvert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState, out *ContainerState, s conversion.Scope) error {
-	if in.Waiting != nil {
-		in, out := &in.Waiting, &out.Waiting
-		*out = new(ContainerStateWaiting)
-		if err := Convert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Waiting = nil
-	}
-	if in.Running != nil {
-		in, out := &in.Running, &out.Running
-		*out = new(ContainerStateRunning)
-		if err := Convert_api_ContainerStateRunning_To_v1_ContainerStateRunning(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Running = nil
-	}
-	if in.Terminated != nil {
-		in, out := &in.Terminated, &out.Terminated
-		*out = new(ContainerStateTerminated)
-		if err := Convert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Terminated = nil
-	}
+	out.Waiting = (*ContainerStateWaiting)(unsafe.Pointer(in.Waiting))
+	out.Running = (*ContainerStateRunning)(unsafe.Pointer(in.Running))
+	out.Terminated = (*ContainerStateTerminated)(unsafe.Pointer(in.Terminated))
 	return nil
 }
 
@@ -1313,17 +1109,9 @@ func autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *a
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	out.GracePeriodSeconds = in.GracePeriodSeconds
-	if in.Preconditions != nil {
-		in, out := &in.Preconditions, &out.Preconditions
-		*out = new(api.Preconditions)
-		if err := Convert_v1_Preconditions_To_api_Preconditions(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Preconditions = nil
-	}
-	out.OrphanDependents = in.OrphanDependents
+	out.GracePeriodSeconds = (*int64)(unsafe.Pointer(in.GracePeriodSeconds))
+	out.Preconditions = (*api.Preconditions)(unsafe.Pointer(in.Preconditions))
+	out.OrphanDependents = (*bool)(unsafe.Pointer(in.OrphanDependents))
 	return nil
 }
 
@@ -1335,17 +1123,9 @@ func autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, ou
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	out.GracePeriodSeconds = in.GracePeriodSeconds
-	if in.Preconditions != nil {
-		in, out := &in.Preconditions, &out.Preconditions
-		*out = new(Preconditions)
-		if err := Convert_api_Preconditions_To_v1_Preconditions(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Preconditions = nil
-	}
-	out.OrphanDependents = in.OrphanDependents
+	out.GracePeriodSeconds = (*int64)(unsafe.Pointer(in.GracePeriodSeconds))
+	out.Preconditions = (*Preconditions)(unsafe.Pointer(in.Preconditions))
+	out.OrphanDependents = (*bool)(unsafe.Pointer(in.OrphanDependents))
 	return nil
 }
 
@@ -1355,24 +1135,8 @@ func Convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *D
 
 func autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
 	out.Path = in.Path
-	if in.FieldRef != nil {
-		in, out := &in.FieldRef, &out.FieldRef
-		*out = new(api.ObjectFieldSelector)
-		if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FieldRef = nil
-	}
-	if in.ResourceFieldRef != nil {
-		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		*out = new(api.ResourceFieldSelector)
-		if err := Convert_v1_ResourceFieldSelector_To_api_ResourceFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceFieldRef = nil
-	}
+	out.FieldRef = (*api.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
+	out.ResourceFieldRef = (*api.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
 	return nil
 }
 
@@ -1382,24 +1146,8 @@ func Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardA
 
 func autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *DownwardAPIVolumeFile, s conversion.Scope) error {
 	out.Path = in.Path
-	if in.FieldRef != nil {
-		in, out := &in.FieldRef, &out.FieldRef
-		*out = new(ObjectFieldSelector)
-		if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FieldRef = nil
-	}
-	if in.ResourceFieldRef != nil {
-		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		*out = new(ResourceFieldSelector)
-		if err := Convert_api_ResourceFieldSelector_To_v1_ResourceFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceFieldRef = nil
-	}
+	out.FieldRef = (*ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
+	out.ResourceFieldRef = (*ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
 	return nil
 }
 
@@ -1408,16 +1156,10 @@ func Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.Downw
 }
 
 func autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.DownwardAPIVolumeFile, len(*in))
-		for i := range *in {
-			if err := Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1427,16 +1169,10 @@ func Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *Downw
 }
 
 func autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *DownwardAPIVolumeSource, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]DownwardAPIVolumeFile, len(*in))
-		for i := range *in {
-			if err := Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1466,15 +1202,7 @@ func Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDi
 func autoConvert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out *api.EndpointAddress, s conversion.Scope) error {
 	out.IP = in.IP
 	out.Hostname = in.Hostname
-	if in.TargetRef != nil {
-		in, out := &in.TargetRef, &out.TargetRef
-		*out = new(api.ObjectReference)
-		if err := Convert_v1_ObjectReference_To_api_ObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.TargetRef = nil
-	}
+	out.TargetRef = (*api.ObjectReference)(unsafe.Pointer(in.TargetRef))
 	return nil
 }
 
@@ -1485,15 +1213,7 @@ func Convert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out 
 func autoConvert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, out *EndpointAddress, s conversion.Scope) error {
 	out.IP = in.IP
 	out.Hostname = in.Hostname
-	if in.TargetRef != nil {
-		in, out := &in.TargetRef, &out.TargetRef
-		*out = new(ObjectReference)
-		if err := Convert_api_ObjectReference_To_v1_ObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.TargetRef = nil
-	}
+	out.TargetRef = (*ObjectReference)(unsafe.Pointer(in.TargetRef))
 	return nil
 }
 
@@ -1524,38 +1244,20 @@ func Convert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *Endp
 }
 
 func autoConvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *api.EndpointSubset, s conversion.Scope) error {
-	if in.Addresses != nil {
-		in, out := &in.Addresses, &out.Addresses
-		*out = make([]api.EndpointAddress, len(*in))
-		for i := range *in {
-			if err := Convert_v1_EndpointAddress_To_api_EndpointAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Addresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Addresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Addresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.NotReadyAddresses != nil {
-		in, out := &in.NotReadyAddresses, &out.NotReadyAddresses
-		*out = make([]api.EndpointAddress, len(*in))
-		for i := range *in {
-			if err := Convert_v1_EndpointAddress_To_api_EndpointAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.NotReadyAddresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NotReadyAddresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NotReadyAddresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]api.EndpointPort, len(*in))
-		for i := range *in {
-			if err := Convert_v1_EndpointPort_To_api_EndpointPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1565,38 +1267,20 @@ func Convert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *ap
 }
 
 func autoConvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset, out *EndpointSubset, s conversion.Scope) error {
-	if in.Addresses != nil {
-		in, out := &in.Addresses, &out.Addresses
-		*out = make([]EndpointAddress, len(*in))
-		for i := range *in {
-			if err := Convert_api_EndpointAddress_To_v1_EndpointAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Addresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Addresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Addresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.NotReadyAddresses != nil {
-		in, out := &in.NotReadyAddresses, &out.NotReadyAddresses
-		*out = make([]EndpointAddress, len(*in))
-		for i := range *in {
-			if err := Convert_api_EndpointAddress_To_v1_EndpointAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.NotReadyAddresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NotReadyAddresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NotReadyAddresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]EndpointPort, len(*in))
-		for i := range *in {
-			if err := Convert_api_EndpointPort_To_v1_EndpointPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1613,16 +1297,10 @@ func autoConvert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Subsets != nil {
-		in, out := &in.Subsets, &out.Subsets
-		*out = make([]api.EndpointSubset, len(*in))
-		for i := range *in {
-			if err := Convert_v1_EndpointSubset_To_api_EndpointSubset(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subsets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subsets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subsets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1638,16 +1316,10 @@ func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Subsets != nil {
-		in, out := &in.Subsets, &out.Subsets
-		*out = make([]EndpointSubset, len(*in))
-		for i := range *in {
-			if err := Convert_api_EndpointSubset_To_v1_EndpointSubset(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subsets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subsets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subsets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1663,16 +1335,10 @@ func autoConvert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *a
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.Endpoints, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Endpoints_To_api_Endpoints(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1688,16 +1354,10 @@ func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, ou
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Endpoints, len(*in))
-		for i := range *in {
-			if err := Convert_api_Endpoints_To_v1_Endpoints(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1709,15 +1369,7 @@ func Convert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *E
 func autoConvert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Value = in.Value
-	if in.ValueFrom != nil {
-		in, out := &in.ValueFrom, &out.ValueFrom
-		*out = new(api.EnvVarSource)
-		if err := Convert_v1_EnvVarSource_To_api_EnvVarSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ValueFrom = nil
-	}
+	out.ValueFrom = (*api.EnvVarSource)(unsafe.Pointer(in.ValueFrom))
 	return nil
 }
 
@@ -1728,15 +1380,7 @@ func Convert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.S
 func autoConvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Value = in.Value
-	if in.ValueFrom != nil {
-		in, out := &in.ValueFrom, &out.ValueFrom
-		*out = new(EnvVarSource)
-		if err := Convert_api_EnvVarSource_To_v1_EnvVarSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ValueFrom = nil
-	}
+	out.ValueFrom = (*EnvVarSource)(unsafe.Pointer(in.ValueFrom))
 	return nil
 }
 
@@ -1745,42 +1389,10 @@ func Convert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.S
 }
 
 func autoConvert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
-	if in.FieldRef != nil {
-		in, out := &in.FieldRef, &out.FieldRef
-		*out = new(api.ObjectFieldSelector)
-		if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FieldRef = nil
-	}
-	if in.ResourceFieldRef != nil {
-		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		*out = new(api.ResourceFieldSelector)
-		if err := Convert_v1_ResourceFieldSelector_To_api_ResourceFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceFieldRef = nil
-	}
-	if in.ConfigMapKeyRef != nil {
-		in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
-		*out = new(api.ConfigMapKeySelector)
-		if err := Convert_v1_ConfigMapKeySelector_To_api_ConfigMapKeySelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ConfigMapKeyRef = nil
-	}
-	if in.SecretKeyRef != nil {
-		in, out := &in.SecretKeyRef, &out.SecretKeyRef
-		*out = new(api.SecretKeySelector)
-		if err := Convert_v1_SecretKeySelector_To_api_SecretKeySelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretKeyRef = nil
-	}
+	out.FieldRef = (*api.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
+	out.ResourceFieldRef = (*api.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
+	out.ConfigMapKeyRef = (*api.ConfigMapKeySelector)(unsafe.Pointer(in.ConfigMapKeyRef))
+	out.SecretKeyRef = (*api.SecretKeySelector)(unsafe.Pointer(in.SecretKeyRef))
 	return nil
 }
 
@@ -1789,42 +1401,10 @@ func Convert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvV
 }
 
 func autoConvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *EnvVarSource, s conversion.Scope) error {
-	if in.FieldRef != nil {
-		in, out := &in.FieldRef, &out.FieldRef
-		*out = new(ObjectFieldSelector)
-		if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FieldRef = nil
-	}
-	if in.ResourceFieldRef != nil {
-		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		*out = new(ResourceFieldSelector)
-		if err := Convert_api_ResourceFieldSelector_To_v1_ResourceFieldSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceFieldRef = nil
-	}
-	if in.ConfigMapKeyRef != nil {
-		in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
-		*out = new(ConfigMapKeySelector)
-		if err := Convert_api_ConfigMapKeySelector_To_v1_ConfigMapKeySelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ConfigMapKeyRef = nil
-	}
-	if in.SecretKeyRef != nil {
-		in, out := &in.SecretKeyRef, &out.SecretKeyRef
-		*out = new(SecretKeySelector)
-		if err := Convert_api_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretKeyRef = nil
-	}
+	out.FieldRef = (*ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
+	out.ResourceFieldRef = (*ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
+	out.ConfigMapKeyRef = (*ConfigMapKeySelector)(unsafe.Pointer(in.ConfigMapKeyRef))
+	out.SecretKeyRef = (*SecretKeySelector)(unsafe.Pointer(in.SecretKeyRef))
 	return nil
 }
 
@@ -1899,16 +1479,10 @@ func autoConvert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.Event, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Event_To_api_Event(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1924,16 +1498,10 @@ func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Event, len(*in))
-		for i := range *in {
-			if err := Convert_api_Event_To_v1_Event(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1963,7 +1531,11 @@ func Convert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSo
 }
 
 func autoConvert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
-	out.Command = in.Command
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -1972,7 +1544,11 @@ func Convert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction
 }
 
 func autoConvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
-	out.Command = in.Command
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -2007,8 +1583,12 @@ func Convert_api_ExportOptions_To_v1_ExportOptions(in *api.ExportOptions, out *E
 }
 
 func autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = in.TargetWWNs
-	out.Lun = in.Lun
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.TargetWWNs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.TargetWWNs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -2019,8 +1599,12 @@ func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *ap
 }
 
 func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = in.TargetWWNs
-	out.Lun = in.Lun
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.TargetWWNs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.TargetWWNs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -2033,17 +1617,12 @@ func Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out
 func autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
 	out.Driver = in.Driver
 	out.FSType = in.FSType
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(api.LocalObjectReference)
-		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*api.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
-	out.Options = in.Options
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Options))
+		out.Options = *m
+	}
 	return nil
 }
 
@@ -2054,17 +1633,12 @@ func Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, o
 func autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *FlexVolumeSource, s conversion.Scope) error {
 	out.Driver = in.Driver
 	out.FSType = in.FSType
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(LocalObjectReference)
-		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
-	out.Options = in.Options
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Options))
+		out.Options = *m
+	}
 	return nil
 }
 
@@ -2166,16 +1740,10 @@ func autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *a
 	}
 	out.Host = in.Host
 	out.Scheme = api.URIScheme(in.Scheme)
-	if in.HTTPHeaders != nil {
-		in, out := &in.HTTPHeaders, &out.HTTPHeaders
-		*out = make([]api.HTTPHeader, len(*in))
-		for i := range *in {
-			if err := Convert_v1_HTTPHeader_To_api_HTTPHeader(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.HTTPHeaders = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.HTTPHeaders))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.HTTPHeaders))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2191,16 +1759,10 @@ func autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, ou
 	}
 	out.Host = in.Host
 	out.Scheme = URIScheme(in.Scheme)
-	if in.HTTPHeaders != nil {
-		in, out := &in.HTTPHeaders, &out.HTTPHeaders
-		*out = make([]HTTPHeader, len(*in))
-		for i := range *in {
-			if err := Convert_api_HTTPHeader_To_v1_HTTPHeader(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.HTTPHeaders = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.HTTPHeaders))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.HTTPHeaders))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2230,33 +1792,9 @@ func Convert_api_HTTPHeader_To_v1_HTTPHeader(in *api.HTTPHeader, out *HTTPHeader
 }
 
 func autoConvert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversion.Scope) error {
-	if in.Exec != nil {
-		in, out := &in.Exec, &out.Exec
-		*out = new(api.ExecAction)
-		if err := Convert_v1_ExecAction_To_api_ExecAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Exec = nil
-	}
-	if in.HTTPGet != nil {
-		in, out := &in.HTTPGet, &out.HTTPGet
-		*out = new(api.HTTPGetAction)
-		if err := Convert_v1_HTTPGetAction_To_api_HTTPGetAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HTTPGet = nil
-	}
-	if in.TCPSocket != nil {
-		in, out := &in.TCPSocket, &out.TCPSocket
-		*out = new(api.TCPSocketAction)
-		if err := Convert_v1_TCPSocketAction_To_api_TCPSocketAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.TCPSocket = nil
-	}
+	out.Exec = (*api.ExecAction)(unsafe.Pointer(in.Exec))
+	out.HTTPGet = (*api.HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
+	out.TCPSocket = (*api.TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
 	return nil
 }
 
@@ -2265,33 +1803,9 @@ func Convert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversi
 }
 
 func autoConvert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conversion.Scope) error {
-	if in.Exec != nil {
-		in, out := &in.Exec, &out.Exec
-		*out = new(ExecAction)
-		if err := Convert_api_ExecAction_To_v1_ExecAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Exec = nil
-	}
-	if in.HTTPGet != nil {
-		in, out := &in.HTTPGet, &out.HTTPGet
-		*out = new(HTTPGetAction)
-		if err := Convert_api_HTTPGetAction_To_v1_HTTPGetAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HTTPGet = nil
-	}
-	if in.TCPSocket != nil {
-		in, out := &in.TCPSocket, &out.TCPSocket
-		*out = new(TCPSocketAction)
-		if err := Convert_api_TCPSocketAction_To_v1_TCPSocketAction(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.TCPSocket = nil
-	}
+	out.Exec = (*ExecAction)(unsafe.Pointer(in.Exec))
+	out.HTTPGet = (*HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
+	out.TCPSocket = (*TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
 	return nil
 }
 
@@ -2367,24 +1881,8 @@ func Convert_api_KeyToPath_To_v1_KeyToPath(in *api.KeyToPath, out *KeyToPath, s 
 }
 
 func autoConvert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
-	if in.PostStart != nil {
-		in, out := &in.PostStart, &out.PostStart
-		*out = new(api.Handler)
-		if err := Convert_v1_Handler_To_api_Handler(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PostStart = nil
-	}
-	if in.PreStop != nil {
-		in, out := &in.PreStop, &out.PreStop
-		*out = new(api.Handler)
-		if err := Convert_v1_Handler_To_api_Handler(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PreStop = nil
-	}
+	out.PostStart = (*api.Handler)(unsafe.Pointer(in.PostStart))
+	out.PreStop = (*api.Handler)(unsafe.Pointer(in.PreStop))
 	return nil
 }
 
@@ -2393,24 +1891,8 @@ func Convert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s 
 }
 
 func autoConvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle, s conversion.Scope) error {
-	if in.PostStart != nil {
-		in, out := &in.PostStart, &out.PostStart
-		*out = new(Handler)
-		if err := Convert_api_Handler_To_v1_Handler(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PostStart = nil
-	}
-	if in.PreStop != nil {
-		in, out := &in.PreStop, &out.PreStop
-		*out = new(Handler)
-		if err := Convert_api_Handler_To_v1_Handler(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PreStop = nil
-	}
+	out.PostStart = (*Handler)(unsafe.Pointer(in.PostStart))
+	out.PreStop = (*Handler)(unsafe.Pointer(in.PreStop))
 	return nil
 }
 
@@ -2479,70 +1961,25 @@ func Convert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out *ap
 
 func autoConvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
 	out.Type = LimitType(in.Type)
-	if in.Max != nil {
-		in, out := &in.Max, &out.Max
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Max = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Max))
+		out.Max = *m
 	}
-	if in.Min != nil {
-		in, out := &in.Min, &out.Min
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Min = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Min))
+		out.Min = *m
 	}
-	if in.Default != nil {
-		in, out := &in.Default, &out.Default
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Default = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Default))
+		out.Default = *m
 	}
-	if in.DefaultRequest != nil {
-		in, out := &in.DefaultRequest, &out.DefaultRequest
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.DefaultRequest = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.DefaultRequest))
+		out.DefaultRequest = *m
 	}
-	if in.MaxLimitRequestRatio != nil {
-		in, out := &in.MaxLimitRequestRatio, &out.MaxLimitRequestRatio
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.MaxLimitRequestRatio = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.MaxLimitRequestRatio))
+		out.MaxLimitRequestRatio = *m
 	}
 	return nil
 }
@@ -2558,16 +1995,10 @@ func autoConvert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.LimitRange, len(*in))
-		for i := range *in {
-			if err := Convert_v1_LimitRange_To_api_LimitRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2583,16 +2014,10 @@ func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList,
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]LimitRange, len(*in))
-		for i := range *in {
-			if err := Convert_api_LimitRange_To_v1_LimitRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2602,16 +2027,10 @@ func Convert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out
 }
 
 func autoConvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *api.LimitRangeSpec, s conversion.Scope) error {
-	if in.Limits != nil {
-		in, out := &in.Limits, &out.Limits
-		*out = make([]api.LimitRangeItem, len(*in))
-		for i := range *in {
-			if err := Convert_v1_LimitRangeItem_To_api_LimitRangeItem(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Limits = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Limits))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Limits))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2621,16 +2040,10 @@ func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *ap
 }
 
 func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
-	if in.Limits != nil {
-		in, out := &in.Limits, &out.Limits
-		*out = make([]LimitRangeItem, len(*in))
-		for i := range *in {
-			if err := Convert_api_LimitRangeItem_To_v1_LimitRangeItem(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Limits = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Limits))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Limits))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2701,7 +2114,7 @@ func autoConvert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.Lis
 	}
 	out.Watch = in.Watch
 	out.ResourceVersion = in.ResourceVersion
-	out.TimeoutSeconds = in.TimeoutSeconds
+	out.TimeoutSeconds = (*int64)(unsafe.Pointer(in.TimeoutSeconds))
 	return nil
 }
 
@@ -2721,7 +2134,7 @@ func autoConvert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *Lis
 	}
 	out.Watch = in.Watch
 	out.ResourceVersion = in.ResourceVersion
-	out.TimeoutSeconds = in.TimeoutSeconds
+	out.TimeoutSeconds = (*int64)(unsafe.Pointer(in.TimeoutSeconds))
 	return nil
 }
 
@@ -2750,16 +2163,10 @@ func Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalan
 }
 
 func autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
-	if in.Ingress != nil {
-		in, out := &in.Ingress, &out.Ingress
-		*out = make([]api.LoadBalancerIngress, len(*in))
-		for i := range *in {
-			if err := Convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ingress = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ingress))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ingress))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2769,16 +2176,10 @@ func Convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerSta
 }
 
 func autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *LoadBalancerStatus, s conversion.Scope) error {
-	if in.Ingress != nil {
-		in, out := &in.Ingress, &out.Ingress
-		*out = make([]LoadBalancerIngress, len(*in))
-		for i := range *in {
-			if err := Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ingress = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ingress))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ingress))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2874,16 +2275,10 @@ func autoConvert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *a
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.Namespace, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Namespace_To_api_Namespace(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2899,16 +2294,10 @@ func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, ou
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Namespace, len(*in))
-		for i := range *in {
-			if err := Convert_api_Namespace_To_v1_Namespace(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2918,14 +2307,10 @@ func Convert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *N
 }
 
 func autoConvert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.NamespaceSpec, s conversion.Scope) error {
-	if in.Finalizers != nil {
-		in, out := &in.Finalizers, &out.Finalizers
-		*out = make([]api.FinalizerName, len(*in))
-		for i := range *in {
-			(*out)[i] = api.FinalizerName((*in)[i])
-		}
-	} else {
-		out.Finalizers = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Finalizers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Finalizers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2935,14 +2320,10 @@ func Convert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.N
 }
 
 func autoConvert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, out *NamespaceSpec, s conversion.Scope) error {
-	if in.Finalizers != nil {
-		in, out := &in.Finalizers, &out.Finalizers
-		*out = make([]FinalizerName, len(*in))
-		for i := range *in {
-			(*out)[i] = FinalizerName((*in)[i])
-		}
-	} else {
-		out.Finalizers = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Finalizers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Finalizers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3032,25 +2413,11 @@ func Convert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *NodeAdd
 }
 
 func autoConvert_v1_NodeAffinity_To_api_NodeAffinity(in *NodeAffinity, out *api.NodeAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = new(api.NodeSelector)
-		if err := Convert_v1_NodeSelector_To_api_NodeSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
-	}
-	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
-		*out = make([]api.PreferredSchedulingTerm, len(*in))
-		for i := range *in {
-			if err := Convert_v1_PreferredSchedulingTerm_To_api_PreferredSchedulingTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.PreferredDuringSchedulingIgnoredDuringExecution = nil
+	out.RequiredDuringSchedulingIgnoredDuringExecution = (*api.NodeSelector)(unsafe.Pointer(in.RequiredDuringSchedulingIgnoredDuringExecution))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.PreferredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3060,25 +2427,11 @@ func Convert_v1_NodeAffinity_To_api_NodeAffinity(in *NodeAffinity, out *api.Node
 }
 
 func autoConvert_api_NodeAffinity_To_v1_NodeAffinity(in *api.NodeAffinity, out *NodeAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = new(NodeSelector)
-		if err := Convert_api_NodeSelector_To_v1_NodeSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
-	}
-	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
-		*out = make([]PreferredSchedulingTerm, len(*in))
-		for i := range *in {
-			if err := Convert_api_PreferredSchedulingTerm_To_v1_PreferredSchedulingTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.PreferredDuringSchedulingIgnoredDuringExecution = nil
+	out.RequiredDuringSchedulingIgnoredDuringExecution = (*NodeSelector)(unsafe.Pointer(in.RequiredDuringSchedulingIgnoredDuringExecution))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.PreferredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3152,16 +2505,10 @@ func autoConvert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s 
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.Node, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Node_To_api_Node(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3177,16 +2524,10 @@ func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s 
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Node, len(*in))
-		for i := range *in {
-			if err := Convert_api_Node_To_v1_Node(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3220,16 +2561,10 @@ func Convert_api_NodeProxyOptions_To_v1_NodeProxyOptions(in *api.NodeProxyOption
 }
 
 func autoConvert_v1_NodeSelector_To_api_NodeSelector(in *NodeSelector, out *api.NodeSelector, s conversion.Scope) error {
-	if in.NodeSelectorTerms != nil {
-		in, out := &in.NodeSelectorTerms, &out.NodeSelectorTerms
-		*out = make([]api.NodeSelectorTerm, len(*in))
-		for i := range *in {
-			if err := Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.NodeSelectorTerms = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NodeSelectorTerms))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NodeSelectorTerms))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3239,16 +2574,10 @@ func Convert_v1_NodeSelector_To_api_NodeSelector(in *NodeSelector, out *api.Node
 }
 
 func autoConvert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *NodeSelector, s conversion.Scope) error {
-	if in.NodeSelectorTerms != nil {
-		in, out := &in.NodeSelectorTerms, &out.NodeSelectorTerms
-		*out = make([]NodeSelectorTerm, len(*in))
-		for i := range *in {
-			if err := Convert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.NodeSelectorTerms = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NodeSelectorTerms))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NodeSelectorTerms))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3260,7 +2589,11 @@ func Convert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *Node
 func autoConvert_v1_NodeSelectorRequirement_To_api_NodeSelectorRequirement(in *NodeSelectorRequirement, out *api.NodeSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = api.NodeSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -3271,7 +2604,11 @@ func Convert_v1_NodeSelectorRequirement_To_api_NodeSelectorRequirement(in *NodeS
 func autoConvert_api_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(in *api.NodeSelectorRequirement, out *NodeSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = NodeSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -3280,16 +2617,10 @@ func Convert_api_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(in *api.N
 }
 
 func autoConvert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *NodeSelectorTerm, out *api.NodeSelectorTerm, s conversion.Scope) error {
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]api.NodeSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_v1_NodeSelectorRequirement_To_api_NodeSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3299,16 +2630,10 @@ func Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *NodeSelectorTerm, o
 }
 
 func autoConvert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *api.NodeSelectorTerm, out *NodeSelectorTerm, s conversion.Scope) error {
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]NodeSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_api_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3350,27 +2675,15 @@ func autoConvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 		return err
 	}
 	out.Phase = api.NodePhase(in.Phase)
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]api.NodeCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1_NodeCondition_To_api_NodeCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Addresses != nil {
-		in, out := &in.Addresses, &out.Addresses
-		*out = make([]api.NodeAddress, len(*in))
-		for i := range *in {
-			if err := Convert_v1_NodeAddress_To_api_NodeAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Addresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Addresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Addresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := Convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
 		return err
@@ -3378,25 +2691,15 @@ func autoConvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 	if err := Convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
 	}
-	if in.Images != nil {
-		in, out := &in.Images, &out.Images
-		*out = make([]api.ContainerImage, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ContainerImage_To_api_ContainerImage(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Images = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Images))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Images))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.VolumesInUse != nil {
-		in, out := &in.VolumesInUse, &out.VolumesInUse
-		*out = make([]api.UniqueVolumeName, len(*in))
-		for i := range *in {
-			(*out)[i] = api.UniqueVolumeName((*in)[i])
-		}
-	} else {
-		out.VolumesInUse = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.VolumesInUse))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.VolumesInUse))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3406,54 +2709,24 @@ func Convert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus
 }
 
 func autoConvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus, s conversion.Scope) error {
-	if in.Capacity != nil {
-		in, out := &in.Capacity, &out.Capacity
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Capacity = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Capacity))
+		out.Capacity = *m
 	}
-	if in.Allocatable != nil {
-		in, out := &in.Allocatable, &out.Allocatable
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Allocatable = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Allocatable))
+		out.Allocatable = *m
 	}
 	out.Phase = NodePhase(in.Phase)
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]NodeCondition, len(*in))
-		for i := range *in {
-			if err := Convert_api_NodeCondition_To_v1_NodeCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Addresses != nil {
-		in, out := &in.Addresses, &out.Addresses
-		*out = make([]NodeAddress, len(*in))
-		for i := range *in {
-			if err := Convert_api_NodeAddress_To_v1_NodeAddress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Addresses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Addresses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Addresses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := Convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
 		return err
@@ -3461,25 +2734,15 @@ func autoConvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeSt
 	if err := Convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
 	}
-	if in.Images != nil {
-		in, out := &in.Images, &out.Images
-		*out = make([]ContainerImage, len(*in))
-		for i := range *in {
-			if err := Convert_api_ContainerImage_To_v1_ContainerImage(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Images = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Images))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Images))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.VolumesInUse != nil {
-		in, out := &in.VolumesInUse, &out.VolumesInUse
-		*out = make([]UniqueVolumeName, len(*in))
-		for i := range *in {
-			(*out)[i] = UniqueVolumeName((*in)[i])
-		}
-	} else {
-		out.VolumesInUse = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.VolumesInUse))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.VolumesInUse))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3556,22 +2819,26 @@ func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
-	out.DeletionTimestamp = in.DeletionTimestamp
-	out.DeletionGracePeriodSeconds = in.DeletionGracePeriodSeconds
-	out.Labels = in.Labels
-	out.Annotations = in.Annotations
-	if in.OwnerReferences != nil {
-		in, out := &in.OwnerReferences, &out.OwnerReferences
-		*out = make([]api.OwnerReference, len(*in))
-		for i := range *in {
-			if err := Convert_v1_OwnerReference_To_api_OwnerReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.OwnerReferences = nil
+	out.DeletionTimestamp = (*unversioned.Time)(unsafe.Pointer(in.DeletionTimestamp))
+	out.DeletionGracePeriodSeconds = (*int64)(unsafe.Pointer(in.DeletionGracePeriodSeconds))
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Labels))
+		out.Labels = *m
 	}
-	out.Finalizers = in.Finalizers
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Annotations))
+		out.Annotations = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.OwnerReferences))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.OwnerReferences))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Finalizers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Finalizers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -3590,22 +2857,26 @@ func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
-	out.DeletionTimestamp = in.DeletionTimestamp
-	out.DeletionGracePeriodSeconds = in.DeletionGracePeriodSeconds
-	out.Labels = in.Labels
-	out.Annotations = in.Annotations
-	if in.OwnerReferences != nil {
-		in, out := &in.OwnerReferences, &out.OwnerReferences
-		*out = make([]OwnerReference, len(*in))
-		for i := range *in {
-			if err := Convert_api_OwnerReference_To_v1_OwnerReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.OwnerReferences = nil
+	out.DeletionTimestamp = (*unversioned.Time)(unsafe.Pointer(in.DeletionTimestamp))
+	out.DeletionGracePeriodSeconds = (*int64)(unsafe.Pointer(in.DeletionGracePeriodSeconds))
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Labels))
+		out.Labels = *m
 	}
-	out.Finalizers = in.Finalizers
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Annotations))
+		out.Annotations = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.OwnerReferences))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.OwnerReferences))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Finalizers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Finalizers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -3648,7 +2919,7 @@ func autoConvert_v1_OwnerReference_To_api_OwnerReference(in *OwnerReference, out
 	out.Kind = in.Kind
 	out.Name = in.Name
 	out.UID = types.UID(in.UID)
-	out.Controller = in.Controller
+	out.Controller = (*bool)(unsafe.Pointer(in.Controller))
 	return nil
 }
 
@@ -3661,7 +2932,7 @@ func autoConvert_api_OwnerReference_To_v1_OwnerReference(in *api.OwnerReference,
 	out.Kind = in.Kind
 	out.Name = in.Name
 	out.UID = types.UID(in.UID)
-	out.Controller = in.Controller
+	out.Controller = (*bool)(unsafe.Pointer(in.Controller))
 	return nil
 }
 
@@ -3758,16 +3029,10 @@ func autoConvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(i
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.PersistentVolumeClaim, len(*in))
-		for i := range *in {
-			if err := Convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3783,16 +3048,10 @@ func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(i
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]PersistentVolumeClaim, len(*in))
-		for i := range *in {
-			if err := Convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -3802,16 +3061,12 @@ func Convert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *a
 }
 
 func autoConvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *PersistentVolumeClaimSpec, out *api.PersistentVolumeClaimSpec, s conversion.Scope) error {
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]api.PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = api.PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.Selector = in.Selector
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
@@ -3824,16 +3079,12 @@ func Convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *P
 }
 
 func autoConvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *api.PersistentVolumeClaimSpec, out *PersistentVolumeClaimSpec, s conversion.Scope) error {
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.Selector = in.Selector
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
@@ -3847,14 +3098,10 @@ func Convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *a
 
 func autoConvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in *PersistentVolumeClaimStatus, out *api.PersistentVolumeClaimStatus, s conversion.Scope) error {
 	out.Phase = api.PersistentVolumeClaimPhase(in.Phase)
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]api.PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = api.PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if err := Convert_v1_ResourceList_To_api_ResourceList(&in.Capacity, &out.Capacity, s); err != nil {
 		return err
@@ -3868,27 +3115,14 @@ func Convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(i
 
 func autoConvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *api.PersistentVolumeClaimStatus, out *PersistentVolumeClaimStatus, s conversion.Scope) error {
 	out.Phase = PersistentVolumeClaimPhase(in.Phase)
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Capacity != nil {
-		in, out := &in.Capacity, &out.Capacity
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Capacity = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Capacity))
+		out.Capacity = *m
 	}
 	return nil
 }
@@ -3968,132 +3202,20 @@ func Convert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Persist
 }
 
 func autoConvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *PersistentVolumeSource, out *api.PersistentVolumeSource, s conversion.Scope) error {
-	if in.GCEPersistentDisk != nil {
-		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		*out = new(api.GCEPersistentDiskVolumeSource)
-		if err := Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GCEPersistentDisk = nil
-	}
-	if in.AWSElasticBlockStore != nil {
-		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		*out = new(api.AWSElasticBlockStoreVolumeSource)
-		if err := Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AWSElasticBlockStore = nil
-	}
-	if in.HostPath != nil {
-		in, out := &in.HostPath, &out.HostPath
-		*out = new(api.HostPathVolumeSource)
-		if err := Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HostPath = nil
-	}
-	if in.Glusterfs != nil {
-		in, out := &in.Glusterfs, &out.Glusterfs
-		*out = new(api.GlusterfsVolumeSource)
-		if err := Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Glusterfs = nil
-	}
-	if in.NFS != nil {
-		in, out := &in.NFS, &out.NFS
-		*out = new(api.NFSVolumeSource)
-		if err := Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NFS = nil
-	}
-	if in.RBD != nil {
-		in, out := &in.RBD, &out.RBD
-		*out = new(api.RBDVolumeSource)
-		if err := Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RBD = nil
-	}
-	if in.ISCSI != nil {
-		in, out := &in.ISCSI, &out.ISCSI
-		*out = new(api.ISCSIVolumeSource)
-		if err := Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
-	}
-	if in.Cinder != nil {
-		in, out := &in.Cinder, &out.Cinder
-		*out = new(api.CinderVolumeSource)
-		if err := Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Cinder = nil
-	}
-	if in.CephFS != nil {
-		in, out := &in.CephFS, &out.CephFS
-		*out = new(api.CephFSVolumeSource)
-		if err := Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CephFS = nil
-	}
-	if in.FC != nil {
-		in, out := &in.FC, &out.FC
-		*out = new(api.FCVolumeSource)
-		if err := Convert_v1_FCVolumeSource_To_api_FCVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FC = nil
-	}
-	if in.Flocker != nil {
-		in, out := &in.Flocker, &out.Flocker
-		*out = new(api.FlockerVolumeSource)
-		if err := Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Flocker = nil
-	}
-	if in.FlexVolume != nil {
-		in, out := &in.FlexVolume, &out.FlexVolume
-		*out = new(api.FlexVolumeSource)
-		if err := Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FlexVolume = nil
-	}
-	if in.AzureFile != nil {
-		in, out := &in.AzureFile, &out.AzureFile
-		*out = new(api.AzureFileVolumeSource)
-		if err := Convert_v1_AzureFileVolumeSource_To_api_AzureFileVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AzureFile = nil
-	}
-	if in.VsphereVolume != nil {
-		in, out := &in.VsphereVolume, &out.VsphereVolume
-		*out = new(api.VsphereVirtualDiskVolumeSource)
-		if err := Convert_v1_VsphereVirtualDiskVolumeSource_To_api_VsphereVirtualDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.VsphereVolume = nil
-	}
+	out.GCEPersistentDisk = (*api.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
+	out.AWSElasticBlockStore = (*api.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
+	out.HostPath = (*api.HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
+	out.Glusterfs = (*api.GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
+	out.NFS = (*api.NFSVolumeSource)(unsafe.Pointer(in.NFS))
+	out.RBD = (*api.RBDVolumeSource)(unsafe.Pointer(in.RBD))
+	out.ISCSI = (*api.ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
+	out.Cinder = (*api.CinderVolumeSource)(unsafe.Pointer(in.Cinder))
+	out.CephFS = (*api.CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
+	out.FC = (*api.FCVolumeSource)(unsafe.Pointer(in.FC))
+	out.Flocker = (*api.FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
+	out.FlexVolume = (*api.FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
+	out.AzureFile = (*api.AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
+	out.VsphereVolume = (*api.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
 	return nil
 }
 
@@ -4102,132 +3224,20 @@ func Convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *Persist
 }
 
 func autoConvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
-	if in.GCEPersistentDisk != nil {
-		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		*out = new(GCEPersistentDiskVolumeSource)
-		if err := Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GCEPersistentDisk = nil
-	}
-	if in.AWSElasticBlockStore != nil {
-		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		*out = new(AWSElasticBlockStoreVolumeSource)
-		if err := Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AWSElasticBlockStore = nil
-	}
-	if in.HostPath != nil {
-		in, out := &in.HostPath, &out.HostPath
-		*out = new(HostPathVolumeSource)
-		if err := Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HostPath = nil
-	}
-	if in.Glusterfs != nil {
-		in, out := &in.Glusterfs, &out.Glusterfs
-		*out = new(GlusterfsVolumeSource)
-		if err := Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Glusterfs = nil
-	}
-	if in.NFS != nil {
-		in, out := &in.NFS, &out.NFS
-		*out = new(NFSVolumeSource)
-		if err := Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NFS = nil
-	}
-	if in.RBD != nil {
-		in, out := &in.RBD, &out.RBD
-		*out = new(RBDVolumeSource)
-		if err := Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RBD = nil
-	}
-	if in.ISCSI != nil {
-		in, out := &in.ISCSI, &out.ISCSI
-		*out = new(ISCSIVolumeSource)
-		if err := Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
-	}
-	if in.FlexVolume != nil {
-		in, out := &in.FlexVolume, &out.FlexVolume
-		*out = new(FlexVolumeSource)
-		if err := Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FlexVolume = nil
-	}
-	if in.Cinder != nil {
-		in, out := &in.Cinder, &out.Cinder
-		*out = new(CinderVolumeSource)
-		if err := Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Cinder = nil
-	}
-	if in.CephFS != nil {
-		in, out := &in.CephFS, &out.CephFS
-		*out = new(CephFSVolumeSource)
-		if err := Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CephFS = nil
-	}
-	if in.FC != nil {
-		in, out := &in.FC, &out.FC
-		*out = new(FCVolumeSource)
-		if err := Convert_api_FCVolumeSource_To_v1_FCVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FC = nil
-	}
-	if in.Flocker != nil {
-		in, out := &in.Flocker, &out.Flocker
-		*out = new(FlockerVolumeSource)
-		if err := Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Flocker = nil
-	}
-	if in.AzureFile != nil {
-		in, out := &in.AzureFile, &out.AzureFile
-		*out = new(AzureFileVolumeSource)
-		if err := Convert_api_AzureFileVolumeSource_To_v1_AzureFileVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AzureFile = nil
-	}
-	if in.VsphereVolume != nil {
-		in, out := &in.VsphereVolume, &out.VsphereVolume
-		*out = new(VsphereVirtualDiskVolumeSource)
-		if err := Convert_api_VsphereVirtualDiskVolumeSource_To_v1_VsphereVirtualDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.VsphereVolume = nil
-	}
+	out.GCEPersistentDisk = (*GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
+	out.AWSElasticBlockStore = (*AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
+	out.HostPath = (*HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
+	out.Glusterfs = (*GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
+	out.NFS = (*NFSVolumeSource)(unsafe.Pointer(in.NFS))
+	out.RBD = (*RBDVolumeSource)(unsafe.Pointer(in.RBD))
+	out.ISCSI = (*ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
+	out.FlexVolume = (*FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
+	out.Cinder = (*CinderVolumeSource)(unsafe.Pointer(in.Cinder))
+	out.CephFS = (*CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
+	out.FC = (*FCVolumeSource)(unsafe.Pointer(in.FC))
+	out.Flocker = (*FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
+	out.AzureFile = (*AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
+	out.VsphereVolume = (*VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
 	return nil
 }
 
@@ -4242,24 +3252,12 @@ func autoConvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persist
 	if err := Convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
 		return err
 	}
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]api.PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = api.PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ClaimRef != nil {
-		in, out := &in.ClaimRef, &out.ClaimRef
-		*out = new(api.ObjectReference)
-		if err := Convert_v1_ObjectReference_To_api_ObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ClaimRef = nil
-	}
+	out.ClaimRef = (*api.ObjectReference)(unsafe.Pointer(in.ClaimRef))
 	out.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
@@ -4269,40 +3267,19 @@ func Convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentV
 }
 
 func autoConvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
-	if in.Capacity != nil {
-		in, out := &in.Capacity, &out.Capacity
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Capacity = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Capacity))
+		out.Capacity = *m
 	}
 	if err := Convert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
 		return err
 	}
-	if in.AccessModes != nil {
-		in, out := &in.AccessModes, &out.AccessModes
-		*out = make([]PersistentVolumeAccessMode, len(*in))
-		for i := range *in {
-			(*out)[i] = PersistentVolumeAccessMode((*in)[i])
-		}
-	} else {
-		out.AccessModes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AccessModes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AccessModes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ClaimRef != nil {
-		in, out := &in.ClaimRef, &out.ClaimRef
-		*out = new(ObjectReference)
-		if err := Convert_api_ObjectReference_To_v1_ObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ClaimRef = nil
-	}
+	out.ClaimRef = (*ObjectReference)(unsafe.Pointer(in.ClaimRef))
 	out.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(in.PersistentVolumeReclaimPolicy)
 	return nil
 }
@@ -4367,16 +3344,10 @@ func autoConvert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) er
 }
 
 func autoConvert_v1_PodAffinity_To_api_PodAffinity(in *PodAffinity, out *api.PodAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = make([]api.PodAffinityTerm, len(*in))
-		for i := range *in {
-			if err := Convert_v1_PodAffinityTerm_To_api_PodAffinityTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -4397,16 +3368,10 @@ func Convert_v1_PodAffinity_To_api_PodAffinity(in *PodAffinity, out *api.PodAffi
 }
 
 func autoConvert_api_PodAffinity_To_v1_PodAffinity(in *api.PodAffinity, out *PodAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = make([]PodAffinityTerm, len(*in))
-		for i := range *in {
-			if err := Convert_api_PodAffinityTerm_To_v1_PodAffinityTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -4427,8 +3392,12 @@ func Convert_api_PodAffinity_To_v1_PodAffinity(in *api.PodAffinity, out *PodAffi
 }
 
 func autoConvert_v1_PodAffinityTerm_To_api_PodAffinityTerm(in *PodAffinityTerm, out *api.PodAffinityTerm, s conversion.Scope) error {
-	out.LabelSelector = in.LabelSelector
-	out.Namespaces = in.Namespaces
+	out.LabelSelector = (*unversioned.LabelSelector)(unsafe.Pointer(in.LabelSelector))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Namespaces))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Namespaces))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.TopologyKey = in.TopologyKey
 	return nil
 }
@@ -4438,8 +3407,12 @@ func Convert_v1_PodAffinityTerm_To_api_PodAffinityTerm(in *PodAffinityTerm, out 
 }
 
 func autoConvert_api_PodAffinityTerm_To_v1_PodAffinityTerm(in *api.PodAffinityTerm, out *PodAffinityTerm, s conversion.Scope) error {
-	out.LabelSelector = in.LabelSelector
-	out.Namespaces = in.Namespaces
+	out.LabelSelector = (*unversioned.LabelSelector)(unsafe.Pointer(in.LabelSelector))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Namespaces))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Namespaces))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.TopologyKey = in.TopologyKey
 	return nil
 }
@@ -4449,16 +3422,10 @@ func Convert_api_PodAffinityTerm_To_v1_PodAffinityTerm(in *api.PodAffinityTerm, 
 }
 
 func autoConvert_v1_PodAntiAffinity_To_api_PodAntiAffinity(in *PodAntiAffinity, out *api.PodAntiAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = make([]api.PodAffinityTerm, len(*in))
-		for i := range *in {
-			if err := Convert_v1_PodAffinityTerm_To_api_PodAffinityTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -4479,16 +3446,10 @@ func Convert_v1_PodAntiAffinity_To_api_PodAntiAffinity(in *PodAntiAffinity, out 
 }
 
 func autoConvert_api_PodAntiAffinity_To_v1_PodAntiAffinity(in *api.PodAntiAffinity, out *PodAntiAffinity, s conversion.Scope) error {
-	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		*out = make([]PodAffinityTerm, len(*in))
-		for i := range *in {
-			if err := Convert_api_PodAffinityTerm_To_v1_PodAffinityTerm(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDuringSchedulingIgnoredDuringExecution))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -4587,7 +3548,11 @@ func autoConvert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	out.Command = in.Command
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -4604,7 +3569,11 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	out.Command = in.Command
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Command))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Command))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -4669,11 +3638,11 @@ func autoConvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *a
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
-	out.SinceSeconds = in.SinceSeconds
-	out.SinceTime = in.SinceTime
+	out.SinceSeconds = (*int64)(unsafe.Pointer(in.SinceSeconds))
+	out.SinceTime = (*unversioned.Time)(unsafe.Pointer(in.SinceTime))
 	out.Timestamps = in.Timestamps
-	out.TailLines = in.TailLines
-	out.LimitBytes = in.LimitBytes
+	out.TailLines = (*int64)(unsafe.Pointer(in.TailLines))
+	out.LimitBytes = (*int64)(unsafe.Pointer(in.LimitBytes))
 	return nil
 }
 
@@ -4688,11 +3657,11 @@ func autoConvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, ou
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
-	out.SinceSeconds = in.SinceSeconds
-	out.SinceTime = in.SinceTime
+	out.SinceSeconds = (*int64)(unsafe.Pointer(in.SinceSeconds))
+	out.SinceTime = (*unversioned.Time)(unsafe.Pointer(in.SinceTime))
 	out.Timestamps = in.Timestamps
-	out.TailLines = in.TailLines
-	out.LimitBytes = in.LimitBytes
+	out.TailLines = (*int64)(unsafe.Pointer(in.TailLines))
+	out.LimitBytes = (*int64)(unsafe.Pointer(in.LimitBytes))
 	return nil
 }
 
@@ -4725,61 +3694,42 @@ func Convert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, 
 }
 
 func autoConvert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
-	if in.SELinuxOptions != nil {
-		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		*out = new(api.SELinuxOptions)
-		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SELinuxOptions = nil
+	out.SELinuxOptions = (*api.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
+	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
+	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.SupplementalGroups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.SupplementalGroups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.RunAsUser = in.RunAsUser
-	out.RunAsNonRoot = in.RunAsNonRoot
-	out.SupplementalGroups = in.SupplementalGroups
-	out.FSGroup = in.FSGroup
+	out.FSGroup = (*int64)(unsafe.Pointer(in.FSGroup))
 	return nil
 }
 
 func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversion.Scope) error {
-	if in.Volumes != nil {
-		in, out := &in.Volumes, &out.Volumes
-		*out = make([]Volume, len(*in))
-		for i := range *in {
-			if err := Convert_api_Volume_To_v1_Volume(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Volumes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Volumes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Volumes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.InitContainers != nil {
-		in, out := &in.InitContainers, &out.InitContainers
-		*out = make([]Container, len(*in))
-		for i := range *in {
-			if err := Convert_api_Container_To_v1_Container(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.InitContainers = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.InitContainers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.InitContainers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Containers != nil {
-		in, out := &in.Containers, &out.Containers
-		*out = make([]Container, len(*in))
-		for i := range *in {
-			if err := Convert_api_Container_To_v1_Container(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Containers = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Containers))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Containers))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
-	out.TerminationGracePeriodSeconds = in.TerminationGracePeriodSeconds
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
+	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
+	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
 	out.DNSPolicy = DNSPolicy(in.DNSPolicy)
-	out.NodeSelector = in.NodeSelector
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.NodeSelector))
+		out.NodeSelector = *m
+	}
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
@@ -4791,16 +3741,10 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	} else {
 		out.SecurityContext = nil
 	}
-	if in.ImagePullSecrets != nil {
-		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
-		*out = make([]LocalObjectReference, len(*in))
-		for i := range *in {
-			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ImagePullSecrets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ImagePullSecrets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ImagePullSecrets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.Hostname = in.Hostname
 	out.Subdomain = in.Subdomain
@@ -4809,43 +3753,25 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 
 func autoConvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s conversion.Scope) error {
 	out.Phase = api.PodPhase(in.Phase)
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]api.PodCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1_PodCondition_To_api_PodCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.Message = in.Message
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
-	out.StartTime = in.StartTime
-	if in.InitContainerStatuses != nil {
-		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
-		*out = make([]api.ContainerStatus, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ContainerStatus_To_api_ContainerStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.InitContainerStatuses = nil
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.InitContainerStatuses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.InitContainerStatuses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ContainerStatuses != nil {
-		in, out := &in.ContainerStatuses, &out.ContainerStatuses
-		*out = make([]api.ContainerStatus, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ContainerStatus_To_api_ContainerStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ContainerStatuses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ContainerStatuses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ContainerStatuses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -4856,43 +3782,25 @@ func Convert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s 
 
 func autoConvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus, s conversion.Scope) error {
 	out.Phase = PodPhase(in.Phase)
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]PodCondition, len(*in))
-		for i := range *in {
-			if err := Convert_api_PodCondition_To_v1_PodCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.Message = in.Message
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
-	out.StartTime = in.StartTime
-	if in.InitContainerStatuses != nil {
-		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
-		*out = make([]ContainerStatus, len(*in))
-		for i := range *in {
-			if err := Convert_api_ContainerStatus_To_v1_ContainerStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.InitContainerStatuses = nil
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.InitContainerStatuses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.InitContainerStatuses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ContainerStatuses != nil {
-		in, out := &in.ContainerStatuses, &out.ContainerStatuses
-		*out = make([]ContainerStatus, len(*in))
-		for i := range *in {
-			if err := Convert_api_ContainerStatus_To_v1_ContainerStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ContainerStatuses = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ContainerStatuses))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ContainerStatuses))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5032,7 +3940,7 @@ func autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSp
 }
 
 func autoConvert_v1_Preconditions_To_api_Preconditions(in *Preconditions, out *api.Preconditions, s conversion.Scope) error {
-	out.UID = in.UID
+	out.UID = (*types.UID)(unsafe.Pointer(in.UID))
 	return nil
 }
 
@@ -5041,7 +3949,7 @@ func Convert_v1_Preconditions_To_api_Preconditions(in *Preconditions, out *api.P
 }
 
 func autoConvert_api_Preconditions_To_v1_Preconditions(in *api.Preconditions, out *Preconditions, s conversion.Scope) error {
-	out.UID = in.UID
+	out.UID = (*types.UID)(unsafe.Pointer(in.UID))
 	return nil
 }
 
@@ -5108,21 +4016,17 @@ func Convert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope
 
 func autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
 	SetDefaults_RBDVolumeSource(in)
-	out.CephMonitors = in.CephMonitors
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.CephMonitors))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.CephMonitors))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(api.LocalObjectReference)
-		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*api.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -5132,21 +4036,17 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out 
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = in.CephMonitors
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.CephMonitors))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.CephMonitors))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
-	if in.SecretRef != nil {
-		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(LocalObjectReference)
-		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SecretRef = nil
-	}
+	out.SecretRef = (*LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -5377,16 +4277,10 @@ func autoConvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuota
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.ResourceQuota, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ResourceQuota_To_api_ResourceQuota(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5402,16 +4296,10 @@ func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQ
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ResourceQuota, len(*in))
-		for i := range *in {
-			if err := Convert_api_ResourceQuota_To_v1_ResourceQuota(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5424,14 +4312,10 @@ func autoConvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuota
 	if err := Convert_v1_ResourceList_To_api_ResourceList(&in.Hard, &out.Hard, s); err != nil {
 		return err
 	}
-	if in.Scopes != nil {
-		in, out := &in.Scopes, &out.Scopes
-		*out = make([]api.ResourceQuotaScope, len(*in))
-		for i := range *in {
-			(*out)[i] = api.ResourceQuotaScope((*in)[i])
-		}
-	} else {
-		out.Scopes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Scopes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Scopes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5441,27 +4325,14 @@ func Convert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuotaSpec
 }
 
 func autoConvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
-	if in.Hard != nil {
-		in, out := &in.Hard, &out.Hard
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Hard = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Hard))
+		out.Hard = *m
 	}
-	if in.Scopes != nil {
-		in, out := &in.Scopes, &out.Scopes
-		*out = make([]ResourceQuotaScope, len(*in))
-		for i := range *in {
-			(*out)[i] = ResourceQuotaScope((*in)[i])
-		}
-	} else {
-		out.Scopes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Scopes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Scopes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5485,31 +4356,13 @@ func Convert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQuota
 }
 
 func autoConvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
-	if in.Hard != nil {
-		in, out := &in.Hard, &out.Hard
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Hard = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Hard))
+		out.Hard = *m
 	}
-	if in.Used != nil {
-		in, out := &in.Used, &out.Used
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Used = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Used))
+		out.Used = *m
 	}
 	return nil
 }
@@ -5533,31 +4386,13 @@ func Convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceReq
 }
 
 func autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *ResourceRequirements, s conversion.Scope) error {
-	if in.Limits != nil {
-		in, out := &in.Limits, &out.Limits
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Limits = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Limits))
+		out.Limits = *m
 	}
-	if in.Requests != nil {
-		in, out := &in.Requests, &out.Requests
-		*out = make(ResourceList, len(*in))
-		for key, val := range *in {
-			newVal := new(resource.Quantity)
-			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[ResourceName(key)] = *newVal
-		}
-	} else {
-		out.Requests = nil
+	{
+		m := (*ResourceList)(unsafe.Pointer(&in.Requests))
+		out.Requests = *m
 	}
 	return nil
 }
@@ -5598,7 +4433,10 @@ func autoConvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversi
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	out.Data = in.Data
+	{
+		m := (*map[string][]byte)(unsafe.Pointer(&in.Data))
+		out.Data = *m
+	}
 	out.Type = api.SecretType(in.Type)
 	return nil
 }
@@ -5614,7 +4452,10 @@ func autoConvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversi
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	out.Data = in.Data
+	{
+		m := (*map[string][]byte)(unsafe.Pointer(&in.Data))
+		out.Data = *m
+	}
 	out.Type = SecretType(in.Type)
 	return nil
 }
@@ -5654,16 +4495,10 @@ func autoConvert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.Secret
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.Secret, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Secret_To_api_Secret(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5679,16 +4514,10 @@ func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *Secret
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Secret, len(*in))
-		for i := range *in {
-			if err := Convert_api_Secret_To_v1_Secret(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5699,16 +4528,10 @@ func Convert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList
 
 func autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
 	out.SecretName = in.SecretName
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.KeyToPath, len(*in))
-		for i := range *in {
-			if err := Convert_v1_KeyToPath_To_api_KeyToPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5719,16 +4542,10 @@ func Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSou
 
 func autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
 	out.SecretName = in.SecretName
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]KeyToPath, len(*in))
-		for i := range *in {
-			if err := Convert_api_KeyToPath_To_v1_KeyToPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5738,28 +4555,12 @@ func Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolum
 }
 
 func autoConvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
-	if in.Capabilities != nil {
-		in, out := &in.Capabilities, &out.Capabilities
-		*out = new(api.Capabilities)
-		if err := Convert_v1_Capabilities_To_api_Capabilities(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Capabilities = nil
-	}
-	out.Privileged = in.Privileged
-	if in.SELinuxOptions != nil {
-		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		*out = new(api.SELinuxOptions)
-		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SELinuxOptions = nil
-	}
-	out.RunAsUser = in.RunAsUser
-	out.RunAsNonRoot = in.RunAsNonRoot
-	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
+	out.Capabilities = (*api.Capabilities)(unsafe.Pointer(in.Capabilities))
+	out.Privileged = (*bool)(unsafe.Pointer(in.Privileged))
+	out.SELinuxOptions = (*api.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
+	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
+	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
+	out.ReadOnlyRootFilesystem = (*bool)(unsafe.Pointer(in.ReadOnlyRootFilesystem))
 	return nil
 }
 
@@ -5768,28 +4569,12 @@ func Convert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out 
 }
 
 func autoConvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *SecurityContext, s conversion.Scope) error {
-	if in.Capabilities != nil {
-		in, out := &in.Capabilities, &out.Capabilities
-		*out = new(Capabilities)
-		if err := Convert_api_Capabilities_To_v1_Capabilities(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Capabilities = nil
-	}
-	out.Privileged = in.Privileged
-	if in.SELinuxOptions != nil {
-		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		*out = new(SELinuxOptions)
-		if err := Convert_api_SELinuxOptions_To_v1_SELinuxOptions(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SELinuxOptions = nil
-	}
-	out.RunAsUser = in.RunAsUser
-	out.RunAsNonRoot = in.RunAsNonRoot
-	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
+	out.Capabilities = (*Capabilities)(unsafe.Pointer(in.Capabilities))
+	out.Privileged = (*bool)(unsafe.Pointer(in.Privileged))
+	out.SELinuxOptions = (*SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
+	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
+	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
+	out.ReadOnlyRootFilesystem = (*bool)(unsafe.Pointer(in.ReadOnlyRootFilesystem))
 	return nil
 }
 
@@ -5872,27 +4657,15 @@ func autoConvert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Secrets != nil {
-		in, out := &in.Secrets, &out.Secrets
-		*out = make([]api.ObjectReference, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ObjectReference_To_api_ObjectReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Secrets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Secrets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Secrets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ImagePullSecrets != nil {
-		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
-		*out = make([]api.LocalObjectReference, len(*in))
-		for i := range *in {
-			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ImagePullSecrets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ImagePullSecrets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ImagePullSecrets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5908,27 +4681,15 @@ func autoConvert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount,
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Secrets != nil {
-		in, out := &in.Secrets, &out.Secrets
-		*out = make([]ObjectReference, len(*in))
-		for i := range *in {
-			if err := Convert_api_ObjectReference_To_v1_ObjectReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Secrets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Secrets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Secrets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.ImagePullSecrets != nil {
-		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
-		*out = make([]LocalObjectReference, len(*in))
-		for i := range *in {
-			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.ImagePullSecrets = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ImagePullSecrets))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ImagePullSecrets))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5944,16 +4705,10 @@ func autoConvert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAcco
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]api.ServiceAccount, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ServiceAccount_To_api_ServiceAccount(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -5969,16 +4724,10 @@ func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.Service
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ServiceAccount, len(*in))
-		for i := range *in {
-			if err := Convert_api_ServiceAccount_To_v1_ServiceAccount(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -6093,46 +4842,56 @@ func Convert_api_ServiceProxyOptions_To_v1_ServiceProxyOptions(in *api.ServicePr
 
 func autoConvert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.ServiceSpec, s conversion.Scope) error {
 	SetDefaults_ServiceSpec(in)
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]api.ServicePort, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ServicePort_To_api_ServicePort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.Selector = in.Selector
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Selector))
+		out.Selector = *m
+	}
 	out.ClusterIP = in.ClusterIP
 	out.Type = api.ServiceType(in.Type)
-	out.ExternalIPs = in.ExternalIPs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ExternalIPs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ExternalIPs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.SessionAffinity = api.ServiceAffinity(in.SessionAffinity)
 	out.LoadBalancerIP = in.LoadBalancerIP
-	out.LoadBalancerSourceRanges = in.LoadBalancerSourceRanges
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.LoadBalancerSourceRanges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
 func autoConvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *ServiceSpec, s conversion.Scope) error {
 	out.Type = ServiceType(in.Type)
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]ServicePort, len(*in))
-		for i := range *in {
-			if err := Convert_api_ServicePort_To_v1_ServicePort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.Selector = in.Selector
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.Selector))
+		out.Selector = *m
+	}
 	out.ClusterIP = in.ClusterIP
-	out.ExternalIPs = in.ExternalIPs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ExternalIPs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ExternalIPs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.LoadBalancerIP = in.LoadBalancerIP
 	out.SessionAffinity = ServiceAffinity(in.SessionAffinity)
-	out.LoadBalancerSourceRanges = in.LoadBalancerSourceRanges
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.LoadBalancerSourceRanges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -6276,186 +5035,26 @@ func Convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeM
 }
 
 func autoConvert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
-	if in.HostPath != nil {
-		in, out := &in.HostPath, &out.HostPath
-		*out = new(api.HostPathVolumeSource)
-		if err := Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HostPath = nil
-	}
-	if in.EmptyDir != nil {
-		in, out := &in.EmptyDir, &out.EmptyDir
-		*out = new(api.EmptyDirVolumeSource)
-		if err := Convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.EmptyDir = nil
-	}
-	if in.GCEPersistentDisk != nil {
-		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		*out = new(api.GCEPersistentDiskVolumeSource)
-		if err := Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GCEPersistentDisk = nil
-	}
-	if in.AWSElasticBlockStore != nil {
-		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		*out = new(api.AWSElasticBlockStoreVolumeSource)
-		if err := Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AWSElasticBlockStore = nil
-	}
-	if in.GitRepo != nil {
-		in, out := &in.GitRepo, &out.GitRepo
-		*out = new(api.GitRepoVolumeSource)
-		if err := Convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GitRepo = nil
-	}
-	if in.Secret != nil {
-		in, out := &in.Secret, &out.Secret
-		*out = new(api.SecretVolumeSource)
-		if err := Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Secret = nil
-	}
-	if in.NFS != nil {
-		in, out := &in.NFS, &out.NFS
-		*out = new(api.NFSVolumeSource)
-		if err := Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NFS = nil
-	}
-	if in.ISCSI != nil {
-		in, out := &in.ISCSI, &out.ISCSI
-		*out = new(api.ISCSIVolumeSource)
-		if err := Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
-	}
-	if in.Glusterfs != nil {
-		in, out := &in.Glusterfs, &out.Glusterfs
-		*out = new(api.GlusterfsVolumeSource)
-		if err := Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Glusterfs = nil
-	}
-	if in.PersistentVolumeClaim != nil {
-		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
-		*out = new(api.PersistentVolumeClaimVolumeSource)
-		if err := Convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PersistentVolumeClaim = nil
-	}
-	if in.RBD != nil {
-		in, out := &in.RBD, &out.RBD
-		*out = new(api.RBDVolumeSource)
-		if err := Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RBD = nil
-	}
-	if in.FlexVolume != nil {
-		in, out := &in.FlexVolume, &out.FlexVolume
-		*out = new(api.FlexVolumeSource)
-		if err := Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FlexVolume = nil
-	}
-	if in.Cinder != nil {
-		in, out := &in.Cinder, &out.Cinder
-		*out = new(api.CinderVolumeSource)
-		if err := Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Cinder = nil
-	}
-	if in.CephFS != nil {
-		in, out := &in.CephFS, &out.CephFS
-		*out = new(api.CephFSVolumeSource)
-		if err := Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CephFS = nil
-	}
-	if in.Flocker != nil {
-		in, out := &in.Flocker, &out.Flocker
-		*out = new(api.FlockerVolumeSource)
-		if err := Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Flocker = nil
-	}
-	if in.DownwardAPI != nil {
-		in, out := &in.DownwardAPI, &out.DownwardAPI
-		*out = new(api.DownwardAPIVolumeSource)
-		if err := Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.DownwardAPI = nil
-	}
-	if in.FC != nil {
-		in, out := &in.FC, &out.FC
-		*out = new(api.FCVolumeSource)
-		if err := Convert_v1_FCVolumeSource_To_api_FCVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FC = nil
-	}
-	if in.AzureFile != nil {
-		in, out := &in.AzureFile, &out.AzureFile
-		*out = new(api.AzureFileVolumeSource)
-		if err := Convert_v1_AzureFileVolumeSource_To_api_AzureFileVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AzureFile = nil
-	}
-	if in.ConfigMap != nil {
-		in, out := &in.ConfigMap, &out.ConfigMap
-		*out = new(api.ConfigMapVolumeSource)
-		if err := Convert_v1_ConfigMapVolumeSource_To_api_ConfigMapVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ConfigMap = nil
-	}
-	if in.VsphereVolume != nil {
-		in, out := &in.VsphereVolume, &out.VsphereVolume
-		*out = new(api.VsphereVirtualDiskVolumeSource)
-		if err := Convert_v1_VsphereVirtualDiskVolumeSource_To_api_VsphereVirtualDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.VsphereVolume = nil
-	}
+	out.HostPath = (*api.HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
+	out.EmptyDir = (*api.EmptyDirVolumeSource)(unsafe.Pointer(in.EmptyDir))
+	out.GCEPersistentDisk = (*api.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
+	out.AWSElasticBlockStore = (*api.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
+	out.GitRepo = (*api.GitRepoVolumeSource)(unsafe.Pointer(in.GitRepo))
+	out.Secret = (*api.SecretVolumeSource)(unsafe.Pointer(in.Secret))
+	out.NFS = (*api.NFSVolumeSource)(unsafe.Pointer(in.NFS))
+	out.ISCSI = (*api.ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
+	out.Glusterfs = (*api.GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
+	out.PersistentVolumeClaim = (*api.PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in.PersistentVolumeClaim))
+	out.RBD = (*api.RBDVolumeSource)(unsafe.Pointer(in.RBD))
+	out.FlexVolume = (*api.FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
+	out.Cinder = (*api.CinderVolumeSource)(unsafe.Pointer(in.Cinder))
+	out.CephFS = (*api.CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
+	out.Flocker = (*api.FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
+	out.DownwardAPI = (*api.DownwardAPIVolumeSource)(unsafe.Pointer(in.DownwardAPI))
+	out.FC = (*api.FCVolumeSource)(unsafe.Pointer(in.FC))
+	out.AzureFile = (*api.AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
+	out.ConfigMap = (*api.ConfigMapVolumeSource)(unsafe.Pointer(in.ConfigMap))
+	out.VsphereVolume = (*api.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
 	return nil
 }
 
@@ -6464,186 +5063,26 @@ func Convert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.Volu
 }
 
 func autoConvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *VolumeSource, s conversion.Scope) error {
-	if in.HostPath != nil {
-		in, out := &in.HostPath, &out.HostPath
-		*out = new(HostPathVolumeSource)
-		if err := Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HostPath = nil
-	}
-	if in.EmptyDir != nil {
-		in, out := &in.EmptyDir, &out.EmptyDir
-		*out = new(EmptyDirVolumeSource)
-		if err := Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.EmptyDir = nil
-	}
-	if in.GCEPersistentDisk != nil {
-		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		*out = new(GCEPersistentDiskVolumeSource)
-		if err := Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GCEPersistentDisk = nil
-	}
-	if in.AWSElasticBlockStore != nil {
-		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		*out = new(AWSElasticBlockStoreVolumeSource)
-		if err := Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AWSElasticBlockStore = nil
-	}
-	if in.GitRepo != nil {
-		in, out := &in.GitRepo, &out.GitRepo
-		*out = new(GitRepoVolumeSource)
-		if err := Convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.GitRepo = nil
-	}
-	if in.Secret != nil {
-		in, out := &in.Secret, &out.Secret
-		*out = new(SecretVolumeSource)
-		if err := Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Secret = nil
-	}
-	if in.NFS != nil {
-		in, out := &in.NFS, &out.NFS
-		*out = new(NFSVolumeSource)
-		if err := Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NFS = nil
-	}
-	if in.ISCSI != nil {
-		in, out := &in.ISCSI, &out.ISCSI
-		*out = new(ISCSIVolumeSource)
-		if err := Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ISCSI = nil
-	}
-	if in.Glusterfs != nil {
-		in, out := &in.Glusterfs, &out.Glusterfs
-		*out = new(GlusterfsVolumeSource)
-		if err := Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Glusterfs = nil
-	}
-	if in.PersistentVolumeClaim != nil {
-		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
-		*out = new(PersistentVolumeClaimVolumeSource)
-		if err := Convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PersistentVolumeClaim = nil
-	}
-	if in.RBD != nil {
-		in, out := &in.RBD, &out.RBD
-		*out = new(RBDVolumeSource)
-		if err := Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.RBD = nil
-	}
-	if in.FlexVolume != nil {
-		in, out := &in.FlexVolume, &out.FlexVolume
-		*out = new(FlexVolumeSource)
-		if err := Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FlexVolume = nil
-	}
-	if in.Cinder != nil {
-		in, out := &in.Cinder, &out.Cinder
-		*out = new(CinderVolumeSource)
-		if err := Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Cinder = nil
-	}
-	if in.CephFS != nil {
-		in, out := &in.CephFS, &out.CephFS
-		*out = new(CephFSVolumeSource)
-		if err := Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CephFS = nil
-	}
-	if in.Flocker != nil {
-		in, out := &in.Flocker, &out.Flocker
-		*out = new(FlockerVolumeSource)
-		if err := Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Flocker = nil
-	}
-	if in.DownwardAPI != nil {
-		in, out := &in.DownwardAPI, &out.DownwardAPI
-		*out = new(DownwardAPIVolumeSource)
-		if err := Convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.DownwardAPI = nil
-	}
-	if in.FC != nil {
-		in, out := &in.FC, &out.FC
-		*out = new(FCVolumeSource)
-		if err := Convert_api_FCVolumeSource_To_v1_FCVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.FC = nil
-	}
-	if in.AzureFile != nil {
-		in, out := &in.AzureFile, &out.AzureFile
-		*out = new(AzureFileVolumeSource)
-		if err := Convert_api_AzureFileVolumeSource_To_v1_AzureFileVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.AzureFile = nil
-	}
-	if in.ConfigMap != nil {
-		in, out := &in.ConfigMap, &out.ConfigMap
-		*out = new(ConfigMapVolumeSource)
-		if err := Convert_api_ConfigMapVolumeSource_To_v1_ConfigMapVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ConfigMap = nil
-	}
-	if in.VsphereVolume != nil {
-		in, out := &in.VsphereVolume, &out.VsphereVolume
-		*out = new(VsphereVirtualDiskVolumeSource)
-		if err := Convert_api_VsphereVirtualDiskVolumeSource_To_v1_VsphereVirtualDiskVolumeSource(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.VsphereVolume = nil
-	}
+	out.HostPath = (*HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
+	out.EmptyDir = (*EmptyDirVolumeSource)(unsafe.Pointer(in.EmptyDir))
+	out.GCEPersistentDisk = (*GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
+	out.AWSElasticBlockStore = (*AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
+	out.GitRepo = (*GitRepoVolumeSource)(unsafe.Pointer(in.GitRepo))
+	out.Secret = (*SecretVolumeSource)(unsafe.Pointer(in.Secret))
+	out.NFS = (*NFSVolumeSource)(unsafe.Pointer(in.NFS))
+	out.ISCSI = (*ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
+	out.Glusterfs = (*GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
+	out.PersistentVolumeClaim = (*PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in.PersistentVolumeClaim))
+	out.RBD = (*RBDVolumeSource)(unsafe.Pointer(in.RBD))
+	out.FlexVolume = (*FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
+	out.Cinder = (*CinderVolumeSource)(unsafe.Pointer(in.Cinder))
+	out.CephFS = (*CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
+	out.Flocker = (*FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
+	out.DownwardAPI = (*DownwardAPIVolumeSource)(unsafe.Pointer(in.DownwardAPI))
+	out.FC = (*FCVolumeSource)(unsafe.Pointer(in.FC))
+	out.AzureFile = (*AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
+	out.ConfigMap = (*ConfigMapVolumeSource)(unsafe.Pointer(in.ConfigMap))
+	out.VsphereVolume = (*VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
 	return nil
 }
 

--- a/pkg/apis/apps/v1alpha1/conversion_generated.go
+++ b/pkg/apis/apps/v1alpha1/conversion_generated.go
@@ -24,6 +24,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -136,7 +137,7 @@ func Convert_apps_PetSetList_To_v1alpha1_PetSetList(in *apps.PetSetList, out *Pe
 }
 
 func autoConvert_v1alpha1_PetSetStatus_To_apps_PetSetStatus(in *PetSetStatus, out *apps.PetSetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
 	out.Replicas = int(in.Replicas)
 	return nil
 }
@@ -146,7 +147,7 @@ func Convert_v1alpha1_PetSetStatus_To_apps_PetSetStatus(in *PetSetStatus, out *a
 }
 
 func autoConvert_apps_PetSetStatus_To_v1alpha1_PetSetStatus(in *apps.PetSetStatus, out *PetSetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
 	out.Replicas = int32(in.Replicas)
 	return nil
 }

--- a/pkg/apis/authentication.k8s.io/v1beta1/conversion_generated.go
+++ b/pkg/apis/authentication.k8s.io/v1beta1/conversion_generated.go
@@ -24,6 +24,8 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	authentication_k8s_io "k8s.io/kubernetes/pkg/apis/authentication.k8s.io"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -121,8 +123,15 @@ func Convert_authenticationk8sio_TokenReviewStatus_To_v1beta1_TokenReviewStatus(
 func autoConvert_v1beta1_UserInfo_To_authenticationk8sio_UserInfo(in *UserInfo, out *authentication_k8s_io.UserInfo, s conversion.Scope) error {
 	out.Username = in.Username
 	out.UID = in.UID
-	out.Groups = in.Groups
-	out.Extra = in.Extra
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Groups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Groups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		m := (*map[string][]string)(unsafe.Pointer(&in.Extra))
+		out.Extra = *m
+	}
 	return nil
 }
 
@@ -133,8 +142,15 @@ func Convert_v1beta1_UserInfo_To_authenticationk8sio_UserInfo(in *UserInfo, out 
 func autoConvert_authenticationk8sio_UserInfo_To_v1beta1_UserInfo(in *authentication_k8s_io.UserInfo, out *UserInfo, s conversion.Scope) error {
 	out.Username = in.Username
 	out.UID = in.UID
-	out.Groups = in.Groups
-	out.Extra = in.Extra
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Groups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Groups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		m := (*map[string][]string)(unsafe.Pointer(&in.Extra))
+		out.Extra = *m
+	}
 	return nil
 }
 

--- a/pkg/apis/authorization/v1beta1/conversion_generated.go
+++ b/pkg/apis/authorization/v1beta1/conversion_generated.go
@@ -24,6 +24,8 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -169,24 +171,8 @@ func Convert_authorization_SelfSubjectAccessReview_To_v1beta1_SelfSubjectAccessR
 }
 
 func autoConvert_v1beta1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAccessReviewSpec(in *SelfSubjectAccessReviewSpec, out *authorization.SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	if in.ResourceAttributes != nil {
-		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		*out = new(authorization.ResourceAttributes)
-		if err := Convert_v1beta1_ResourceAttributes_To_authorization_ResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceAttributes = nil
-	}
-	if in.NonResourceAttributes != nil {
-		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		*out = new(authorization.NonResourceAttributes)
-		if err := Convert_v1beta1_NonResourceAttributes_To_authorization_NonResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NonResourceAttributes = nil
-	}
+	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
+	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
 	return nil
 }
 
@@ -195,24 +181,8 @@ func Convert_v1beta1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAcc
 }
 
 func autoConvert_authorization_SelfSubjectAccessReviewSpec_To_v1beta1_SelfSubjectAccessReviewSpec(in *authorization.SelfSubjectAccessReviewSpec, out *SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	if in.ResourceAttributes != nil {
-		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		*out = new(ResourceAttributes)
-		if err := Convert_authorization_ResourceAttributes_To_v1beta1_ResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceAttributes = nil
-	}
-	if in.NonResourceAttributes != nil {
-		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		*out = new(NonResourceAttributes)
-		if err := Convert_authorization_NonResourceAttributes_To_v1beta1_NonResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NonResourceAttributes = nil
-	}
+	out.ResourceAttributes = (*ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
+	out.NonResourceAttributes = (*NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
 	return nil
 }
 
@@ -255,27 +225,18 @@ func Convert_authorization_SubjectAccessReview_To_v1beta1_SubjectAccessReview(in
 }
 
 func autoConvert_v1beta1_SubjectAccessReviewSpec_To_authorization_SubjectAccessReviewSpec(in *SubjectAccessReviewSpec, out *authorization.SubjectAccessReviewSpec, s conversion.Scope) error {
-	if in.ResourceAttributes != nil {
-		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		*out = new(authorization.ResourceAttributes)
-		if err := Convert_v1beta1_ResourceAttributes_To_authorization_ResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceAttributes = nil
-	}
-	if in.NonResourceAttributes != nil {
-		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		*out = new(authorization.NonResourceAttributes)
-		if err := Convert_v1beta1_NonResourceAttributes_To_authorization_NonResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NonResourceAttributes = nil
-	}
+	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
+	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
 	out.User = in.User
-	out.Groups = in.Groups
-	out.Extra = in.Extra
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Groups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Groups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		m := (*map[string][]string)(unsafe.Pointer(&in.Extra))
+		out.Extra = *m
+	}
 	return nil
 }
 
@@ -284,27 +245,18 @@ func Convert_v1beta1_SubjectAccessReviewSpec_To_authorization_SubjectAccessRevie
 }
 
 func autoConvert_authorization_SubjectAccessReviewSpec_To_v1beta1_SubjectAccessReviewSpec(in *authorization.SubjectAccessReviewSpec, out *SubjectAccessReviewSpec, s conversion.Scope) error {
-	if in.ResourceAttributes != nil {
-		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		*out = new(ResourceAttributes)
-		if err := Convert_authorization_ResourceAttributes_To_v1beta1_ResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ResourceAttributes = nil
-	}
-	if in.NonResourceAttributes != nil {
-		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		*out = new(NonResourceAttributes)
-		if err := Convert_authorization_NonResourceAttributes_To_v1beta1_NonResourceAttributes(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NonResourceAttributes = nil
-	}
+	out.ResourceAttributes = (*ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
+	out.NonResourceAttributes = (*NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
 	out.User = in.User
-	out.Groups = in.Groups
-	out.Extra = in.Extra
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Groups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Groups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		m := (*map[string][]string)(unsafe.Pointer(&in.Extra))
+		out.Extra = *m
+	}
 	return nil
 }
 

--- a/pkg/apis/autoscaling/v1/conversion_generated.go
+++ b/pkg/apis/autoscaling/v1/conversion_generated.go
@@ -22,8 +22,11 @@ package v1
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -122,16 +125,10 @@ func autoConvert_v1_HorizontalPodAutoscalerList_To_autoscaling_HorizontalPodAuto
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]autoscaling.HorizontalPodAutoscaler, len(*in))
-		for i := range *in {
-			if err := Convert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -147,16 +144,10 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v1_HorizontalPodAuto
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]HorizontalPodAutoscaler, len(*in))
-		for i := range *in {
-			if err := Convert_autoscaling_HorizontalPodAutoscaler_To_v1_HorizontalPodAutoscaler(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -169,9 +160,9 @@ func autoConvert_v1_HorizontalPodAutoscalerSpec_To_autoscaling_HorizontalPodAuto
 	if err := Convert_v1_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(&in.ScaleTargetRef, &out.ScaleTargetRef, s); err != nil {
 		return err
 	}
-	out.MinReplicas = in.MinReplicas
+	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
-	out.TargetCPUUtilizationPercentage = in.TargetCPUUtilizationPercentage
+	out.TargetCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.TargetCPUUtilizationPercentage))
 	return nil
 }
 
@@ -183,9 +174,9 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 	if err := Convert_autoscaling_CrossVersionObjectReference_To_v1_CrossVersionObjectReference(&in.ScaleTargetRef, &out.ScaleTargetRef, s); err != nil {
 		return err
 	}
-	out.MinReplicas = in.MinReplicas
+	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
-	out.TargetCPUUtilizationPercentage = in.TargetCPUUtilizationPercentage
+	out.TargetCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.TargetCPUUtilizationPercentage))
 	return nil
 }
 
@@ -194,11 +185,11 @@ func Convert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAutoscal
 }
 
 func autoConvert_v1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *autoscaling.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastScaleTime = in.LastScaleTime
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	out.LastScaleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
+	out.CurrentCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.CurrentCPUUtilizationPercentage))
 	return nil
 }
 
@@ -207,11 +198,11 @@ func Convert_v1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutosc
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutoscalerStatus(in *autoscaling.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastScaleTime = in.LastScaleTime
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	out.LastScaleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
+	out.CurrentCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.CurrentCPUUtilizationPercentage))
 	return nil
 }
 

--- a/pkg/apis/batch/v1/conversion_generated.go
+++ b/pkg/apis/batch/v1/conversion_generated.go
@@ -26,6 +26,8 @@ import (
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -180,19 +182,11 @@ func Convert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s conv
 }
 
 func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(unversioned.LabelSelector)
-		if err := Convert_v1_LabelSelector_To_unversioned_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	out.ManualSelector = in.ManualSelector
+	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
+	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
 	if err := api_v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -200,19 +194,11 @@ func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s 
 }
 
 func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v1_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	out.ManualSelector = in.ManualSelector
+	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
+	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
+	out.Selector = (*LabelSelector)(unsafe.Pointer(in.Selector))
+	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
 	if err := api_v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -220,19 +206,13 @@ func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *JobSpec, s 
 }
 
 func autoConvert_v1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]batch.JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1_JobCondition_To_batch_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -244,19 +224,13 @@ func Convert_v1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobStatus
 }
 
 func autoConvert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_batch_JobCondition_To_v1_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -268,17 +242,14 @@ func Convert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *JobStatus
 }
 
 func autoConvert_v1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_v1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -288,17 +259,14 @@ func Convert_v1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, ou
 }
 
 func autoConvert_unversioned_LabelSelector_To_v1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_unversioned_LabelSelectorRequirement_To_v1_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -310,7 +278,11 @@ func Convert_unversioned_LabelSelector_To_v1_LabelSelector(in *unversioned.Label
 func autoConvert_v1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -321,7 +293,11 @@ func Convert_v1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement
 func autoConvert_unversioned_LabelSelectorRequirement_To_v1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 

--- a/pkg/apis/batch/v2alpha1/conversion_generated.go
+++ b/pkg/apis/batch/v2alpha1/conversion_generated.go
@@ -26,6 +26,8 @@ import (
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -192,19 +194,11 @@ func Convert_batch_JobList_To_v2alpha1_JobList(in *batch.JobList, out *JobList, 
 }
 
 func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(unversioned.LabelSelector)
-		if err := Convert_v2alpha1_LabelSelector_To_unversioned_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	out.ManualSelector = in.ManualSelector
+	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
+	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
 	if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -212,19 +206,11 @@ func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSp
 }
 
 func autoConvert_batch_JobSpec_To_v2alpha1_JobSpec(in *batch.JobSpec, out *JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v2alpha1_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	out.ManualSelector = in.ManualSelector
+	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
+	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
+	out.Selector = (*LabelSelector)(unsafe.Pointer(in.Selector))
+	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
 	if err := v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -232,19 +218,13 @@ func autoConvert_batch_JobSpec_To_v2alpha1_JobSpec(in *batch.JobSpec, out *JobSp
 }
 
 func autoConvert_v2alpha1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]batch.JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v2alpha1_JobCondition_To_batch_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -256,19 +236,13 @@ func Convert_v2alpha1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.Job
 }
 
 func autoConvert_batch_JobStatus_To_v2alpha1_JobStatus(in *batch.JobStatus, out *JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_batch_JobCondition_To_v2alpha1_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -346,17 +320,14 @@ func Convert_batch_JobTemplateSpec_To_v2alpha1_JobTemplateSpec(in *batch.JobTemp
 }
 
 func autoConvert_v2alpha1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -366,17 +337,14 @@ func Convert_v2alpha1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelect
 }
 
 func autoConvert_unversioned_LabelSelector_To_v2alpha1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -388,7 +356,11 @@ func Convert_unversioned_LabelSelector_To_v2alpha1_LabelSelector(in *unversioned
 func autoConvert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -399,7 +371,11 @@ func Convert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequi
 func autoConvert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -502,9 +478,9 @@ func Convert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList(in *batch.Sched
 
 func autoConvert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJobSpec, out *batch.ScheduledJobSpec, s conversion.Scope) error {
 	out.Schedule = in.Schedule
-	out.StartingDeadlineSeconds = in.StartingDeadlineSeconds
+	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
 	out.ConcurrencyPolicy = batch.ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = in.Suspend
+	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
 	if err := Convert_v2alpha1_JobTemplateSpec_To_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
 		return err
 	}
@@ -517,9 +493,9 @@ func Convert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJo
 
 func autoConvert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in *batch.ScheduledJobSpec, out *ScheduledJobSpec, s conversion.Scope) error {
 	out.Schedule = in.Schedule
-	out.StartingDeadlineSeconds = in.StartingDeadlineSeconds
+	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
 	out.ConcurrencyPolicy = ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = in.Suspend
+	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
 	if err := Convert_batch_JobTemplateSpec_To_v2alpha1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
 		return err
 	}
@@ -531,19 +507,12 @@ func Convert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in *batch.Sched
 }
 
 func autoConvert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus(in *ScheduledJobStatus, out *batch.ScheduledJobStatus, s conversion.Scope) error {
-	if in.Active != nil {
-		in, out := &in.Active, &out.Active
-		*out = make([]api.ObjectReference, len(*in))
-		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Active = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Active))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Active))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.LastScheduleTime = in.LastScheduleTime
+	out.LastScheduleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScheduleTime))
 	return nil
 }
 
@@ -552,19 +521,12 @@ func Convert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus(in *Schedul
 }
 
 func autoConvert_batch_ScheduledJobStatus_To_v2alpha1_ScheduledJobStatus(in *batch.ScheduledJobStatus, out *ScheduledJobStatus, s conversion.Scope) error {
-	if in.Active != nil {
-		in, out := &in.Active, &out.Active
-		*out = make([]v1.ObjectReference, len(*in))
-		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Active = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Active))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Active))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.LastScheduleTime = in.LastScheduleTime
+	out.LastScheduleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScheduleTime))
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
@@ -24,6 +24,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	componentconfig "k8s.io/kubernetes/pkg/apis/componentconfig"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -50,12 +51,12 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyCon
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.HealthzPort = in.HealthzPort
 	out.HostnameOverride = in.HostnameOverride
-	out.IPTablesMasqueradeBit = in.IPTablesMasqueradeBit
+	out.IPTablesMasqueradeBit = (*int32)(unsafe.Pointer(in.IPTablesMasqueradeBit))
 	out.IPTablesSyncPeriod = in.IPTablesSyncPeriod
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
-	out.OOMScoreAdj = in.OOMScoreAdj
+	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
 	out.Mode = componentconfig.ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer
@@ -78,12 +79,12 @@ func autoConvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyCon
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.HealthzPort = in.HealthzPort
 	out.HostnameOverride = in.HostnameOverride
-	out.IPTablesMasqueradeBit = in.IPTablesMasqueradeBit
+	out.IPTablesMasqueradeBit = (*int32)(unsafe.Pointer(in.IPTablesMasqueradeBit))
 	out.IPTablesSyncPeriod = in.IPTablesSyncPeriod
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
-	out.OOMScoreAdj = in.OOMScoreAdj
+	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
 	out.Mode = ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -28,6 +28,9 @@ import (
 	batch "k8s.io/kubernetes/pkg/apis/batch"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	intstr "k8s.io/kubernetes/pkg/util/intstr"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -211,16 +214,10 @@ func Convert_extensions_CustomMetricCurrentStatus_To_v1beta1_CustomMetricCurrent
 }
 
 func autoConvert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCurrentStatusList(in *CustomMetricCurrentStatusList, out *extensions.CustomMetricCurrentStatusList, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.CustomMetricCurrentStatus, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_CustomMetricCurrentStatus_To_extensions_CustomMetricCurrentStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -230,16 +227,10 @@ func Convert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCur
 }
 
 func autoConvert_extensions_CustomMetricCurrentStatusList_To_v1beta1_CustomMetricCurrentStatusList(in *extensions.CustomMetricCurrentStatusList, out *CustomMetricCurrentStatusList, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]CustomMetricCurrentStatus, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_CustomMetricCurrentStatus_To_v1beta1_CustomMetricCurrentStatus(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -273,16 +264,10 @@ func Convert_extensions_CustomMetricTarget_To_v1beta1_CustomMetricTarget(in *ext
 }
 
 func autoConvert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList(in *CustomMetricTargetList, out *extensions.CustomMetricTargetList, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.CustomMetricTarget, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_CustomMetricTarget_To_extensions_CustomMetricTarget(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -292,16 +277,10 @@ func Convert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList
 }
 
 func autoConvert_extensions_CustomMetricTargetList_To_v1beta1_CustomMetricTargetList(in *extensions.CustomMetricTargetList, out *CustomMetricTargetList, s conversion.Scope) error {
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]CustomMetricTarget, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_CustomMetricTarget_To_v1beta1_CustomMetricTarget(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -404,15 +383,7 @@ func Convert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extensions.Da
 }
 
 func autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(unversioned.LabelSelector)
-		if err := Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -424,15 +395,7 @@ func Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec
 }
 
 func autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = (*LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -563,7 +526,10 @@ func autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback(in 
 		return err
 	}
 	out.Name = in.Name
-	out.UpdatedAnnotations = in.UpdatedAnnotations
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.UpdatedAnnotations))
+		out.UpdatedAnnotations = *m
+	}
 	if err := Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
 		return err
 	}
@@ -579,7 +545,10 @@ func autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback(in 
 		return err
 	}
 	out.Name = in.Name
-	out.UpdatedAnnotations = in.UpdatedAnnotations
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.UpdatedAnnotations))
+		out.UpdatedAnnotations = *m
+	}
 	if err := Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
 		return err
 	}
@@ -646,16 +615,10 @@ func autoConvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in 
 
 func autoConvert_v1beta1_FSGroupStrategyOptions_To_extensions_FSGroupStrategyOptions(in *FSGroupStrategyOptions, out *extensions.FSGroupStrategyOptions, s conversion.Scope) error {
 	out.Rule = extensions.FSGroupStrategyType(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]extensions.IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_IDRange_To_extensions_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -666,16 +629,10 @@ func Convert_v1beta1_FSGroupStrategyOptions_To_extensions_FSGroupStrategyOptions
 
 func autoConvert_extensions_FSGroupStrategyOptions_To_v1beta1_FSGroupStrategyOptions(in *extensions.FSGroupStrategyOptions, out *FSGroupStrategyOptions, s conversion.Scope) error {
 	out.Rule = FSGroupStrategyType(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_IDRange_To_v1beta1_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -709,16 +666,10 @@ func Convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *extension
 }
 
 func autoConvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *extensions.HTTPIngressRuleValue, s conversion.Scope) error {
-	if in.Paths != nil {
-		in, out := &in.Paths, &out.Paths
-		*out = make([]extensions.HTTPIngressPath, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Paths = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Paths))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Paths))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -728,16 +679,10 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
-	if in.Paths != nil {
-		in, out := &in.Paths, &out.Paths
-		*out = make([]HTTPIngressPath, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Paths = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Paths))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Paths))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -840,11 +785,11 @@ func Convert_autoscaling_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAut
 }
 
 func autoConvert_v1beta1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *autoscaling.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastScaleTime = in.LastScaleTime
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	out.LastScaleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
+	out.CurrentCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.CurrentCPUUtilizationPercentage))
 	return nil
 }
 
@@ -853,11 +798,11 @@ func Convert_v1beta1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodA
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *autoscaling.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastScaleTime = in.LastScaleTime
+	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	out.LastScaleTime = (*unversioned.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
+	out.CurrentCPUUtilizationPercentage = (*int32)(unsafe.Pointer(in.CurrentCPUUtilizationPercentage))
 	return nil
 }
 
@@ -978,16 +923,10 @@ func autoConvert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, 
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.Ingress, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_Ingress_To_extensions_Ingress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1003,16 +942,10 @@ func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.In
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]Ingress, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_Ingress_To_v1beta1_Ingress(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1046,15 +979,7 @@ func Convert_extensions_IngressRule_To_v1beta1_IngressRule(in *extensions.Ingres
 }
 
 func autoConvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *IngressRuleValue, out *extensions.IngressRuleValue, s conversion.Scope) error {
-	if in.HTTP != nil {
-		in, out := &in.HTTP, &out.HTTP
-		*out = new(extensions.HTTPIngressRuleValue)
-		if err := Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HTTP = nil
-	}
+	out.HTTP = (*extensions.HTTPIngressRuleValue)(unsafe.Pointer(in.HTTP))
 	return nil
 }
 
@@ -1063,15 +988,7 @@ func Convert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *Ingress
 }
 
 func autoConvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensions.IngressRuleValue, out *IngressRuleValue, s conversion.Scope) error {
-	if in.HTTP != nil {
-		in, out := &in.HTTP, &out.HTTP
-		*out = new(HTTPIngressRuleValue)
-		if err := Convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.HTTP = nil
-	}
+	out.HTTP = (*HTTPIngressRuleValue)(unsafe.Pointer(in.HTTP))
 	return nil
 }
 
@@ -1080,36 +997,16 @@ func Convert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensi
 }
 
 func autoConvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out *extensions.IngressSpec, s conversion.Scope) error {
-	if in.Backend != nil {
-		in, out := &in.Backend, &out.Backend
-		*out = new(extensions.IngressBackend)
-		if err := Convert_v1beta1_IngressBackend_To_extensions_IngressBackend(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Backend = nil
+	out.Backend = (*extensions.IngressBackend)(unsafe.Pointer(in.Backend))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.TLS))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.TLS))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.TLS != nil {
-		in, out := &in.TLS, &out.TLS
-		*out = make([]extensions.IngressTLS, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_IngressTLS_To_extensions_IngressTLS(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.TLS = nil
-	}
-	if in.Rules != nil {
-		in, out := &in.Rules, &out.Rules
-		*out = make([]extensions.IngressRule, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_IngressRule_To_extensions_IngressRule(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Rules))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Rules))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1119,36 +1016,16 @@ func Convert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out 
 }
 
 func autoConvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.IngressSpec, out *IngressSpec, s conversion.Scope) error {
-	if in.Backend != nil {
-		in, out := &in.Backend, &out.Backend
-		*out = new(IngressBackend)
-		if err := Convert_extensions_IngressBackend_To_v1beta1_IngressBackend(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Backend = nil
+	out.Backend = (*IngressBackend)(unsafe.Pointer(in.Backend))
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.TLS))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.TLS))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.TLS != nil {
-		in, out := &in.TLS, &out.TLS
-		*out = make([]IngressTLS, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_IngressTLS_To_v1beta1_IngressTLS(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.TLS = nil
-	}
-	if in.Rules != nil {
-		in, out := &in.Rules, &out.Rules
-		*out = make([]IngressRule, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_IngressRule_To_v1beta1_IngressRule(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Rules))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Rules))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1182,7 +1059,11 @@ func Convert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.In
 }
 
 func autoConvert_v1beta1_IngressTLS_To_extensions_IngressTLS(in *IngressTLS, out *extensions.IngressTLS, s conversion.Scope) error {
-	out.Hosts = in.Hosts
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Hosts))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Hosts))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.SecretName = in.SecretName
 	return nil
 }
@@ -1192,7 +1073,11 @@ func Convert_v1beta1_IngressTLS_To_extensions_IngressTLS(in *IngressTLS, out *ex
 }
 
 func autoConvert_extensions_IngressTLS_To_v1beta1_IngressTLS(in *extensions.IngressTLS, out *IngressTLS, s conversion.Scope) error {
-	out.Hosts = in.Hosts
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Hosts))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Hosts))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	out.SecretName = in.SecretName
 	return nil
 }
@@ -1331,19 +1216,13 @@ func Convert_batch_JobList_To_v1beta1_JobList(in *batch.JobList, out *JobList, s
 }
 
 func autoConvert_v1beta1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]batch.JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_JobCondition_To_batch_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -1355,19 +1234,13 @@ func Convert_v1beta1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobS
 }
 
 func autoConvert_batch_JobStatus_To_v1beta1_JobStatus(in *batch.JobStatus, out *JobStatus, s conversion.Scope) error {
-	if in.Conditions != nil {
-		in, out := &in.Conditions, &out.Conditions
-		*out = make([]JobCondition, len(*in))
-		for i := range *in {
-			if err := Convert_batch_JobCondition_To_v1beta1_JobCondition(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Conditions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Conditions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Conditions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.StartTime = in.StartTime
-	out.CompletionTime = in.CompletionTime
+	out.StartTime = (*unversioned.Time)(unsafe.Pointer(in.StartTime))
+	out.CompletionTime = (*unversioned.Time)(unsafe.Pointer(in.CompletionTime))
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -1379,17 +1252,14 @@ func Convert_batch_JobStatus_To_v1beta1_JobStatus(in *batch.JobStatus, out *JobS
 }
 
 func autoConvert_v1beta1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1399,17 +1269,14 @@ func Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelecto
 }
 
 func autoConvert_unversioned_LabelSelector_To_v1beta1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	out.MatchLabels = in.MatchLabels
-	if in.MatchExpressions != nil {
-		in, out := &in.MatchExpressions, &out.MatchExpressions
-		*out = make([]LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if err := Convert_unversioned_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.MatchExpressions = nil
+	{
+		m := (*map[string]string)(unsafe.Pointer(&in.MatchLabels))
+		out.MatchLabels = *m
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.MatchExpressions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.MatchExpressions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1421,7 +1288,11 @@ func Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(in *unversioned.
 func autoConvert_v1beta1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -1432,7 +1303,11 @@ func Convert_v1beta1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequir
 func autoConvert_unversioned_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	out.Values = in.Values
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Values))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Values))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -1478,27 +1353,15 @@ func Convert_extensions_NetworkPolicy_To_v1beta1_NetworkPolicy(in *extensions.Ne
 }
 
 func autoConvert_v1beta1_NetworkPolicyIngressRule_To_extensions_NetworkPolicyIngressRule(in *NetworkPolicyIngressRule, out *extensions.NetworkPolicyIngressRule, s conversion.Scope) error {
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]extensions.NetworkPolicyPort, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_NetworkPolicyPort_To_extensions_NetworkPolicyPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.From != nil {
-		in, out := &in.From, &out.From
-		*out = make([]extensions.NetworkPolicyPeer, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.From = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.From))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.From))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1508,27 +1371,15 @@ func Convert_v1beta1_NetworkPolicyIngressRule_To_extensions_NetworkPolicyIngress
 }
 
 func autoConvert_extensions_NetworkPolicyIngressRule_To_v1beta1_NetworkPolicyIngressRule(in *extensions.NetworkPolicyIngressRule, out *NetworkPolicyIngressRule, s conversion.Scope) error {
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]NetworkPolicyPort, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_NetworkPolicyPort_To_v1beta1_NetworkPolicyPort(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ports = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ports))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ports))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.From != nil {
-		in, out := &in.From, &out.From
-		*out = make([]NetworkPolicyPeer, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.From = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.From))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.From))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1544,16 +1395,10 @@ func autoConvert_v1beta1_NetworkPolicyList_To_extensions_NetworkPolicyList(in *N
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.NetworkPolicy, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_NetworkPolicy_To_extensions_NetworkPolicy(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1569,16 +1414,10 @@ func autoConvert_extensions_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *e
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]NetworkPolicy, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_NetworkPolicy_To_v1beta1_NetworkPolicy(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1588,24 +1427,8 @@ func Convert_extensions_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *exten
 }
 
 func autoConvert_v1beta1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(in *NetworkPolicyPeer, out *extensions.NetworkPolicyPeer, s conversion.Scope) error {
-	if in.PodSelector != nil {
-		in, out := &in.PodSelector, &out.PodSelector
-		*out = new(unversioned.LabelSelector)
-		if err := Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PodSelector = nil
-	}
-	if in.NamespaceSelector != nil {
-		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		*out = new(unversioned.LabelSelector)
-		if err := Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NamespaceSelector = nil
-	}
+	out.PodSelector = (*unversioned.LabelSelector)(unsafe.Pointer(in.PodSelector))
+	out.NamespaceSelector = (*unversioned.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	return nil
 }
 
@@ -1614,24 +1437,8 @@ func Convert_v1beta1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(in *Netwo
 }
 
 func autoConvert_extensions_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(in *extensions.NetworkPolicyPeer, out *NetworkPolicyPeer, s conversion.Scope) error {
-	if in.PodSelector != nil {
-		in, out := &in.PodSelector, &out.PodSelector
-		*out = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.PodSelector = nil
-	}
-	if in.NamespaceSelector != nil {
-		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		*out = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.NamespaceSelector = nil
-	}
+	out.PodSelector = (*LabelSelector)(unsafe.Pointer(in.PodSelector))
+	out.NamespaceSelector = (*LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	return nil
 }
 
@@ -1640,14 +1447,8 @@ func Convert_extensions_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(in *exten
 }
 
 func autoConvert_v1beta1_NetworkPolicyPort_To_extensions_NetworkPolicyPort(in *NetworkPolicyPort, out *extensions.NetworkPolicyPort, s conversion.Scope) error {
-	if in.Protocol != nil {
-		in, out := &in.Protocol, &out.Protocol
-		*out = new(api.Protocol)
-		**out = api.Protocol(**in)
-	} else {
-		out.Protocol = nil
-	}
-	out.Port = in.Port
+	out.Protocol = (*api.Protocol)(unsafe.Pointer(in.Protocol))
+	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
 	return nil
 }
 
@@ -1656,14 +1457,8 @@ func Convert_v1beta1_NetworkPolicyPort_To_extensions_NetworkPolicyPort(in *Netwo
 }
 
 func autoConvert_extensions_NetworkPolicyPort_To_v1beta1_NetworkPolicyPort(in *extensions.NetworkPolicyPort, out *NetworkPolicyPort, s conversion.Scope) error {
-	if in.Protocol != nil {
-		in, out := &in.Protocol, &out.Protocol
-		*out = new(v1.Protocol)
-		**out = v1.Protocol(**in)
-	} else {
-		out.Protocol = nil
-	}
-	out.Port = in.Port
+	out.Protocol = (*v1.Protocol)(unsafe.Pointer(in.Protocol))
+	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
 	return nil
 }
 
@@ -1675,16 +1470,10 @@ func autoConvert_v1beta1_NetworkPolicySpec_To_extensions_NetworkPolicySpec(in *N
 	if err := Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(&in.PodSelector, &out.PodSelector, s); err != nil {
 		return err
 	}
-	if in.Ingress != nil {
-		in, out := &in.Ingress, &out.Ingress
-		*out = make([]extensions.NetworkPolicyIngressRule, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_NetworkPolicyIngressRule_To_extensions_NetworkPolicyIngressRule(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ingress = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ingress))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ingress))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1697,16 +1486,10 @@ func autoConvert_extensions_NetworkPolicySpec_To_v1beta1_NetworkPolicySpec(in *e
 	if err := Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(&in.PodSelector, &out.PodSelector, s); err != nil {
 		return err
 	}
-	if in.Ingress != nil {
-		in, out := &in.Ingress, &out.Ingress
-		*out = make([]NetworkPolicyIngressRule, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_NetworkPolicyIngressRule_To_v1beta1_NetworkPolicyIngressRule(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ingress = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ingress))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ingress))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -1803,41 +1586,25 @@ func Convert_extensions_PodSecurityPolicyList_To_v1beta1_PodSecurityPolicyList(i
 
 func autoConvert_v1beta1_PodSecurityPolicySpec_To_extensions_PodSecurityPolicySpec(in *PodSecurityPolicySpec, out *extensions.PodSecurityPolicySpec, s conversion.Scope) error {
 	out.Privileged = in.Privileged
-	if in.DefaultAddCapabilities != nil {
-		in, out := &in.DefaultAddCapabilities, &out.DefaultAddCapabilities
-		*out = make([]api.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = api.Capability((*in)[i])
-		}
-	} else {
-		out.DefaultAddCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.DefaultAddCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.DefaultAddCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.RequiredDropCapabilities != nil {
-		in, out := &in.RequiredDropCapabilities, &out.RequiredDropCapabilities
-		*out = make([]api.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = api.Capability((*in)[i])
-		}
-	} else {
-		out.RequiredDropCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDropCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDropCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.AllowedCapabilities != nil {
-		in, out := &in.AllowedCapabilities, &out.AllowedCapabilities
-		*out = make([]api.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = api.Capability((*in)[i])
-		}
-	} else {
-		out.AllowedCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AllowedCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AllowedCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Volumes != nil {
-		in, out := &in.Volumes, &out.Volumes
-		*out = make([]extensions.FSType, len(*in))
-		for i := range *in {
-			(*out)[i] = extensions.FSType((*in)[i])
-		}
-	} else {
-		out.Volumes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Volumes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Volumes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.HostNetwork = in.HostNetwork
 	if in.HostPorts != nil {
@@ -1875,41 +1642,25 @@ func Convert_v1beta1_PodSecurityPolicySpec_To_extensions_PodSecurityPolicySpec(i
 
 func autoConvert_extensions_PodSecurityPolicySpec_To_v1beta1_PodSecurityPolicySpec(in *extensions.PodSecurityPolicySpec, out *PodSecurityPolicySpec, s conversion.Scope) error {
 	out.Privileged = in.Privileged
-	if in.DefaultAddCapabilities != nil {
-		in, out := &in.DefaultAddCapabilities, &out.DefaultAddCapabilities
-		*out = make([]v1.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = v1.Capability((*in)[i])
-		}
-	} else {
-		out.DefaultAddCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.DefaultAddCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.DefaultAddCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.RequiredDropCapabilities != nil {
-		in, out := &in.RequiredDropCapabilities, &out.RequiredDropCapabilities
-		*out = make([]v1.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = v1.Capability((*in)[i])
-		}
-	} else {
-		out.RequiredDropCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.RequiredDropCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.RequiredDropCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.AllowedCapabilities != nil {
-		in, out := &in.AllowedCapabilities, &out.AllowedCapabilities
-		*out = make([]v1.Capability, len(*in))
-		for i := range *in {
-			(*out)[i] = v1.Capability((*in)[i])
-		}
-	} else {
-		out.AllowedCapabilities = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.AllowedCapabilities))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.AllowedCapabilities))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	if in.Volumes != nil {
-		in, out := &in.Volumes, &out.Volumes
-		*out = make([]FSType, len(*in))
-		for i := range *in {
-			(*out)[i] = FSType((*in)[i])
-		}
-	} else {
-		out.Volumes = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Volumes))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Volumes))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	out.HostNetwork = in.HostNetwork
 	if in.HostPorts != nil {
@@ -2102,16 +1853,10 @@ func Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in *extensions.
 
 func autoConvert_v1beta1_RunAsUserStrategyOptions_To_extensions_RunAsUserStrategyOptions(in *RunAsUserStrategyOptions, out *extensions.RunAsUserStrategyOptions, s conversion.Scope) error {
 	out.Rule = extensions.RunAsUserStrategy(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]extensions.IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_IDRange_To_extensions_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2122,16 +1867,10 @@ func Convert_v1beta1_RunAsUserStrategyOptions_To_extensions_RunAsUserStrategyOpt
 
 func autoConvert_extensions_RunAsUserStrategyOptions_To_v1beta1_RunAsUserStrategyOptions(in *extensions.RunAsUserStrategyOptions, out *RunAsUserStrategyOptions, s conversion.Scope) error {
 	out.Rule = RunAsUserStrategy(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_IDRange_To_v1beta1_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2142,16 +1881,7 @@ func Convert_extensions_RunAsUserStrategyOptions_To_v1beta1_RunAsUserStrategyOpt
 
 func autoConvert_v1beta1_SELinuxStrategyOptions_To_extensions_SELinuxStrategyOptions(in *SELinuxStrategyOptions, out *extensions.SELinuxStrategyOptions, s conversion.Scope) error {
 	out.Rule = extensions.SELinuxStrategy(in.Rule)
-	if in.SELinuxOptions != nil {
-		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		*out = new(api.SELinuxOptions)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.SELinuxOptions = nil
-	}
+	out.SELinuxOptions = (*api.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
 	return nil
 }
 
@@ -2161,16 +1891,7 @@ func Convert_v1beta1_SELinuxStrategyOptions_To_extensions_SELinuxStrategyOptions
 
 func autoConvert_extensions_SELinuxStrategyOptions_To_v1beta1_SELinuxStrategyOptions(in *extensions.SELinuxStrategyOptions, out *SELinuxStrategyOptions, s conversion.Scope) error {
 	out.Rule = SELinuxStrategy(in.Rule)
-	if in.SELinuxOptions != nil {
-		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		*out = new(v1.SELinuxOptions)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.SELinuxOptions = nil
-	}
+	out.SELinuxOptions = (*v1.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
 	return nil
 }
 
@@ -2240,16 +1961,10 @@ func Convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec,
 
 func autoConvert_v1beta1_SupplementalGroupsStrategyOptions_To_extensions_SupplementalGroupsStrategyOptions(in *SupplementalGroupsStrategyOptions, out *extensions.SupplementalGroupsStrategyOptions, s conversion.Scope) error {
 	out.Rule = extensions.SupplementalGroupsStrategyType(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]extensions.IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_IDRange_To_extensions_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2260,16 +1975,10 @@ func Convert_v1beta1_SupplementalGroupsStrategyOptions_To_extensions_Supplementa
 
 func autoConvert_extensions_SupplementalGroupsStrategyOptions_To_v1beta1_SupplementalGroupsStrategyOptions(in *extensions.SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, s conversion.Scope) error {
 	out.Rule = SupplementalGroupsStrategyType(in.Rule)
-	if in.Ranges != nil {
-		in, out := &in.Ranges, &out.Ranges
-		*out = make([]IDRange, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_IDRange_To_v1beta1_IDRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Ranges = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Ranges))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Ranges))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2287,16 +1996,10 @@ func autoConvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in 
 		return err
 	}
 	out.Description = in.Description
-	if in.Versions != nil {
-		in, out := &in.Versions, &out.Versions
-		*out = make([]extensions.APIVersion, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_APIVersion_To_extensions_APIVersion(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Versions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Versions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Versions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2314,16 +2017,10 @@ func autoConvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in 
 		return err
 	}
 	out.Description = in.Description
-	if in.Versions != nil {
-		in, out := &in.Versions, &out.Versions
-		*out = make([]APIVersion, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_APIVersion_To_v1beta1_APIVersion(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Versions = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Versions))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Versions))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2375,16 +2072,10 @@ func autoConvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyReso
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.ThirdPartyResourceData, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2400,16 +2091,10 @@ func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyReso
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ThirdPartyResourceData, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2425,16 +2110,10 @@ func autoConvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResource
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]extensions.ThirdPartyResource, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -2450,16 +2129,10 @@ func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResource
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ThirdPartyResource, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }

--- a/pkg/apis/policy/v1alpha1/conversion_generated.go
+++ b/pkg/apis/policy/v1alpha1/conversion_generated.go
@@ -22,8 +22,11 @@ package v1alpha1
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -91,16 +94,10 @@ func autoConvert_v1alpha1_PodDisruptionBudgetList_To_policy_PodDisruptionBudgetL
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]policy.PodDisruptionBudget, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_PodDisruptionBudget_To_policy_PodDisruptionBudget(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -116,16 +113,10 @@ func autoConvert_policy_PodDisruptionBudgetList_To_v1alpha1_PodDisruptionBudgetL
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]PodDisruptionBudget, len(*in))
-		for i := range *in {
-			if err := Convert_policy_PodDisruptionBudget_To_v1alpha1_PodDisruptionBudget(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -138,7 +129,7 @@ func autoConvert_v1alpha1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetS
 	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.MinAvailable, &out.MinAvailable, s); err != nil {
 		return err
 	}
-	out.Selector = in.Selector
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
 	return nil
 }
 
@@ -150,7 +141,7 @@ func autoConvert_policy_PodDisruptionBudgetSpec_To_v1alpha1_PodDisruptionBudgetS
 	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.MinAvailable, &out.MinAvailable, s); err != nil {
 		return err
 	}
-	out.Selector = in.Selector
+	out.Selector = (*unversioned.LabelSelector)(unsafe.Pointer(in.Selector))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1alpha1/conversion_generated.go
+++ b/pkg/apis/rbac/v1alpha1/conversion_generated.go
@@ -273,7 +273,13 @@ func autoConvert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rba
 		return err
 	}
 	out.APIGroups = in.APIGroups
-	out.Resources = in.Resources
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	} else {
+		out.Resources = nil
+	}
 	out.ResourceNames = in.ResourceNames
 	out.NonResourceURLs = in.NonResourceURLs
 	return nil
@@ -289,7 +295,13 @@ func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out
 		return err
 	}
 	out.APIGroups = in.APIGroups
-	out.Resources = in.Resources
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = make(Resources, len(*in))
+		copy(*out, *in)
+	} else {
+		out.Resources = nil
+	}
 	out.ResourceNames = in.ResourceNames
 	out.NonResourceURLs = in.NonResourceURLs
 	return nil

--- a/pkg/apis/rbac/v1alpha1/conversion_generated.go
+++ b/pkg/apis/rbac/v1alpha1/conversion_generated.go
@@ -25,6 +25,8 @@ import (
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 func init() {
@@ -115,16 +117,10 @@ func autoConvert_v1alpha1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *Clus
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
-	if in.Subjects != nil {
-		in, out := &in.Subjects, &out.Subjects
-		*out = make([]rbac.Subject, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_Subject_To_rbac_Subject(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subjects = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subjects))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subjects))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.RoleRef, &out.RoleRef, 0); err != nil {
@@ -145,16 +141,10 @@ func autoConvert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(in *rbac
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
-	if in.Subjects != nil {
-		in, out := &in.Subjects, &out.Subjects
-		*out = make([]Subject, len(*in))
-		for i := range *in {
-			if err := Convert_rbac_Subject_To_v1alpha1_Subject(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subjects = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subjects))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subjects))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.RoleRef, &out.RoleRef, 0); err != nil {
@@ -174,16 +164,10 @@ func autoConvert_v1alpha1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]rbac.ClusterRoleBinding, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -199,16 +183,10 @@ func autoConvert_rbac_ClusterRoleBindingList_To_v1alpha1_ClusterRoleBindingList(
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]ClusterRoleBinding, len(*in))
-		for i := range *in {
-			if err := Convert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -268,20 +246,34 @@ func Convert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRo
 }
 
 func autoConvert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.PolicyRule, s conversion.Scope) error {
-	out.Verbs = in.Verbs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Verbs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Verbs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
-	out.APIGroups = in.APIGroups
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Resources = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.APIGroups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.APIGroups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.ResourceNames = in.ResourceNames
-	out.NonResourceURLs = in.NonResourceURLs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Resources))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Resources))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ResourceNames))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ResourceNames))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NonResourceURLs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NonResourceURLs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -290,20 +282,34 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Po
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = in.Verbs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Verbs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Verbs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
-	out.APIGroups = in.APIGroups
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = make(Resources, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Resources = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.APIGroups))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.APIGroups))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
-	out.ResourceNames = in.ResourceNames
-	out.NonResourceURLs = in.NonResourceURLs
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Resources))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Resources))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.ResourceNames))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.ResourceNames))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.NonResourceURLs))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.NonResourceURLs))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
+	}
 	return nil
 }
 
@@ -371,16 +377,10 @@ func autoConvert_v1alpha1_RoleBinding_To_rbac_RoleBinding(in *RoleBinding, out *
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
-	if in.Subjects != nil {
-		in, out := &in.Subjects, &out.Subjects
-		*out = make([]rbac.Subject, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_Subject_To_rbac_Subject(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subjects = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subjects))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subjects))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.RoleRef, &out.RoleRef, 0); err != nil {
@@ -401,16 +401,10 @@ func autoConvert_rbac_RoleBinding_To_v1alpha1_RoleBinding(in *rbac.RoleBinding, 
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
-	if in.Subjects != nil {
-		in, out := &in.Subjects, &out.Subjects
-		*out = make([]Subject, len(*in))
-		for i := range *in {
-			if err := Convert_rbac_Subject_To_v1alpha1_Subject(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subjects = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Subjects))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Subjects))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.RoleRef, &out.RoleRef, 0); err != nil {
@@ -430,16 +424,10 @@ func autoConvert_v1alpha1_RoleBindingList_To_rbac_RoleBindingList(in *RoleBindin
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]rbac.RoleBinding, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha1_RoleBinding_To_rbac_RoleBinding(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }
@@ -455,16 +443,10 @@ func autoConvert_rbac_RoleBindingList_To_v1alpha1_RoleBindingList(in *rbac.RoleB
 	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]RoleBinding, len(*in))
-		for i := range *in {
-			if err := Convert_rbac_RoleBinding_To_v1alpha1_RoleBinding(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
+	{
+		outHdr := (*reflect.SliceHeader)(unsafe.Pointer(&out.Items))
+		inHdr := (*reflect.SliceHeader)(unsafe.Pointer(&in.Items))
+		outHdr.Data, outHdr.Len = inHdr.Data, inHdr.Len
 	}
 	return nil
 }

--- a/pkg/apis/rbac/v1alpha1/deep_copy_generated.go
+++ b/pkg/apis/rbac/v1alpha1/deep_copy_generated.go
@@ -153,7 +153,7 @@ func DeepCopy_v1alpha1_PolicyRule(in PolicyRule, out *PolicyRule, c *conversion.
 	}
 	if in.Resources != nil {
 		in, out := in.Resources, &out.Resources
-		*out = make([]string, len(in))
+		*out = make(Resources, len(in))
 		copy(*out, in)
 	} else {
 		out.Resources = nil

--- a/pkg/apis/rbac/v1alpha1/generated.pb.go
+++ b/pkg/apis/rbac/v1alpha1/generated.pb.go
@@ -30,6 +30,7 @@ limitations under the License.
 		ClusterRoleBindingList
 		ClusterRoleList
 		PolicyRule
+		Resources
 		Role
 		RoleBinding
 		RoleBindingList
@@ -69,6 +70,10 @@ func (m *PolicyRule) Reset()         { *m = PolicyRule{} }
 func (m *PolicyRule) String() string { return proto.CompactTextString(m) }
 func (*PolicyRule) ProtoMessage()    {}
 
+func (m *Resources) Reset()         { *m = Resources{} }
+func (m *Resources) String() string { return proto.CompactTextString(m) }
+func (*Resources) ProtoMessage()    {}
+
 func (m *Role) Reset()         { *m = Role{} }
 func (m *Role) String() string { return proto.CompactTextString(m) }
 func (*Role) ProtoMessage()    {}
@@ -95,6 +100,7 @@ func init() {
 	proto.RegisterType((*ClusterRoleBindingList)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.ClusterRoleBindingList")
 	proto.RegisterType((*ClusterRoleList)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.ClusterRoleList")
 	proto.RegisterType((*PolicyRule)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.PolicyRule")
+	proto.RegisterType((*Resources)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.Resources")
 	proto.RegisterType((*Role)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.Role")
 	proto.RegisterType((*RoleBinding)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.RoleBinding")
 	proto.RegisterType((*RoleBindingList)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.RoleBindingList")
@@ -314,20 +320,15 @@ func (m *PolicyRule) MarshalTo(data []byte) (int, error) {
 			i += copy(data[i:], s)
 		}
 	}
-	if len(m.Resources) > 0 {
-		for _, s := range m.Resources {
-			data[i] = 0x22
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				data[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			data[i] = uint8(l)
-			i++
-			i += copy(data[i:], s)
+	if m.Resources != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintGenerated(data, i, uint64(m.Resources.Size()))
+		n7, err := m.Resources.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
 		}
+		i += n7
 	}
 	if len(m.ResourceNames) > 0 {
 		for _, s := range m.ResourceNames {
@@ -362,6 +363,39 @@ func (m *PolicyRule) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m Resources) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m Resources) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m) > 0 {
+		for _, s := range m {
+			data[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				data[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			data[i] = uint8(l)
+			i++
+			i += copy(data[i:], s)
+		}
+	}
+	return i, nil
+}
+
 func (m *Role) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -380,11 +414,11 @@ func (m *Role) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n7, err := m.ObjectMeta.MarshalTo(data[i:])
+	n8, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n8
 	if len(m.Rules) > 0 {
 		for _, msg := range m.Rules {
 			data[i] = 0x12
@@ -418,11 +452,11 @@ func (m *RoleBinding) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n8, err := m.ObjectMeta.MarshalTo(data[i:])
+	n9, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n8
+	i += n9
 	if len(m.Subjects) > 0 {
 		for _, msg := range m.Subjects {
 			data[i] = 0x12
@@ -438,11 +472,11 @@ func (m *RoleBinding) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.RoleRef.Size()))
-	n9, err := m.RoleRef.MarshalTo(data[i:])
+	n10, err := m.RoleRef.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n10
 	return i, nil
 }
 
@@ -464,11 +498,11 @@ func (m *RoleBindingList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n10, err := m.ListMeta.MarshalTo(data[i:])
+	n11, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n10
+	i += n11
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -502,11 +536,11 @@ func (m *RoleList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n11, err := m.ListMeta.MarshalTo(data[i:])
+	n12, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n11
+	i += n12
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -658,11 +692,9 @@ func (m *PolicyRule) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
-	if len(m.Resources) > 0 {
-		for _, s := range m.Resources {
-			l = len(s)
-			n += 1 + l + sovGenerated(uint64(l))
-		}
+	if m.Resources != nil {
+		l = m.Resources.Size()
+		n += 1 + l + sovGenerated(uint64(l))
 	}
 	if len(m.ResourceNames) > 0 {
 		for _, s := range m.ResourceNames {
@@ -672,6 +704,18 @@ func (m *PolicyRule) Size() (n int) {
 	}
 	if len(m.NonResourceURLs) > 0 {
 		for _, s := range m.NonResourceURLs {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m Resources) Size() (n int) {
+	var l int
+	_ = l
+	if len(m) > 0 {
+		for _, s := range m {
 			l = len(s)
 			n += 1 + l + sovGenerated(uint64(l))
 		}
@@ -1359,7 +1403,7 @@ func (m *PolicyRule) Unmarshal(data []byte) error {
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Resources", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowGenerated
@@ -1369,20 +1413,24 @@ func (m *PolicyRule) Unmarshal(data []byte) error {
 				}
 				b := data[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				msglen |= (int(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return ErrInvalidLengthGenerated
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Resources = append(m.Resources, string(data[iNdEx:postIndex]))
+			if m.Resources == nil {
+				m.Resources = Resources{}
+			}
+			if err := m.Resources.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -1441,6 +1489,85 @@ func (m *PolicyRule) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.NonResourceURLs = append(m.NonResourceURLs, string(data[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Resources) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Resources: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Resources: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Items", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			*m = append(*m, string(data[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/rbac/v1alpha1/generated.proto
+++ b/pkg/apis/rbac/v1alpha1/generated.proto
@@ -86,7 +86,7 @@ message PolicyRule {
   repeated string apiGroups = 3;
 
   // Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
-  repeated string resources = 4;
+  optional Resources resources = 4;
 
   // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
   repeated string resourceNames = 5;
@@ -95,6 +95,12 @@ message PolicyRule {
   // This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.
   // Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
   repeated string nonResourceURLs = 6;
+}
+
+// +protobuf.nullable=true
+message Resources {
+  // items, if empty, will result in an empty slice
+  repeated string items = 1;
 }
 
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.

--- a/pkg/apis/rbac/v1alpha1/types.generated.go
+++ b/pkg/apis/rbac/v1alpha1/types.generated.go
@@ -198,12 +198,7 @@ func (x *PolicyRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Resources == nil {
 					r.EncodeNil()
 				} else {
-					yym15 := z.EncBinary()
-					_ = yym15
-					if false {
-					} else {
-						z.F.EncSliceStringV(x.Resources, false, e)
-					}
+					x.Resources.CodecEncodeSelf(e)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
@@ -212,12 +207,7 @@ func (x *PolicyRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Resources == nil {
 					r.EncodeNil()
 				} else {
-					yym16 := z.EncBinary()
-					_ = yym16
-					if false {
-					} else {
-						z.F.EncSliceStringV(x.Resources, false, e)
-					}
+					x.Resources.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -391,35 +381,30 @@ func (x *PolicyRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Resources = nil
 			} else {
 				yyv10 := &x.Resources
-				yym11 := z.DecBinary()
-				_ = yym11
-				if false {
-				} else {
-					z.F.DecSliceStringX(yyv10, false, d)
-				}
+				yyv10.CodecDecodeSelf(d)
 			}
 		case "resourceNames":
 			if r.TryDecodeAsNil() {
 				x.ResourceNames = nil
 			} else {
-				yyv12 := &x.ResourceNames
-				yym13 := z.DecBinary()
-				_ = yym13
+				yyv11 := &x.ResourceNames
+				yym12 := z.DecBinary()
+				_ = yym12
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv12, false, d)
+					z.F.DecSliceStringX(yyv11, false, d)
 				}
 			}
 		case "nonResourceURLs":
 			if r.TryDecodeAsNil() {
 				x.NonResourceURLs = nil
 			} else {
-				yyv14 := &x.NonResourceURLs
-				yym15 := z.DecBinary()
-				_ = yym15
+				yyv13 := &x.NonResourceURLs
+				yym14 := z.DecBinary()
+				_ = yym14
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv14, false, d)
+					z.F.DecSliceStringX(yyv13, false, d)
 				}
 			}
 		default:
@@ -433,16 +418,16 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj16 int
-	var yyb16 bool
-	var yyhl16 bool = l >= 0
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	var yyj15 int
+	var yyb15 bool
+	var yyhl15 bool = l >= 0
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -450,21 +435,21 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Verbs = nil
 	} else {
-		yyv17 := &x.Verbs
-		yym18 := z.DecBinary()
-		_ = yym18
+		yyv16 := &x.Verbs
+		yym17 := z.DecBinary()
+		_ = yym17
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv17, false, d)
+			z.F.DecSliceStringX(yyv16, false, d)
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -472,24 +457,24 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.AttributeRestrictions = pkg1_runtime.RawExtension{}
 	} else {
-		yyv19 := &x.AttributeRestrictions
-		yym20 := z.DecBinary()
-		_ = yym20
+		yyv18 := &x.AttributeRestrictions
+		yym19 := z.DecBinary()
+		_ = yym19
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv19) {
-		} else if !yym20 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv19)
+		} else if z.HasExtensions() && z.DecExt(yyv18) {
+		} else if !yym19 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv18)
 		} else {
-			z.DecFallback(yyv19, false)
+			z.DecFallback(yyv18, false)
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -497,21 +482,21 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.APIGroups = nil
 	} else {
-		yyv21 := &x.APIGroups
-		yym22 := z.DecBinary()
-		_ = yym22
+		yyv20 := &x.APIGroups
+		yym21 := z.DecBinary()
+		_ = yym21
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv21, false, d)
+			z.F.DecSliceStringX(yyv20, false, d)
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -519,21 +504,16 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Resources = nil
 	} else {
-		yyv23 := &x.Resources
-		yym24 := z.DecBinary()
-		_ = yym24
-		if false {
-		} else {
-			z.F.DecSliceStringX(yyv23, false, d)
-		}
+		yyv22 := &x.Resources
+		yyv22.CodecDecodeSelf(d)
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -541,21 +521,21 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ResourceNames = nil
 	} else {
-		yyv25 := &x.ResourceNames
-		yym26 := z.DecBinary()
-		_ = yym26
+		yyv23 := &x.ResourceNames
+		yym24 := z.DecBinary()
+		_ = yym24
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv25, false, d)
+			z.F.DecSliceStringX(yyv23, false, d)
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj15++
+	if yyhl15 {
+		yyb15 = yyj15 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb15 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb15 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -563,28 +543,58 @@ func (x *PolicyRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.NonResourceURLs = nil
 	} else {
-		yyv27 := &x.NonResourceURLs
-		yym28 := z.DecBinary()
-		_ = yym28
+		yyv25 := &x.NonResourceURLs
+		yym26 := z.DecBinary()
+		_ = yym26
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv27, false, d)
+			z.F.DecSliceStringX(yyv25, false, d)
 		}
 	}
 	for {
-		yyj16++
-		if yyhl16 {
-			yyb16 = yyj16 > l
+		yyj15++
+		if yyhl15 {
+			yyb15 = yyj15 > l
 		} else {
-			yyb16 = r.CheckBreak()
+			yyb15 = r.CheckBreak()
 		}
-		if yyb16 {
+		if yyb15 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj16-1, "")
+		z.DecStructFieldNotFound(yyj15-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x Resources) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1 := z.EncBinary()
+		_ = yym1
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			h.encResources((Resources)(x), e)
+		}
+	}
+}
+
+func (x *Resources) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1 := z.DecBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		h.decResources((*Resources)(x), d)
+	}
 }
 
 func (x *Subject) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3610,6 +3620,121 @@ func (x *ClusterRoleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		z.DecStructFieldNotFound(yyj10-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) encResources(v Resources, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv1 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+		yym2 := z.EncBinary()
+		_ = yym2
+		if false {
+		} else {
+			r.EncodeString(codecSelferC_UTF81234, string(yyv1))
+		}
+	}
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) decResources(v *Resources, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv1 := *v
+	yyh1, yyl1 := z.DecSliceHelperStart()
+	var yyc1 bool
+	_ = yyc1
+	if yyl1 == 0 {
+		if yyv1 == nil {
+			yyv1 = []string{}
+			yyc1 = true
+		} else if len(yyv1) != 0 {
+			yyv1 = yyv1[:0]
+			yyc1 = true
+		}
+	} else if yyl1 > 0 {
+		var yyrr1, yyrl1 int
+		var yyrt1 bool
+		_, _ = yyrl1, yyrt1
+		yyrr1 = yyl1 // len(yyv1)
+		if yyl1 > cap(yyv1) {
+
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1 {
+				if yyrl1 <= cap(yyv1) {
+					yyv1 = yyv1[:yyrl1]
+				} else {
+					yyv1 = make([]string, yyrl1)
+				}
+			} else {
+				yyv1 = make([]string, yyrl1)
+			}
+			yyc1 = true
+			yyrr1 = len(yyv1)
+		} else if yyl1 != len(yyv1) {
+			yyv1 = yyv1[:yyl1]
+			yyc1 = true
+		}
+		yyj1 := 0
+		for ; yyj1 < yyrr1; yyj1++ {
+			yyh1.ElemContainerState(yyj1)
+			if r.TryDecodeAsNil() {
+				yyv1[yyj1] = ""
+			} else {
+				yyv1[yyj1] = string(r.DecodeString())
+			}
+
+		}
+		if yyrt1 {
+			for ; yyj1 < yyl1; yyj1++ {
+				yyv1 = append(yyv1, "")
+				yyh1.ElemContainerState(yyj1)
+				if r.TryDecodeAsNil() {
+					yyv1[yyj1] = ""
+				} else {
+					yyv1[yyj1] = string(r.DecodeString())
+				}
+
+			}
+		}
+
+	} else {
+		yyj1 := 0
+		for ; !r.CheckBreak(); yyj1++ {
+
+			if yyj1 >= len(yyv1) {
+				yyv1 = append(yyv1, "") // var yyz1 string
+				yyc1 = true
+			}
+			yyh1.ElemContainerState(yyj1)
+			if yyj1 < len(yyv1) {
+				if r.TryDecodeAsNil() {
+					yyv1[yyj1] = ""
+				} else {
+					yyv1[yyj1] = string(r.DecodeString())
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		if yyj1 < len(yyv1) {
+			yyv1 = yyv1[:yyj1]
+			yyc1 = true
+		} else if yyj1 == 0 && yyv1 == nil {
+			yyv1 = []string{}
+			yyc1 = true
+		}
+	}
+	yyh1.End()
+	if yyc1 {
+		*v = yyv1
+	}
 }
 
 func (x codecSelfer1234) encSlicePolicyRule(v []PolicyRule, e *codec1978.Encoder) {

--- a/pkg/apis/rbac/v1alpha1/types.go
+++ b/pkg/apis/rbac/v1alpha1/types.go
@@ -39,7 +39,7 @@ type PolicyRule struct {
 	// the enumerated resources in any API group will be allowed.
 	APIGroups []string `json:"apiGroups" protobuf:"bytes,3,rep,name=apiGroups"`
 	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
-	Resources []string `json:"resources" protobuf:"bytes,4,rep,name=resources"`
+	Resources Resources `json:"resources" protobuf:"bytes,4,rep,name=resources"`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string `json:"resourceNames,omitempty" protobuf:"bytes,5,rep,name=resourceNames"`
 	// NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
@@ -47,6 +47,9 @@ type PolicyRule struct {
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	NonResourceURLs []string `json:"nonResourceURLs,omitempty" protobuf:"bytes,6,rep,name=nonResourceURLs"`
 }
+
+// +protobuf.nullable=true
+type Resources []string
 
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.


### PR DESCRIPTION
The majority of our internal - external conversions are between identical types (memory identical, down to the individual field). This alters the generated conversions to use the unsafe package (optionally) to perform a direct copy of types with identical memory layout and size. The calculation to determine equality is identical types all the way down in the same order. Presence of a custom conversion at any level should terminate the equality check at that level.

Work still remaining:
- [ ] Ensure we have correct testing to catch any issues
- [ ] Add the check that if a conversion or defaulter is registered anywhere down the chain we treat them not the same
- [ ] Identify types that are not optimally aligned and align them
- [ ] Move defaulters up the stack (top level defaulter?)
- [ ] Allow both unsafe and safe versions to be compiled in if necessary so that clients that run where unsafe is not allowed can run

The first five commits are from the optional slices pr #27258

```
benchmark                                      old ns/op     new ns/op     delta
BenchmarkPodConversion-8                       8629          3286          -61.92%
BenchmarkNodeConversion-8                      4986          2056          -58.76%
BenchmarkReplicationControllerConversion-8     4018          3129          -22.13%
BenchmarkEncodeCodecFromInternalProtobuf-8     12765         9040          -29.18%
BenchmarkDecodeCodecToInternalProtobuf-8       19052         14624         -23.24%
BenchmarkEncodeCodecFromInternal-8             43218         39110         -9.51%
BenchmarkDecodeCodec-8                         111268        95846         -13.86%

benchmark                                      old allocs     new allocs     delta
BenchmarkPodConversion-8                       49             12             -75.51%
BenchmarkNodeConversion-8                      18             6              -66.67%
BenchmarkReplicationControllerConversion-8     20             14             -30.00%
BenchmarkEncodeCodecFromInternalProtobuf-8     32             9              -71.88%
BenchmarkDecodeCodecToInternalProtobuf-8       132            109            -17.42%
BenchmarkEncodeCodecFromInternal-8             101            78             -22.77%
BenchmarkDecodeCodec-8                         384            361            -5.99%

benchmark                                      old bytes     new bytes     delta
BenchmarkPodConversion-8                       6338          2446          -61.41%
BenchmarkNodeConversion-8                      4560          1456          -68.07%
BenchmarkReplicationControllerConversion-8     3056          2672          -12.57%
BenchmarkEncodeCodecFromInternalProtobuf-8     7200          4800          -33.33%
BenchmarkDecodeCodecToInternalProtobuf-8       10345         7944          -23.21%
BenchmarkEncodeCodecFromInternal-8             11071         8640          -21.96%
BenchmarkDecodeCodec-8                         19313         16913         -12.43%
```

@kubernetes/sig-api-machinery

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27659)

<!-- Reviewable:end -->
