### PR TITLE
Federation e2e support for AWS

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1491,7 +1491,7 @@ function test-build-release {
 # Assumed vars:
 #   Variables from config.sh
 function test-setup {
-  "${KUBE_ROOT}/cluster/kube-up.sh"
+  . "${KUBE_ROOT}/cluster/kube-up.sh"
 
   VPC_ID=$(get_vpc_id)
   detect-security-groups

--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -22,7 +22,11 @@ spec:
         - --etcd-servers=http://localhost:2379
         - --service-cluster-ip-range={{.FEDERATION_SERVICE_CIDR}}
         - --secure-port=443
+        {{if eq .KUBERNETES_PROVIDER "aws"}}
+        - --external-hostname={{.FEDERATION_API_HOST}}
+        {{else}}
         - --advertise-address={{.FEDERATION_API_HOST}}
+        {{end}}
         # TODO: --admission-control values must be set when support is added for each type of control.
         - --token-auth-file=/srv/kubernetes/known-tokens.csv
         ports:


### PR DESCRIPTION
I've observed e2e test failures on the two local runs I did, but the framework seems to come up successfully. [logs](http://pastebin.com/tsJpKUc4). Ideas on this?

I'm in the process of validating GKE as well, and will modify the title if it succeeds.

\cc @nikhiljindal @quinton-hoole 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
