### PR TITLE
Skip test if ssh is not supported by provider

### DIFF
--- a/test/e2e/node_problem_detector.go
+++ b/test/e2e/node_problem_detector.go
@@ -86,6 +86,7 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 		}
 
 		BeforeEach(func() {
+			framework.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 			// Randomize the source name to avoid conflict with real node problem detector
 			source = "kernel-monitor-" + uid
 			config = `


### PR DESCRIPTION
On local vagrant cluster this test is failing because there is no ssh support.
