### PR TITLE
Fix top level models lookup in update-api-reference-docs.sh

### DIFF
--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -370,6 +370,12 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
+<p><a href="#_v1beta1_daemonset">v1beta1.DaemonSet</a></p>
+</li>
+<li>
+<p><a href="#_v1beta1_daemonsetlist">v1beta1.DaemonSetList</a></p>
+</li>
+<li>
 <p><a href="#_v1beta1_deployment">v1beta1.Deployment</a></p>
 </li>
 <li>
@@ -385,10 +391,22 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <p><a href="#_v1beta1_horizontalpodautoscalerlist">v1beta1.HorizontalPodAutoscalerList</a></p>
 </li>
 <li>
+<p><a href="#_v1beta1_ingress">v1beta1.Ingress</a></p>
+</li>
+<li>
+<p><a href="#_v1beta1_ingresslist">v1beta1.IngressList</a></p>
+</li>
+<li>
 <p><a href="#_v1beta1_job">v1beta1.Job</a></p>
 </li>
 <li>
 <p><a href="#_v1beta1_joblist">v1beta1.JobList</a></p>
+</li>
+<li>
+<p><a href="#_v1beta1_replicaset">v1beta1.ReplicaSet</a></p>
+</li>
+<li>
+<p><a href="#_v1beta1_replicasetlist">v1beta1.ReplicaSetList</a></p>
 </li>
 <li>
 <p><a href="#_v1beta1_scale">v1beta1.Scale</a></p>
@@ -398,24 +416,6 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </li>
 <li>
 <p><a href="#_v1beta1_thirdpartyresourcelist">v1beta1.ThirdPartyResourceList</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_daemonset">v1beta1.DaemonSet</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_daemonsetlist">v1beta1.DaemonSetList</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_ingress">v1beta1.Ingress</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_ingresslist">v1beta1.IngressList</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_replicaset">v1beta1.ReplicaSet</a></p>
-</li>
-<li>
-<p><a href="#_v1beta1_replicasetlist">v1beta1.ReplicaSetList</a></p>
 </li>
 </ul>
 </div>
@@ -6093,7 +6093,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-06 17:05:19 UTC
+Last updated 2016-06-20 08:32:04 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -370,6 +370,66 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
+<p><a href="#_v1_binding">v1.Binding</a></p>
+</li>
+<li>
+<p><a href="#_v1_componentstatus">v1.ComponentStatus</a></p>
+</li>
+<li>
+<p><a href="#_v1_componentstatuslist">v1.ComponentStatusList</a></p>
+</li>
+<li>
+<p><a href="#_v1_configmap">v1.ConfigMap</a></p>
+</li>
+<li>
+<p><a href="#_v1_configmaplist">v1.ConfigMapList</a></p>
+</li>
+<li>
+<p><a href="#_v1_deleteoptions">v1.DeleteOptions</a></p>
+</li>
+<li>
+<p><a href="#_v1_endpoints">v1.Endpoints</a></p>
+</li>
+<li>
+<p><a href="#_v1_endpointslist">v1.EndpointsList</a></p>
+</li>
+<li>
+<p><a href="#_v1_event">v1.Event</a></p>
+</li>
+<li>
+<p><a href="#_v1_eventlist">v1.EventList</a></p>
+</li>
+<li>
+<p><a href="#_v1_limitrange">v1.LimitRange</a></p>
+</li>
+<li>
+<p><a href="#_v1_limitrangelist">v1.LimitRangeList</a></p>
+</li>
+<li>
+<p><a href="#_v1_namespace">v1.Namespace</a></p>
+</li>
+<li>
+<p><a href="#_v1_namespacelist">v1.NamespaceList</a></p>
+</li>
+<li>
+<p><a href="#_v1_node">v1.Node</a></p>
+</li>
+<li>
+<p><a href="#_v1_nodelist">v1.NodeList</a></p>
+</li>
+<li>
+<p><a href="#_v1_persistentvolume">v1.PersistentVolume</a></p>
+</li>
+<li>
+<p><a href="#_v1_persistentvolumeclaim">v1.PersistentVolumeClaim</a></p>
+</li>
+<li>
+<p><a href="#_v1_persistentvolumeclaimlist">v1.PersistentVolumeClaimList</a></p>
+</li>
+<li>
+<p><a href="#_v1_persistentvolumelist">v1.PersistentVolumeList</a></p>
+</li>
+<li>
 <p><a href="#_v1_pod">v1.Pod</a></p>
 </li>
 <li>
@@ -388,49 +448,10 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <p><a href="#_v1_replicationcontrollerlist">v1.ReplicationControllerList</a></p>
 </li>
 <li>
-<p><a href="#_v1_service">v1.Service</a></p>
-</li>
-<li>
-<p><a href="#_v1_servicelist">v1.ServiceList</a></p>
-</li>
-<li>
-<p><a href="#_v1_endpoints">v1.Endpoints</a></p>
-</li>
-<li>
-<p><a href="#_v1_endpointslist">v1.EndpointsList</a></p>
-</li>
-<li>
-<p><a href="#_v1_node">v1.Node</a></p>
-</li>
-<li>
-<p><a href="#_v1_nodelist">v1.NodeList</a></p>
-</li>
-<li>
-<p><a href="#_v1_binding">v1.Binding</a></p>
-</li>
-<li>
-<p><a href="#_v1_event">v1.Event</a></p>
-</li>
-<li>
-<p><a href="#_v1_eventlist">v1.EventList</a></p>
-</li>
-<li>
-<p><a href="#_v1_limitrange">v1.LimitRange</a></p>
-</li>
-<li>
-<p><a href="#_v1_limitrangelist">v1.LimitRangeList</a></p>
-</li>
-<li>
 <p><a href="#_v1_resourcequota">v1.ResourceQuota</a></p>
 </li>
 <li>
 <p><a href="#_v1_resourcequotalist">v1.ResourceQuotaList</a></p>
