### PR TITLE
fix return of empty list in kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -235,20 +235,22 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			allErrs = append(allErrs, err)
 		}
 
-		// the outermost object will be converted to the output-version, but inner
-		// objects can use their mappings
-		version, err := cmdutil.OutputVersion(cmd, clientConfig.GroupVersion)
-		if err != nil {
-			return err
-		}
+		if len(infos) > 0 {
+			// the outermost object will be converted to the output-version, but inner
+			// objects can use their mappings
+			version, err := cmdutil.OutputVersion(cmd, clientConfig.GroupVersion)
+			if err != nil {
+				return err
+			}
 
-		obj, err := resource.AsVersionedObject(infos, !singular, version, f.JSONEncoder())
-		if err != nil {
-			return err
-		}
+			obj, err := resource.AsVersionedObject(infos, !singular, version, f.JSONEncoder())
+			if err != nil {
+				return err
+			}
 
-		if err := printer.PrintObj(obj, out); err != nil {
-			allErrs = append(allErrs, err)
+			if err := printer.PrintObj(obj, out); err != nil {
+				allErrs = append(allErrs, err)
+			}
 		}
 		return utilerrors.NewAggregate(allErrs)
 	}


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/28243

When printing the obj in a generic `kubectl get` (where the `obj` is a versioned object of `infos`), it should only be printing valid objects from `infos`. In the case of the referred issue, if `infos` is nil, then it will print out the empty object along with the error, rather than just the error.

This PR ensures that the printing of objects only occurs if `infos` is not empty.

Is it viable to try to squeeze this into v1.3 given that it hasn't been cut yet and this is an outward-facing bug?
