### PR TITLE
Represent unversioned.Time correctly in swagger spec

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
+	"GodepVersion": "v67",
 	"Packages": [
 		"github.com/ugorji/go/codec/codecgen",
 		"github.com/onsi/ginkgo/ginkgo",
@@ -744,18 +744,18 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.2-54-g7c47e25",
-			"Rev": "7c47e2558a0bbbaba9ecab06bc6681e73028a28a"
+			"Comment": "v1.2-66-gc4afa8e",
+			"Rev": "c4afa8e5421428d584b32d36d7b35f2c9ae5f823"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful/log",
-			"Comment": "v1.2-54-g7c47e25",
-			"Rev": "7c47e2558a0bbbaba9ecab06bc6681e73028a28a"
+			"Comment": "v1.2-66-gc4afa8e",
+			"Rev": "c4afa8e5421428d584b32d36d7b35f2c9ae5f823"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful/swagger",
-			"Comment": "v1.2-54-g7c47e25",
-			"Rev": "7c47e2558a0bbbaba9ecab06bc6681e73028a28a"
+			"Comment": "v1.2-66-gc4afa8e",
+			"Rev": "c4afa8e5421428d584b32d36d7b35f2c9ae5f823"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/api/swagger-spec/apps_v1alpha1.json
+++ b/api/swagger-spec/apps_v1alpha1.json
@@ -1076,10 +1076,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -1079,10 +1079,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
@@ -1212,6 +1214,7 @@
      },
      "lastScaleTime": {
       "type": "string",
+      "format": "date-time",
       "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
      },
      "currentReplicas": {

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1079,10 +1079,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
@@ -2475,10 +2477,12 @@
      },
      "startTime": {
       "type": "string",
+      "format": "date-time",
       "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
      },
      "completionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
      },
      "active": {
@@ -2516,10 +2520,12 @@
      },
      "lastProbeTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition was checked."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transit from one status to another."
      },
      "reason": {

--- a/api/swagger-spec/certificates_v1alpha1.json
+++ b/api/swagger-spec/certificates_v1alpha1.json
@@ -786,10 +786,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
@@ -921,6 +923,7 @@
      },
      "lastUpdateTime": {
       "type": "string",
+      "format": "date-time",
       "description": "timestamp for the last update to this condition"
      }
     }

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -6925,10 +6925,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
@@ -8840,6 +8842,7 @@
      },
      "lastScaleTime": {
       "type": "string",
+      "format": "date-time",
       "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
      },
      "currentReplicas": {
@@ -9158,10 +9161,12 @@
      },
      "startTime": {
       "type": "string",
+      "format": "date-time",
       "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
      },
      "completionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
      },
      "active": {
@@ -9199,10 +9204,12 @@
      },
      "lastProbeTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition was checked."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transit from one status to another."
      },
      "reason": {

--- a/api/swagger-spec/policy_v1alpha1.json
+++ b/api/swagger-spec/policy_v1alpha1.json
@@ -1076,10 +1076,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -2749,10 +2749,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -15860,10 +15860,12 @@
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
@@ -16433,10 +16435,12 @@
      },
      "firstTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)"
      },
      "lastTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "The time at which the most recent occurrence of this event was recorded."
      },
      "count": {
@@ -16796,10 +16800,12 @@
      },
      "lastHeartbeatTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time we got an update on a given condition."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transit from one status to another."
      },
      "reason": {
@@ -18565,6 +18571,7 @@
      },
      "startTime": {
       "type": "string",
+      "format": "date-time",
       "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
      },
      "containerStatuses": {
@@ -18594,10 +18601,12 @@
      },
      "lastProbeTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time we probed the condition."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transitioned from one status to another."
      },
      "reason": {
@@ -18694,6 +18703,7 @@
     "properties": {
      "startedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which the container was last (re-)started"
      }
     }
