### PR TITLE
Fix the node upgrade failure issue #27764

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -211,6 +211,10 @@ function prepare-node-upgrade() {
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
   #                 through all create-node-instance-template implementations).
   local template_name=$(get-template-name-from-version ${SANITIZED_VERSION})
+  # For master on GCI, we support the hybrid mode with nodes on ContainerVM.
+  if [[  "${OS_DISTRIBUTION}" == "gci" && "${NODE_IMAGE}" == container* ]]; then
+    source "${KUBE_ROOT}/cluster/gce/debian/helper.sh"
+  fi
   create-node-instance-template "${template_name}"
   # The following is echo'd so that callers can get the template name.
   echo $template_name


### PR DESCRIPTION
This PR fixes the logic of node template creation when upgrading the node group. Without this fix, the new node group template is created based on distro 'GCI' but the image in use is ContainerVM.

I verified that the template creation is correct with this fix, including the metadata fields and image in use

cc/ @davidopp @roberthbailey @wojtek-t @kubernetes/goog-image 
