### PR TITLE
add lastsyncresourceversion to sharedinformer

### DIFF
--- a/pkg/controller/framework/shared_informer.go
+++ b/pkg/controller/framework/shared_informer.go
@@ -44,6 +44,7 @@ type SharedInformer interface {
 	GetController() ControllerInterface
 	Run(stopCh <-chan struct{})
 	HasSynced() bool
+	LastSyncResourceVersion() string
 }
 
 type SharedIndexInformer interface {
@@ -159,6 +160,16 @@ func (s *sharedIndexInformer) HasSynced() bool {
 		return false
 	}
 	return s.controller.HasSynced()
+}
+
+func (s *sharedIndexInformer) LastSyncResourceVersion() string {
+	s.startedLock.Lock()
+	defer s.startedLock.Unlock()
+
+	if s.controller == nil {
+		return ""
+	}
+	return s.controller.reflector.LastSyncResourceVersion()
 }
 
 func (s *sharedIndexInformer) GetStore() cache.Store {


### PR DESCRIPTION
Indexer consumers can use the `LastSyncResourceVersion` to know if its possible that any change has happened since they last checked.

@derekwaynecarr you used this downstream.
