### PR TITLE
Kubelet should mark VolumeInUse before checking if it is Attached

### DIFF
--- a/pkg/controller/volume/attach_detach_controller.go
+++ b/pkg/controller/volume/attach_detach_controller.go
@@ -50,7 +50,7 @@ const (
 	// attach detach controller will wait for a volume to be safely unmounted
 	// from its node. Once this time has expired, the controller will assume the
 	// node or kubelet are unresponsive and will detach the volume anyway.
-	reconcilerMaxWaitForUnmountDuration time.Duration = 3 * time.Minute
+	reconcilerMaxWaitForUnmountDuration time.Duration = 6 * time.Minute
 
 	// desiredStateOfWorldPopulatorLoopSleepPeriod is the amount of time the
 	// DesiredStateOfWorldPopulator loop waits between successive executions

--- a/pkg/controller/volume/reconciler/reconciler.go
+++ b/pkg/controller/volume/reconciler/reconciler.go
@@ -109,7 +109,7 @@ func (rc *reconciler) reconciliationLoopFunc() func() {
 
 				if !attachedVolume.MountedByNode {
 					glog.V(5).Infof("Attempting to start DetachVolume for volume %q from node %q", attachedVolume.VolumeName, attachedVolume.NodeName)
-					err := rc.attacherDetacher.DetachVolume(attachedVolume.AttachedVolume, rc.actualStateOfWorld)
+					err := rc.attacherDetacher.DetachVolume(attachedVolume.AttachedVolume, true /* verifySafeToDetach */, rc.actualStateOfWorld)
 					if err == nil {
 						glog.Infof("Started DetachVolume for volume %q from node %q", attachedVolume.VolumeName, attachedVolume.NodeName)
 					}
@@ -129,7 +129,7 @@ func (rc *reconciler) reconciliationLoopFunc() func() {
 					// If volume is not safe to detach (is mounted) wait a max amount of time before detaching any way.
 					if timeElapsed > rc.maxWaitForUnmountDuration {
 						glog.V(5).Infof("Attempting to start DetachVolume for volume %q from node %q. Volume is not safe to detach, but maxWaitForUnmountDuration expired.", attachedVolume.VolumeName, attachedVolume.NodeName)
-						err := rc.attacherDetacher.DetachVolume(attachedVolume.AttachedVolume, rc.actualStateOfWorld)
+						err := rc.attacherDetacher.DetachVolume(attachedVolume.AttachedVolume, false /* verifySafeToDetach */, rc.actualStateOfWorld)
 						if err == nil {
 							glog.Infof("Started DetachVolume for volume %q from node %q due to maxWaitForUnmountDuration expiry.", attachedVolume.VolumeName, attachedVolume.NodeName)
 						}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3404,7 +3404,11 @@ func (kl *Kubelet) tryUpdateNodeStatus() error {
 		return err
 	}
 	// Update the current status on the API server
-	_, err = kl.kubeClient.Core().Nodes().UpdateStatus(node)
+	updatedNode, err := kl.kubeClient.Core().Nodes().UpdateStatus(node)
+	if err == nil {
+		kl.volumeManager.MarkVolumesAsReportedInUse(
+			updatedNode.Status.VolumesInUse)
+	}
 	return err
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -597,7 +597,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	}
 
 	// Verify volumes detached and no longer reported as in use
-	err = waitForVolumeDetach(kubelet.volumeManager)
+	err = waitForVolumeDetach(api.UniqueVolumeName("fake/vol1"), kubelet.volumeManager)
 	if err != nil {
 		t.Error(err)
 	}
@@ -611,7 +611,6 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 }
 
 func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
@@ -657,6 +656,13 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	}()
 
 	kubelet.podManager.SetPods([]*api.Pod{pod})
+
+	// Fake node status update
+	go simulateVolumeInUseUpdate(
+		api.UniqueVolumeName("fake/vol1"),
+		stopCh,
+		kubelet.volumeManager)
+
 	err := kubelet.volumeManager.WaitForAttachAndMount(pod)
 	if err != nil {
 		t.Errorf("Expected success: %v", err)
@@ -747,6 +753,12 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	// Add pod
 	kubelet.podManager.SetPods([]*api.Pod{pod})
 
+	// Fake node status update
+	go simulateVolumeInUseUpdate(
+		api.UniqueVolumeName("fake/vol1"),
+		stopCh,
+		kubelet.volumeManager)
+
 	// Verify volumes attached
 	err := kubelet.volumeManager.WaitForAttachAndMount(pod)
 	if err != nil {
@@ -815,7 +827,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	}
 
 	// Verify volumes detached and no longer reported as in use
-	err = waitForVolumeDetach(kubelet.volumeManager)
+	err = waitForVolumeDetach(api.UniqueVolumeName("fake/vol1"), kubelet.volumeManager)
 	if err != nil {
 		t.Error(err)
 	}
@@ -828,7 +840,6 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 }
 
 func TestPodVolumesExist(t *testing.T) {
@@ -4987,19 +4998,15 @@ func waitForVolumeUnmount(
 }
 
 func waitForVolumeDetach(
+	volumeName api.UniqueVolumeName,
 	volumeManager kubeletvolume.VolumeManager) error {
 	attachedVolumes := []api.UniqueVolumeName{}
 	err := retryWithExponentialBackOff(
 		time.Duration(50*time.Millisecond),
 		func() (bool, error) {
 			// Verify volumes detached
-			attachedVolumes = volumeManager.GetVolumesInUse()
-
-			if len(attachedVolumes) != 0 {
-				return false, nil
-			}
-
-			return true, nil
+			volumeAttached := volumeManager.VolumeIsAttached(volumeName)
+			return !volumeAttached, nil
 		},
 	)
 
@@ -5019,4 +5026,21 @@ func retryWithExponentialBackOff(initialDuration time.Duration, fn wait.Conditio
 		Steps:    6,
 	}
 	return wait.ExponentialBackoff(backoff, fn)
+}
+
+func simulateVolumeInUseUpdate(
+	volumeName api.UniqueVolumeName,
+	stopCh <-chan struct{},
+	volumeManager kubeletvolume.VolumeManager) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			volumeManager.MarkVolumesAsReportedInUse(
+				[]api.UniqueVolumeName{volumeName})
+		case <-stopCh:
+			return
+		}
+	}
 }

