### PR TITLE
expose: bump service name length to DNS1123_LABEL

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -605,7 +605,7 @@ runTests() {
   kubectl label pods valid-pod record-change=true --record=true "${kube_flags[@]}"
   # Post-condition: valid-pod has record annotation
   kube::test::get_object_assert 'pod valid-pod' "{{range$annotations_field}}{{.}}:{{end}}" ".*--record=true.*"
-  
+
   ### Do not record label change
   # Command
   kubectl label pods valid-pod no-record-change=true --record=false "${kube_flags[@]}"
@@ -618,7 +618,7 @@ runTests() {
   # Post-condition: valid-pod's record annotation contains new change
   kube::test::get_object_assert 'pod valid-pod' "{{range$annotations_field}}{{.}}:{{end}}" ".*new-record-change=true.*"
 
-    
+
   ### Delete POD by label
   # Pre-condition: valid-pod POD exists
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
@@ -1765,15 +1765,15 @@ __EOF__
 
   ### Try to generate a service with invalid name (exceeding maximum valid size)
   # Pre-condition: use --name flag
-  output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name --port=8081 2>&1 "${kube_flags[@]}")
+  output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name-that-has-more-than-63-characters --port=8081 2>&1 "${kube_flags[@]}")
   # Post-condition: should fail due to invalid name
   kube::test::if_has_string "${output_message}" 'metadata.name: Invalid value'
   # Pre-condition: default run without --name flag; should succeed by truncating the inherited name
   output_message=$(kubectl expose -f hack/testdata/pod-with-large-name.yaml --port=8081 2>&1 "${kube_flags[@]}")
   # Post-condition: inherited name from pod has been truncated
-  kube::test::if_has_string "${output_message}" '\"kubernetes-serve-hostnam\" exposed'
+  kube::test::if_has_string "${output_message}" '\"kubernetes-serve-hostname-testing-sixty-three-characters-in-len\" exposed'
   # Clean-up
-  kubectl delete svc kubernetes-serve-hostnam "${kube_flags[@]}"
+  kubectl delete svc kubernetes-serve-hostname-testing-sixty-three-characters-in-len "${kube_flags[@]}"
 
   ### Expose multiport object as a new service
   # Pre-condition: don't use --port flag
@@ -1893,7 +1893,7 @@ __EOF__
   # Clean up
   kubectl delete deployment nginx "${kube_flags[@]}"
 
-  ### Set image of a deployment 
+  ### Set image of a deployment
   # Pre-condition: no deployment exists
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Create a deployment
@@ -1901,13 +1901,13 @@ __EOF__
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx-deployment:'
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_PERL}:"
-  # Set the deployment's image 
+  # Set the deployment's image
   kubectl set image deployment nginx-deployment nginx="${IMAGE_DEPLOYMENT_R2}" "${kube_flags[@]}"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R2}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_PERL}:"
-  # Set non-existing container should fail 
+  # Set non-existing container should fail
   ! kubectl set image deployment nginx-deployment redis=redis "${kube_flags[@]}"
-  # Set image of deployments without specifying name 
+  # Set image of deployments without specifying name
   kubectl set image deployments --all nginx="${IMAGE_DEPLOYMENT_R1}" "${kube_flags[@]}"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_PERL}:"
@@ -1915,11 +1915,11 @@ __EOF__
   kubectl set image -f hack/testdata/deployment-multicontainer.yaml nginx="${IMAGE_DEPLOYMENT_R2}" "${kube_flags[@]}"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R2}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_PERL}:"
-  # Set image of a local file without talking to the server 
+  # Set image of a local file without talking to the server
   kubectl set image -f hack/testdata/deployment-multicontainer.yaml nginx="${IMAGE_DEPLOYMENT_R1}" "${kube_flags[@]}" --local -o yaml
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R2}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_PERL}:"
-  # Set image of all containers of the deployment 
+  # Set image of all containers of the deployment
   kubectl set image deployment nginx-deployment "*"="${IMAGE_DEPLOYMENT_R1}" "${kube_flags[@]}"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_second_image_field}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: kubernetes-serve-hostname
