### PR TITLE
Add printf formatting for rrset objects.

### DIFF
--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrset.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clouddns
 
 import (
+	"fmt"
+
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
@@ -28,6 +30,10 @@ var _ dnsprovider.ResourceRecordSet = ResourceRecordSet{}
 type ResourceRecordSet struct {
 	impl   interfaces.ResourceRecordSet
 	rrsets *ResourceRecordSets
+}
+
+func (rrset ResourceRecordSet) String() string {
+	return fmt.Sprintf("<(clouddns) %q type=%s rrdatas=%q ttl=%v>", rrset.Name(), rrset.Type(), rrset.Rrdatas(), rrset.Ttl())
 }
 
 func (rrset ResourceRecordSet) Name() string {

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -212,7 +212,7 @@ func (s *ServiceController) ensureDnsRrsets(dnsZoneName, dnsName string, endpoin
 			} else {
 				// Need to replace the existing one with a better one (or just remove it if we have no healthy endpoints).
 				// TODO: Ideally do these inside a transaction, or do an atomic update, but dnsprovider interface doesn't support that yet.
-				glog.V(4).Infof("Existing recordset %v is not equal to needed recordset %v, removing existing and adding needed.", rrset, newRrset)
+				glog.V(4).Infof("Existing recordset %v not equal to needed recordset %v removing existing and adding needed.", rrset, newRrset)
 				if err = rrsets.Remove(rrset); err != nil {
 					return err
 				}


### PR DESCRIPTION
Without this you just get two pointers in the debug log.

Before:

```
I0627 21:48:44.136615       1 dns.go:215] Existing recordset {0xc820168830 0xc820691540} is not equal to needed recordset &{0xc820168848 0xc820686040}, removing existing and adding needed.
```

After:

```
I0627 22:26:46.221856       1 dns.go:215] Existing recordset                <(clouddns) "federated-service.e2e-tests-service-cuza5.federation.svc.us-central1-c.us-central1.kube.5yetis.net." type=CNAME rrdatas=["federated-service.e2e-tests-service-cuza5.federation.svc.us-central1.kube.5yetis.net."] ttl=180>
I0627 22:26:46.221885       1 dns.go:216] ... not equal to needed recordset <(clouddns) "federated-service.e2e-tests-service-cuza5.federation.svc.us-central1-c.us-central1.kube.5yetis.net." type=CNAME rrdatas=["federated-service.e2e-tests-service-cuza5.federation.svc.us-central1.kube.5yetis.net."] ttl=180>
I0627 22:26:46.221919       1 dns.go:217] ... removing existing and adding needed.
```
