### PR TITLE
make sure node e2e test will fail when we turn off the xunit plugin

### DIFF
--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -28,7 +28,7 @@ set -x
 
 . $1
 
-go build test/e2e_node/environment/conformance.go
+go build test/e2e_node/environment/conformance.go || exit 1
 
 WORKSPACE=${WORKSPACE:-"/tmp/"}
 ARTIFACTS=${WORKSPACE}/_artifacts
@@ -38,4 +38,4 @@ go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="g
   --zone="$GCE_ZONE" --project="$GCE_PROJECT" --image-project="$GCE_IMAGE_PROJECT" \
   --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --cleanup="$CLEANUP" \
   --results-dir="$ARTIFACTS" --ginkgo-flags="$GINKGO_FLAGS" \
-  --setup-node="$SETUP_NODE"
+  --setup-node="$SETUP_NODE" || exit 1


### PR DESCRIPTION
Needed before it will be safe to merge https://github.com/kubernetes/test-infra/pull/237.

@pwittrock can you review?

@ixdy can you tell me if I need any other similar fixes?
