### PR TITLE
Should verify --secure-port and --insecure-port when starting kube-apiserver

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -572,6 +572,10 @@ func NewConfig(options *options.ServerRunOptions) *Config {
 }
 
 func verifyServiceNodePort(options *options.ServerRunOptions) {
+	if options.KubernetesServiceNodePort < 0 || options.KubernetesServiceNodePort > 65535 {
+		glog.Fatalf("--kubernetes-service-node-port %v must be between 0 and 65535, inclusive. If 0, the Kubernetes master service will be of type ClusterIP.", options.KubernetesServiceNodePort)
+	}
+
 	if options.KubernetesServiceNodePort > 0 && !options.ServiceNodePortRange.Contains(options.KubernetesServiceNodePort) {
 		glog.Fatalf("Kubernetes service port range %v doesn't contain %v", options.ServiceNodePortRange, (options.KubernetesServiceNodePort))
 	}
@@ -583,10 +587,25 @@ func verifyEtcdServersList(options *options.ServerRunOptions) {
 	}
 }
 
+func verifySecurePort(options *options.ServerRunOptions) {
+	if options.SecurePort < 0 || options.SecurePort > 65535 {
+		glog.Fatalf("--secure-port %v must be between 0 and 65535, inclusive. 0 for turning off secure port.", options.SecurePort)
+	}
+}
+
+// TODO: Allow 0 to turn off insecure port.
+func verifyInsecurePort(options *options.ServerRunOptions) {
+	if options.InsecurePort < 1 || options.InsecurePort > 65535 {
+		glog.Fatalf("--insecure-port %v must be between 1 and 65535, inclusive.", options.InsecurePort)
+	}
+}
+
 func ValidateRunOptions(options *options.ServerRunOptions) {
 	verifyClusterIPFlags(options)
 	verifyServiceNodePort(options)
 	verifyEtcdServersList(options)
+	verifySecurePort(options)
+	verifyInsecurePort(options)
 }
 
 func DefaultAndValidateRunOptions(options *options.ServerRunOptions) {


### PR DESCRIPTION
When starting kube-apiserver, if we pass the flag `--secure-port` or `--insecure-port` with an invalid value (i.e. < 1 or > 65535), though there is an error message, the apiserver still runs normally. Actually, it should exit (as when not passing the flag `--etcd-servers` does), or else it's meaningless.

This fix is similar to #27762.

Maybe there is still other flags which have to be verified, if found, I will try to fix them.

Before fix:

```
root@vm:/home/paas/zxp/log/kube# kube-apiserver --etcd-servers=http://172.16.1.11:4001 --service-cluster-ip-range=192.168.122.0/24 --insecure-bind-address=0.0.0.0 --logtostderr=false --log-dir=/home/paas/zxp/log/kube --v=10 --secure-port=-1 &
[1] 1500
root@vm:/home/paas/zxp/log/kube# E0623 04:14:15.378332    1500 controller.go:97] Unable to perform initial Kubernetes service initialization: Endpoints "kubernetes" is invalid: [subsets[0].ports[0].port: Invalid value: -1: must be between 1 and 65535, inclusive, subsets[0].ports[0].port: Invalid value: -1: must be between 1 and 65535, inclusive]
[restful] 2016/06/23 04:14:15 log.go:30: [restful/swagger] listing is available at https://172.16.1.11:-1/swaggerapi/
[restful] 2016/06/23 04:14:15 log.go:30: [restful/swagger] https://172.16.1.11:-1/swaggerui/ is mapped to folder /swagger-ui/
E0623 04:14:15.422742    1500 genericapiserver.go:730] Unable to listen for secure (listen tcp: invalid port -1); will try again.

root@vm:/home/paas/zxp/log/kube# 
root@vm:/home/paas/zxp/log/kube# E0623 04:14:30.425211    1500 genericapiserver.go:730] Unable to listen for secure (listen tcp: invalid port -1); will try again.

root@vm:/home/paas/zxp/log/kube# ps -ef|grep kube
root      1500 13507  1 04:14 pts/1    00:00:00 kube-apiserver --etcd-servers=http://172.16.1.11:4001 --service-cluster-ip-range=192.168.122.0/24 --insecure-bind-address=0.0.0.0 --logtostderr=false --log-dir=/home/paas/zxp/log/kube --v=10 --secure-port=-1
```

After:

```
root@vm:/home/paas/zxp/log/kube# kube-apiserver --etcd-servers=http://172.16.1.11:4001 --service-cluster-ip-range=192.168.122.0/24 --insecure-bind-address=0.0.0.0 --logtostderr=false --log-dir=/home/paas/zxp/log/kube --v=10 --insecure-port=-1 &
[1] 10570
root@vm:/home/paas/zxp/log/kube# F0623 05:37:16.124206   10570 genericapiserver.go:594] --insecure-port -1 must be between 1 and 65535, inclusive
goroutine 1 [running]:
k8s.io/kubernetes/vendor/github.com/golang/glog.stacks(0x4418400, 0x0, 0x0, 0x0)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:766 +0xb8
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).output(0x43f7f60, 0xc800000003, 0xc8200e4600, 0x42b2d5a, 0x13, 0x252, 0x0)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:717 +0x259
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).printf(0x43f7f60, 0xc800000003, 0x32278a0, 0x39, 0xc82037ac90, 0x1, 0x1)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:655 +0x1d4
k8s.io/kubernetes/vendor/github.com/golang/glog.Fatalf(0x32278a0, 0x39, 0xc82037ac90, 0x1, 0x1)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:1145 +0x5d
k8s.io/kubernetes/pkg/genericapiserver.verifyInsecurePort(0xc820199800)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:594 +0x103
k8s.io/kubernetes/pkg/genericapiserver.ValidateRunOptions(0xc820199800)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:603 +0x59
k8s.io/kubernetes/pkg/genericapiserver.DefaultAndValidateRunOptions(0xc820199800)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:607 +0x4e
k8s.io/kubernetes/cmd/kube-apiserver/app.Run(0xc820468b40, 0x0, 0x0)
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:83 +0x344
main.main()
    /home/paas/zxp/code/k8s/train_test/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/apiserver.go:50 +0x121

[1]+  Exit 255                kube-apiserver --etcd-servers=http://172.16.1.11:4001 --service-cluster-ip-range=192.168.122.0/24 --insecure-bind-address=0.0.0.0 --logtostderr=false --log-dir=/home/paas/zxp/log/kube --v=10 --insecure-port=-1
root@vm:/home/paas/zxp/log/kube# 
```
