### PR TITLE
AWS kube-up: set net.ipv4.neigh.default.gc_thresh1=0 to avoid ARP over-caching

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -23,6 +23,20 @@ pkg-core:
       - git
 {% endif %}
 
+# Fix ARP cache issues on AWS by setting net.ipv4.neigh.default.gc_thresh1=0
+# See issue #23395
+{% if grains.get('cloud') == 'aws' %}
+# Work around Salt #18089: https://github.com/saltstack/salt/issues/18089
+# (we also have to give it a different id from the same fix elsewhere)
+99-salt-conf-with-a-different-id:
+  file.touch:
+    - name: /etc/sysctl.d/99-salt.conf
+
+net.ipv4.neigh.default.gc_thresh1:
+  sysctl.present:
+    - value: 0
+{% endif %}
+
 /usr/local/share/doc/kubernetes:
   file.directory:
     - user: root


### PR DESCRIPTION
This works around a linux kernel bug with overly aggressive caching of
ARP entries, which was causing problems when we reused IP addresses in
VPCs, for example with an ASG in a relatively small subnet.

See #23395 for more explanation.

Fixes #23395
