### PR TITLE
kubectl: don't display an empty list when trying to get a single resource that isn't found

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -975,6 +975,20 @@ __EOF__
   # Post-condition: POD abc should error since it doesn't exist
   kube::test::if_has_string "${output_message}" 'pods "abc" not found'
 
+  ### Test retrieval of non-existing POD with json output flag specified
+  # Pre-condition: no POD exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  output_message=$(! kubectl get pods abc 2>&1 "${kube_flags[@]}" -o json)
+  # Post-condition: POD abc should error since it doesn't exist
+  kube::test::if_has_string "${output_message}" 'pods "abc" not found'
+  # Post-condition: make sure we don't display an empty List
+  if kube::test::if_has_string "${output_message}" 'List'; then
+    echo 'Unexpected List output'
+    echo "${LINENO} $(basename $0)"
+    exit 1
+  fi
+
   #####################################
   # Third Party Resources             #
   #####################################

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -232,6 +232,9 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		singular := false
 		infos, err := r.IntoSingular(&singular).Infos()
 		if err != nil {
+			if singular {
+				return err
+			}
 			allErrs = append(allErrs, err)
 		}
 


### PR DESCRIPTION
Return immediately when attempting to get a singular resource that isn't found, so that we avoid
printing out a List if the output format is something like json or yaml.

Before:

```
$ kubectl get pod/foo -o yaml
apiVersion: v1
items: []
kind: List
metadata: {}
pods "foo" not found
```

After:

```
$ kubectl get pod/foo -o yaml
pods "foo" not found
```

Fixes #28243 

@kubernetes/kubectl @kubernetes/rh-ux @smarterclayton @liggitt @deads2k @metral 
