### PR TITLE
Walkaround bug in route controller.

### DIFF
--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -174,7 +174,7 @@ func (f *FakeCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 
 // Implementation of Instances.CurrentNodeName
 func (f *FakeCloud) CurrentNodeName(hostname string) (string, error) {
-	return hostname, nil
+	return hostname, f.Err
 }
 
 // NodeAddresses is a test-spy implementation of Instances.NodeAddresses.
@@ -195,13 +195,13 @@ func (f *FakeCloud) ExternalID(instance string) (string, error) {
 // InstanceID returns the cloud provider ID of the specified instance.
 func (f *FakeCloud) InstanceID(instance string) (string, error) {
 	f.addCall("instance-id")
-	return f.ExtID[instance], nil
+	return f.ExtID[instance], f.Err
 }
 
 // InstanceType returns the type of the specified instance.
 func (f *FakeCloud) InstanceType(instance string) (string, error) {
 	f.addCall("instance-type")
-	return f.InstanceTypes[instance], nil
+	return f.InstanceTypes[instance], f.Err
 }
 
 // List is a test-spy implementation of Instances.List.
@@ -240,6 +240,9 @@ func (f *FakeCloud) CreateRoute(clusterName string, nameHint string, route *clou
 	f.Lock.Lock()
 	defer f.Lock.Unlock()
 	f.addCall("create-route")
+	if f.Err != nil {
+		return f.Err
+	}
 	name := clusterName + "-" + nameHint
 	if _, exists := f.RouteMap[name]; exists {
 		f.Err = fmt.Errorf("route %q already exists", name)
@@ -257,6 +260,9 @@ func (f *FakeCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) 
 	f.Lock.Lock()
 	defer f.Lock.Unlock()
 	f.addCall("delete-route")
+	if f.Err != nil {
+		return f.Err
+	}
 	name := route.Name
 	if _, exists := f.RouteMap[name]; !exists {
 		f.Err = fmt.Errorf("no route found with name %q", name)

--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -19,6 +19,7 @@ package route
 import (
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -87,6 +88,12 @@ func (rc *RouteController) reconcileNodeRoutes() error {
 	return rc.reconcile(nodeList.Items, routeList)
 }
 
+const alreadyExistError = "googleapi: Error 409"
+
+func isRouteAlreadyExistError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), alreadyExistError)
+}
+
 func (rc *RouteController) reconcile(nodes []api.Node, routes []*cloudprovider.Route) error {
 	// nodeCIDRs maps nodeName->nodeCIDR
 	nodeCIDRs := make(map[string]string)
@@ -125,13 +132,21 @@ func (rc *RouteController) reconcile(nodes []api.Node, routes []*cloudprovider.R
 					err := rc.routes.CreateRoute(rc.clusterName, nameHint, route)
 					<-rateLimiter
 
-					rc.updateNetworkingCondition(nodeName, err == nil)
-					if err != nil {
-						glog.Errorf("Could not create route %s %s for node %s after %v: %v", nameHint, route.DestinationCIDR, nodeName, time.Now().Sub(startTime), err)
-					} else {
+					rc.updateNetworkingCondition(nodeName, err == nil || isRouteAlreadyExistError(err))
+					if err == nil {
+						// The route is sucessfully created, just return
 						glog.Infof("Created route for node %s %s with hint %s after %v", nodeName, route.DestinationCIDR, nameHint, time.Now().Sub(startTime))
 						return
 					}
+					if isRouteAlreadyExistError(err) {
+						// The route already exists, just return
+						// This is only a workaround, in fact there seems to be a race here (see issue https://github.com/kubernetes/kubernetes/issues/28362)
+						// TODO: Figure out and fix the race.
+						glog.Warningf("The route %s %s for node %s exists already after %v: %v", nodeName, route.DestinationCIDR, nameHint, time.Now().Sub(startTime), err)
+						return
+					}
+					// Failed to create route, keep trying
+					glog.Errorf("Could not create route %s %s for node %s after %v: %v", nameHint, route.DestinationCIDR, nodeName, time.Now().Sub(startTime), err)
 				}
 			}(node.Name, nameHint, route)
 		} else {


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/28362.

This PR didn't fix the original bug, because we still didn't understand it and even haven't successfully reproduced it yet. This PR only makes sure that route controller won't mark the node as NetworkUnavailable if the route is already created.

I don't know whether we want a walkaround like this, so I haven't added a unit test yet. If we want this, I'll add a unit test.

@dchen1107 @erictune @fgrzadkowski 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
