### PR TITLE
Include static docker binary in kubekins-test image

### DIFF
--- a/hack/jenkins/dockerized-e2e-runner.sh
+++ b/hack/jenkins/dockerized-e2e-runner.sh
@@ -42,7 +42,6 @@ docker_extra_args=()
 if [[ "${JENKINS_ENABLE_DOCKER_IN_DOCKER:-}" =~ ^[yY]$ ]]; then
     docker_extra_args+=(\
       -v /var/run/docker.sock:/var/run/docker.sock \
-      -v "$(which docker)":/bin/docker:ro \
       -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
       -e "REPO_DIR=${REPO_DIR}" \
       -e "HOST_ARTIFACTS_DIR=${HOST_ARTIFACTS_DIR}" \
@@ -62,5 +61,5 @@ docker run --rm=true -i \
   -e "WORKSPACE=/workspace" \
   "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
   "${METADATA_SERVER_ADD_HOST_ARGS[@]:+${METADATA_SERVER_ADD_HOST_ARGS[@]}}" \
-  gcr.io/google_containers/kubekins-test:0.11 \
+  gcr.io/google_containers/kubekins-test:go1.6.2-docker1.9.1-rev1 \
   bash -c "bash <(curl -fsS --retry 3 --keepalive-time 2 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh')"

--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -37,7 +37,6 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 
 docker run --rm=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "$(which docker)":/bin/docker \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${WORKSPACE}/_artifacts":/workspace/artifacts \
   -v /etc/localtime:/etc/localtime:ro \
@@ -45,5 +44,5 @@ docker run --rm=true \
   -e "KUBE_VERIFY_GIT_BRANCH=${KUBE_VERIFY_GIT_BRANCH:-}" \
   -e "REPO_DIR=${REPO_DIR}" \
   -e "HOST_ARTIFACTS_DIR=${HOST_ARTIFACTS_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.11 \
+  -i gcr.io/google_containers/kubekins-test:go1.6.2-docker1.9.1-rev1 \
   bash -c "cd kubernetes && ${KUBE_TEST_SCRIPT:-./hack/jenkins/test-dockerized.sh}"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -20,18 +20,26 @@ MAINTAINER  Jeff Lowdermilk <jeffml@google.com>
 
 ENV WORKSPACE               /workspace
 ENV TERM                    xterm
+# Note: 1.11+ changes the format of the tarball, so that line likely will need to be
+# changed.
+ENV DOCKER_VERSION          1.9.1
 
 WORKDIR /workspace
 
-RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
+# dnsutils is needed by federation cluster scripts.
 # file is used when uploading test artifacts to GCS.
-RUN apt-get install -y file
-# libapparmor1 is needed for docker-in-docker.
-RUN apt-get install -y libapparmor1
+# jq is used by hack/verify-godep-licenses.sh.
 # netcat is used by integration test scripts.
-RUN apt-get install -y netcat-openbsd
-# jq is used by hack/verify-godep-licenses.sh
-RUN apt-get install -y jq
+RUN apt-get update && apt-get install -y \
+  dnsutils \
+  file \
+  jq \
+  netcat-openbsd \
+  rsync \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" |\
+  tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
 RUN mkdir -p /go/src/k8s.io/kubernetes
 RUN ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -14,7 +14,9 @@
 
 all: push
 
-TAG = 0.11
+# Tag format: $GO_VERSION-$EMBEDDED_DOCKER_VERSION-$REVISION
+# These versions are specified in the Dockerfile
+TAG = go1.6.2-docker1.9.1-rev1
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .


### PR DESCRIPTION
Fixes kubernetes/test-infra/issues/47.

I haven't pushed this image yet, so I expect CI to fail for now.
