### PR TITLE
Enable the docker debug mode in a e2e test cluster

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -65,6 +65,9 @@ TERMINATED_POD_GC_THRESHOLD=${TERMINATED_POD_GC_THRESHOLD:-100}
 # Extra docker options for nodes.
 EXTRA_DOCKER_OPTS="${EXTRA_DOCKER_OPTS:-}"
 
+# Enable the docker debug mode.
+EXTRA_DOCKER_OPTS="${EXTRA_DOCKER_OPTS} --debug"
+
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 
 # When set to true, Docker Cache is enabled by default as part of the cluster bring up.


### PR DESCRIPTION
This helps debugging a test cluster (e.g., #28124).
