### PR TITLE
reverted the code from 23688 that cause race condition with older version of Go

### DIFF
--- a/pkg/client/record/event_test.go
+++ b/pkg/client/record/event_test.go
@@ -350,10 +350,7 @@ func TestEventf(t *testing.T) {
 	recorder := recorderWithFakeClock(api.EventSource{Component: "eventTest"}, eventBroadcaster, clock)
 	for index, item := range table {
 		clock.Step(1 * time.Second)
-		// TODO: uncomment this after we upgrade to Go 1.6.1.
-		// testing.(*common).log() is racing with testing.(*T).report() in Go 1.6.
-		// See #23533 for more details.
-		// logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
+		logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
 		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
 			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
@@ -372,8 +369,7 @@ func TestEventf(t *testing.T) {
 			actualEvent := <-createEvent
 			validateEvent(string(index), actualEvent, item.expect, t)
 		}
-		// TODO: uncomment this after we upgrade to Go 1.6.1.
-		// logWatcher1.Stop()
+		logWatcher1.Stop()
 		logWatcher2.Stop()
 	}
 	sinkWatcher.Stop()
@@ -601,10 +597,7 @@ func TestEventfNoNamespace(t *testing.T) {
 
 	for index, item := range table {
 		clock.Step(1 * time.Second)
-		// TODO: uncomment this after we upgrade to Go 1.6.1.
-		// testing.(*common).log() is racing with testing.(*T).report() in Go 1.6.
-		// See #23533 for more details.
-		// logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
+		logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
 		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
 			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
@@ -624,8 +617,7 @@ func TestEventfNoNamespace(t *testing.T) {
 			validateEvent(string(index), actualEvent, item.expect, t)
 		}
 
-		// TODO: uncomment this after we upgrade to Go 1.6.1.
-		// logWatcher1.Stop()
+		logWatcher1.Stop()
 		logWatcher2.Stop()
 	}
 	sinkWatcher.Stop()


### PR DESCRIPTION
``` release-note
* release-note-None
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
