### PR TITLE
Describe container volume mounts

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -887,7 +887,28 @@ func describeContainers(label string, containers []api.Container, containerStatu
 			probe := DescribeProbe(container.ReadinessProbe)
 			fmt.Fprintf(out, "    Readiness:\t%s\n", probe)
 		}
+
 		none := ""
+		if len(container.VolumeMounts) == 0 {
+			none = "\t<none>"
+		}
+
+		fmt.Fprintf(out, "    Volume Mounts:%s\n", none)
+		sort.Sort(SortableVolumeMounts(container.VolumeMounts))
+		for _, mount := range container.VolumeMounts {
+			flags := []string{}
+			switch {
+			case mount.ReadOnly:
+				flags = append(flags, "ro")
+			case !mount.ReadOnly:
+				flags = append(flags, "rw")
+			case len(mount.SubPath) > 0:
+				flags = append(flags, fmt.Sprintf("path=%q", mount.SubPath))
+			}
+			fmt.Fprintf(out, "      %s from %s (%s)\n", mount.MountPath, mount.Name, strings.Join(flags, ","))
+		}
+
+		none = ""
 		if len(container.Env) == 0 {
 			none = "\t<none>"
 		}

--- a/pkg/kubectl/sorted_resource_name_list.go
+++ b/pkg/kubectl/sorted_resource_name_list.go
@@ -61,6 +61,20 @@ func (list SortableResourceQuotas) Less(i, j int) bool {
 	return list[i].Name < list[j].Name
 }
 
+type SortableVolumeMounts []api.VolumeMount
+
+func (list SortableVolumeMounts) Len() int {
+	return len(list)
+}
+
+func (list SortableVolumeMounts) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableVolumeMounts) Less(i, j int) bool {
+	return list[i].MountPath < list[j].MountPath
+}
+
 // SortedQoSResourceNames returns the sorted resource names of a QoS list.
 func SortedQoSResourceNames(list qos.QoSList) []api.ResourceName {
 	resources := make([]api.ResourceName, 0, len(list))


### PR DESCRIPTION
This patch will list the volume mounts defined for the container in `kubectl describe`:

``` console
[root@localhost origin]# kubectl describe pods/ruby-ex-3-ehchv
Name:           ruby-ex-3-ehchv
Namespace:      test
Security Policy:    restricted
Node:           localhost/10.0.2.15
Start Time:     Mon, 27 Jun 2016 11:15:19 +0000
Labels:         app=ruby-ex
            deployment=ruby-ex-3
            deploymentconfig=ruby-ex
Status:         Running
IP:         172.17.0.3
Controllers:        ReplicationController/ruby-ex-3
Containers:
  ruby-ex:
    Container ID:   docker://75869f5dd5da39025ebfcf4cb970004d9cc99ee2f95524732f9102254b289b1e
    Image:      172.30.159.185:5000/test/ruby-ex@sha256:0faa1fcca255a269378a4db51b8eef2ae67312de8b21b033c46fe0ff414efaea
    Image ID:       docker://052fe9b4b929cc883fcbbf1e223373d2fbe8bdf407170210ee29a94c33b40cd3
    Port:       8080/TCP
    QoS Tier:
      cpu:      BestEffort
      memory:       BestEffort
    State:      Running
      Started:      Mon, 27 Jun 2016 11:15:20 +0000
    Ready:      True
    Restart Count:  0
    Volume Mounts:
      volume-eckcb:     /test
      default-token-uffs0:  /var/run/secrets/kubernetes.io/serviceaccount
    Environment Variables:  <none>
```
