### PR TITLE
Tracked addition of federation, sed support in kube DNS

### DIFF
--- a/cluster/saltbase/salt/kube-dns/README.md
+++ b/cluster/saltbase/salt/kube-dns/README.md
@@ -7,6 +7,14 @@ Due to a varied preference in templating language choices, the transform
 Makefile in this directory should be enhanced to generate all required
 formats from the base underscore templates.
 
+**NOTE WELL**: Developers, when you add a parameter you should also
+update the various scripts that supply values for your new parameter.
+Here is one way you might find those scripts:
+```
+cd kubernetes
+find [a-zA-Z0-9]* -type f -exec grep skydns-rc.yaml \{\} \; -print -exec echo \;
+```
+
 ## Base Template files
 
 These are the authoritative base templates.

--- a/cluster/ubuntu/deployAddons.sh
+++ b/cluster/ubuntu/deployAddons.sh
@@ -42,7 +42,7 @@ function init {
 function deploy_dns {
   echo "Deploying DNS on Kubernetes"
   sed -e "s/\\\$DNS_REPLICAS/${DNS_REPLICAS}/g;s/\\\$DNS_DOMAIN/${DNS_DOMAIN}/g;" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed" > skydns-rc.yaml
-  sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-svc.yaml.in" > skydns-svc.yaml
+  sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-svc.yaml.sed" > skydns-svc.yaml
 
   KUBEDNS=`eval "${KUBECTL} get services --namespace=kube-system | grep kube-dns | cat"`
       

--- a/cluster/ubuntu/deployAddons.sh
+++ b/cluster/ubuntu/deployAddons.sh
@@ -41,8 +41,8 @@ function init {
 
 function deploy_dns {
   echo "Deploying DNS on Kubernetes"
-  sed -e "s/{{ pillar\['dns_replicas'\] }}/${DNS_REPLICAS}/g;s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g;" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in" > skydns-rc.yaml
-  sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-svc.yaml.in" > skydns-svc.yaml
+  sed -e "s/\\\$DNS_REPLICAS/${DNS_REPLICAS}/g;s/\\\$DNS_DOMAIN/${DNS_DOMAIN}/g;" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed" > skydns-rc.yaml
+  sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/saltbase/salt/kube-dns/skydns-svc.yaml.in" > skydns-svc.yaml
 
   KUBEDNS=`eval "${KUBECTL} get services --namespace=kube-system | grep kube-dns | cat"`
       


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

The kube DNS app recently gained support for federation (whatever that
is), including a new Salt parameter.  This broke the deployAddons.sh script for cluster ubuntu.  The DNS app also gained alternate
templates, intended to be friendly to `sed`.  Fortunately, those do
not demand a federation parameter.

This PR fixes up the `cluster/ubuntu/deployAddons.sh` script to track those changes, by switching to the `sed`-friendly templates.
