### PR TITLE
Fix broken links in on-call-user-support.md

### DIFF
--- a/docs/devel/on-call-user-support.md
+++ b/docs/devel/on-call-user-support.md
@@ -91,8 +91,8 @@ ensure your questions don't go unanswered.
 Before posting a new question, please search stackoverflow for answers to
 similar questions, and also familiarize yourself with:
 
-  * [user guide](http://kubernetes.io/v1.1/)
-  * [troubleshooting guide](http://kubernetes.io/v1.1/docs/troubleshooting.html)
+  * [user guide](http://kubernetes.io/docs/user-guide/)
+  * [troubleshooting guide](http://kubernetes.io/docs/troubleshooting/)
 
 Again, thanks for using Kubernetes.
 


### PR DESCRIPTION
Links in `Example response` are broken.
