### PR TITLE
Switch hyperkube addon pod to use google_containers

### DIFF
--- a/cluster/images/hyperkube/static-pods/addon-manager.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "gcr.io/google-containers/kube-addon-manager-ARCH:v4",
+        "image": "gcr.io/google_containers/kube-addon-manager-ARCH:v4",
         "resources": {
           "requests": {
             "cpu": "5m",


### PR DESCRIPTION
In support of https://github.com/kubernetes/kube-deploy/issues/167 -- all of the other pods that the hyperkube image uses are in gcr.io/google_containers, so this one should be in that namespace as well.

The image appears to exist in gcr.io/google-containers and gcr.io/google_containers, but all the other pods seem to use google_containers.
