### PR TITLE
SchedulerExtender: add failedPredicateMap in Filter() returns

### DIFF
--- a/plugin/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface.go
@@ -26,8 +26,9 @@ import (
 // managed by Kubernetes.
 type SchedulerExtender interface {
 	// Filter based on extender-implemented predicate functions. The filtered list is
-	// expected to be a subset of the supplied list.
-	Filter(pod *api.Pod, nodes []*api.Node) (filteredNodes []*api.Node, err error)
+	// expected to be a subset of the supplied list. failedNodesMap optionally contains
+	// the list of failed nodes and failure reasons.
+	Filter(pod *api.Pod, nodes []*api.Node) (filteredNodes []*api.Node, failedNodesMap schedulerapi.FailedNodesMap, err error)
 
 	// Prioritize based on extender-implemented priority functions. The returned scores & weight
 	// are used to compute the weighted score for an extender. The weighted scores are added to

--- a/plugin/pkg/scheduler/api/types.go
+++ b/plugin/pkg/scheduler/api/types.go
@@ -139,10 +139,15 @@ type ExtenderArgs struct {
 	Nodes api.NodeList `json:"nodes"`
 }
 
+// FailedNodesMap represents the filtered out nodes, with node names and failure messages
+type FailedNodesMap map[string]string
+
 // ExtenderFilterResult represents the results of a filter call to an extender
 type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled
 	Nodes api.NodeList `json:"nodes,omitempty"`
+	// Filtered out nodes where the pod can't be scheduled and the failure messages
+	FailedNodes FailedNodesMap `json:"failedNodes,omitempty"`
 	// Error message indicating failure
 	Error string `json:"error,omitempty"`
 }

--- a/plugin/pkg/scheduler/api/v1/types.go
+++ b/plugin/pkg/scheduler/api/v1/types.go
@@ -139,10 +139,15 @@ type ExtenderArgs struct {
 	Nodes apiv1.NodeList `json:"nodes"`
 }
 
+// FailedNodesMap represents the filtered out nodes, with node names and failure messages
+type FailedNodesMap map[string]string
+
 // ExtenderFilterResult represents the results of a filter call to an extender
 type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled
 	Nodes apiv1.NodeList `json:"nodes,omitempty"`
+	// Filtered out nodes where the pod can't be scheduled and the failure messages
+	FailedNodes FailedNodesMap `json:"failedNodes,omitempty"`
 	// Error message indicating failure
 	Error string `json:"error,omitempty"`
 }

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -183,9 +183,13 @@ func findNodesThatFit(
 
 	if len(filtered) > 0 && len(extenders) != 0 {
 		for _, extender := range extenders {
-			filteredList, err := extender.Filter(pod, filtered)
+			filteredList, failedMap, err := extender.Filter(pod, filtered)
 			if err != nil {
 				return []*api.Node{}, FailedPredicateMap{}, err
+			}
+
+			for failedNodeName, failedMsg := range failedMap {
+				failedPredicateMap[failedNodeName] = failedMsg
 			}
 			filtered = filteredList
 			if len(filtered) == 0 {


### PR DESCRIPTION
Fix #25797. modify extender.Filter for adding extenders information to “failedPredicateMap” in findNodesThatFit.
When all the filtered nodes that passed "predicateFuncs" don’t pass the extenders filter, the failedPredicateMap hasn’t the extenders information, should add it, I think. So when the length of the “filteredNodes.Items” is 0, we can know the integral information. (The length of the “filteredNodes.Items” is 0, may be because the extenders filter failed.)