--- a/pkg/kubelet/volume/reconciler/reconciler.go
+++ b/pkg/kubelet/volume/reconciler/reconciler.go
@@ -295,7 +295,7 @@ func (rc *reconciler) reconciliationLoopFunc() func() {
 							attachedVolume.VolumeName,
 							attachedVolume.VolumeSpec.Name())
 						err := rc.operationExecutor.DetachVolume(
-							attachedVolume.AttachedVolume, rc.actualStateOfWorld)
+							attachedVolume.AttachedVolume, false /* verifySafeToDetach */, rc.actualStateOfWorld)
 						if err != nil &&
 							!goroutinemap.IsAlreadyExists(err) &&
 							!goroutinemap.IsExponentialBackoff(err) {

--- a/pkg/kubelet/volume/volume_manager.go
+++ b/pkg/kubelet/volume/volume_manager.go
@@ -102,10 +102,24 @@ type VolumeManager interface {
 	// pod object is bad, and should be avoided.
 	GetVolumesForPodAndAppendSupplementalGroups(pod *api.Pod) container.VolumeMap
 
-	// Returns a list of all volumes that are currently attached according to
-	// the actual state of the world cache and implement the volume.Attacher
-	// interface.
+	// Returns a list of all volumes that implement the volume.Attacher
+	// interface and are currently in use according to the actual and desired
+	// state of the world caches. A volume is considered "in use" as soon as it
+	// is added to the desired state of world, indicating it *should* be
+	// attached to this node and remains "in use" until it is removed from both
+	// the desired state of the world and the actual state of the world, or it
+	// has been unmounted (as indicated in actual state of world).
+	// TODO(#27653): VolumesInUse should be handled gracefully on kubelet'
+	// restarts.
 	GetVolumesInUse() []api.UniqueVolumeName
+
+	// VolumeIsAttached returns true if the given volume is attached to this
+	// node.
+	VolumeIsAttached(volumeName api.UniqueVolumeName) bool
+
+	// Marks the specified volume as having successfully been reported as "in
+	// use" in the nodes's volume status.
+	MarkVolumesAsReportedInUse(volumesReportedAsInUse []api.UniqueVolumeName)
 }
 
 // NewVolumeManager returns a new concrete instance implementing the
@@ -209,16 +223,47 @@ func (vm *volumeManager) GetVolumesForPodAndAppendSupplementalGroups(
 }
 
 func (vm *volumeManager) GetVolumesInUse() []api.UniqueVolumeName {
-	attachedVolumes := vm.actualStateOfWorld.GetAttachedVolumes()
-	volumesInUse :=
-		make([]api.UniqueVolumeName, 0 /* len */, len(attachedVolumes) /* cap */)
-	for _, attachedVolume := range attachedVolumes {
-		if attachedVolume.PluginIsAttachable {
-			volumesInUse = append(volumesInUse, attachedVolume.VolumeName)
+	// Report volumes in desired state of world and actual state of world so
+	// that volumes are marked in use as soon as the decision is made that the
+	// volume *should* be attached to this node until it is safely unmounted.
+	desiredVolumes := vm.desiredStateOfWorld.GetVolumesToMount()
+	mountedVolumes := vm.actualStateOfWorld.GetGloballyMountedVolumes()
+	volumesToReportInUse :=
+		make(
+			[]api.UniqueVolumeName,
+			0, /* len */
+			len(desiredVolumes)+len(mountedVolumes) /* cap */)
+	desiredVolumesMap :=
+		make(
+			map[api.UniqueVolumeName]bool,
+			len(desiredVolumes)+len(mountedVolumes) /* cap */)
+
+	for _, volume := range desiredVolumes {
+		if volume.PluginIsAttachable {
+			desiredVolumesMap[volume.VolumeName] = true
+			volumesToReportInUse = append(volumesToReportInUse, volume.VolumeName)
 		}
 	}
 
-	return volumesInUse
+	for _, volume := range mountedVolumes {
+		if volume.PluginIsAttachable {
+			if _, exists := desiredVolumesMap[volume.VolumeName]; !exists {
+				volumesToReportInUse = append(volumesToReportInUse, volume.VolumeName)
+			}
+		}
+	}
+
+	return volumesToReportInUse
+}
+
+func (vm *volumeManager) VolumeIsAttached(
+	volumeName api.UniqueVolumeName) bool {
+	return vm.actualStateOfWorld.VolumeExists(volumeName)
+}
+
+func (vm *volumeManager) MarkVolumesAsReportedInUse(
+	volumesReportedAsInUse []api.UniqueVolumeName) {
+	vm.desiredStateOfWorld.MarkVolumesReportedInUse(volumesReportedAsInUse)
 }
 
 // getVolumesForPodHelper is a helper method implements the common logic for

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -60,8 +60,10 @@ type OperationExecutor interface {
 
 	// DetachVolume detaches the volume from the node specified in
 	// volumeToDetach, and updates the actual state of the world to reflect
-	// that.
-	DetachVolume(volumeToDetach AttachedVolume, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
+	// that. If verifySafeToDetach is set, a call is made to the fetch the node
+	// object and it is used to verify that the volume does not exist in Node's
+	// Status.VolumesInUse list (operation fails with error if it is).
+	DetachVolume(volumeToDetach AttachedVolume, verifySafeToDetach bool, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
 
 	// MountVolume mounts the volume to the pod specified in volumeToMount.
 	// Specifically it will:
@@ -183,6 +185,10 @@ type VolumeToMount struct {
 	// DevicePath contains the path on the node where the volume is attached.
 	// For non-attachable volumes this is empty.
 	DevicePath string
+
+	// ReportedInUse indicates that the volume was successfully added to the
+	// VolumesInUse field in the node's status.
+	ReportedInUse bool
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -335,9 +341,10 @@ func (oe *operationExecutor) AttachVolume(
 
 func (oe *operationExecutor) DetachVolume(
 	volumeToDetach AttachedVolume,
+	verifySafeToDetach bool,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) error {
 	detachFunc, err :=
-		oe.generateDetachVolumeFunc(volumeToDetach, actualStateOfWorld)
+		oe.generateDetachVolumeFunc(volumeToDetach, verifySafeToDetach, actualStateOfWorld)
 	if err != nil {
 		return err
 	}
@@ -465,6 +472,7 @@ func (oe *operationExecutor) generateAttachVolumeFunc(
 
 func (oe *operationExecutor) generateDetachVolumeFunc(
 	volumeToDetach AttachedVolume,
+	verifySafeToDetach bool,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) (func() error, error) {
 	// Get attacher plugin
 	attachableVolumePlugin, err :=
@@ -500,6 +508,44 @@ func (oe *operationExecutor) generateDetachVolumeFunc(
 	}
 
 	return func() error {
+		if verifySafeToDetach {
+			// Fetch current node object
+			node, fetchErr := oe.kubeClient.Core().Nodes().Get(volumeToDetach.NodeName)
+			if fetchErr != nil {
+				// On failure, return error. Caller will log and retry.
+				return fmt.Errorf(
+					"DetachVolume failed fetching node from API server for volume %q (spec.Name: %q) from node %q with: %v",
+					volumeToDetach.VolumeName,
+					volumeToDetach.VolumeSpec.Name(),
+					volumeToDetach.NodeName,
+					fetchErr)
+			}
+
+			if node == nil {
+				// On failure, return error. Caller will log and retry.
+				return fmt.Errorf(
+					"DetachVolume failed fetching node from API server for volume %q (spec.Name: %q) from node %q. Error: node object retrieved from API server is nil.",
+					volumeToDetach.VolumeName,
+					volumeToDetach.VolumeSpec.Name(),
+					volumeToDetach.NodeName)
+			}
+
+			for _, inUseVolume := range node.Status.VolumesInUse {
+				if inUseVolume == volumeToDetach.VolumeName {
+					return fmt.Errorf("DetachVolume failed for volume %q (spec.Name: %q) from node %q. Error: volume is still in use by node, according to Node status.",
+						volumeToDetach.VolumeName,
+						volumeToDetach.VolumeSpec.Name(),
+						volumeToDetach.NodeName)
+				}
+			}
+
+			// Volume not attached, return error. Caller will log and retry.
+			glog.Infof("Verified volume is safe to detach for volume %q (spec.Name: %q) from node %q.",
+				volumeToDetach.VolumeName,
+				volumeToDetach.VolumeSpec.Name(),
+				volumeToDetach.NodeName)
+		}
+
 		// Execute detach
 		detachErr := volumeDetacher.Detach(volumeName, volumeToDetach.NodeName)
 		if detachErr != nil {
@@ -862,6 +908,20 @@ func (oe *operationExecutor) generateVerifyControllerAttachedVolumeFunc(
 			}
 
 			return nil
+		}
+
+		if !volumeToMount.ReportedInUse {
+			// If the given volume has not yet been added to the list of
+			// VolumesInUse in the node's volume status, do not proceed, return
+			// error. Caller will log and retry. The node status is updated
+			// periodically by kubelet, so it may take as much as 10 seconds
+			// before this clears.
+			// Issue #28141 to enable on demand status updates.
+			return fmt.Errorf("Volume %q (spec.Name: %q) pod %q (UID: %q) has not yet been added to the list of VolumesInUse in the node's volume status.",
+				volumeToMount.VolumeName,
+				volumeToMount.VolumeSpec.Name(),
+				volumeToMount.PodName,
+				volumeToMount.Pod.UID)
 		}
 
 		// Fetch current node object


### PR DESCRIPTION
Kubelet should mark VolumeInUse before checking if it is Attached.
Controller should fetch fresh copy of node object before detach instead of relying on node informer cache.

Fixes #27836
