### PR TITLE
cache bug

### DIFF
--- a/pkg/util/cache/lruexpirecache.go
+++ b/pkg/util/cache/lruexpirecache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/groupcache/lru"
 )
 
+// 1. ttlcache 2. 同时是个lru cache 3.ttl时间不能修改
 type LRUExpireCache struct {
 	cache *lru.Cache
 	lock  sync.RWMutex
@@ -41,8 +42,6 @@ func (c *LRUExpireCache) Add(key lru.Key, value interface{}, ttl time.Duration) 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.cache.Add(key, &cacheEntry{value, time.Now().Add(ttl)})
-	// Remove entry from cache after ttl.
-	time.AfterFunc(ttl, func() { c.remove(key) })
 }
 
 func (c *LRUExpireCache) Get(key lru.Key) (interface{}, bool) {


### PR DESCRIPTION
1. not a lru cache if same key is get or add multiple time
2. not efficient
3. no need at all, keep it a lru cache with max volumn and it has ttl check when get operation already

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28085)

<!-- Reviewable:end -->
