### PR TITLE
Invoking container GC immediately when a container has stopped

### DIFF
--- a/pkg/kubelet/garbage_collection_controller.go
+++ b/pkg/kubelet/garbage_collection_controller.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+const (
+	// Minimum period between consecutive container garbage collection.
+	containerGCPerioMinInterval = time.Second
+	// Period for performing container garbage collection.
+	containerGCPeriod = 60 * containerGCPerioMinInterval
+)
+
+type garbageCollectionController struct {
+	clock              util.Clock
+	containerGCTrigger chan struct{}
+}
+
+func newGarbageCollectionController() garbageCollectionController {
+	gcController := garbageCollectionController{clock: util.RealClock{}}
+	gcController.containerGCTrigger = make(chan struct{}, 1)
+	return gcController
+}
+
+func (gcController *garbageCollectionController) startContainerGarbageCollection(gcCallBack func()) {
+	go wait.Until(func() {
+		// Garbage collection may be triggered by a timer or by an explicit invocation of triggerContainerGarbageCollection().
+		timer := gcController.clock.After(containerGCPeriod)
+		earliestTimeToGC := gcController.clock.Now()
+		for {
+			timer, earliestTimeToGC = gcController.doContainerGarbageCollection(gcCallBack, timer, earliestTimeToGC)
+		}
+	}, 0, wait.NeverStop)
+}
+
+func (gcController *garbageCollectionController) doContainerGarbageCollection(gcCallBack func(), timer <-chan time.Time, earliestTimeToGC time.Time) (<-chan time.Time, time.Time) {
+	for {
+		select {
+		case <-gcController.containerGCTrigger:
+			now := gcController.clock.Now()
+			if now.Before(earliestTimeToGC) {
+				// It's too soon to run GC, reschedule the timer
+				return gcController.clock.After(earliestTimeToGC.Sub(now)), earliestTimeToGC
+			}
+			gcCallBack()
+			return gcController.clock.After(containerGCPeriod), gcController.clock.Now().Add(containerGCPerioMinInterval)
+		case <-timer:
+			gcController.triggerContainerGarbageCollection()
+		}
+	}
+}
+
+func (gcController *garbageCollectionController) triggerContainerGarbageCollection() {
+	select {
+	case gcController.containerGCTrigger <- struct{}{}:
+	default:
+	}
+}

--- a/pkg/kubelet/garbage_collection_controller_test.go
+++ b/pkg/kubelet/garbage_collection_controller_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var gcCallBackCount = 0
+
+func TestContainerGarbageCollectionInvokedPeriodically(t *testing.T) {
+	oldValue := gcCallBackCount
+	mockClock := util.NewFakeClock(time.Now())
+	mockGCController := getMockGarbageCollectionController(mockClock)
+	timer := mockGCController.clock.After(containerGCPeriod)
+	earliestTimeToGC := mockClock.Now()
+	mockClock.Step(containerGCPeriod)
+	_, earliestTimeToGC = mockGCController.doContainerGarbageCollection(mockGCCallback, timer, earliestTimeToGC)
+	assert := assert.New(t)
+	assert.Equal(oldValue+1, gcCallBackCount)
+	assert.Equal(mockClock.Now().Add(containerGCPerioMinInterval), earliestTimeToGC)
+}
+
+func TestContainerGarbageCollectionInvocationBeingCapped(t *testing.T) {
+	oldValue := gcCallBackCount
+	mockClock := util.NewFakeClock(time.Now())
+	mockGCController := getMockGarbageCollectionController(mockClock)
+	earliestTimeToGC := mockClock.Now().Add(containerGCPerioMinInterval * 2)
+	timer := mockGCController.clock.After(containerGCPerioMinInterval)
+
+	mockClock.Step(containerGCPerioMinInterval)
+	// The GC cannot run because it's not yet the next eligible time to run
+	timer, earliestTimeToGC = mockGCController.doContainerGarbageCollection(mockGCCallback, timer, earliestTimeToGC)
+	assert := assert.New(t)
+	assert.Equal(oldValue, gcCallBackCount)
+
+	mockClock.Step(containerGCPerioMinInterval)
+	mockGCController.doContainerGarbageCollection(mockGCCallback, timer, earliestTimeToGC)
+	assert.Equal(oldValue+1, gcCallBackCount)
+}
+
+func getMockGarbageCollectionController(mockClock util.Clock) garbageCollectionController {
+	gcController := newGarbageCollectionController()
+	gcController.clock = mockClock
+	return gcController
+}
+
+func mockGCCallback() {
+	gcCallBackCount++
+}


### PR DESCRIPTION
- Support on-demand invocation of container GC 
- When PLEG detects a container has died, the container GC logic is invoked right away. Besides, the container GC logic gets invoked once per minute. 
