### PR TITLE
Fix block-local err bug in service_helper.go

### DIFF
--- a/federation/pkg/federation-controller/service/service_helper.go
+++ b/federation/pkg/federation-controller/service/service_helper.go
@@ -89,7 +89,8 @@ func (cc *clusterClientCache) syncService(key, clusterName string, clusterCache 
 
 	if needUpdate {
 		for i := 0; i < clientRetryCount; i++ {
-			if err := sc.ensureDnsRecords(clusterName, cachedService); err == nil {
+			err := sc.ensureDnsRecords(clusterName, cachedService)
+			if err == nil {
 				break
 			}
 			glog.V(4).Infof("Error ensuring DNS Records for service %s on cluster %s: %v", key, clusterName, err)


### PR DESCRIPTION
The real error message goes out of scope before we try to log it.
