### PR TITLE
Cover port_allocator_test with more conditions

### DIFF
--- a/pkg/proxy/userspace/port_allocator_test.go
+++ b/pkg/proxy/userspace/port_allocator_test.go
@@ -37,7 +37,9 @@ func TestRangeAllocatorEmpty(t *testing.T) {
 func TestRangeAllocatorFullyAllocated(t *testing.T) {
 	r := &net.PortRange{}
 	r.Set("1-1")
-	a := newPortRangeAllocator(*r)
+	pra := newPortRangeAllocator(*r)
+	a := pra.(*rangeAllocator)
+
 	p, err := a.AllocateNext()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -46,12 +48,26 @@ func TestRangeAllocatorFullyAllocated(t *testing.T) {
 		t.Fatalf("unexpected allocated port: %d", p)
 	}
 
+	a.lock.Lock()
+	if bit := a.used.Bit(p - a.Base); bit != 1 {
+		a.lock.Unlock()
+		t.Fatalf("unexpected used bit for allocated port: %d", p)
+	}
+	a.lock.Unlock()
+
 	_, err = a.AllocateNext()
 	if err == nil {
 		t.Fatalf("expected error because of fully-allocated range")
 	}
 
 	a.Release(p)
+	a.lock.Lock()
+	if bit := a.used.Bit(p - a.Base); bit != 0 {
+		a.lock.Unlock()
+		t.Fatalf("unexpected used bit for allocated port: %d", p)
+	}
+	a.lock.Unlock()
+
 	p, err = a.AllocateNext()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -59,6 +75,12 @@ func TestRangeAllocatorFullyAllocated(t *testing.T) {
 	if p != 1 {
 		t.Fatalf("unexpected allocated port: %d", p)
 	}
+	a.lock.Lock()
+	if bit := a.used.Bit(p - a.Base); bit != 1 {
+		a.lock.Unlock()
+		t.Fatalf("unexpected used bit for allocated port: %d", p)
+	}
+	a.lock.Unlock()
 
 	_, err = a.AllocateNext()
 	if err == nil {
@@ -69,7 +91,8 @@ func TestRangeAllocatorFullyAllocated(t *testing.T) {
 func TestRangeAllocator_RandomishAllocation(t *testing.T) {
 	r := &net.PortRange{}
 	r.Set("1-100")
-	a := newPortRangeAllocator(*r)
+	pra := newPortRangeAllocator(*r)
+	a := pra.(*rangeAllocator)
 
 	// allocate all the ports
 	var err error
@@ -79,11 +102,26 @@ func TestRangeAllocator_RandomishAllocation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		if ports[i] < 1 || ports[i] > 100 {
+			t.Fatalf("unexpected allocated port: %d", ports[i])
+		}
+		a.lock.Lock()
+		if bit := a.used.Bit(ports[i] - a.Base); bit != 1 {
+			a.lock.Unlock()
+			t.Fatalf("unexpected used bit for allocated port: %d", ports[i])
+		}
+		a.lock.Unlock()
 	}
 
 	// release them all
 	for i := 0; i < 100; i++ {
 		a.Release(ports[i])
+		a.lock.Lock()
+		if bit := a.used.Bit(ports[i] - a.Base); bit != 0 {
+			a.lock.Unlock()
+			t.Fatalf("unexpected used bit for allocated port: %d", ports[i])
+		}
+		a.lock.Unlock()
 	}
 
 	// allocate the ports again
@@ -93,6 +131,15 @@ func TestRangeAllocator_RandomishAllocation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		if rports[i] < 1 || rports[i] > 100 {
+			t.Fatalf("unexpected allocated port: %d", rports[i])
+		}
+		a.lock.Lock()
+		if bit := a.used.Bit(rports[i] - a.Base); bit != 1 {
+			a.lock.Unlock()
+			t.Fatalf("unexpected used bit for allocated port: %d", rports[i])
+		}
+		a.lock.Unlock()
 	}
 
 	if reflect.DeepEqual(ports, rports) {


### PR DESCRIPTION
The test cases of port_allocator_test should cover more conditions, such as `rangeAllocator.used.Bit`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27711)

<!-- Reviewable:end -->
