### PR TITLE
Update influxdb to 0.12.0

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-petset.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-petset.yaml
@@ -17,7 +17,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster_influxdb:v0.5
+        - image: gcr.io/google_containers/heapster_influxdb:v0.7
           name: influxdb
           resources:
             # keep request = limit to keep this container in guaranteed class


### PR DESCRIPTION
Updates Infuxdb to 0.12.2_1 to reduce memory consumption. Previous version (0.9) could easily go beyond limits if pods were created and deleted in large numbers. More details here: kubernetes/kubernetes#27630.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28279)

<!-- Reviewable:end -->
