### PR TITLE
Catch the case where we cannot find any nodes.

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -659,6 +659,10 @@ func (kd *KubeDNS) getClusterZone() (string, error) {
 		}
 	}
 
+	if node == nil {
+		return "", fmt.Errorf("Could not find any nodes")
+	}
+
 	zone, ok := node.Annotations[unversioned.LabelZoneFailureDomain]
 	if !ok || zone == "" {
 		return "", fmt.Errorf("unknown cluster zone")


### PR DESCRIPTION
It's possible to fall through the loops above with node still nil.  This
catches this and reports an error.

Found this working on #27819.
