### PR TITLE
Add ssl certs to federation-controller-manager container.

### DIFF
--- a/federation/manifests/federation-controller-manager-deployment.yaml
+++ b/federation/manifests/federation-controller-manager-deployment.yaml
@@ -13,8 +13,16 @@ spec:
         app: federated-cluster
         module: federation-controller-manager
     spec:
+      volumes:
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
       containers:
       - name: controller-manager
+        volumeMounts:
+        - name: ssl-certs
+          readOnly: true
+          mountPath: /etc/ssl/certs
         image: {{.FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO}}:{{.FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG}}
         command:
         - /usr/local/bin/federation-controller-manager


### PR DESCRIPTION
Fixes #27684.

For now, I'm simply poking a hole to grab the system /etc/ssl/certs.  If
we decide we want something less dependent on the node filesystem, we
will need to decide how we pick a "distro" more sophisticated than
busybox for federation components running on k8s.  I'll open a followup
issue to discuss this.
