### PR TITLE
Adding lock files for kubeconfig updating

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader_test.go
+++ b/pkg/client/unversioned/clientcmd/loader_test.go
@@ -376,6 +376,22 @@ func TestMigratingFileSourceMissingSkip(t *testing.T) {
 	}
 }
 
+func TestFileLocking(t *testing.T) {
+	f, _ := ioutil.TempFile("", "")
+	defer os.Remove(f.Name())
+
+	err := lockFile(f.Name())
+	if err != nil {
+		t.Errorf("unexpected error while locking file: %v", err)
+	}
+	defer unlockFile(f.Name())
+
+	err = lockFile(f.Name())
+	if err == nil {
+		t.Error("expected error while locking file.")
+	}
+}
+
 func Example_noMergingOnExplicitPaths() {
 	commandLineFile, _ := ioutil.TempFile("", "")
 	defer os.Remove(commandLineFile.Name())


### PR DESCRIPTION
This is to prevent concurrent executions from corrupting the kubeconfig file. 

Also, release note?
#23964
