### PR TITLE
Fix hack/update-api-reference-docs on master and (future) branches

### DIFF
--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -400,10 +400,10 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <p><a href="#_v1beta1_thirdpartyresourcelist">v1beta1.ThirdPartyResourceList</a></p>
 </li>
 <li>
-<p><a href="#_v1beta1_daemonset">v1beta1.DaemonSet</a></p>
+<p><a href="#_v1beta1_daemonsetlist">v1beta1.DaemonSetList</a></p>
 </li>
 <li>
-<p><a href="#_v1beta1_daemonsetlist">v1beta1.DaemonSetList</a></p>
+<p><a href="#_v1beta1_daemonset">v1beta1.DaemonSet</a></p>
 </li>
 <li>
 <p><a href="#_v1beta1_ingress">v1beta1.Ingress</a></p>
@@ -6093,7 +6093,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-06 17:05:19 UTC
+Last updated 2016-06-20 07:50:53 UTC
 </div>
 </div>
 </body>

--- a/hack/gen-swagger-doc/Dockerfile
+++ b/hack/gen-swagger-doc/Dockerfile
@@ -28,12 +28,12 @@ COPY build.gradle build/
 COPY gen-swagger-docs.sh build/
 
 #run the script once to download the dependent java libraries into the image
-RUN mkdir /output
-RUN mkdir /swagger-source
+RUN mkdir /output /swagger-source
 RUN wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/swagger-spec/v1.json -O /swagger-source/v1.json
-RUN build/gen-swagger-docs.sh v1 https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/pkg/api/v1/register.go
-RUN rm /output/*
-RUN rm /swagger-source/*
+RUN wget https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/pkg/api/v1/register.go -O /register.go
+RUN build/gen-swagger-docs.sh v1
+RUN rm /output/* /swagger-source/* /register.go
+
 RUN chmod -R 777 build/
 RUN chmod -R 777 gradle-cache/
 

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -22,16 +22,6 @@ set -o pipefail
 
 cd /build
 
-# wget doesn't retry on 503, so adding a loop to make it more resilient.
-for i in {1..3}; do
-  if wget "$2" -O register.go; then
-    break
-  fi
-  if [ $i -eq 3 ]; then
-    exit 1
-  fi
-done
-
 # gendocs takes "input.json" as the input swagger spec.
 # $1 is expected to be <group>_<version>
 cp /swagger-source/"$1".json input.json
@@ -40,8 +30,7 @@ cp /swagger-source/"$1".json input.json
 
 #insert a TOC for top level API objects
 buf="== Top Level API Objects\n\n"
-top_level_models=$(grep GetObjectKind ./register.go | sed 's/func (obj \*\(.*\)) GetObjectKind(\(.*\)) .*/\1/g' \
-    | tr -d '()' | tr -d '{}' | tr -d ' ')
+top_level_models=$(grep '&[A-Za-z]*{},' /register.go | sed 's/.*&//;s/{},//')
 
 # check if the top level models exist in the definitions.adoc. If they exist,
 # their name will be <version>.<model_name>

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -60,20 +60,19 @@ fi
 
 for ver in $VERSIONS; do
   TMP_IN_HOST="${OUTPUT_TMP_IN_HOST}/${ver}"
-  REGISTER_FILE_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg"
   if [[ ${ver} == "v1" ]]; then
-    REGISTER_FILE_URL="${REGISTER_FILE_URL}/api/${ver}/register.go"
+    REGISTER_FILE="${REPO_DIR}/pkg/api/${ver}/register.go"
   else
-    REGISTER_FILE_URL="${REGISTER_FILE_URL}/apis/${ver}/register.go"
+    REGISTER_FILE="${REPO_DIR}/pkg/apis/${ver}/register.go"
   fi
   SWAGGER_JSON_NAME="$(kube::util::gv-to-swagger-name "${ver}")"
 
   docker run ${user_flags} \
     --rm -v "${TMP_IN_HOST}":/output:z \
     -v "${SWAGGER_PATH}":/swagger-source:z \
-    gcr.io/google_containers/gen-swagger-docs:v5 \
-    "${SWAGGER_JSON_NAME}" \
-    "${REGISTER_FILE_URL}"
+    -v "${REGISTER_FILE}":/register.go:z \
+    gcr.io/google_containers/gen-swagger-docs:v6 \
+    "${SWAGGER_JSON_NAME}"
 done
 
 # Check if we actually changed anything

--- a/hack/verify-api-reference-docs.sh
+++ b/hack/verify-api-reference-docs.sh
@@ -25,9 +25,6 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-# TODO: Remove when #27685 is fixed. Disable this test until then.
-exit 0
-
 API_REFERENCE_DOCS_ROOT="${KUBE_ROOT}/docs/api-reference"
 OUTPUT_DIR="${KUBE_ROOT}/_tmp/api-reference"
 mkdir -p ${OUTPUT_DIR}


### PR DESCRIPTION
- update toplevel api object pattern in swagger doc script: the format of the `register.go` file was changed in https://github.com/kubernetes/kubernetes/pull/27168/commits/e3af3451c8445639c33644bbcbdc94da16968b87. This fixes the bleeding.
- make `hack/update-api-reference-docs.sh` independent from master during **container run**. Container build is still dependent on master, but container rebuilds never happen I guess on a branch.

A rebuild of `gcr.io/google_containers/gen-swagger-docs:v6` is necessary, plus a cherry-pick onto the v1.3 branch.

Fixes the symptoms of #27685 and makes sure future branches do not break again.
