### PR TITLE
Revert kube-proxy as a DaemonSet in hyperkube for the v1.3 release

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -43,9 +43,15 @@ COPY static-pods/master.json /etc/kubernetes/manifests/
 COPY static-pods/etcd.json /etc/kubernetes/manifests/
 COPY static-pods/addon-manager.json /etc/kubernetes/manifests/
 
+# TODO: Move out kube-proxy to a DaemonSet again
+COPY static-pods/kube-proxy.json /etc/kubernetes/manifests/
+
 # Manifests for the docker-multinode guide
 COPY static-pods/master-multi.json /etc/kubernetes/manifests-multi/
 COPY static-pods/addon-manager.json /etc/kubernetes/manifests-multi/
+
+# TODO: Move out kube-proxy to a DaemonSet again
+COPY static-pods/kube-proxy.json /etc/kubernetes/manifests-multi/
 
 # Copy over all addons
 COPY addons /etc/kubernetes/addons

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -61,7 +61,9 @@ endif
 	cp ../../saltbase/salt/kube-dns/skydns-svc.yaml.base ${TEMP_DIR}/addons/skydns-svc.yaml
 	cp ../../addons/dashboard/dashboard-controller.yaml ${TEMP_DIR}/addons
 	cp ../../addons/dashboard/dashboard-service.yaml ${TEMP_DIR}/addons
-	cp kube-proxy-ds.yaml ${TEMP_DIR}/addons/kube-proxy.yaml
+	
+	# TODO: Move out kube-proxy to a DaemonSet again
+	#cp kube-proxy-ds.yaml ${TEMP_DIR}/addons/kube-proxy.yaml
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
 
 	cd ${TEMP_DIR} && sed -i.back "s|VERSION|${VERSION}|g" addons/*.yaml static-pods/*.json

--- a/cluster/images/hyperkube/kube-proxy-ds.yaml
+++ b/cluster/images/hyperkube/kube-proxy-ds.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Move out kube-proxy to a DaemonSet again
+# This is disabled for the v1.3 release, due to bootstrapping complexities
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/cluster/images/hyperkube/static-pods/addon-manager.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "gcr.io/google-containers/kube-addon-manager-ARCH:v3",
+        "image": "gcr.io/google-containers/kube-addon-manager-ARCH:v4",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/kube-proxy.json
+++ b/cluster/images/hyperkube/static-pods/kube-proxy.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "k8s-proxy",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "kube-proxy",
+        "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+        "command": [
+                "/hyperkube",
+                "proxy",
+                "--master=http://127.0.0.1:8080",
+                "--v=2",
+                "--resource-container=\"\""
+        ],
+        "securityContext": {
+          "privileged": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
It was a bit sad, but I was a bit too fast with the kube-proxy DaemonSet thing, so we have to target v1.4 for that one. Reverting to a static-pod

This one is for v1.3
@mikedanese @cheld @zreigz 
