### PR TITLE
Fix node problem detector e2e flake

### DIFF
--- a/test/e2e/node_problem_detector.go
+++ b/test/e2e/node_problem_detector.go
@@ -198,8 +198,8 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 			Consistently(func() error {
 				return verifyNoEvents(c.Events(eventNamespace), eventListOptions)
 			}, pollConsistent, pollInterval).Should(Succeed())
-			By("Make sure the default node condition is false")
-			Consistently(func() error {
+			By("Make sure the default node condition is generated")
+			Eventually(func() error {
 				return verifyCondition(c.Nodes(), node.Name, condition, api.ConditionFalse, defaultReason, defaultMessage)
 			}, pollConsistent, pollInterval).Should(Succeed())
 


### PR DESCRIPTION
Fix #28069.

The [original code](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node_problem_detector.go#L198-L204) assumes the test condition will be generated after 5s ([`pollConsistently`](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node_problem_detector.go#L39)), however sometimes that may not be enough, see #28096

So, this PR changes it to use `Eventually` instead of `Consistently` to make the code waits longer before the test condition to be generated. The original `Consistently` checking is a bit redundant, so I removed it.

@dchen1107 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
