### PR TITLE
Unify DeleteAllEtcdKeys in integration tests & start using namespaces in some tests

### DIFF
--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -412,6 +412,7 @@ func getTestRequests() []struct {
 //
 // TODO(etune): write a fuzz test of the REST API.
 func TestAuthModeAlwaysAllow(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// Set up a master
@@ -517,6 +518,7 @@ func getPreviousResourceVersionKey(url, id string) string {
 }
 
 func TestAuthModeAlwaysDeny(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// Set up a master
@@ -571,7 +573,7 @@ func (allowAliceAuthorizer) Authorize(a authorizer.Attributes) error {
 // TestAliceNotForbiddenOrUnauthorized tests a user who is known to
 // the authentication system and authorized to do any actions.
 func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
-
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -652,6 +654,7 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 // the authentication system but not authorized to do any actions
 // should receive "Forbidden".
 func TestBobIsForbidden(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -701,6 +704,7 @@ func TestBobIsForbidden(t *testing.T) {
 // An authorization module is installed in this scenario for integration
 // test purposes, but requests aren't expected to reach it.
 func TestUnknownUserIsUnauthorized(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -772,6 +776,7 @@ func (impersonateAuthorizer) Authorize(a authorizer.Attributes) error {
 }
 
 func TestImpersonateIsForbidden(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master
@@ -923,6 +928,7 @@ func (a *trackingAuthorizer) Authorize(attributes authorizer.Attributes) error {
 
 // TestAuthorizationAttributeDetermination tests that authorization attributes are built correctly
 func TestAuthorizationAttributeDetermination(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	trackingAuthorizer := &trackingAuthorizer{}
@@ -993,6 +999,7 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 // TestNamespaceAuthorization tests that authorization can be controlled
 // by namespace.
 func TestNamespaceAuthorization(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -1096,6 +1103,7 @@ func TestNamespaceAuthorization(t *testing.T) {
 // TestKindAuthorization tests that authorization can be controlled
 // by namespace.
 func TestKindAuthorization(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -1189,6 +1197,7 @@ func TestKindAuthorization(t *testing.T) {
 // TestReadOnlyAuthorization tests that authorization can be controlled
 // by namespace.
 func TestReadOnlyAuthorization(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	// This file has alice and bob in it.
@@ -1253,6 +1262,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 // authenticator to call out to a remote web server for authentication
 // decisions.
 func TestWebhookTokenAuthenticator(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -44,11 +44,13 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	ns := api.NamespaceDefault
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	info, err := client.Discovery().ServerVersion()
@@ -114,10 +116,12 @@ func TestClient(t *testing.T) {
 }
 
 func TestAtomicPut(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	rcBody := api.ReplicationController{
@@ -203,10 +207,12 @@ func TestAtomicPut(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	name := "patchpod"
@@ -309,10 +315,12 @@ func TestPatch(t *testing.T) {
 }
 
 func TestPatchWithCreateOnUpdate(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	endpointTemplate := &api.Endpoints{
@@ -415,10 +423,12 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 }
 
 func TestAPIVersions(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	clientVersion := c.APIVersion().String()
@@ -438,11 +448,13 @@ func TestAPIVersions(t *testing.T) {
 }
 
 func TestSingleWatch(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	ns := "blargh"
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	mkEvent := func(i int) *api.Event {
@@ -518,11 +530,13 @@ func TestMultiWatch(t *testing.T) {
 	// Disable this test as long as it demonstrates a problem.
 	// TODO: Reenable this test when we get #6059 resolved.
 	return
+
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	const watcherCount = 50
 	rt.GOMAXPROCS(watcherCount)
 
-	framework.DeleteAllEtcdKeys()
-	defer framework.DeleteAllEtcdKeys()
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
@@ -777,10 +791,12 @@ func runSelfLinkTestOnNamespace(t *testing.T, c *client.Client, namespace string
 }
 
 func TestSelfLinkOnNamespace(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	runSelfLinkTestOnNamespace(t, c, api.NamespaceDefault)

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -44,14 +44,13 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	ns := api.NamespaceDefault
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
+
+	ns := framework.CreateTestingNamespace("client", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
 
 	info, err := client.Discovery().ServerVersion()
 	if err != nil {
@@ -61,7 +60,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", e, a)
 	}
 
-	pods, err := client.Pods(ns).List(api.ListOptions{})
+	pods, err := client.Pods(ns.Name).List(api.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -73,6 +72,7 @@ func TestClient(t *testing.T) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			GenerateName: "test",
+			Namespace:    ns.Name,
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
@@ -83,14 +83,14 @@ func TestClient(t *testing.T) {
 		},
 	}
 
-	got, err := client.Pods(ns).Create(pod)
+	got, err := client.Pods(ns.Name).Create(pod)
 	if err == nil {
 		t.Fatalf("unexpected non-error: %v", got)
 	}
 
 	// get a created pod
 	pod.Spec.Containers[0].Image = "an-image"
-	got, err = client.Pods(ns).Create(pod)
+	got, err = client.Pods(ns.Name).Create(pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestClient(t *testing.T) {
 	}
 
 	// pod is shown, but not scheduled
-	pods, err = client.Pods(ns).List(api.ListOptions{})
+	pods, err = client.Pods(ns.Name).List(api.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,20 +116,21 @@ func TestClient(t *testing.T) {
 }
 
 func TestAtomicPut(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
+
+	ns := framework.CreateTestingNamespace("atomic-put", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
 
 	rcBody := api.ReplicationController{
 		TypeMeta: unversioned.TypeMeta{
 			APIVersion: c.APIVersion().String(),
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: "atomicrc",
+			Name:      "atomicrc",
+			Namespace: ns.Name,
 			Labels: map[string]string{
 				"name": "atomicrc",
 			},
@@ -153,7 +154,7 @@ func TestAtomicPut(t *testing.T) {
 			},
 		},
 	}
-	rcs := c.ReplicationControllers(api.NamespaceDefault)
+	rcs := c.ReplicationControllers(ns.Name)
 	rc, err := rcs.Create(&rcBody)
 	if err != nil {
 		t.Fatalf("Failed creating atomicRC: %v", err)
@@ -207,13 +208,13 @@ func TestAtomicPut(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
+
+	ns := framework.CreateTestingNamespace("patch", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
 
 	name := "patchpod"
 	resource := "pods"
@@ -222,8 +223,9 @@ func TestPatch(t *testing.T) {
 			APIVersion: c.APIVersion().String(),
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{},
+			Name:      name,
+			Namespace: ns.Name,
+			Labels:    map[string]string{},
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
@@ -231,7 +233,7 @@ func TestPatch(t *testing.T) {
 			},
 		},
 	}
-	pods := c.Pods(api.NamespaceDefault)
+	pods := c.Pods(ns.Name)
 	pod, err := pods.Create(&podBody)
 	if err != nil {
 		t.Fatalf("Failed creating patchpods: %v", err)
@@ -266,7 +268,7 @@ func TestPatch(t *testing.T) {
 	execPatch := func(pt api.PatchType, body []byte) error {
 		return c.Patch(pt).
 			Resource(resource).
-			Namespace(api.NamespaceDefault).
+			Namespace(ns.Name).
 			Name(name).
 			Body(body).
 			Do().
@@ -315,16 +317,19 @@ func TestPatch(t *testing.T) {
 }
 
 func TestPatchWithCreateOnUpdate(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
+	ns := framework.CreateTestingNamespace("patch-with-create", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
 	endpointTemplate := &api.Endpoints{
-		ObjectMeta: api.ObjectMeta{Name: "patchendpoint"},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "patchendpoint",
+			Namespace: ns.Name,
+		},
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
@@ -334,7 +339,7 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 	}
 
 	patchEndpoint := func(json []byte) (runtime.Object, error) {
-		return c.Patch(api.MergePatchType).Resource("endpoints").Namespace(api.NamespaceDefault).Name("patchendpoint").Body(json).Do().Get()
+		return c.Patch(api.MergePatchType).Resource("endpoints").Namespace(ns.Name).Name("patchendpoint").Body(json).Do().Get()
 	}
 
 	// Make sure patch doesn't get to CreateOnUpdate
@@ -349,7 +354,7 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 	}
 
 	// Create the endpoint (endpoints set AllowCreateOnUpdate=true) to get a UID and resource version
-	createdEndpoint, err := c.Endpoints(api.NamespaceDefault).Update(endpointTemplate)
+	createdEndpoint, err := c.Endpoints(ns.Name).Update(endpointTemplate)
 	if err != nil {
 		t.Fatalf("Failed creating endpoint: %v", err)
 	}
@@ -423,9 +428,6 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 }
 
 func TestAPIVersions(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
@@ -448,24 +450,23 @@ func TestAPIVersions(t *testing.T) {
 }
 
 func TestSingleWatch(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	ns := "blargh"
+	ns := framework.CreateTestingNamespace("single-watch", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	mkEvent := func(i int) *api.Event {
 		name := fmt.Sprintf("event-%v", i)
 		return &api.Event{
 			ObjectMeta: api.ObjectMeta{
-				Namespace: ns,
+				Namespace: ns.Name,
 				Name:      name,
 			},
 			InvolvedObject: api.ObjectReference{
-				Namespace: ns,
+				Namespace: ns.Name,
 				Name:      name,
 			},
 			Reason: fmt.Sprintf("event %v", i),
@@ -475,7 +476,7 @@ func TestSingleWatch(t *testing.T) {
 	rv1 := ""
 	for i := 0; i < 10; i++ {
 		event := mkEvent(i)
-		got, err := client.Events(ns).Create(event)
+		got, err := client.Events(ns.Name).Create(event)
 		if err != nil {
 			t.Fatalf("Failed creating event %#q: %v", event, err)
 		}
@@ -490,7 +491,7 @@ func TestSingleWatch(t *testing.T) {
 
 	w, err := client.Get().
 		Prefix("watch").
-		NamespaceIfScoped(ns, len(ns) > 0).
+		Namespace(ns.Name).
 		Resource("events").
 		Name("event-9").
 		Param("resourceVersion", rv1).
@@ -531,16 +532,15 @@ func TestMultiWatch(t *testing.T) {
 	// TODO: Reenable this test when we get #6059 resolved.
 	return
 
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	const watcherCount = 50
 	rt.GOMAXPROCS(watcherCount)
 
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	ns := api.NamespaceDefault
+	ns := framework.CreateTestingNamespace("multi-watch", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	dummyEvent := func(i int) *api.Event {
@@ -548,11 +548,11 @@ func TestMultiWatch(t *testing.T) {
 		return &api.Event{
 			ObjectMeta: api.ObjectMeta{
 				Name:      fmt.Sprintf("%v.%x", name, time.Now().UnixNano()),
-				Namespace: ns,
+				Namespace: ns.Name,
 			},
 			InvolvedObject: api.ObjectReference{
 				Name:      name,
-				Namespace: ns,
+				Namespace: ns.Name,
 			},
 			Reason: fmt.Sprintf("unrelated change %v", i),
 		}
@@ -570,7 +570,7 @@ func TestMultiWatch(t *testing.T) {
 	for i := 0; i < watcherCount; i++ {
 		watchesStarted.Add(1)
 		name := fmt.Sprintf("multi-watch-%v", i)
-		got, err := client.Pods(ns).Create(&api.Pod{
+		got, err := client.Pods(ns.Name).Create(&api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   name,
 				Labels: labels.Set{"watchlabel": name},
@@ -591,7 +591,7 @@ func TestMultiWatch(t *testing.T) {
 				LabelSelector:   labels.Set{"watchlabel": name}.AsSelector(),
 				ResourceVersion: rv,
 			}
-			w, err := client.Pods(ns).Watch(options)
+			w, err := client.Pods(ns.Name).Watch(options)
 			if err != nil {
 				panic(fmt.Sprintf("watch error for %v: %v", name, err))
 			}
@@ -640,7 +640,7 @@ func TestMultiWatch(t *testing.T) {
 					if !ok {
 						return
 					}
-					if _, err := client.Events(ns).Create(dummyEvent(i)); err != nil {
+					if _, err := client.Events(ns.Name).Create(dummyEvent(i)); err != nil {
 						panic(fmt.Sprintf("couldn't make an event: %v", err))
 					}
 					changeMade <- i
@@ -677,7 +677,7 @@ func TestMultiWatch(t *testing.T) {
 						return
 					}
 					name := fmt.Sprintf("unrelated-%v", i)
-					_, err := client.Pods(ns).Create(&api.Pod{
+					_, err := client.Pods(ns.Name).Create(&api.Pod{
 						ObjectMeta: api.ObjectMeta{
 							Name: name,
 						},
@@ -711,13 +711,13 @@ func TestMultiWatch(t *testing.T) {
 	for i := 0; i < watcherCount; i++ {
 		go func(i int) {
 			name := fmt.Sprintf("multi-watch-%v", i)
-			pod, err := client.Pods(ns).Get(name)
+			pod, err := client.Pods(ns.Name).Get(name)
 			if err != nil {
 				panic(fmt.Sprintf("Couldn't get %v: %v", name, err))
 			}
 			pod.Spec.Containers[0].Image = e2e.GetPauseImageName(client)
 			sentTimes <- timePair{time.Now(), name}
-			if _, err := client.Pods(ns).Update(pod); err != nil {
+			if _, err := client.Pods(ns.Name).Update(pod); err != nil {
 				panic(fmt.Sprintf("Couldn't make %v: %v", name, err))
 			}
 		}(i)

--- a/test/integration/configmap_test.go
+++ b/test/integration/configmap_test.go
@@ -35,6 +35,9 @@ import (
 
 // TestConfigMap tests apiserver-side behavior of creation of ConfigMaps and pods that consume them.
 func TestConfigMap(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -47,7 +50,6 @@ func TestConfigMap(t *testing.T) {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
 
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	DoTestConfigMap(t, client)

--- a/test/integration/configmap_test.go
+++ b/test/integration/configmap_test.go
@@ -21,46 +21,33 @@ package integration
 // This file tests use of the configMap API resource.
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
 // TestConfigMap tests apiserver-side behavior of creation of ConfigMaps and pods that consume them.
 func TestConfigMap(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
-
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
 
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
-	DoTestConfigMap(t, client)
+	ns := framework.CreateTestingNamespace("config-map", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	DoTestConfigMap(t, client, ns)
 }
 
-func DoTestConfigMap(t *testing.T, client *client.Client) {
-	ns := "ns"
+func DoTestConfigMap(t *testing.T, client *client.Client, ns *api.Namespace) {
 	cfg := api.ConfigMap{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "configmap",
-			Namespace: ns,
+			Namespace: ns.Name,
 		},
 		Data: map[string]string{
 			"data-1": "value-1",
@@ -76,7 +63,8 @@ func DoTestConfigMap(t *testing.T, client *client.Client) {
 
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name: "XXX",
+			Name:      "XXX",
+			Namespace: ns.Name,
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
@@ -123,10 +111,10 @@ func DoTestConfigMap(t *testing.T, client *client.Client) {
 	}
 
 	pod.ObjectMeta.Name = "uses-configmap"
-	if _, err := client.Pods(ns).Create(pod); err != nil {
+	if _, err := client.Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod: %v", err)
 	}
-	defer deletePodOrErrorf(t, client, ns, pod.Name)
+	defer deletePodOrErrorf(t, client, ns.Name, pod.Name)
 }
 
 func deleteConfigMapOrErrorf(t *testing.T, c *client.Client, ns, name string) {

--- a/test/integration/dynamic_client_test.go
+++ b/test/integration/dynamic_client_test.go
@@ -34,10 +34,12 @@ import (
 )
 
 func TestDynamicClient(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	gv := testapi.Default.GroupVersion()
 	config := &restclient.Config{
 		Host:          s.URL,

--- a/test/integration/extender_test.go
+++ b/test/integration/extender_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
@@ -189,17 +188,8 @@ func TestSchedulerExtender(t *testing.T) {
 	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
-
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("error in bringing up the master: %v", err)
-	}
 
 	restClient := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 

--- a/test/integration/extender_test.go
+++ b/test/integration/extender_test.go
@@ -186,6 +186,7 @@ func machine_3_Prioritizer(pod *api.Pod, nodes *api.NodeList) (*schedulerapi.Hos
 }
 
 func TestSchedulerExtender(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master

--- a/test/integration/framework/etcd_utils.go
+++ b/test/integration/framework/etcd_utils.go
@@ -79,5 +79,4 @@ func DeleteAllEtcdKeys() {
 			glog.Fatalf("Unable delete key: %v", err)
 		}
 	}
-
 }

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -239,6 +239,22 @@ func (m *MasterComponents) Stop(apiServer, rcManager bool) {
 	}
 }
 
+func CreateTestingNamespace(baseName string, apiserver *httptest.Server, t *testing.T) *api.Namespace {
+	// TODO: Create a namespace with a given basename.
+	// Currently we neither create the namespace nor delete all its contents at the end.
+	// But as long as tests are not using the same namespaces, this should work fine.
+	return &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			// TODO: Once we start creating namespaces, switch to GenerateName.
+			Name: baseName,
+		},
+	}
+}
+
+func DeleteTestingNamespace(ns *api.Namespace, apiserver *httptest.Server, t *testing.T) {
+	// TODO: Remove all resources from a given namespace once we implement CreateTestingNamespace.
+}
+
 // RCFromManifest reads a .json file and returns the rc in it.
 func RCFromManifest(fileName string) *api.ReplicationController {
 	data, err := ioutil.ReadFile(fileName)

--- a/test/integration/garbage_collector_test.go
+++ b/test/integration/garbage_collector_test.go
@@ -117,6 +117,9 @@ func newOwnerRC(name string) *v1.ReplicationController {
 }
 
 func setup(t *testing.T) (*garbagecollector.GarbageCollector, clientset.Interface) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -130,7 +133,6 @@ func setup(t *testing.T) (*garbagecollector.GarbageCollector, clientset.Interfac
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
 
-	framework.DeleteAllEtcdKeys()
 	clientSet, err := clientset.NewForConfig(&restclient.Config{Host: s.URL})
 	if err != nil {
 		t.Fatalf("Error in create clientset: %v", err)

--- a/test/integration/master_test.go
+++ b/test/integration/master_test.go
@@ -392,6 +392,9 @@ func countEndpoints(eps *api.Endpoints) int {
 }
 
 func TestMasterService(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	m, err := master.New(framework.NewIntegrationTestMasterConfig())
 	if err != nil {
 		t.Fatalf("Error in bringing up the master: %v", err)
@@ -401,7 +404,6 @@ func TestMasterService(t *testing.T) {
 	}))
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	err = wait.Poll(time.Second, time.Minute, func() (bool, error) {

--- a/test/integration/persistent_volumes_test.go
+++ b/test/integration/persistent_volumes_test.go
@@ -104,11 +104,13 @@ func testSleep() {
 }
 
 func TestPersistentVolumeRecycler(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	glog.V(2).Infof("TestPersistentVolumeRecycler started")
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, ctrl, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -152,11 +154,13 @@ func TestPersistentVolumeRecycler(t *testing.T) {
 }
 
 func TestPersistentVolumeDeleter(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	glog.V(2).Infof("TestPersistentVolumeDeleter started")
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, ctrl, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -202,13 +206,15 @@ func TestPersistentVolumeDeleter(t *testing.T) {
 }
 
 func TestPersistentVolumeBindRace(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	// Test a race binding many claims to a PV that is pre-bound to a specific
 	// PVC. Only this specific PVC should get bound.
 	glog.V(2).Infof("TestPersistentVolumeBindRace started")
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, ctrl, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -270,10 +276,12 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 
 // TestPersistentVolumeClaimLabelSelector test binding using label selectors
 func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, controller, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -343,10 +351,12 @@ func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 // TestPersistentVolumeClaimLabelSelectorMatchExpressions test binding using
 // MatchExpressions label selectors
 func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, controller, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -435,10 +445,12 @@ func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 // TestPersistentVolumeMultiPVs tests binding of one PVC to 100 PVs with
 // different size.
 func TestPersistentVolumeMultiPVs(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, controller, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -512,17 +524,17 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 
 	waitForAnyPersistentVolumePhase(watchPV, api.VolumeReleased)
 	t.Log("volumes released")
-
-	framework.DeleteAllEtcdKeys()
 }
 
 // TestPersistentVolumeMultiPVsPVCs tests binding of 100 PVC to 100 PVs.
 // This test is configurable by KUBE_INTEGRATION_PV_* variables.
 func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, binder, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -593,16 +605,17 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 		glog.V(2).Infof("PVC %q is bound to PV %q", pvc.Name, pvc.Spec.VolumeName)
 	}
 	testSleep()
-	framework.DeleteAllEtcdKeys()
 }
 
 // TestPersistentVolumeProvisionMultiPVCs tests provisioning of many PVCs.
 // This test is configurable by KUBE_INTEGRATION_PV_* variables.
 func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, binder, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -671,17 +684,17 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 	glog.V(2).Infof("TestPersistentVolumeProvisionMultiPVCs: volumes are deleted")
-
-	framework.DeleteAllEtcdKeys()
 }
 
 // TestPersistentVolumeMultiPVsDiffAccessModes tests binding of one PVC to two
 // PVs with different access modes.
 func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	framework.DeleteAllEtcdKeys()
 	testClient, controller, watchPV, watchPVC := createClients(t, s)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -746,8 +759,6 @@ func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 
 	waitForAnyPersistentVolumePhase(watchPV, api.VolumeReleased)
 	t.Log("volume released")
-
-	framework.DeleteAllEtcdKeys()
 }
 
 func waitForPersistentVolumePhase(client *clientset.Clientset, pvName string, w watch.Interface, phase api.PersistentVolumePhase) {

--- a/test/integration/pods_test.go
+++ b/test/integration/pods_test.go
@@ -20,34 +20,21 @@ package integration
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	ns := "pod-activedeadline-update"
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
+	ns := framework.CreateTestingNamespace("pod-activedeadline-update", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
 
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -142,40 +129,30 @@ func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
 		pod.Spec.ActiveDeadlineSeconds = tc.original
 		pod.ObjectMeta.Name = fmt.Sprintf("activedeadlineseconds-test-%v", i)
 
-		if _, err := client.Pods(ns).Create(pod); err != nil {
+		if _, err := client.Pods(ns.Name).Create(pod); err != nil {
 			t.Errorf("Failed to create pod: %v", err)
 		}
 
 		pod.Spec.ActiveDeadlineSeconds = tc.update
 
-		_, err := client.Pods(ns).Update(pod)
+		_, err := client.Pods(ns.Name).Update(pod)
 		if tc.valid && err != nil {
 			t.Errorf("%v: failed to update pod: %v", tc.name, err)
 		} else if !tc.valid && err == nil {
 			t.Errorf("%v: unexpected allowed update to pod", tc.name)
 		}
 
-		deletePodOrErrorf(t, client, ns, pod.Name)
+		deletePodOrErrorf(t, client, ns.Name, pod.Name)
 	}
 }
 
 func TestPodReadOnlyFilesystem(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
 	isReadOnly := true
-	ns := "pod-readonly-root"
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
+	ns := framework.CreateTestingNamespace("pod-readonly-root", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
 
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -196,9 +173,9 @@ func TestPodReadOnlyFilesystem(t *testing.T) {
 		},
 	}
 
-	if _, err := client.Pods(ns).Create(pod); err != nil {
+	if _, err := client.Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod: %v", err)
 	}
 
-	deletePodOrErrorf(t, client, ns, pod.Name)
+	deletePodOrErrorf(t, client, ns.Name, pod.Name)
 }

--- a/test/integration/pods_test.go
+++ b/test/integration/pods_test.go
@@ -33,6 +33,9 @@ import (
 )
 
 func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -46,7 +49,6 @@ func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
 
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	var (
@@ -158,6 +160,9 @@ func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
 }
 
 func TestPodReadOnlyFilesystem(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -172,7 +177,6 @@ func TestPodReadOnlyFilesystem(t *testing.T) {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
 
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
 	pod := &api.Pod{

--- a/test/integration/quota_test.go
+++ b/test/integration/quota_test.go
@@ -54,6 +54,7 @@ func init() {
 // 	quota_test.go:100: Took 4.196205966s to scale up without quota
 // 	quota_test.go:115: Took 12.021640372s to scale up with quota
 func TestQuota(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	initializationCh := make(chan struct{})

--- a/test/integration/rbac_test.go
+++ b/test/integration/rbac_test.go
@@ -355,6 +355,7 @@ func TestRBAC(t *testing.T) {
 	}
 
 	for i, tc := range tests {
+		// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 		framework.DeleteAllEtcdKeys()
 
 		var m *master.Master

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -53,6 +53,7 @@ type nodeStateManager struct {
 }
 
 func TestUnschedulableNodes(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master
@@ -300,6 +301,7 @@ func DoTestUnschedulableNodes(t *testing.T, restClient *client.Client, nodeStore
 }
 
 func TestMultiScheduler(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -22,8 +22,6 @@ package integration
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -36,7 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
@@ -56,17 +53,8 @@ func TestUnschedulableNodes(t *testing.T) {
 	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
-
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
 
 	restClient := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -304,18 +292,10 @@ func TestMultiScheduler(t *testing.T) {
 	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
 	framework.DeleteAllEtcdKeys()
 
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	// TODO: Uncomment when fix #19254
+	// This seems to be a different issue - it still doesn't work.
 	// defer s.Close()
-
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
 
 	/*
 		This integration tests the multi-scheduler feature in the following way:
@@ -493,17 +473,8 @@ func createPod(client *client.Client, name string, annotation map[string]string)
 func TestAllocatable(t *testing.T) {
 	framework.DeleteAllEtcdKeys()
 
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
+	_, s := framework.RunAMaster(t)
 	defer s.Close()
-
-	masterConfig := framework.NewIntegrationTestMasterConfig()
-	m, err := master.New(masterConfig)
-	if err != nil {
-		t.Fatalf("Error in bringing up the master: %v", err)
-	}
 
 	// 1. create and start default-scheduler
 	restClient := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -41,6 +41,9 @@ func deleteSecretOrErrorf(t *testing.T, c *client.Client, ns, name string) {
 
 // TestSecrets tests apiserver-side behavior of creation of secret objects and their use by pods.
 func TestSecrets(t *testing.T) {
+	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
+	framework.DeleteAllEtcdKeys()
+
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -53,7 +56,6 @@ func TestSecrets(t *testing.T) {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
 
-	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 	DoTestSecrets(t, client)
 }

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -336,7 +336,6 @@ func TestServiceAccountTokenAuthentication(t *testing.T) {
 // startServiceAccountTestServer returns a started server
 // It is the responsibility of the caller to ensure the returned stopFunc is called
 func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclient.Config, func()) {
-
 	framework.DeleteAllEtcdKeys()
 
 	// Listener


### PR DESCRIPTION
Getting rid of DeleteAllEtcdKeys() and running all tests in separate namespace is necessary to run integration tests in parallel.

Aside from that, this is first step of reducing amount of annoying logs in integration tests...
