### PR TITLE
Allow to flush events to sink

### DIFF
--- a/pkg/client/record/fake.go
+++ b/pkg/client/record/fake.go
@@ -30,6 +30,8 @@ type FakeRecorder struct {
 	Events chan string
 }
 
+func (f *FakeRecorder) Flush() {}
+
 func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
 	if f.Events != nil {
 		f.Events <- fmt.Sprintf("%s %s %s", eventtype, reason, message)

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -181,6 +181,8 @@ func (irecorder *innerEventRecorder) PastEventf(object runtime.Object, timestamp
 	}
 }
 
+func (irecorder *innerEventRecorder) Flush() {}
+
 // Pod must not be nil.
 func IsHostNetworkPod(pod *api.Pod) bool {
 	return pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/27858

Added the `recorder.Flush()` function that will wait until all events are recorded to sink.
