### PR TITLE
Fix node confomance test

### DIFF
--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -261,14 +261,22 @@ while true; do sleep 1; done
 					Expect(container.Create()).To(Succeed())
 					defer container.Delete()
 
-					By("check the pod phase")
-					Eventually(container.GetPhase, retryTimeout, pollInterval).Should(Equal(testCase.phase))
-					Consistently(container.GetPhase, consistentCheckTimeout, pollInterval).Should(Equal(testCase.phase))
-
+					// We need to check container state first. The default pod status is pending, If we check
+					// pod phase first, and the expected pod phase is Pending, the container status may not
+					// even show up when we check it.
 					By("check the container state")
-					status, err := container.GetStatus()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(GetContainerState(status.State)).To(Equal(testCase.state))
+					getState := func() (ContainerState, error) {
+						status, err := container.GetStatus()
+						if err != nil {
+							return ContainerStateUnknown, err
+						}
+						return GetContainerState(status.State), nil
+					}
+					Eventually(getState, retryTimeout, pollInterval).Should(Equal(testCase.state))
+					Consistently(getState, consistentCheckTimeout, pollInterval).Should(Equal(testCase.state))
+
+					By("check the pod phase")
+					Expect(container.GetPhase()).To(Equal(testCase.phase))
 
 					By("it should be possible to delete")
 					Expect(container.Delete()).To(Succeed())


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/28255, https://github.com/kubernetes/kubernetes/issues/28250, https://github.com/kubernetes/kubernetes/issues/28341.

The main reason of the flake is that in the failed test expects the `PodPhase` to keep `Pending`. It did `Eventually` check and `Consistently` check for 5 seconds. However, the default `PodPhase` is `Pending`, when the check passes, the `PodStatus` could still be in default state.

After that, the test expects the container status to be `Waiting`, which may not be the case, because the default `ContainerStatuses` is empty, and the pod could still be in the default state.

This PR changes the test to ensure `ContainerStatuses` first and then check the `PodPhase` after that.

Mark P1 because the test fails relatively frequently and does block some PRs.

@pwittrock 

/cc @liangchenye @ncdc 
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
