### PR TITLE
oidc auth plugin: don't hard fail if provider is unavailable

### DIFF
--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -156,8 +156,6 @@ func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClai
 		CAFile:        caFile,
 		UsernameClaim: usernameClaim,
 		GroupsClaim:   groupsClaim,
-		MaxRetries:    oidc.DefaultRetries,
-		RetryBackoff:  oidc.DefaultBackoff,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When using OpenID Connect authentication, don't cause the API
server to fail if the provider is unavailable. This allows
installations to run OpenID Connect providers after starting the
API server, a common case when the provider is running on the
cluster itself.

Errors are now deferred to the authenticate method.

cc @sym3tri @erictune @aaronlevy @kubernetes/sig-auth
