### PR TITLE
code-of-conduct: provide concrete points of contact

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,8 +32,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-opening an issue or contacting one or more of the project maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a Kubernetes maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
Provide concrete information about who to contact about CoC issues. Having unambiguous people to contact is important to resolve issues in a timely manner.