+  name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
   labels:
-    name: kubernetes-serve-hostname
+    name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
 spec:
   containers:
-  - name: kubernetes-serve-hostname
+  - name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
     image: gcr.io/google_containers/serve_hostname:v1.4

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -204,7 +204,7 @@ var ValidateReplicationControllerName = NameIsDNSSubdomain
 // ValidateServiceName can be used to check whether the given service name is valid.
 // Prefix indicates this name will be used as part of generation, in which case
 // trailing dashes are allowed.
-var ValidateServiceName = NameIsDNS952Label
+var ValidateServiceName = NameIsDNS1123Label
 
 // ValidateNodeName can be used to check whether the given node name is valid.
 // Prefix indicates this name will be used as part of generation, in which case
@@ -264,6 +264,14 @@ func NameIsDNS952Label(name string, prefix bool) []string {
 		name = maskTrailingDash(name)
 	}
 	return validation.IsDNS952Label(name)
+}
+
+// NameIsDNS1123Label is a ValidateNameFunc for names that must be a DNS 1123 label.
+func NameIsDNS1123Label(name string, prefix bool) []string {
+	if prefix {
+		name = maskTrailingDash(name)
+	}
+	return validation.IsDNS1123Label(name)
 }
 
 // Validates that given value is not negative.

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3449,7 +3449,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "too long name",
 			tweakSvc: func(s *api.Service) {
-				s.Name = strings.Repeat("a", 25)
+				s.Name = strings.Repeat("a", 64)
 			},
 			numErrs: 1,
 		},
