### PR TITLE
Make GKE detect-instance-groups work on Mac.

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -318,7 +318,7 @@ function detect-node-instance-groups {
   ALL_INSTANCE_GROUP_URLS=${urls[*]}
   NODE_INSTANCE_GROUPS=()
   for url in "${urls[@]:-}"; do
-    local igm_zone=$(expr match ${url} '.*/zones/\([a-z0-9-]*\)/')
+    local igm_zone=$(expr ${url} : '.*/zones/\([a-z0-9-]*\)/')
     if [[ "${igm_zone}" == "${ZONE}" ]]; then
       NODE_INSTANCE_GROUPS+=("${url##*/}")
     fi


### PR DESCRIPTION
Make the fix from #27803 also work on mac.

The GNU `expr` command supports both the `expr match STRING REGEXP` and `expr STRING : REGEXP` command syntax.

The BSD `expr` command only has the `expr STRING : REGEXP` syntax.

@fabioy @a-robinson 
