### PR TITLE
Increase pod CPU/memory for fluentd, dns and kube-proxy.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -326,7 +326,7 @@ function assemble-docker-flags {
 
   echo "DOCKER_OPTS=\"${docker_opts} ${EXTRA_DOCKER_OPTS:-}\"" > /etc/default/docker
   # If using a network plugin, we need to explicitly restart docker daemon, because
-  # kubelet will not do it. 
+  # kubelet will not do it.
   if [[ "${use_net_plugin}" == "true" ]]; then
     echo "Docker command line is updated. Restart docker to pick it up"
     systemctl restart docker
@@ -474,7 +474,7 @@ function start-kube-proxy {
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${src_file}
   sed -i -e "s@{{pillar\['kube-proxy_docker_tag'\]}}@${kube_proxy_docker_tag}@g" ${src_file}
   sed -i -e "s@{{test_args}}@${KUBEPROXY_TEST_ARGS:-}@g" ${src_file}
-  sed -i -e "s@{{ cpurequest }}@20m@g" ${src_file}
+  sed -i -e "s@{{ cpurequest }}@100m@g" ${src_file}
   sed -i -e "s@{{log_level}}@${KUBEPROXY_TEST_LOG_LEVEL:-"--v=2"}@g" ${src_file}
   sed -i -e "s@{{api_servers_with_port}}@${api_servers}@g" ${src_file}
   if [[ -n "${CLUSTER_IP_RANGE:-}" ]]; then

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -212,7 +212,7 @@ script
 	sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${tmp_file}
 	sed -i -e "s@{{pillar\['kube-proxy_docker_tag'\]}}@${kube_proxy_docker_tag}@g" ${tmp_file}
 	sed -i -e "s@{{test_args}}@${test_args}@g" ${tmp_file}
-	sed -i -e "s@{{ cpurequest }}@20m@g" ${tmp_file}
+	sed -i -e "s@{{ cpurequest }}@100m@g" ${tmp_file}
 	sed -i -e "s@{{log_level}}@${log_level}@g" ${tmp_file}
 	sed -i -e "s@{{api_servers_with_port}}@${api_servers}@g" ${tmp_file}
 	if [ -n "${CLUSTER_IP_RANGE:-}" ]; then

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -18,7 +18,7 @@ spec:
       requests:
         # Any change here should be accompanied by a proportional change in CPU
         # requests of other per-node add-ons (e.g. kube-proxy).
-        cpu: 80m
+        cpu: 100m
         memory: 200Mi
     env:
     - name: FLUENTD_ARGS

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
@@ -52,7 +52,7 @@ spec:
             memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
@@ -52,7 +52,7 @@ spec:
             memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
@@ -52,7 +52,7 @@ spec:
             memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -17,12 +17,10 @@
     - makedirs: true
     - dir_mode: 755
     - context:
-        # 20m might cause kube-proxy CPU starvation on full nodes, resulting in
-        # delayed service updates. But, giving it more would be a breaking change 
-        # to the overhead requirements for existing clusters.
+        # Increasing to 100m to avoid CPU starvation on full nodes.
         # Any change here should be accompanied by a proportional change in CPU
         # requests of other per-node add-ons (e.g. fluentd).
-        cpurequest: '20m'
+        cpurequest: '100m'
     - require:
       - service: docker
       - service: kubelet


### PR DESCRIPTION
Improvements in cluster-wide resource utilization allows us to restore some of the CPU and memory limits on pods that was previously shrunk in 1.2.
