### PR TITLE
endpointsController get podServices should not return nil while encounted key error

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -184,7 +184,8 @@ func (e *EndpointController) getPodServiceMemberships(pod *api.Pod) (sets.String
 	for i := range services {
 		key, err := keyFunc(&services[i])
 		if err != nil {
-			return nil, err
+			glog.Errorf("Unable to get key for service %#v", &services[i])
+			continue
 		}
 		set.Insert(key)
 	}


### PR DESCRIPTION
I think getPodServiceMemberships method shouldn't return directly while anyone service gets key error,
when other services maybe ok
