### PR TITLE
Add a missing $ for bash variable evaluation

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -87,7 +87,7 @@ fi
 
 if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
   detect-node-instance-groups
-  NODE_INSTANCE_GROUP=$(kube::util::join , NODE_INSTANCE_GROUPS)
+  NODE_INSTANCE_GROUP=$(kube::util::join , "${NODE_INSTANCE_GROUPS[@]}")
 fi
 
 ginkgo_args=()


### PR DESCRIPTION
This is causing failures that look like:

``` console
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/resize_nodes.go:479
Expected error:
    <*exec.ExitError | 0xc820eae2c0>: {
        ProcessState: {
            pid: 2881,
            status: 256,
            rusage: {
                Utime: {Sec: 0, Usec: 256000},
                Stime: {Sec: 0, Usec: 68000},
                Maxrss: 36560,
                Ixrss: 0,
                Idrss: 0,
                Isrss: 0,
                Minflt: 16155,
                Majflt: 0,
                Nswap: 0,
                Inblock: 0,
                Oublock: 16,
                Msgsnd: 0,
                Msgrcv: 0,
                Nsignals: 0,
                Nvcsw: 47,
                Nivcsw: 25,
            },
        },
        Stderr: nil,
    }
    exit status 1
not to have occurred
```

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-gke-serial/1588#k8sio-nodes-disruptive-k8sio-resize-slow-should-be-able-to-add-nodes

One of the many behind #27537

cc @lavalamp 
