### PR TITLE
Add support for Docker for MacOS

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -170,10 +170,14 @@ function kube::build::verify_prereqs() {
 
 function kube::build::docker_available_on_osx() {
   if [[ -z "${DOCKER_HOST}" ]]; then
+    if [[ -S "/var/run/docker.sock" ]]; then
+      kube::log::status "Using Docker for MacOS"
+      return 0
+    fi
+    
     kube::log::status "No docker host is set. Checking options for setting one..."
-
     if [[ -z "$(which docker-machine)" && -z "$(which boot2docker)" ]]; then
-      kube::log::status "It looks like you're running Mac OS X, and neither docker-machine or boot2docker are nowhere to be found."
+      kube::log::status "It looks like you're running Mac OS X, and neither Docker for Mac, docker-machine or boot2docker are nowhere to be found."
       kube::log::status "See: https://docs.docker.com/machine/ for installation instructions."
       return 1
     elif [[ -n "$(which docker-machine)" ]]; then


### PR DESCRIPTION
With Docker for MacOS [public beta](https://docs.docker.com/docker-for-mac) you don't need docker-machine on MacOS to build kubernetes instead you can use docker "natively". Per Default Docker for MacOS will be installed to `/Applications/Docker.app/Contents/MacOS/Docker` so if Docker for Mac is installed we should use the native version.

I tested it locally with `15.5.0 Darwin Kernel Version 15.5.0`  and Docker version `1.12.0-rc2`
