### PR TITLE
increase addon check interval

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,7 +15,7 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v3
+VERSION=v4
 
 # amd64 and arm has "stable" binaries pushed for v1.2, arm64 and ppc64le hasn't so they have to fetch the latest alpha
 # however, arm64 and ppc64le are very experimental right now, so it's okay

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -19,7 +19,7 @@
 # managed result is of that. Start everything below that directory.
 KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
 
-ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-10}
+ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-60}
 
 SYSTEM_NAMESPACE=kube-system
 trusty_master=${TRUSTY_MASTER:-false}

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -3,12 +3,14 @@ kind: Pod
 metadata:
   name: kube-addon-manager
   namespace: kube-system
-  version: v1
+  labels:
+    component: kube-addon-manager
+    version: v4
 spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: gcr.io/google-containers/kube-addon-manager:v1
+    image: gcr.io/google-containers/kube-addon-manager:v4
     resources:
       requests:
         cpu: 5m

--- a/test/e2e/addon_update.go
+++ b/test/e2e/addon_update.go
@@ -216,7 +216,7 @@ var _ = framework.KubeDescribe("Addon update", func() {
 	})
 
 	// WARNING: the test is not parallel-friendly!
-	It("should propagate add-on file changes", func() {
+	It("should propagate add-on file changes [Slow]", func() {
 		// This test requires:
 		// - SSH
 		// - master access


### PR DESCRIPTION
Do static pods have a crash loop back off? If so, this test would be much faster if we restarted the kubelet to clear that.

Fixes #26770
