### PR TITLE
[Kubelet] Change default for --cgroup-root flag to be "/"

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -82,7 +82,7 @@ func NewKubeletServer() *KubeletServer {
 			CAdvisorPort:                 4194,
 			VolumeStatsAggPeriod:         unversioned.Duration{Duration: time.Minute},
 			CertDirectory:                "/var/run/kubernetes",
-			CgroupRoot:                   "",
+			CgroupRoot:                   "/",
 			ConfigureCBR0:                false,
 			ContainerRuntime:             "docker",
 			RuntimeRequestTimeout:        unversioned.Duration{Duration: 2 * time.Minute},

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -355,7 +355,7 @@ func run(s *options.KubeletServer, kcfg *KubeletConfig) (err error) {
 	}
 
 	if kcfg.ContainerManager == nil {
-		if kcfg.SystemCgroups != "" && kcfg.CgroupRoot == "" {
+		if kcfg.SystemCgroups != "" && kcfg.CgroupRoot == "/" {
 			return fmt.Errorf("invalid configuration: system container was specified and cgroup root was not specified")
 		}
 
@@ -557,7 +557,7 @@ func SimpleKubelet(client *clientset.Clientset,
 		Address:                      net.ParseIP(address),
 		CAdvisorInterface:            cadvisorInterface,
 		VolumeStatsAggPeriod:         time.Minute,
-		CgroupRoot:                   "",
+		CgroupRoot:                   "/",
 		Cloud:                        cloud,
 		ClusterDNS:                   clusterDNS,
 		ConfigFile:                   configFilePath,


### PR DESCRIPTION
Currently the default --cgroup-root is set as the empty string "". When no cgroup root is specified we pass the empty string to docker as the container cgroup parent. And docker handles the empty string appropriately based on the cgroup driver being used. I am  working on adding support for pod level cgroups. For pod level cgroup creation we would have to determine the cgroup driver based on system configuration. And pass appropriate cgroup parent name depending on the cgroup driver.

Some considerations: 
1. We would not want to force the runtime to use a specified cgroup driver. 
2. So we would ideally want to determine the cgroup driver being used by the runtime and pass cgroup names depending on the cgroup driver. Docker supports cgroup driver info in versions >=v1.11.  Have a look at @vishh's [comment](https://github.com/kubernetes/kubernetes/pull/28094#issuecomment-228888148). But we would also want to have the knowledge about the cgroup driver the runtime is configured to use during Kubelet bootstrapping.

@euank @derekwaynecarr @vishh Lets have the discussion on possible solutions on this thread.

For #27204
