### PR TITLE
Copy and display source location prominently on Kubernetes instances

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -106,7 +106,9 @@ Welcome to Kubernetes ${version}!
 You can find documentation for Kubernetes at:
   http://docs.kubernetes.io/
 
-You can download the build image for this release at:
+The source for this release can be found at:
+  /usr/local/share/doc/kubernetes/kubernetes-src.tar.gz
+Or you can download it at:
   https://storage.googleapis.com/kubernetes-release/release/${version}/kubernetes-src.tar.gz
 
 It is based on the Kubernetes source at:

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -910,7 +910,9 @@ Welcome to Kubernetes ${version}!
 You can find documentation for Kubernetes at:
   http://docs.kubernetes.io/
 
-You can download the build image for this release at:
+The source for this release can be found at:
+  /home/kubernetes/kubernetes-src.tar.gz
+Or you can download it at:
   https://storage.googleapis.com/kubernetes-release/release/${version}/kubernetes-src.tar.gz
 
 It is based on the Kubernetes source at:

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -158,6 +158,9 @@ function install-kube-binary-config {
   fi
 
   cp "${KUBE_HOME}/kubernetes/LICENSES" "${KUBE_HOME}"
+  cp "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz" "${KUBE_HOME}"
+  chmod a+r "${KUBE_HOME}/kubernetes/LICENSES"
+  chmod a+r "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz"
 
   # Put kube-system pods manifests in ${KUBE_HOME}/kube-manifests/.
   dst_dir="${KUBE_HOME}/kube-manifests"

--- a/cluster/saltbase/install.sh
+++ b/cluster/saltbase/install.sh
@@ -68,6 +68,7 @@ mkdir -p /srv/salt-new/salt/kube-bins
 mkdir -p /srv/salt-new/salt/kube-docs
 cp -v "${KUBE_TEMP}/kubernetes/server/bin/"* /srv/salt-new/salt/kube-bins/
 cp -v "${KUBE_TEMP}/kubernetes/LICENSES" /srv/salt-new/salt/kube-docs/
+cp -v "${KUBE_TEMP}/kubernetes/kubernetes-src.tar.gz" /srv/salt-new/salt/kube-docs/
 
 kube_bin_dir="/srv/salt-new/salt/kube-bins";
 docker_images_sls_file="/srv/salt-new/pillar/docker-images.sls";

--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -50,3 +50,10 @@ net.ipv4.neigh.default.gc_thresh1:
     - user: root
     - group: root
     - mode: 644
+
+/usr/local/share/doc/kubernetes/kubernetes-src.tar.gz:
+  file.managed:
+    - source: salt://kube-docs/kubernetes-src.tar.gz
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
Following from #27830, this copies the source onto the instance and displays the location of it prominently (keeping the download link for anyone that just wants to curl it).

Example output (this tag doesn't exist yet):

```
Welcome to Kubernetes v1.4.0!

You can find documentation for Kubernetes at:
  http://docs.kubernetes.io/

The source for this release can be found at:
  /usr/local/share/doc/kubernetes/kubernetes-src.tar.gz
Or you can download it at:
  https://storage.googleapis.com/kubernetes-release/release/v1.4.0/kubernetes-src.tar.gz

It is based on the Kubernetes source at:
  https://github.com/kubernetes/kubernetes/tree/v1.4.0

For Kubernetes copyright and licensing information, see:
  /usr/local/share/doc/kubernetes/LICENSES
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
