### PR TITLE
Use gcloud for default node pool and api for other in cluster autoscaler e2e test

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -273,18 +273,44 @@ func isAutoscalerEnabled(expectedMinNodeCountInTargetPool int) (bool, error) {
 }
 
 func enableAutoscaler(nodePool string, minCount, maxCount int) error {
-	output, err := exec.Command("gcloud", "alpha", "container", "clusters", "update", framework.TestContext.CloudConfig.Cluster,
-		"--enable-autoscaling",
-		"--min-nodes="+strconv.Itoa(minCount),
-		"--max-nodes="+strconv.Itoa(maxCount),
-		"--node-pool="+nodePool,
-		"--project="+framework.TestContext.CloudConfig.ProjectID,
-		"--zone="+framework.TestContext.CloudConfig.Zone).Output()
 
-	if err != nil {
-		return fmt.Errorf("Failed to enable autoscaling: %v", err)
+	if nodePool == "default-pool" {
+		glog.Infof("Using gcloud to enable autoscaling for pool %s", nodePool)
+
+		output, err := exec.Command("gcloud", "alpha", "container", "clusters", "update", framework.TestContext.CloudConfig.Cluster,
+			"--enable-autoscaling",
+			"--min-nodes="+strconv.Itoa(minCount),
+			"--max-nodes="+strconv.Itoa(maxCount),
+			"--node-pool="+nodePool,
+			"--project="+framework.TestContext.CloudConfig.ProjectID,
+			"--zone="+framework.TestContext.CloudConfig.Zone).Output()
+
+		if err != nil {
+			return fmt.Errorf("Failed to enable autoscaling: %v", err)
+		}
+		glog.Infof("Config update result: %s", output)
+
+	} else {
+		glog.Infof("Using direct api access to enable autoscaling for pool %s", nodePool)
+		updateRequest := "{" +
+			" \"update\": {" +
+			"  \"desiredNodePoolId\": \"" + nodePool + "\"," +
+			"  \"desiredNodePoolAutoscaling\": {" +
+			"   \"enabled\": \"true\"," +
+			"   \"minNodeCount\": \"" + strconv.Itoa(minCount) + "\"," +
+			"   \"maxNodeCount\": \"" + strconv.Itoa(maxCount) + "\"" +
+			"  }" +
+			" }" +
+			"}"
+
+		url := getGKEClusterUrl()
+		glog.Infof("Using gke api url %s", url)
+		putResult, err := doPut(url, updateRequest)
+		if err != nil {
+			return fmt.Errorf("Failed to put %s: %v", url, err)
+		}
+		glog.Infof("Config update result: %s", putResult)
 	}
-	glog.Infof("Config update result: %s", output)
 
 	for startTime := time.Now(); startTime.Add(gkeUpdateTimeout).After(time.Now()); time.Sleep(30 * time.Second) {
 		if val, err := isAutoscalerEnabled(minCount); err == nil && val {


### PR DESCRIPTION
cc: @piosz @jszczepkowski @fgrzadkowski 

Currently there is a problem with gcloud when non-default pool is used for cluster update. So we temporarily switch to the old ca-enable method for non-default pools until it is fixed.