@@ -18725,10 +18735,12 @@
      },
      "startedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which previous execution of the container started"
      },
      "finishedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which the container last terminated"
      },
      "containerID": {

--- a/docs/api-reference/autoscaling/v1/definitions.html
+++ b/docs/api-reference/autoscaling/v1/definitions.html
@@ -976,7 +976,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastScaleTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1147,7 +1147,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <br>
 Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1156,7 +1156,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <br>
 Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1327,7 +1327,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-05-23 07:07:20 UTC
+Last updated 2016-06-28 21:15:27 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -1579,14 +1579,14 @@ Examples:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">startTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">completionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1702,7 +1702,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <br>
 Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1711,7 +1711,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <br>
 Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -2404,14 +2404,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastProbeTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition was checked.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastTransitionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition transit from one status to another.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -4103,7 +4103,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-06 17:05:30 UTC
+Last updated 2016-06-28 21:15:21 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/certificates/v1alpha1/definitions.html
+++ b/docs/api-reference/certificates/v1alpha1/definitions.html
@@ -747,7 +747,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastUpdateTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timestamp for the last update to this condition</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
@@ -1124,7 +1124,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <br>
 Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1133,7 +1133,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <br>
 Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1304,7 +1304,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-28 18:40:30 UTC
+Last updated 2016-06-30 07:06:23 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -1377,14 +1377,14 @@ Examples:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">startTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">completionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1609,7 +1609,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <br>
 Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1618,7 +1618,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <br>
 Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -2472,14 +2472,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastProbeTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition was checked.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastTransitionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition transit from one status to another.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -4232,7 +4232,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastScaleTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -6093,7 +6093,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-20 07:50:53 UTC
+Last updated 2016-06-28 21:15:14 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -752,7 +752,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <td class="tableblock halign-left valign-top"><p class="tableblock">startedAt</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Time at which the container was last (re-)started</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
@@ -1740,14 +1740,14 @@ Examples:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastHeartbeatTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time we got an update on a given condition.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastTransitionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition transit from one status to another.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1965,7 +1965,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <br>
 Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -1974,7 +1974,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <br>
 Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -4097,7 +4097,7 @@ The resulting set of endpoints can be viewed as:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">startTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -4944,14 +4944,14 @@ The resulting set of endpoints can be viewed as:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastProbeTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time we probed the condition.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastTransitionTime</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last time the condition transitioned from one status to another.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -6362,14 +6362,14 @@ The resulting set of endpoints can be viewed as:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">startedAt</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Time at which previous execution of the container started</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">finishedAt</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Time at which the container last terminated</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -7023,14 +7023,14 @@ The resulting set of endpoints can be viewed as:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">firstTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">lastTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The time at which the most recent occurrence of this event was recorded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string (date-time)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -8160,7 +8160,7 @@ The resulting set of endpoints can be viewed as:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-28 21:36:31 UTC
+Last updated 2016-06-29 05:55:28 UTC
 </div>
 </div>
 </body>

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -900,6 +900,13 @@ func (s *GenericAPIServer) InstallSwaggerAPI() {
 		ApiPath:         "/swaggerapi/",
 		SwaggerPath:     "/swaggerui/",
 		SwaggerFilePath: "/swagger-ui/",
+		SchemaFormatHandler: func(typeName string) string {
+			switch typeName {
+			case "unversioned.Time", "*unversioned.Time":
+				return "date-time"
+			}
+			return ""
+		},
 	}
 	swagger.RegisterSwaggerService(swaggerConfig, s.HandlerContainer)
 }

--- a/vendor/github.com/emicklei/go-restful/README.md
+++ b/vendor/github.com/emicklei/go-restful/README.md
@@ -40,7 +40,7 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 
 - Routes for request &#8594; function mapping with path parameter (e.g. {id}) support
 - Configurable router:
