### PR TITLE
Fix port range checking, port should not be greater than 65535.

### DIFF
--- a/pkg/util/net/port_range.go
+++ b/pkg/util/net/port_range.go
@@ -71,12 +71,17 @@ func (pr *PortRange) Set(value string) error {
 		high, err = strconv.Atoi(value[hyphenIndex+1:])
 	}
 	if err != nil {
-		return fmt.Errorf("unable to parse port range: %s", value)
+		return fmt.Errorf("unable to parse port range: %s: %v", value, err)
+	}
+
+	if low > 65535 || high > 65535 {
+		return fmt.Errorf("the port range cannot be greater than 65535: %s", value)
 	}
 
 	if high < low {
 		return fmt.Errorf("end port cannot be less than start port: %s", value)
 	}
+
 	pr.Base = low
 	pr.Size = 1 + high - low
 	return nil

--- a/pkg/util/net/port_range_test.go
+++ b/pkg/util/net/port_range_test.go
@@ -38,6 +38,9 @@ func TestPortRange(t *testing.T) {
 		{"100 - 200", false, "", -1, -1},
 		{"-100", false, "", -1, -1},
 		{"100-", false, "", -1, -1},
+		{"200-100", false, "", -1, -1},
+		{"60000-70000", false, "", -1, -1},
+		{"70000-80000", false, "", -1, -1},
 	}
 
 	for i := range testCases {


### PR DESCRIPTION
When passing flag `--proxy-port-range` to kube-proxy with an invalid range which is greater than 65535, the proxy doesn't exit. That's not what we want.

Should we fix this in v1.3?
/cc @thockin @mikedanese @resouer 

Before fixing:

```
root@vm:/home/paas/zxp# kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=65536-65599 &
[6] 6671
root@vm:/home/paas/zxp# ps -ef | grep kube-proxy
root      6671 13507  0 03:48 pts/1    00:00:00 kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=65536-65599
```

After:

```
root@vm:/home/paas/zxp# kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=65536-65599 &
[6] 6725
root@vm:/home/paas/zxp# invalid argument "65536-65599" for --proxy-port-range=65536-65599: "65536-65599" is not a valid port range: the port range cannot be greater than 65535: 65536-65599
..............
[6]+  Exit 2                  kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=65536-65599
```

```
root@vm:/home/paas/zxp# kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=6000-65599 &
[6] 6732
root@vm:/home/paas/zxp# invalid argument "6000-65599" for --proxy-port-range=6000-65599: "6000-65599" is not a valid port range: the port range cannot be greater than 65535: 6000-65599
..............
[6]+  Exit 2                  kube-proxy --master=172.16.1.11:8080 --logtostderr=false --log-dir=/home/user/log/kube --proxy-port-range=6000-65599
```
