### PR TITLE
Fix a node e2e panic

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -305,7 +305,10 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 }
 
 func (es *e2eService) stopService(cmd *killCmd) error {
-	return cmd.Kill()
+	if cmd != nil {
+		return cmd.Kill()
+	}
+	return fmt.Errorf("can not stop a nil service")
 }
 
 // killCmd is a struct to kill a given cmd. The cmd member specifies a command


### PR DESCRIPTION
Fix a node e2e panic when there is already a running instance of etc/kube-apiserver/kubelet:

```
------------------------------
I0627 12:26:54.394263    8546 e2e_node_suite_test.go:107] Stopping node services...
Panic [0.000 seconds]
[AfterSuite] AfterSuite
/root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:113

  Test Panicked
  runtime error: invalid memory address or nil pointer dereference
  /usr/lib/golang/src/runtime/panic.go:443

  Full Stack Trace
    /usr/lib/golang/src/runtime/panic.go:443 +0x4e9
  k8s.io/kubernetes/test/e2e_node.(*killCmd).Kill(0x0, 0x0, 0x0)
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_service.go:322 +0x4c
  k8s.io/kubernetes/test/e2e_node.(*e2eService).stopService(0xc820198be0, 0x0, 0x0, 0x0)
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_service.go:308 +0x2d
  k8s.io/kubernetes/test/e2e_node.(*e2eService).stop(0xc820198be0)
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_service.go:155 +0x6c
  k8s.io/kubernetes/test/e2e_node.glob.func4()
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:108 +0x8d
  k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc8201a9b00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:62 +0x2c3
  testing.tRunner(0xc820094000, 0x2e6b0d0)
    /usr/lib/golang/src/testing/testing.go:473 +0x98
  created by testing.RunTests
    /usr/lib/golang/src/testing/testing.go:582 +0x892

------------------------------
```

@kubernetes/rh-cluster-infra 
