### PR TITLE
Fix node e2e issues on selinux enabled systems

### DIFF
--- a/test/e2e_node/container.go
+++ b/test/e2e_node/container.go
@@ -34,7 +34,8 @@ type ConformanceContainer struct {
 	Volumes          []api.Volume
 	ImagePullSecrets []string
 
-	podName string
+	podName            string
+	PodSecurityContext *api.PodSecurityContext
 }
 
 func (cc *ConformanceContainer) Create() {
@@ -52,6 +53,7 @@ func (cc *ConformanceContainer) Create() {
 			Containers: []api.Container{
 				cc.Container,
 			},
+			SecurityContext:  cc.PodSecurityContext,
 			Volumes:          cc.Volumes,
 			ImagePullSecrets: imagePullSecrets,
 		},

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -178,6 +178,11 @@ func createSummaryTestPods(f *framework.Framework, podNamePrefix string, count i
 						},
 					},
 				},
+				SecurityContext: &api.PodSecurityContext{
+					SELinuxOptions: &api.SELinuxOptions{
+						Level: "s0",
+					},
+				},
 				Volumes: []api.Volume{
 					// TODO: Test secret volumes
 					// TODO: Test hostpath volumes

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -18,8 +18,6 @@ package e2e_node
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path"
 	"time"
 
@@ -58,9 +56,7 @@ var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 					{
 						Name: restartCountVolumeName,
 						VolumeSource: api.VolumeSource{
-							HostPath: &api.HostPathVolumeSource{
-								Path: os.TempDir(),
-							},
+							EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory},
 						},
 					},
 				}
@@ -77,9 +73,6 @@ var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 					{"terminate-cmd-rpn", api.RestartPolicyNever, api.PodFailed, ContainerStateTerminated, 0, false},
 				}
 				for _, testCase := range testCases {
-					tmpFile, err := ioutil.TempFile("", "restartCount")
-					Expect(err).NotTo(HaveOccurred())
-					defer os.Remove(tmpFile.Name())
 
 					// It failed at the 1st run, then succeeded at 2nd run, then run forever
 					cmdScripts := `
@@ -93,7 +86,7 @@ if [ $count -eq 2 ]; then
 fi
 while true; do sleep 1; done
 `
-					tmpCmd := fmt.Sprintf(cmdScripts, path.Join(restartCountVolumePath, path.Base(tmpFile.Name())))
+					tmpCmd := fmt.Sprintf(cmdScripts, path.Join(restartCountVolumePath, "restartCount"))
 					testContainer.Name = testCase.Name
 					testContainer.Command = []string{"sh", "-c", tmpCmd}
 					terminateContainer := ConformanceContainer{
@@ -101,6 +94,11 @@ while true; do sleep 1; done
 						Container:     testContainer,
 						RestartPolicy: testCase.RestartPolicy,
 						Volumes:       testVolumes,
+						PodSecurityContext: &api.PodSecurityContext{
+							SELinuxOptions: &api.SELinuxOptions{
+								Level: "s0",
+							},
+						},
 					}
 					terminateContainer.Create()
 					defer terminateContainer.Delete()

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -131,6 +131,7 @@ while true; do sleep 1; done
 				name := "termination-message-container"
 				terminationMessage := "DONE"
 				terminationMessagePath := "/dev/termination-log"
+				priv := true
 				c := ConformanceContainer{
 					Framework: f,
 					Container: api.Container{
@@ -139,6 +140,9 @@ while true; do sleep 1; done
 						Command: []string{"/bin/sh", "-c"},
 						Args:    []string{fmt.Sprintf("/bin/echo -n %s > %s", terminationMessage, terminationMessagePath)},
 						TerminationMessagePath: terminationMessagePath,
+						SecurityContext: &api.SecurityContext{
+							Privileged: &priv,
+						},
 					},
 					RestartPolicy: api.RestartPolicyNever,
 				}


### PR DESCRIPTION
It fixes following 3 node e2es:

```
[Fail] [k8s.io] Container Runtime Conformance Test container runtime conformance blackbox test when starting a container that exits [It] it should run with the expected status [Conformance] 
/root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/runtime_conformance_test.go:114

[Fail] [k8s.io] Kubelet metrics api when querying /stats/summary [It] it should report resource usage through the stats api 
/root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:158
```

```
[Fail] [k8s.io] Container Runtime Conformance Test container runtime conformance blackbox test when starting a container that exits [It] should report termination message if TerminationMessagePath is set [Conformance]
/root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/runtime_conformance_test.go:150
```

@kubernetes/rh-cluster-infra 
