### PR TITLE
 Changed default pods-per-core to 10 and max-pods to 250

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -109,7 +109,7 @@ func NewKubeletServer() *KubeletServer {
 			MaxContainerCount:            -1,
 			MaxPerPodContainerCount:      1,
 			MaxOpenFiles:                 1000000,
-			MaxPods:                      110,
+			MaxPods:                      250,
 			NvidiaGPUs:                   0,
 			MinimumGCAge:                 unversioned.Duration{Duration: 0},
 			NetworkPluginDir:             "/usr/libexec/kubernetes/kubelet-plugins/net/exec/",
@@ -149,7 +149,7 @@ func NewKubeletServer() *KubeletServer {
 			HairpinMode:                      componentconfig.PromiscuousBridge,
 			BabysitDaemons:                   false,
 			EvictionPressureTransitionPeriod: unversioned.Duration{Duration: 5 * time.Minute},
-			PodsPerCore:                      0,
+			PodsPerCore:                      10,
 		},
 	}
 }


### PR DESCRIPTION
This is a continuation of #25813.

``` release-note
Changed kubelet max-pods default to 250 and pods-per-core default to 10
```
