### PR TITLE
Revert "Federation e2e supports aws"

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1491,7 +1491,7 @@ function test-build-release {
 # Assumed vars:
 #   Variables from config.sh
 function test-setup {
-  . "${KUBE_ROOT}/cluster/kube-up.sh"
+  "${KUBE_ROOT}/cluster/kube-up.sh"
 
   VPC_ID=$(get_vpc_id)
   detect-security-groups

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -135,30 +135,6 @@ function create-federation-api-objects {
 	    fi
 	    sleep 5
 	done
-
-	# Poll until DNS record for federation-apiserver is propagated
-	# TODO(colhom): REQUIREMENT for any other providers which use a DNS name for routing to loadbalancers
-	# right now it's just AWS that does this.
-	which nslookup
-	set +o errexit
-	if [[ "$KUBERNETES_PROVIDER" == "aws" ]];then
-	    for i in {1..60};do
-		echo "attempting to nslookup ${FEDERATION_API_HOST} ($i / 60)"
-		nslookup "${FEDERATION_API_HOST}"
-		if [[ $? -eq 0 ]];then
-		    echo "Lookup for ${FEDERATION_API_HOST} successful!"
-		    break
-		fi
-		sleep 10
-	    done
-
-	    if [[ $i -eq 60 ]];then
-		echo "Failed to resolve A record for ${FEDERATION_API_HOST}. Will exit"
-		exit 1
-	    fi
-	fi
-	set -o errexit
-
 	KUBE_MASTER_IP="${FEDERATION_API_HOST}:443"
     else
 	echo "provider ${KUBERNETES_PROVIDER} is not (yet) supported for e2e testing"

--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -22,11 +22,7 @@ spec:
         - --etcd-servers=http://localhost:2379
         - --service-cluster-ip-range={{.FEDERATION_SERVICE_CIDR}}
         - --secure-port=443
-        {{if eq .KUBERNETES_PROVIDER "aws"}}
-        - --external-hostname={{.FEDERATION_API_HOST}}
-        {{else}}
         - --advertise-address={{.FEDERATION_API_HOST}}
-        {{end}}
         # TODO: --admission-control values must be set when support is added for each type of control.
         - --token-auth-file=/srv/kubernetes/known-tokens.csv
         ports:


### PR DESCRIPTION
Reverting https://github.com/kubernetes/kubernetes/pull/27791 to get our Jenkins tests green again.

cc @kubernetes/sig-cluster-federation 