-	- Routing algorithm after [JSR311](http://jsr311.java.net/nonav/releases/1.1/spec/spec.html) that is implemented using (but doest **not** accept) regular expressions (See RouterJSR311 which is used by default)
+	- Routing algorithm after [JSR311](http://jsr311.java.net/nonav/releases/1.1/spec/spec.html) that is implemented using (but does **not** accept) regular expressions (See RouterJSR311 which is used by default)
 	- Fast routing algorithm that allows static elements, regular expressions and dynamic parameters in the URL path (e.g. /meetings/{id} or /static/{subpath:*}, See CurlyRouter)
 - Request API for reading structs from JSON/XML and accesing parameters (path,query,header)
 - Response API for writing structs to JSON/XML and setting headers

--- a/vendor/github.com/emicklei/go-restful/curly.go
+++ b/vendor/github.com/emicklei/go-restful/curly.go
@@ -44,16 +44,16 @@ func (c CurlyRouter) SelectRoute(
 }
 
 // selectRoutes return a collection of Route from a WebService that matches the path tokens from the request.
-func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) []Route {
-	candidates := &sortableCurlyRoutes{[]*curlyRoute{}}
+func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortableCurlyRoutes {
+	candidates := sortableCurlyRoutes{}
 	for _, each := range ws.routes {
 		matches, paramCount, staticCount := c.matchesRouteByPathTokens(each.pathParts, requestTokens)
 		if matches {
-			candidates.add(&curlyRoute{each, paramCount, staticCount}) // TODO make sure Routes() return pointers?
+			candidates.add(curlyRoute{each, paramCount, staticCount}) // TODO make sure Routes() return pointers?
 		}
 	}
 	sort.Sort(sort.Reverse(candidates))
-	return candidates.routes()
+	return candidates
 }
 
 // matchesRouteByPathTokens computes whether it matches, howmany parameters do match and what the number of static path elements are.
@@ -110,9 +110,9 @@ func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, reque
 
 // detectRoute selectes from a list of Route the first match by inspecting both the Accept and Content-Type
 // headers of the Request. See also RouterJSR311 in jsr311.go
-func (c CurlyRouter) detectRoute(candidateRoutes []Route, httpRequest *http.Request) (*Route, error) {
+func (c CurlyRouter) detectRoute(candidateRoutes sortableCurlyRoutes, httpRequest *http.Request) (*Route, error) {
 	// tracing is done inside detectRoute
-	return RouterJSR311{}.detectRoute(candidateRoutes, httpRequest)
+	return RouterJSR311{}.detectRoute(candidateRoutes.routes(), httpRequest)
 }
 
 // detectWebService returns the best matching webService given the list of path tokens.

--- a/vendor/github.com/emicklei/go-restful/curly_route.go
+++ b/vendor/github.com/emicklei/go-restful/curly_route.go
@@ -11,30 +11,28 @@ type curlyRoute struct {
 	staticCount int
 }
 
-type sortableCurlyRoutes struct {
-	candidates []*curlyRoute
+type sortableCurlyRoutes []curlyRoute
+
+func (s *sortableCurlyRoutes) add(route curlyRoute) {
+	*s = append(*s, route)
 }
 
-func (s *sortableCurlyRoutes) add(route *curlyRoute) {
-	s.candidates = append(s.candidates, route)
-}
-
-func (s *sortableCurlyRoutes) routes() (routes []Route) {
-	for _, each := range s.candidates {
+func (s sortableCurlyRoutes) routes() (routes []Route) {
+	for _, each := range s {
 		routes = append(routes, each.route) // TODO change return type
 	}
 	return routes
 }
 
-func (s *sortableCurlyRoutes) Len() int {
-	return len(s.candidates)
+func (s sortableCurlyRoutes) Len() int {
+	return len(s)
 }
-func (s *sortableCurlyRoutes) Swap(i, j int) {
-	s.candidates[i], s.candidates[j] = s.candidates[j], s.candidates[i]
+func (s sortableCurlyRoutes) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }
-func (s *sortableCurlyRoutes) Less(i, j int) bool {
-	ci := s.candidates[i]
-	cj := s.candidates[j]
+func (s sortableCurlyRoutes) Less(i, j int) bool {
+	ci := s[i]
+	cj := s[j]
 
 	// primary key
 	if ci.staticCount < cj.staticCount {

--- a/vendor/github.com/emicklei/go-restful/jsr311.go
+++ b/vendor/github.com/emicklei/go-restful/jsr311.go
@@ -74,7 +74,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 	// accept
 	outputMediaOk := []Route{}
 	accept := httpRequest.Header.Get(HEADER_Accept)
-	if accept == "" {
+	if len(accept) == 0 {
 		accept = "*/*"
 	}
 	for _, each := range inputMediaOk {
@@ -88,7 +88,8 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 		}
 		return nil, NewError(http.StatusNotAcceptable, "406: Not Acceptable")
 	}
-	return r.bestMatchByMedia(outputMediaOk, contentType, accept), nil
+	// return r.bestMatchByMedia(outputMediaOk, contentType, accept), nil
+	return &outputMediaOk[0], nil
 }
 
 // http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-360003.7.2

--- a/vendor/github.com/emicklei/go-restful/response.go
+++ b/vendor/github.com/emicklei/go-restful/response.go
@@ -130,25 +130,25 @@ func (r *Response) WriteHeaderAndEntity(status int, value interface{}) error {
 }
 
 // WriteAsXml is a convenience method for writing a value in xml (requires Xml tags on the value)
-// It uses the standard encoding/xml package for marshalling the valuel ; not using a registered EntityReaderWriter.
+// It uses the standard encoding/xml package for marshalling the value ; not using a registered EntityReaderWriter.
 func (r *Response) WriteAsXml(value interface{}) error {
 	return writeXML(r, http.StatusOK, MIME_XML, value)
 }
 
 // WriteHeaderAndXml is a convenience method for writing a status and value in xml (requires Xml tags on the value)
-// It uses the standard encoding/xml package for marshalling the valuel ; not using a registered EntityReaderWriter.
+// It uses the standard encoding/xml package for marshalling the value ; not using a registered EntityReaderWriter.
 func (r *Response) WriteHeaderAndXml(status int, value interface{}) error {
 	return writeXML(r, status, MIME_XML, value)
 }
 
 // WriteAsJson is a convenience method for writing a value in json.
-// It uses the standard encoding/json package for marshalling the valuel ; not using a registered EntityReaderWriter.
+// It uses the standard encoding/json package for marshalling the value ; not using a registered EntityReaderWriter.
 func (r *Response) WriteAsJson(value interface{}) error {
 	return writeJSON(r, http.StatusOK, MIME_JSON, value)
 }
 
 // WriteJson is a convenience method for writing a value in Json with a given Content-Type.
-// It uses the standard encoding/json package for marshalling the valuel ; not using a registered EntityReaderWriter.
+// It uses the standard encoding/json package for marshalling the value ; not using a registered EntityReaderWriter.
 func (r *Response) WriteJson(value interface{}, contentType string) error {
 	return writeJSON(r, http.StatusOK, contentType, value)
 }

--- a/vendor/github.com/emicklei/go-restful/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/route_builder.go
@@ -128,7 +128,7 @@ func (b *RouteBuilder) Param(parameter *Parameter) *RouteBuilder {
 	return b
 }
 
-// Operation allows you to document what the acutal method/function call is of the Route.
+// Operation allows you to document what the actual method/function call is of the Route.
 // Unless called, the operation name is derived from the RouteFunction set using To(..).
 func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 	b.operation = name

--- a/vendor/github.com/emicklei/go-restful/swagger/config.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/config.go
@@ -9,6 +9,8 @@ import (
 // PostBuildDeclarationMapFunc can be used to modify the api declaration map.
 type PostBuildDeclarationMapFunc func(apiDeclarationMap *ApiDeclarationList)
 
+type MapSchemaFormatFunc func(typeName string) string
+
 type Config struct {
 	// url where the services are available, e.g. http://localhost:8080
 	// if left empty then the basePath of Swagger is taken from the actual request
@@ -31,4 +33,6 @@ type Config struct {
 	PostBuildHandler PostBuildDeclarationMapFunc
 	// Swagger global info struct
 	Info Info
+	// [optional] If set, model builder should call this handler to get addition typename-to-swagger-format-field convertion.
+	SchemaFormatHandler MapSchemaFormatFunc
 }

--- a/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
@@ -14,6 +14,7 @@ type ModelBuildable interface {
 
 type modelBuilder struct {
 	Models *ModelList
+	Config *Config
 }
 
 type documentable interface {
@@ -231,7 +232,7 @@ func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonNam
 
 	if field.Name == fieldType.Name() && field.Anonymous && !hasNamedJSONTag(field) {
 		// embedded struct
-		sub := modelBuilder{new(ModelList)}
+		sub := modelBuilder{new(ModelList), b.Config}
 		sub.addModel(fieldType, "")
 		subKey := sub.keyFrom(fieldType)
 		// merge properties from sub
@@ -410,6 +411,11 @@ func (b modelBuilder) jsonSchemaType(modelName string) string {
 }
 
 func (b modelBuilder) jsonSchemaFormat(modelName string) string {
+	if b.Config != nil && b.Config.SchemaFormatHandler != nil {
+		if mapped := b.Config.SchemaFormatHandler(modelName); mapped != "" {
+			return mapped
+		}
+	}
 	schemaMap := map[string]string{
 		"int":        "int32",
 		"int32":      "int32",

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -241,7 +241,7 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 				DataTypeFields:   DataTypeFields{Type: &voidString},
 				Parameters:       []Parameter{},
 				Nickname:         route.Operation,
-				ResponseMessages: composeResponseMessages(route, &decl)}
+				ResponseMessages: composeResponseMessages(route, &decl, &sws.config)}
 
 			operation.Consumes = route.Consumes
 			operation.Produces = route.Produces
@@ -271,7 +271,7 @@ func withoutWildcard(path string) string {
 }
 
 // composeResponseMessages takes the ResponseErrors (if any) and creates ResponseMessages from them.
-func composeResponseMessages(route restful.Route, decl *ApiDeclaration) (messages []ResponseMessage) {
+func composeResponseMessages(route restful.Route, decl *ApiDeclaration, config *Config) (messages []ResponseMessage) {
 	if route.ResponseErrors == nil {
 		return messages
 	}
@@ -294,7 +294,7 @@ func composeResponseMessages(route restful.Route, decl *ApiDeclaration) (message
 			if isCollection {
 				modelName = "array[" + modelName + "]"
 			}
-			modelBuilder{&decl.Models}.addModel(st, "")
+			modelBuilder{Models: &decl.Models, Config: config}.addModel(st, "")
 			// reference the model
 			message.ResponseModel = modelName
 		}
@@ -332,11 +332,11 @@ func detectCollectionType(st reflect.Type) (bool, reflect.Type) {
 // addModelFromSample creates and adds (or overwrites) a Model from a sample resource
 func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse bool, sample interface{}, models *ModelList) {
 	if isResponse {
-		type_, items := asDataType(sample)
+		type_, items := asDataType(sample, &sws.config)
 		operation.Type = type_
 		operation.Items = items
 	}
-	modelBuilder{models}.addModelFrom(sample)
+	modelBuilder{Models: models, Config: &sws.config}.addModelFrom(sample)
 }
 
 func asSwaggerParameter(param restful.ParameterData) Parameter {
@@ -411,7 +411,7 @@ func asParamType(kind int) string {
 	return ""
 }
 
-func asDataType(any interface{}) (*string, *Item) {
+func asDataType(any interface{}, config *Config) (*string, *Item) {
 	// If it's not a collection, return the suggested model name
 	st := reflect.TypeOf(any)
 	isCollection, st := detectCollectionType(st)
@@ -424,7 +424,7 @@ func asDataType(any interface{}) (*string, *Item) {
 	// XXX: This is not very elegant
 	// We create an Item object referring to the given model
 	models := ModelList{}
-	mb := modelBuilder{&models}
+	mb := modelBuilder{Models: &models, Config: config}
 	mb.addModelFrom(any)
 
 	elemTypeName := mb.getElementTypeName(modelName, "", st)


### PR DESCRIPTION
unversioned.Time previously represented as "string" type with no format while the correct representation should also have "date-time" as format. fixes #2968
