### PR TITLE
rbac authorizer: cleanups to rule evaluation for non-resource URLs

### DIFF
--- a/pkg/apis/rbac/validation/policy_comparator.go
+++ b/pkg/apis/rbac/validation/policy_comparator.go
@@ -69,9 +69,11 @@ func breakdownRule(rule rbac.PolicyRule) []rbac.PolicyRule {
 		}
 	}
 
-	// Non-resource URLs are unique because they don't combine with other policy rule fields.
+	// Non-resource URLs are unique because they only combine with verbs.
 	for _, nonResourceURL := range rule.NonResourceURLs {
-		subrules = append(subrules, rbac.PolicyRule{NonResourceURLs: []string{nonResourceURL}})
+		for _, verb := range rule.Verbs {
+			subrules = append(subrules, rbac.PolicyRule{NonResourceURLs: []string{nonResourceURL}, Verbs: []string{verb}})
+		}
 	}
 
 	return subrules

--- a/pkg/apis/rbac/validation/policy_comparator_test.go
+++ b/pkg/apis/rbac/validation/policy_comparator_test.go
@@ -333,7 +333,7 @@ func TestCoversNonResourceURLsWithOtherFieldsFailure(t *testing.T) {
 		},
 
 		expectedCovered:        false,
-		expectedUncoveredRules: []rbac.PolicyRule{{NonResourceURLs: []string{"/apis"}}},
+		expectedUncoveredRules: []rbac.PolicyRule{{NonResourceURLs: []string{"/apis"}, Verbs: []string{"get"}}},
 	}.test(t)
 }
 

--- a/pkg/apis/rbac/validation/policy_comparator_test.go
+++ b/pkg/apis/rbac/validation/policy_comparator_test.go
@@ -284,10 +284,10 @@ func TestCoversEnumerationNotCoveringResourceNameEmpty(t *testing.T) {
 func TestCoversNonResourceURLs(t *testing.T) {
 	escalationTest{
 		ownerRules: []rbac.PolicyRule{
-			{NonResourceURLs: []string{"/apis"}},
+			{NonResourceURLs: []string{"/apis"}, Verbs: []string{"*"}},
 		},
 		servantRules: []rbac.PolicyRule{
-			{NonResourceURLs: []string{"/apis"}},
+			{NonResourceURLs: []string{"/apis"}, Verbs: []string{"*"}},
 		},
 
 		expectedCovered:        true,
@@ -298,10 +298,40 @@ func TestCoversNonResourceURLs(t *testing.T) {
 func TestCoversNonResourceURLsStar(t *testing.T) {
 	escalationTest{
 		ownerRules: []rbac.PolicyRule{
-			{NonResourceURLs: []string{"*"}},
+			{NonResourceURLs: []string{"*"}, Verbs: []string{"*"}},
 		},
 		servantRules: []rbac.PolicyRule{
-			{NonResourceURLs: []string{"/apis", "/apis/v1", "/"}},
+			{NonResourceURLs: []string{"/apis", "/apis/v1", "/"}, Verbs: []string{"*"}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []rbac.PolicyRule{},
+	}.test(t)
+}
+
+func TestCoversNonResourceURLsStarAfterPrefixDoesntCover(t *testing.T) {
+	escalationTest{
+		ownerRules: []rbac.PolicyRule{
+			{NonResourceURLs: []string{"/apis/*"}, Verbs: []string{"*"}},
+		},
+		servantRules: []rbac.PolicyRule{
+			{NonResourceURLs: []string{"/apis", "/apis/v1"}, Verbs: []string{"get"}},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []rbac.PolicyRule{
+			{NonResourceURLs: []string{"/apis"}, Verbs: []string{"get"}},
+		},
+	}.test(t)
+}
+
+func TestCoversNonResourceURLsStarAfterPrefix(t *testing.T) {
+	escalationTest{
+		ownerRules: []rbac.PolicyRule{
+			{NonResourceURLs: []string{"/apis/*"}, Verbs: []string{"*"}},
+		},
+		servantRules: []rbac.PolicyRule{
+			{NonResourceURLs: []string{"/apis/v1/foo", "/apis/v1"}, Verbs: []string{"get"}},
 		},
 
 		expectedCovered:        true,

--- a/pkg/apis/rbac/validation/validation_test.go
+++ b/pkg/apis/rbac/validation/validation_test.go
@@ -219,3 +219,28 @@ func TestValidateRole(t *testing.T) {
 		}
 	}
 }
+
+func TestNonResourceURLCovers(t *testing.T) {
+	tests := []struct {
+		owner     string
+		requested string
+		want      bool
+	}{
+		{"*", "/api", true},
+		{"/api", "/api", true},
+		{"/apis", "/api", false},
+		{"/api/v1", "/api", false},
+		{"/api/v1", "/api/v1", true},
+		{"/api/*", "/api/v1", true},
+		{"/api/*", "/api", false},
+		{"/api/*/*", "/api/v1", false},
+		{"/*/v1/*", "/api/v1", false},
+	}
+
+	for _, tc := range tests {
+		got := nonResourceURLCovers(tc.owner, tc.requested)
+		if got != tc.want {
+			t.Errorf("nonResourceURLCovers(%q, %q): want=(%t), got=(%t)", tc.owner, tc.requested, tc.want, got)
+		}
+	}
+}

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -58,6 +58,7 @@ func (r *RBACAuthorizer) Authorize(attr authorizer.Attributes) error {
 		}
 	} else {
 		requestedRule = rbac.PolicyRule{
+			Verbs:           []string{attr.GetVerb()},
 			NonResourceURLs: []string{attr.GetPath()},
 		}
 	}

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -150,10 +150,12 @@ func TestAuthorizer(t *testing.T) {
 			clusterRoles: []rbac.ClusterRole{
 				newClusterRole("non-resource-url-getter", newRule("get", "", "", "/apis")),
 				newClusterRole("non-resource-url", newRule("*", "", "", "/apis")),
+				newClusterRole("non-resource-url-prefix", newRule("get", "", "", "/apis/*")),
 			},
 			clusterRoleBindings: []rbac.ClusterRoleBinding{
 				newClusterRoleBinding("non-resource-url-getter", "User:foo", "Group:bar"),
 				newClusterRoleBinding("non-resource-url", "User:admin", "Group:admin"),
+				newClusterRoleBinding("non-resource-url-prefix", "User:prefixed", "Group:prefixed"),
 			},
 			shouldPass: []authorizer.Attributes{
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "get", Path: "/apis"},
@@ -162,6 +164,11 @@ func TestAuthorizer(t *testing.T) {
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/apis"},
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "watch", Path: "/apis"},
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "watch", Path: "/apis"},
+
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1/foobar"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1/foorbar"},
 			},
 			shouldFail: []authorizer.Attributes{
 				// wrong verb
@@ -173,6 +180,10 @@ func TestAuthorizer(t *testing.T) {
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "get", Path: "/api/v1"},
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "get", Path: "/api/v1"},
 				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/api/v1"},
+
+				// not covered by prefix
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/api/v1"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/api/v1"},
 			},
 		},
 	}


### PR DESCRIPTION
An few oversights in the RBAC authorizer. Fixes #28291 and permits non-resource URLs to use stars in the path. E.g. ("/apis/*").

cc @liggitt @kubernetes/sig-auth 
