### PR TITLE
error should return while get api versions from server

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -296,7 +296,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 			return true, nil
 		}
 		glog.Errorf("Failed to get api versions from server: %v", err)
-		return false, nil
+		return false, err
 	})
 	if err != nil {
 		glog.Fatalf("Failed to get api versions from server: %v", err)


### PR DESCRIPTION
If apiserver is not running and failed to get api versions from server, the error should return, then the code below  could print error log
