### PR TITLE
Bump Cluster Autoscaler to 0.2.1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.2.0",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.2.1",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
Workaround for https://github.com/kubernetes/kubernetes/issues/27821. Contains https://github.com/kubernetes/contrib/pull/1252

cc: @piosz @fgrzadkowski @jszczepkowski 
