### PR TITLE
Make GCI_DOCKER_VERSION optional

### DIFF
--- a/cluster/gce/gci/helper.sh
+++ b/cluster/gce/gci/helper.sh
@@ -32,7 +32,7 @@ EOF
   fi
   if [[ ! -f "${KUBE_TEMP}/gci-docker-version.txt" ]]; then
     cat >"${KUBE_TEMP}/gci-docker-version.txt" << EOF
-${GCI_DOCKER_VERSION}
+${GCI_DOCKER_VERSION:-}
 EOF
   fi
 }


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

fixes #26813

This env var is only set in `config-test.sh` and trying to evaluate it with
`nounset` set will end up with an "unbound variable" error.

@girishkalele @dchen1107 This is a XS fix. Can you review?
