### PR TITLE
Make sure --record=false is acknowledged when passed to commands

### DIFF
--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -301,7 +301,7 @@ func TestGenerateService(t *testing.T) {
 		}
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool(cmdutil.ApplyAnnotationsFlag, false, "")
-		cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation.")
+		cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
 		cmdutil.AddPrinterFlags(cmd)
 		cmdutil.AddInclude3rdPartyFlags(cmd)
 		addRunFlags(cmd)

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -435,7 +435,7 @@ func UpdateObject(info *resource.Info, codec runtime.Codec, updateFn func(runtim
 
 // AddCmdRecordFlag adds --record flag to command
 func AddRecordFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation.")
+	cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
 }
 
 func GetRecordFlag(cmd *cobra.Command) bool {
@@ -489,7 +489,7 @@ func ContainsChangeCause(info *resource.Info) bool {
 
 // ShouldRecord checks if we should record current change cause
 func ShouldRecord(cmd *cobra.Command, info *resource.Info) bool {
-	return GetRecordFlag(cmd) || ContainsChangeCause(info)
+	return GetRecordFlag(cmd) || (ContainsChangeCause(info) && !cmd.Flags().Changed("record"))
 }
 
 // GetThirdPartyGroupVersions returns the thirdparty "group/versions"s and


### PR DESCRIPTION
``` release-note
Change setting "kubectl --record=false" to stop updating the change-cause when a previous change-cause is found.
```

Ensures that when `--record=false` is explicity set that no `ChangeCauseAnnotation`s are set on the object. Previously, if `--record=true` was used then all following actions triggered a `ChangeCauseAnnotation` even if `--record=false` was set, due to the prior `ChangeCauseAnnotation` existing.

Reference to bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1351127

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