-</li>
-<li>
-<p><a href="#_v1_namespace">v1.Namespace</a></p>
-</li>
-<li>
-<p><a href="#_v1_namespacelist">v1.NamespaceList</a></p>
 </li>
 <li>
 <p><a href="#_v1_secret">v1.Secret</a></p>
@@ -439,37 +460,16 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <p><a href="#_v1_secretlist">v1.SecretList</a></p>
 </li>
 <li>
+<p><a href="#_v1_service">v1.Service</a></p>
+</li>
+<li>
 <p><a href="#_v1_serviceaccount">v1.ServiceAccount</a></p>
 </li>
 <li>
 <p><a href="#_v1_serviceaccountlist">v1.ServiceAccountList</a></p>
 </li>
 <li>
-<p><a href="#_v1_persistentvolume">v1.PersistentVolume</a></p>
-</li>
-<li>
-<p><a href="#_v1_persistentvolumelist">v1.PersistentVolumeList</a></p>
-</li>
-<li>
-<p><a href="#_v1_persistentvolumeclaim">v1.PersistentVolumeClaim</a></p>
-</li>
-<li>
-<p><a href="#_v1_persistentvolumeclaimlist">v1.PersistentVolumeClaimList</a></p>
-</li>
-<li>
-<p><a href="#_v1_deleteoptions">v1.DeleteOptions</a></p>
-</li>
-<li>
-<p><a href="#_v1_componentstatus">v1.ComponentStatus</a></p>
-</li>
-<li>
-<p><a href="#_v1_componentstatuslist">v1.ComponentStatusList</a></p>
-</li>
-<li>
-<p><a href="#_v1_configmap">v1.ConfigMap</a></p>
-</li>
-<li>
-<p><a href="#_v1_configmaplist">v1.ConfigMapList</a></p>
+<p><a href="#_v1_servicelist">v1.ServiceList</a></p>
 </li>
 </ul>
 </div>
@@ -8105,7 +8105,7 @@ The resulting set of endpoints can be viewed as:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-08 04:10:38 UTC
+Last updated 2016-06-20 08:31:58 UTC
 </div>
 </div>
 </body>

--- a/hack/gen-swagger-doc/Dockerfile
+++ b/hack/gen-swagger-doc/Dockerfile
@@ -31,7 +31,7 @@ COPY gen-swagger-docs.sh build/
 RUN mkdir /output
 RUN mkdir /swagger-source
 RUN wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/swagger-spec/v1.json -O /swagger-source/v1.json
-RUN build/gen-swagger-docs.sh v1 https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/pkg/api/v1/register.go
+RUN build/gen-swagger-docs.sh v1 https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/pkg/api/v1/types.go
 RUN rm /output/*
 RUN rm /swagger-source/*
 RUN chmod -R 777 build/

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -24,7 +24,7 @@ cd /build
 
 # wget doesn't retry on 503, so adding a loop to make it more resilient.
 for i in {1..3}; do
-  if wget "$2" -O register.go; then
+  if wget "$2" -O types.go; then
     break
   fi
   if [ $i -eq 3 ]; then
@@ -40,8 +40,7 @@ cp /swagger-source/"$1".json input.json
 
 #insert a TOC for top level API objects
 buf="== Top Level API Objects\n\n"
-top_level_models=$(grep GetObjectKind ./register.go | sed 's/func (obj \*\(.*\)) GetObjectKind(\(.*\)) .*/\1/g' \
-    | tr -d '()' | tr -d '{}' | tr -d ' ')
+top_level_models=$(grep -B 1 "unversioned\.TypeMeta" ./types.go | awk '/type/{print $2;}' | sort)
 
 # check if the top level models exist in the definitions.adoc. If they exist,
 # their name will be <version>.<model_name>

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -60,11 +60,11 @@ fi
 
 for ver in $VERSIONS; do
   TMP_IN_HOST="${OUTPUT_TMP_IN_HOST}/${ver}"
-  REGISTER_FILE_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg"
+  TYPES_FILE_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg"
   if [[ ${ver} == "v1" ]]; then
-    REGISTER_FILE_URL="${REGISTER_FILE_URL}/api/${ver}/register.go"
+    TYPES_FILE_URL="${TYPES_FILE_URL}/api/${ver}/types.go"
   else
-    REGISTER_FILE_URL="${REGISTER_FILE_URL}/apis/${ver}/register.go"
+    TYPES_FILE_URL="${TYPES_FILE_URL}/apis/${ver}/types.go"
   fi
   SWAGGER_JSON_NAME="$(kube::util::gv-to-swagger-name "${ver}")"
 
@@ -73,7 +73,7 @@ for ver in $VERSIONS; do
     -v "${SWAGGER_PATH}":/swagger-source:z \
     gcr.io/google_containers/gen-swagger-docs:v5 \
     "${SWAGGER_JSON_NAME}" \
-    "${REGISTER_FILE_URL}"
+    "${TYPES_FILE_URL}"
 done
 
 # Check if we actually changed anything


### PR DESCRIPTION
The following commit[1] removed GetObjectKind methods from register.go, which resulted in update-api-reference-docs.sh errors. That's because this script looked up for top level models by searching type names in GetObjectKind receivers.

To make this script working again, another way for models lookup is needed, so this commit provides a lookup based on types.go file.

Changes in generated swagger docs occur because of the changed way of ordering of model names.

[1] https://github.com/kubernetes/kubernetes/commit/e3af3451c8445639c33644bbcbdc94da16968b87

Fixes #27705
