### PR TITLE
fix duplicated text in cassandra example

### DIFF
--- a/examples/cassandra/README.md
+++ b/examples/cassandra/README.md
@@ -281,7 +281,7 @@ The `selector` attribute contains the controller's selector query. It can be
 explicitly specified, or applied automatically from the labels in the pod
 template if not set, as is done here.
 
-The pod template's label, `app:cassandra`, matches matches the Service selector
+The pod template's label, `app:cassandra`, matches the Service selector
 from Step 1. This is how pods created by this replication controller are picked up
 by the Service."
 


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

removes an accidentally duplicated word from
the cassandra example doc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27782)

<!-- Reviewable:end -->
