### PR TITLE
Image GC logic should compensate for reserved blocks

### DIFF
--- a/pkg/kubelet/image_manager.go
+++ b/pkg/kubelet/image_manager.go
@@ -213,8 +213,12 @@ func (im *realImageManager) GarbageCollect() error {
 	if err != nil {
 		return err
 	}
-	usage := int64(fsInfo.Usage)
 	capacity := int64(fsInfo.Capacity)
+	available := int64(fsInfo.Available)
+	if available > capacity {
+		glog.Warningf("available %d is larger than capacity %d", available, capacity)
+		available = capacity
+	}
 
 	// Check valid capacity.
 	if capacity == 0 {
@@ -224,9 +228,9 @@ func (im *realImageManager) GarbageCollect() error {
 	}
 
 	// If over the max threshold, free enough to place us at the lower threshold.
-	usagePercent := int(usage * 100 / capacity)
+	usagePercent := 100 - int(available*100/capacity)
 	if usagePercent >= im.policy.HighThresholdPercent {
-		amountToFree := usage - (int64(im.policy.LowThresholdPercent) * capacity / 100)
+		amountToFree := capacity*int64(100-im.policy.LowThresholdPercent)/100 - available
 		glog.Infof("[ImageManager]: Disk usage on %q (%s) is at %d%% which is over the high threshold (%d%%). Trying to free %d bytes", fsInfo.Device, fsInfo.Mountpoint, usagePercent, im.policy.HighThresholdPercent, amountToFree)
 		freed, err := im.freeSpace(amountToFree, time.Now())
 		if err != nil {

--- a/pkg/kubelet/image_manager_test.go
+++ b/pkg/kubelet/image_manager_test.go
@@ -374,8 +374,8 @@ func TestGarbageCollectBelowLowThreshold(t *testing.T) {
 
 	// Expect 40% usage.
 	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    400,
-		Capacity: 1000,
+		Available: 600,
+		Capacity:  1000,
 	}, nil)
 
 	assert.NoError(t, manager.GarbageCollect())
@@ -401,8 +401,8 @@ func TestGarbageCollectBelowSuccess(t *testing.T) {
 
 	// Expect 95% usage and most of it gets freed.
 	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    950,
-		Capacity: 1000,
+		Available: 50,
+		Capacity:  1000,
 	}, nil)
 	fakeRuntime.ImageList = []container.Image{
 		makeImage(0, 450),
@@ -420,8 +420,8 @@ func TestGarbageCollectNotEnoughFreed(t *testing.T) {
 
 	// Expect 95% usage and little of it gets freed.
 	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    950,
-		Capacity: 1000,
+		Available: 50,
+		Capacity:  1000,
 	}, nil)
 	fakeRuntime.ImageList = []container.Image{
 		makeImage(0, 50),


### PR DESCRIPTION
Calculating the disk usage based on available bytes instead of usage bytes to account for reserved blocks in image GC
#27169
