### PR TITLE
bump(google/cadvisor): v0.23.5

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -927,203 +927,203 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1/test",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.23.4",
-			"Rev": "7d22cf63253c17bad8ab64b8eef679718d00342e"
+			"Comment": "v0.23.5",
+			"Rev": "3ecedda96383d3342a5c8e5b8f39c7c9db65982f"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",


### PR DESCRIPTION
Fix an issue where cadvisor was unable to report container filesystem stats for LVM-based
devicemapper thin pools.

Fix an issue where cadvisor would not report any stats for a container if it failed to get the
filesystem stats when Docker's storage driver is devicemapper.

@kubernetes/sig-node @kubernetes/rh-cluster-infra 
