### PR TITLE
kubectl/run: remove log "object created" when --dry-run=true

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -223,3 +223,38 @@ kube::test::if_has_string() {
     return 1
   fi
 }
+
+kube::test::kubectl_dry_run() {
+  local name=$1
+  local image=$2
+
+  out=$(eval kubectl run $name "--image=$image" --dry-run=true "${kube_flags[@]}")
+  if [[ "$out" == $(echo) ]]; then
+    echo ${bold}${red}
+    echo "FAIL!"
+    echo "Run with --dry-run=true"
+    echo "No output found"
+    echo ${reset}${red}
+    caller
+    echo ${reset}
+    return 1
+  fi
+
+  if [[ $(echo "$out" | grep "created") ]]; then
+    echo ${bold}${red}
+    echo "FAIL!"
+    echo "run with --dry-run-true"
+    echo "Deployment created log found in:"
+    echo "$out"
+    echo ${reset}${red}
+    caller
+    echo ${reset}
+    return 1
+  fi
+
+  echo -n ${green}
+  echo "Succesfull run with --dry-run=true"
+  echo "$out"
+  echo -n ${reset}
+  return 0
+}

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -243,7 +243,7 @@ kube::test::kubectl_dry_run() {
   if [[ $(echo "$out" | grep "created") ]]; then
     echo ${bold}${red}
     echo "FAIL!"
-    echo "run with --dry-run-true"
+    echo "run with --dry-run=true"
     echo "Deployment created log found in:"
     echo "$out"
     echo ${reset}${red}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -940,6 +940,14 @@ __EOF__
   # Clean up
   kubectl delete deployment nginx "${kube_flags[@]}"
 
+  ## kubectl run --dry-run=true should show object info
+  # Pre-Condition: no pods exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kube::test::kubectl_dry_run nginx $IMAGE_NGINX
+  # Post-Condition: no pods exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+
   ###############
   # Kubectl get #
   ###############

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -273,10 +273,12 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 	}
 
 	outputFormat := cmdutil.GetFlagString(cmd, "output")
-	if outputFormat != "" {
-		return f.PrintObject(cmd, mapper, obj, cmdOut)
+	if outputFormat != "" || cmdutil.GetDryRunFlag(cmd) {
+		f.PrintObject(cmd, mapper, obj, cmdOut)
 	}
-	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
+	if !cmdutil.GetDryRunFlag(cmd) {
+		cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Since no object is created when --dry-run=true there is no point in showing log: "object created".

bug 1270697
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1270697

This is the output on my instance:

```
$ kubectl run example --image=busybox --dry-run=true
NAME       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
example   1         0         0            0           <unknown>
```
