### PR TITLE
Change references to gs://kubernetes-release/ci

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -292,7 +292,7 @@ function detect-master-from-kubeconfig() {
 
 # Sets KUBE_VERSION variable to the proper version number (e.g. "v1.0.6",
 # "v1.2.0-alpha.1.881+376438b69c7612") or a version' publication of the form
-# <bucket>/<version> (e.g. "release/stable",' "ci/latest-1").
+# <path>/<version> (e.g. "release/stable",' "ci/latest-1").
 #
 # See the docs on getting builds for more information about version
 # publication.
@@ -303,7 +303,12 @@ function detect-master-from-kubeconfig() {
 #   KUBE_VERSION
 function set_binary_version() {
   if [[ "${1}" =~ "/" ]]; then
-    KUBE_VERSION=$(gsutil cat gs://kubernetes-release/${1}.txt)
+    IFS='/' read -a path <<< "${1}"
+    if [[ "${path[0]}" == "release" ]]; then
+      KUBE_VERSION=$(gsutil cat "gs://kubernetes-release/${1}.txt")
+    else
+      KUBE_VERSION=$(gsutil cat "gs://kubernetes-release-dev/${1}.txt")
+    fi
   else
     KUBE_VERSION=${1}
   fi
@@ -334,8 +339,8 @@ function tars_from_version() {
     KUBE_MANIFESTS_TAR_URL="${SERVER_BINARY_TAR_URL/server-linux-amd64/manifests}"
     KUBE_MANIFESTS_TAR_HASH=$(curl ${KUBE_MANIFESTS_TAR_URL} | sha1sum | awk '{print $1}')
   elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
-    SERVER_BINARY_TAR_URL="https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes-server-linux-amd64.tar.gz"
-    SALT_TAR_URL="https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes-salt.tar.gz"
+    SERVER_BINARY_TAR_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${KUBE_VERSION}/kubernetes-server-linux-amd64.tar.gz"
+    SALT_TAR_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${KUBE_VERSION}/kubernetes-salt.tar.gz"
     # TODO: Clean this up.
     KUBE_MANIFESTS_TAR_URL="${SERVER_BINARY_TAR_URL/server-linux-amd64/manifests}"
     KUBE_MANIFESTS_TAR_HASH=$(curl ${KUBE_MANIFESTS_TAR_URL} | sha1sum | awk '{print $1}')
@@ -484,7 +489,7 @@ function build-runtime-config() {
   if [[ -n ${appends} ]]; then
     if [[ -n ${RUNTIME_CONFIG} ]]; then
       RUNTIME_CONFIG="${RUNTIME_CONFIG},${appends}"
-    else 
+    else
       RUNTIME_CONFIG="${appends}"
     fi
   fi

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -59,7 +59,7 @@ function usage() {
 
   release_stable=$(gsutil cat gs://kubernetes-release/release/stable.txt)
   release_latest=$(gsutil cat gs://kubernetes-release/release/latest.txt)
-  ci_latest=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
+  ci_latest=$(gsutil cat gs://kubernetes-release-dev/ci/latest.txt)
 
   echo "Right now, versions are as follows:"
   echo "  release/stable: ${0} ${release_stable}"

--- a/docs/devel/getting-builds.md
+++ b/docs/devel/getting-builds.md
@@ -59,9 +59,9 @@ Finally, you can just print the latest or stable version:
 You can also use the gsutil tool to explore the Google Cloud Storage release buckets. Here are some examples:
 
 ```sh
-gsutil cat gs://kubernetes-release/ci/latest.txt          # output the latest ci version number
-gsutil cat gs://kubernetes-release/ci/latest-green.txt    # output the latest ci version number that passed gce e2e
-gsutil ls gs://kubernetes-release/ci/v0.20.0-29-g29a55cc/ # list the contents of a ci release
+gsutil cat gs://kubernetes-release-dev/ci/latest.txt          # output the latest ci version number
+gsutil cat gs://kubernetes-release-dev/ci/latest-green.txt    # output the latest ci version number that passed gce e2e
+gsutil ls gs://kubernetes-release-dev/ci/v0.20.0-29-g29a55cc/ # list the contents of a ci release
 gsutil ls gs://kubernetes-release/release                 # list all official releases and rcs
 ```
 

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -23,6 +23,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/common.sh"
 
 declare -r KUBE_RELEASE_BUCKET_URL="https://storage.googleapis.com/kubernetes-release"
+declare -r KUBE_DEV_RELEASE_BUCKET_URL="https://storage.googleapis.com/kubernetes-release-dev"
 declare -r KUBE_TAR_NAME="kubernetes.tar.gz"
 
 usage() {
@@ -74,7 +75,7 @@ else
   if [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
     curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_RELEASE_BUCKET_URL}/release/${KUBE_VERSION}/${KUBE_TAR_NAME}"
   elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
-    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_RELEASE_BUCKET_URL}/ci/${KUBE_VERSION}/${KUBE_TAR_NAME}"
+    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_DEV_RELEASE_BUCKET_URL}/ci/${KUBE_VERSION}/${KUBE_TAR_NAME}"
   else
     echo "Version doesn't match regexp" >&2
     exit 1

--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -22,6 +22,7 @@ set -o pipefail
 set -o xtrace
 
 : ${KUBE_GCS_RELEASE_BUCKET:="kubernetes-release"}
+: ${KUBE_GCS_DEV_RELEASE_BUCKET:="kubernetes-release-dev"}
 
 function running_in_docker() {
     grep -q docker /proc/self/cgroup
@@ -47,10 +48,15 @@ function fetch_server_version_tars() {
 function fetch_published_version_tars() {
     local -r published_version="${1}"
     IFS='/' read -a varr <<< "${published_version}"
-    bucket="${varr[0]}"
-    build_version=$(gsutil cat gs://${KUBE_GCS_RELEASE_BUCKET}/${published_version}.txt)
+    path="${varr[0]}"
+    if [[ "${path}" == "release" ]]; then
+      local -r bucket="${KUBE_GCS_RELEASE_BUCKET}"
+    else
+      local -r bucket="${KUBE_GCS_DEV_RELEASE_BUCKET}"
+    fi
+    build_version=$(gsutil cat "gs://${bucket}/${published_version}.txt")
     echo "Using published version $bucket/$build_version (from ${published_version})"
-    fetch_tars_from_gcs "${bucket}" "${build_version}"
+    fetch_tars_from_gcs "gs://${bucket}/${path}" "${build_version}"
     unpack_binaries
     # Set CLUSTER_API_VERSION for GKE CI
     export CLUSTER_API_VERSION=$(echo ${build_version} | cut -c 2-)
@@ -64,13 +70,10 @@ function clean_binaries() {
 }
 
 function fetch_tars_from_gcs() {
-    local -r bucket="${1}"
+    local -r gspath="${1}"
     local -r build_version="${2}"
-    echo "Pulling binaries from GCS; using server version ${bucket}/${build_version}."
-    gsutil -mq cp \
-        "gs://${KUBE_GCS_RELEASE_BUCKET}/${bucket}/${build_version}/kubernetes.tar.gz" \
-        "gs://${KUBE_GCS_RELEASE_BUCKET}/${bucket}/${build_version}/kubernetes-test.tar.gz" \
-        .
+    echo "Pulling binaries from GCS; using server version ${gspath}/${build_version}."
+    gsutil -mq cp "${gspath}/${build_version}/kubernetes.tar.gz" "${gspath}/${build_version}/kubernetes-test.tar.gz" .
 }
 
 function unpack_binaries() {
@@ -190,7 +193,7 @@ function e2e_test() {
     if [[ "${E2E_PUBLISH_GREEN_VERSION:-}" == "true" && ${exitcode} == 0 ]]; then
         # Use plaintext version file packaged with kubernetes.tar.gz
         echo "Publish version to ci/latest-green.txt: $(cat version)"
-        gsutil cp ./version gs://kubernetes-release/ci/latest-green.txt
+        gsutil cp ./version "gs://${KUBE_GCS_DEV_RELEASE_BUCKET}/ci/latest-green.txt"
     fi
 }
 


### PR DESCRIPTION
Change over to gs://kubernetes-release-dev/ci. This should be all the
places we reference gs://kubernetes-release/ci or
https://storage.googleapis.com/kubernetes-release/ci. I'm happy to be
wrong.

Follow-on to #28172

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
