### PR TITLE
Prune the semantic version before it is passed to dockerversion parser

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -922,10 +922,19 @@ func (v dockerVersion) String() string {
 	return string(v)
 }
 
+func pruneSemver(semver string) string {
+	// prune strings like 1.10.4-28.gitf476348.fc23 to 1.10.4
+	parts := strings.SplitN(semver, "-", 2)
+	return parts[0]
+}
+
 func (v dockerVersion) Compare(other string) (int, error) {
-	if dockerversion.LessThan(string(v), other) {
+	v1 := pruneSemver(string(v))
+	v2 := pruneSemver(other)
+
+	if dockerversion.LessThan(v1, v2) {
 		return -1, nil
-	} else if dockerversion.GreaterThan(string(v), other) {
+	} else if dockerversion.GreaterThan(v1, v2) {
 		return 1, nil
 	}
 	return 0, nil

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2062,8 +2062,8 @@ func TestCheckVersionCompatibility(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	expectedVersion := "1.8.1"
-	expectedAPIVersion := "1.20"
+	expectedVersion := "1.10.3"
+	expectedAPIVersion := "1.10.4-28.gitf476348.fc23"
 	dm, _ := newTestDockerManagerWithVersion(expectedVersion, expectedAPIVersion)
 	version, err := dm.Version()
 	if err != nil {
@@ -2080,6 +2080,14 @@ func TestVersion(t *testing.T) {
 	if e, a := expectedAPIVersion, apiVersion.String(); e != a {
 		t.Errorf("expect docker api version %q, got %q", e, a)
 	}
+
+	t.Logf("Prunning Version: %q, APIVersion: %q", pruneSemver(expectedVersion), pruneSemver(expectedAPIVersion))
+
+	comparison, _ := version.Compare(expectedAPIVersion)
+	if comparison != -1 {
+		t.Errorf("expected %q < %q, got otherwise", expectedVersion, expectedAPIVersion)
+	}
+
 }
 
 func TestGetPodStatusNoSuchContainer(t *testing.T) {


### PR DESCRIPTION
Fixes #28221 
