### PR TITLE
Set Dashboard UI version to v1.1.0

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.1.0-beta3
+  name: kubernetes-dashboard-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta3
+    version: v1.1.0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta3
+        version: v1.1.0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   # Keep this file in sync with addons/dashboard/dashboard-controller.yaml
-  name: kubernetes-dashboard-v1.1.0-beta3
+  name: kubernetes-dashboard-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta3
+    version: v1.1.0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta3
+        version: v1.1.0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

This is our final release for this quarter.

Release info and changelog will go there:
https://github.com/kubernetes/dashboard/releases/tag/v1.1.0