@@ -3463,7 +3463,7 @@ func TestValidateService(t *testing.T) {
 		{
 			name: "too long generateName",
 			tweakSvc: func(s *api.Service) {
-				s.GenerateName = strings.Repeat("a", 25)
+				s.GenerateName = strings.Repeat("a", 64)
 			},
 			numErrs: 1,
 		},

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -52,7 +52,7 @@ var (
 		for that resource as the selector for a new service on the specified port. A deployment or replica set
 		will be exposed as a service only if its selector is convertible to a selector that service supports,
 		i.e. when the selector contains only the matchLabels component. Note that if no port is specified via
-		--port and the exposed resource has multiple ports, all will be re-used by the new service. Also if no 
+		--port and the exposed resource has multiple ports, all will be re-used by the new service. Also if no
 		labels are specified, the new service will re-use the labels from the resource it exposes.
 
 		Possible resources include (case insensitive): `) + expose_resources
@@ -170,8 +170,8 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 
 		params := kubectl.MakeParams(cmd, names)
 		name := info.Name
-		if len(name) > validation.DNS952LabelMaxLength {
-			name = name[:validation.DNS952LabelMaxLength]
+		if len(name) > validation.DNS1123LabelMaxLength {
+			name = name[:validation.DNS1123LabelMaxLength]
 		}
 		params["default-name"] = name
 

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -230,18 +230,18 @@ func TestRunExposeService(t *testing.T) {
 		},
 		{
 			name: "truncate-name",
-			args: []string{"pod", "a-name-that-is-toooo-big-for-a-service"},
+			args: []string{"pod", "a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/pods/a-name-that-is-toooo-big-for-a-service",
+				"GET":  "/namespaces/test/pods/a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters",
 				"POST": "/namespaces/test/services",
 			},
 			input: &api.Pod{
-				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
+				ObjectMeta: api.ObjectMeta{Name: "a-name-that-is-toooo-big-for-a-service", Namespace: "test", ResourceVersion: "12"},
 			},
 			flags: map[string]string{"selector": "svc=frompod", "port": "90", "labels": "svc=frompod", "generator": "service/v2"},
 			output: &api.Service{
-				ObjectMeta: api.ObjectMeta{Name: "a-name-that-is-toooo-big", Namespace: "", Labels: map[string]string{"svc": "frompod"}},
+				ObjectMeta: api.ObjectMeta{Name: "a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand", Namespace: "", Labels: map[string]string{"svc": "frompod"}},
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
@@ -253,7 +253,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"svc": "frompod"},
 				},
 			},
-			expected: "service \"a-name-that-is-toooo-big\" exposed",
+			expected: "service \"a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand\" exposed",
 			status:   200,
 		},
 		{

--- a/pkg/kubelet/envvars/envvars_test.go
+++ b/pkg/kubelet/envvars/envvars_test.go
@@ -79,6 +79,26 @@ func TestFromServices(t *testing.T) {
 					},
 				},
 			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "1337"},
+				Spec: api.ServiceSpec{
+					Selector:  map[string]string{"bar": "baz"},
+					ClusterIP: "1.2.3.4",
+					Ports: []api.ServicePort{
+						{Port: 8084, Protocol: "TCP"},
+					},
+				},
+			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "name.with.dots"},
+				Spec: api.ServiceSpec{
+					Selector:  map[string]string{"bar": "baz"},
+					ClusterIP: "1.2.3.4",
+					Ports: []api.ServicePort{
+						{Port: 8085, Protocol: "TCP"},
+					},
+				},
+			},
 		},
 	}
 	vars := envvars.FromServices(&sl)
@@ -115,6 +135,20 @@ func TestFromServices(t *testing.T) {
 		{Name: "Q_U_U_X_PORT_8083_TCP_PROTO", Value: "tcp"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_PORT", Value: "8083"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_ADDR", Value: "9.8.7.6"},
+		{Name: "_1337_SERVICE_HOST", Value: "1.2.3.4"},
+		{Name: "_1337_SERVICE_PORT", Value: "8084"},
+		{Name: "_1337_PORT", Value: "tcp://1.2.3.4:8084"},
+		{Name: "_1337_PORT_8084_TCP", Value: "tcp://1.2.3.4:8084"},
+		{Name: "_1337_PORT_8084_TCP_PROTO", Value: "tcp"},
+		{Name: "_1337_PORT_8084_TCP_PORT", Value: "8084"},
+		{Name: "_1337_PORT_8084_TCP_ADDR", Value: "1.2.3.4"},
+		{Name: "NAME_WITH_DOTS_SERVICE_HOST", Value: "1.2.3.4"},
+		{Name: "NAME_WITH_DOTS_SERVICE_PORT", Value: "8085"},
+		{Name: "NAME_WITH_DOTS_PORT", Value: "tcp://1.2.3.4:8085"},
+		{Name: "NAME_WITH_DOTS_PORT_8085_TCP", Value: "tcp://1.2.3.4:8085"},
+		{Name: "NAME_WITH_DOTS_PORT_8085_TCP_PROTO", Value: "tcp"},
+		{Name: "NAME_WITH_DOTS_PORT_8085_TCP_PORT", Value: "8085"},
+		{Name: "NAME_WITH_DOTS_PORT_8085_TCP_ADDR", Value: "1.2.3.4"},
 	}
 	if len(vars) != len(expected) {
 		t.Errorf("Expected %d env vars, got: %+v", len(expected), vars)
@@ -122,7 +156,7 @@ func TestFromServices(t *testing.T) {
 	}
 	for i := range expected {
 		if !reflect.DeepEqual(vars[i], expected[i]) {
-			t.Errorf("expected %#v, got %#v", vars[i], expected[i])
+			t.Errorf("expected %#v, got %#v", expected[i], vars[i])
 		}
 	}
 }


### PR DESCRIPTION
This bumps the maximum service name length to 63 characters, which is the maximum length of a
domain name label as per RFC 1123.

This is a continuation of #25041 

closes #3572
