### PR TITLE
node_e2e: Update framework to provide OS distro

### DIFF
--- a/test/e2e_node/configmap.go
+++ b/test/e2e_node/configmap.go
@@ -192,7 +192,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 	})
 })
 
-func newConfigMap(f *framework.Framework, name string) *api.ConfigMap {
+func newConfigMap(f *NodeFramework, name string) *api.ConfigMap {
 	return &api.ConfigMap{
 		ObjectMeta: api.ObjectMeta{
 			Namespace: f.Namespace.Name,
@@ -206,7 +206,7 @@ func newConfigMap(f *framework.Framework, name string) *api.ConfigMap {
 	}
 }
 
-func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64) {
+func doConfigMapE2EWithoutMappings(f *NodeFramework, uid, fsGroup int64) {
 	var (
 		name            = "configmap-test-volume-" + string(util.NewUUID())
 		volumeName      = "configmap-volume"
@@ -273,7 +273,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64) {
 
 }
 
-func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64) {
+func doConfigMapE2EWithMappings(f *NodeFramework, uid, fsGroup int64) {
 	var (
 		name            = "configmap-test-volume-map-" + string(util.NewUUID())
 		volumeName      = "configmap-volume"

--- a/test/e2e_node/downward_api_test.go
+++ b/test/e2e_node/downward_api_test.go
@@ -130,7 +130,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 	})
 })
 
-func testDownwardAPI(f *framework.Framework, podName string, env []api.EnvVar, expectations []string) {
+func testDownwardAPI(f *NodeFramework, podName string, env []api.EnvVar, expectations []string) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   podName,

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -19,10 +19,8 @@ limitations under the License.
 package e2e_node
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -83,11 +81,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
-	// TODO(yifan): Temporary workaround to disable coreos from auto restart
-	// by masking the locksmithd.
-	// We should mask locksmithd when provisioning the machine.
-	maskLocksmithdOnCoreos()
-
 	if *startServices {
 		e2es = newE2eService(*nodeName)
 		if err := e2es.start(); err != nil {
@@ -111,16 +104,3 @@ var _ = AfterSuite(func() {
 
 	glog.Infof("Tests Finished")
 })
-
-func maskLocksmithdOnCoreos() {
-	data, err := ioutil.ReadFile("/etc/os-release")
-	if err != nil {
-		glog.Fatalf("Could not read /etc/os-release: %v", err)
-	}
-	if bytes.Contains(data, []byte("ID=coreos")) {
-		if output, err := exec.Command("sudo", "systemctl", "mask", "--now", "locksmithd").CombinedOutput(); err != nil {
-			glog.Fatalf("Could not mask locksmithd: %v, output: %q", err, string(output))
-		}
-		glog.Infof("Locksmithd is masked successfully")
-	}
-}

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -165,7 +165,7 @@ const (
 	containerSuffix = "-c"
 )
 
-func createSummaryTestPods(f *framework.Framework, podNamePrefix string, count int, volumeNamePrefix string) (sets.String, sets.String) {
+func createSummaryTestPods(f *NodeFramework, podNamePrefix string, count int, volumeNamePrefix string) (sets.String, sets.String) {
 	podNames := sets.NewString()
 	volumes := sets.NewString(volumeNamePrefix)
 	for i := 0; i < count; i++ {
@@ -192,7 +192,7 @@ func createSummaryTestPods(f *framework.Framework, podNamePrefix string, count i
 	return podNames, volumes
 }
 
-func createPod(f *framework.Framework, podName string, containers []api.Container, volumes []api.Volume) {
+func createPod(f *NodeFramework, podName string, containers []api.Container, volumes []api.Volume) {
 	podClient := f.Client.Pods(f.Namespace.Name)
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
This PR is a result of this comment: https://github.com/kubernetes/kubernetes/issues/28192#issuecomment-229470987

I tested locally that adding a test that looked something like:

```
It("should skip coreos", func() {
  if f.OSDistro == "coreos" {
    framework.Skipf("skip")
  }
})
```

worked as expected.

I also trimmed a bit of old code related to coreos.

cc @vishh @yifan-gu @dubstack @mtaufen 
