### PR TITLE
in e2e pd test, sync after echo data to a file

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -443,7 +443,7 @@ func (f *Framework) WriteFileViaContainer(podName, containerName string, path st
 			return fmt.Errorf("Unsupported character in string to write: %v", c)
 		}
 	}
-	command := fmt.Sprintf("echo '%s' > '%s'", contents, path)
+	command := fmt.Sprintf("echo '%s' > '%s';sync;sync", contents, path)
 	stdout, stderr, err := kubectlExecWithRetry(f.Namespace.Name, podName, containerName, "--", "/bin/sh", "-c", command)
 	if err != nil {
 		Logf("error running kubectl exec to write file: %v\nstdout=%v\nstderr=%v)", err, string(stdout), string(stderr))


### PR DESCRIPTION
this is to fix #27691 

in this test, host0pod writes data to the disk. While exiting, another pod host1pod tries to read the file from the disk. But since pod delete doesn't really watch the pod is deleted and disk detached, the pod is probably still running and data is not flushed yet. 

This fix ensures the data is flushed. 
