### PR TITLE
Increase kube-dns requirements on CoreOS.

### DIFF
--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -32,7 +32,7 @@ spec:
             memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Missed changing the kube-dns memory limit on CoreOS. Follow of PR #28032.
