### PR TITLE
Check for an error before checking for nil.

### DIFF
--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -283,11 +283,11 @@ func (s *ServiceController) ensureDnsRecords(clusterName string, cachedService *
 	serviceName := cachedService.lastState.Name
 	namespaceName := cachedService.lastState.Namespace
 	zoneNames, regionName, err := s.getClusterZoneNames(clusterName)
-	if zoneNames == nil {
-		return fmt.Errorf("fail to get cluster zone names")
-	}
 	if err != nil {
 		return err
+	}
+	if zoneNames == nil {
+		return fmt.Errorf("failed to get cluster zone names")
 	}
 	dnsZoneName, err := s.getFederationDNSZoneName()
 	if err != nil {


### PR DESCRIPTION
The error object, if it exists, probably has more specific information
to hand to the caller.
