### PR TITLE
Enable HTTP2 by default

### DIFF
--- a/pkg/util/net/http.go
+++ b/pkg/util/net/http.go
@@ -77,8 +77,10 @@ func SetOldTransportDefaults(t *http.Transport) *http.Transport {
 // for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
 func SetTransportDefaults(t *http.Transport) *http.Transport {
 	t = SetOldTransportDefaults(t)
-	// Allow HTTP2 clients but default off for now
-	if s := os.Getenv("ENABLE_HTTP2"); len(s) > 0 {
+	// Allow clients to disable http2 if needed.
+	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
+		glog.Infof("HTTP2 has been explicitly disabled")
+	} else {
 		if err := http2.ConfigureTransport(t); err != nil {
 			glog.Warningf("Transport failed http2 configuration: %v", err)
 		}


### PR DESCRIPTION
Update to enable HTTP2 by default, with the option to disable.  

This is a continuation of #25280 for the 1.4 release.  This should provide ample time for vetting. 

/cc @krousey 
