### PR TITLE
README: remove go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Kubernetes
 
-[![Submit Queue Widget]][Submit Queue] [![GoReportCard Widget]][GoReportCard] [![GoDoc Widget]][GoDoc] [![Coverage Status Widget]][Coverage Status]
+[![Submit Queue Widget]][Submit Queue] [![GoDoc Widget]][GoDoc] [![Coverage Status Widget]][Coverage Status]
 
 [Submit Queue]: http://submit-queue.k8s.io/#/e2e
 [Submit Queue Widget]: http://submit-queue.k8s.io/health.svg?v=1
 [GoDoc]: https://godoc.org/k8s.io/kubernetes
 [GoDoc Widget]: https://godoc.org/k8s.io/kubernetes?status.svg
-[GoReportCard]: https://goreportcard.com/report/k8s.io/kubernetes
-[GoReportCard Widget]: https://goreportcard.com/badge/k8s.io/kubernetes
 [Coverage Status]: https://coveralls.io/r/kubernetes/kubernetes
 [Coverage Status Widget]: https://coveralls.io/repos/kubernetes/kubernetes/badge.svg
 


### PR DESCRIPTION
This service seems broken, probably because the k8s repo is larger than
the normal project. I have emailed the service author but for the time
being remove the badge.
