### PR TITLE
Add cache-busting to the submit queue health badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Submit Queue Widget]][Submit Queue] [![GoReportCard Widget]][GoReportCard] [![GoDoc Widget]][GoDoc] [![Coverage Status Widget]][Coverage Status]
 
 [Submit Queue]: http://submit-queue.k8s.io/#/e2e
-[Submit Queue Widget]: http://submit-queue.k8s.io/health.svg
+[Submit Queue Widget]: http://submit-queue.k8s.io/health.svg?v=1
 [GoDoc]: https://godoc.org/k8s.io/kubernetes
 [GoDoc Widget]: https://godoc.org/k8s.io/kubernetes?status.svg
 [GoReportCard]: https://goreportcard.com/report/k8s.io/kubernetes


### PR DESCRIPTION
Github is caching an old version for a year. See kubernetes/contrib#1241
for more details.
