### PR TITLE
Bump cluster autoscaler to 0.2.2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.2.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.2.2",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
0.2.2 version has https://github.com/kubernetes/contrib/issues/1283 fixed. Whereas the issues has little impact for GCE and OSS Kubernetes it is important to have it merged to 1.3 because in GKE the situation, when a cluster has multiple migs/node pools, will be much more common.  

E2e tests that check this particular issue will be added in a separate PR.

cc: @piosz @jszczepkowski @fgrzadkowski 
