### PR TITLE
kubelet summary stats api reports if imagefs is same as rootfs

### DIFF
--- a/pkg/kubelet/api/v1alpha1/stats/types.go
+++ b/pkg/kubelet/api/v1alpha1/stats/types.go
@@ -56,6 +56,8 @@ type RuntimeStats struct {
 	// This filesystem could be the same as the primary (root) filesystem.
 	// Usage here refers to the total number of bytes occupied by images on the filesystem.
 	ImageFs *FsStats `json:"imageFs,omitempty"`
+	// This value is true if the filesystem where container images are stored is the same as the primary (root) filesystem.
+	PrimaryFs bool `json:"primaryFs,omitempty"`
 }
 
 const (

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -135,6 +135,7 @@ func (sb *summaryBuilder) build() (*stats.Summary, error) {
 				CapacityBytes:  &sb.imageFsInfo.Capacity,
 				UsedBytes:      &sb.imageStats.TotalStorageBytes,
 			},
+			PrimaryFs: sb.imageFsInfo.Device == sb.rootFsInfo.Device,
 		},
 	}
 

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -110,8 +110,8 @@ func TestBuildSummary(t *testing.T) {
 		"/pod2-c0": summaryTestContainerInfo(seedPod2Container, pName2, namespace2, cName20),
 	}
 
-	rootfs := v2.FsInfo{}
-	imagefs := v2.FsInfo{}
+	rootfs := v2.FsInfo{Device: "device-1"}
+	imagefs := v2.FsInfo{Device: "device-1"}
 
 	// memory limit overrides for each container (used to test available bytes if a memory limit is known)
 	memoryLimitOverrides := map[string]uint64{
@@ -138,6 +138,7 @@ func TestBuildSummary(t *testing.T) {
 	checkCPUStats(t, "Node", seedRoot, nodeStats.CPU)
 	checkMemoryStats(t, "Node", seedRoot, infos["/"], nodeStats.Memory)
 	checkNetworkStats(t, "Node", seedRoot, nodeStats.Network)
+	assert.Equal(t, nodeStats.Runtime.PrimaryFs, true)
 
 	systemSeeds := map[string]int{
 		kubestats.SystemContainerRuntime: seedRuntime,


### PR DESCRIPTION
Adds the ability to know if the runtime imagefs is the same as the node rootfs.
