### PR TITLE
Rephrase 'pv not found in cache' warnings.

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -582,7 +582,7 @@ func (s *StoreToPVFetcher) GetPersistentVolumeInfo(id string) (*api.PersistentVo
 	}
 
 	if !exists {
-		return nil, fmt.Errorf("PersistentVolume '%v' is not in cache", id)
+		return nil, fmt.Errorf("PersistentVolume '%v' not found", id)
 	}
 
 	return o.(*api.PersistentVolume), nil
@@ -601,7 +601,7 @@ func (s *StoreToPVCFetcher) GetPersistentVolumeClaimInfo(namespace string, id st
 	}
 
 	if !exists {
-		return nil, fmt.Errorf("PersistentVolumeClaim '%s/%s' is not in cache", namespace, id)
+		return nil, fmt.Errorf("PersistentVolumeClaim '%s/%s' not found", namespace, id)
 	}
 
 	return o.(*api.PersistentVolumeClaim), nil

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -59,7 +59,7 @@ func (c *CachedNodeInfo) GetNodeInfo(id string) (*api.Node, error) {
 	}
 
 	if !exists {
-		return nil, fmt.Errorf("node '%v' is not in cache", id)
+		return nil, fmt.Errorf("node '%v' not found", id)
 	}
 
 	return node.(*api.Node), nil


### PR DESCRIPTION
When kubelet starts a pod that refers to non-existing PV, PVC or Node, it should clearly show that the requested element does not exist.

Previous `PersistentVolumeClaim 'default/ceph-claim-wm' is not in cache` looks like random kubelet hiccup, while `PersistentVolumeClaim 'default/ceph-claim-wm' not found` suggests that the object may not exist at all and it might be an user error.

Fixes #27523
