### PR TITLE
Fixes a node e2e test error

### DIFF
--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -176,7 +176,7 @@ func createSummaryTestPods(f *framework.Framework, podNamePrefix string, count i
 		createPod(f, podName, []api.Container{
 			{
 				Image:   ImageRegistry[busyBoxImage],
-				Command: []string{"sh", "-c", "while true; do echo 'hello world' | tee ~/file | tee /test-empty-dir-mnt ; sleep 1; done"},
+				Command: []string{"sh", "-c", "while true; do echo 'hello world' | tee /test-empty-dir-mnt/file ; sleep 1; done"},
 				Name:    podName + containerSuffix,
 				VolumeMounts: []api.VolumeMount{
 					{MountPath: "/test-empty-dir-mnt", Name: volumeNamePrefix},


### PR DESCRIPTION
Fixes following node e2e test error:
[k8s.io] Kubelet metrics api when querying /stats/summary [It] it should report resource usage through the stats api

And the logs show following error:

```
Jun 21 15:57:13 localhost journal: tee: /test-empty-dir-mnt: Is a directory
```

And the test fails with:

```
------------------------------
• Failure [310.665 seconds]
[k8s.io] Kubelet
/root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e/framework/framework.go:685
  metrics api
  /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:161
    when querying /stats/summary
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:160
      it should report resource usage through the stats api [It]
      /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:159

      Timed out after 300.000s.
      Expected
          <*errors.errorString | 0xc82026b6f0>: {
              s: "expected \"volume used\" to not be zero",
          }
      to be nil

      /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:158
------------------------------
```

@kubernetes/rh-cluster-infra 
