### PR TITLE
Add additional testing scenarios for compute resource requests=0

### DIFF
--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -509,13 +509,17 @@ func TestSetDefaultObjectFieldSelectorAPIVersion(t *testing.T) {
 }
 
 func TestSetDefaultRequestsPod(t *testing.T) {
-	// verify we default if limits are specified
+	// verify we default if limits are specified (and that request=0 is preserved)
 	s := versioned.PodSpec{}
 	s.Containers = []versioned.Container{
 		{
 			Resources: versioned.ResourceRequirements{
+				Requests: versioned.ResourceList{
+					versioned.ResourceMemory: resource.MustParse("0"),
+				},
 				Limits: versioned.ResourceList{
-					versioned.ResourceCPU: resource.MustParse("100m"),
+					versioned.ResourceCPU:    resource.MustParse("100m"),
+					versioned.ResourceMemory: resource.MustParse("1Gi"),
 				},
 			},
 		},
@@ -526,9 +530,11 @@ func TestSetDefaultRequestsPod(t *testing.T) {
 	output := roundTrip(t, runtime.Object(pod))
 	pod2 := output.(*versioned.Pod)
 	defaultRequest := pod2.Spec.Containers[0].Resources.Requests
-	requestValue := defaultRequest[versioned.ResourceCPU]
-	if requestValue.String() != "100m" {
+	if requestValue := defaultRequest[versioned.ResourceCPU]; requestValue.String() != "100m" {
 		t.Errorf("Expected request cpu: %s, got: %s", "100m", requestValue.String())
+	}
+	if requestValue := defaultRequest[versioned.ResourceMemory]; requestValue.String() != "0" {
+		t.Errorf("Expected request memory: %s, got: %s", "0", requestValue.String())
 	}
 
 	// verify we do nothing if no limits are specified
@@ -540,8 +546,7 @@ func TestSetDefaultRequestsPod(t *testing.T) {
 	output = roundTrip(t, runtime.Object(pod))
 	pod2 = output.(*versioned.Pod)
 	defaultRequest = pod2.Spec.Containers[0].Resources.Requests
-	requestValue = defaultRequest[versioned.ResourceCPU]
-	if requestValue.String() != "0" {
+	if requestValue := defaultRequest[versioned.ResourceCPU]; requestValue.String() != "0" {
 		t.Errorf("Expected 0 request value, got: %s", requestValue.String())
 	}
 }

--- a/pkg/kubelet/qos/qos_test.go
+++ b/pkg/kubelet/qos/qos_test.go
@@ -123,6 +123,12 @@ func TestGetPodQos(t *testing.T) {
 			}),
 			expected: Burstable,
 		},
+		{
+			pod: newPod("burstable", []api.Container{
+				newContainer("burstable", getResourceList("0", "0"), getResourceList("100m", "200Mi")),
+			}),
+			expected: Burstable,
+		},
 	}
 	for _, testCase := range testCases {
 		if actual := GetPodQos(testCase.pod); testCase.expected != actual {


### PR DESCRIPTION
I was asked about the qos tier of a pod that specified 

`--requests=cpu=0,memory=0 --limits=cpu=100m,memory=1Gi`

and in just investigating current behavior, realized we should have an explicit test case to ensure that 0 values are preserved in defaulting passes, and that this is still a burstable pod (but the lowest for that tier as it related to eviction)

/cc @vishh 
