### PR TITLE
Removing name field from Member for compatibility with OpenStack Liberty

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -394,7 +394,6 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(apiService *api.Service, hosts []string
 		waitLoadbalancerActiveProvisioningStatus(lbaas.network, loadbalancer.ID)
 
 		_, err = v2_pools.CreateAssociateMember(lbaas.network, pool.ID, v2_pools.MemberCreateOpts{
-			Name:         name,
 			ProtocolPort: int(ports[0].NodePort), //TODO: need to handle multi-port
 			Address:      addr,
 			SubnetID:     lbaas.opts.SubnetId,


### PR DESCRIPTION
In OpenStack Mitaka, the name field for members was added as an optional field but does not exist in Liberty.  Therefore the current implementation for lbaas v2 will not work in Liberty.
