### PR TITLE
Make the .lock file cross the Read-Modify-Write

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -382,12 +382,6 @@ func WriteToFile(config clientcmdapi.Config, filename string) error {
 		}
 	}
 
-	err = lockFile(filename)
-	if err != nil {
-		return err
-	}
-	defer unlockFile(filename)
-
 	if err := ioutil.WriteFile(filename, content, 0600); err != nil {
 		return err
 	}


### PR DESCRIPTION
Should help prevent concurrent calls to ModifyConfig (with one field changed) from producing an invalid kubeconfig.

We should still eventually rework this to give some stronger semantics around kubeconfig file modification.
