### PR TITLE
controller: wait for synced old replica sets on Recreate

### DIFF
--- a/pkg/util/replicaset/replicaset.go
+++ b/pkg/util/replicaset/replicaset.go
@@ -108,3 +108,25 @@ func MatchingPodsFunc(rs *extensions.ReplicaSet) (func(api.Pod) bool, error) {
 		return selector.Matches(podLabelsSelector)
 	}, nil
 }
+
+// ReplicaSetIsInactive returns a condition that will be true when a replica set is inactive ie.
+// it has zero running replicas.
+func ReplicaSetIsInactive(c unversionedextensions.ExtensionsInterface, replicaSet *extensions.ReplicaSet) wait.ConditionFunc {
+
+	// If we're given a ReplicaSet where the status lags the spec, it either means that the
+	// ReplicaSet is stale, or that the ReplicaSet manager hasn't noticed the update yet.
+	// Polling status.Replicas is not safe in the latter case.
+	desiredGeneration := replicaSet.Generation
+
+	return func() (bool, error) {
+		rs, err := c.ReplicaSets(replicaSet.Namespace).Get(replicaSet.Name)
+		if err != nil {
+			return false, err
+		}
+
+		return rs.Status.ObservedGeneration >= desiredGeneration &&
+			rs.Spec.Replicas == 0 &&
+			rs.Status.Replicas == 0 &&
+			rs.Status.FullyLabeledReplicas == 0, nil
+	}
+}


### PR DESCRIPTION
Partially fixes https://github.com/kubernetes/kubernetes/issues/27362

Any other work on it should be handled in the replica set level (and/or kubelet if it's required)

@kubernetes/deployment PTAL
