### PR TITLE
Kubelet: add initial client/server container runtime

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -548,7 +548,7 @@ type PodSandboxConfig struct {
 	//     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
 	//     ContainerConfig.LogPath = `containerName_Instance#.log`
 	//
-	// WARNING: Log managment and how kubelet should interface with the
+	// WARNING: Log management and how kubelet should interface with the
 	// container logs are under active discussion in
 	// https://issues.k8s.io/24677. There *may* be future change of direction
 	// for logging as the discussion carries on.
@@ -561,7 +561,7 @@ type PodSandboxConfig struct {
 	// aggregate cpu/memory resources limits of all containers).
 	// Note: On a Linux host, kubelet will create a pod-level cgroup and pass
 	// it as the cgroup parent for the PodSandbox. For some runtimes, this is
-	// sufficent. For others, e.g., hypervisor-based runtimes, explicit
+	// sufficient. For others, e.g., hypervisor-based runtimes, explicit
 	// resource limits for the sandbox are needed at creation time.
 	Resources *PodSandboxResources `protobuf:"bytes,6,opt,name=resources" json:"resources,omitempty"`
 	// Labels are key value pairs that may be used to scope and select individual resources.
@@ -1326,7 +1326,7 @@ type ContainerConfig struct {
 	//     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
 	//     ContainerConfig.LogPath = `containerName_Instance#.log`
 	//
-	// WARNING: Log managment and how kubelet should interface with the
+	// WARNING: Log management and how kubelet should interface with the
 	// container logs are under active discussion in
 	// https://issues.k8s.io/24677. There *may* be future change of direction
 	// for logging as the discussion carries on.
@@ -1602,7 +1602,7 @@ type ContainerFilter struct {
 	Name *string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	// ID of the container.
 	Id *string `protobuf:"bytes,2,opt,name=id" json:"id,omitempty"`
-	// State of the contianer.
+	// State of the container.
 	State *ContainerState `protobuf:"varint,3,opt,name=state,enum=runtime.ContainerState" json:"state,omitempty"`
 	// The id of the pod sandbox
 	PodSandboxId *string `protobuf:"bytes,4,opt,name=pod_sandbox_id" json:"pod_sandbox_id,omitempty"`
@@ -1684,7 +1684,10 @@ type Container struct {
 	// State is the state of the container.
 	State *ContainerState `protobuf:"varint,5,opt,name=state,enum=runtime.ContainerState" json:"state,omitempty"`
 	// Labels are key value pairs that may be used to scope and select individual resources.
-	Labels           map[string]string `protobuf:"bytes,6,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels map[string]string `protobuf:"bytes,6,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Annotations is an unstructured key value map that may be set by external
+	// tools to store and retrieve arbitrary metadata.
+	Annotations      map[string]string `protobuf:"bytes,7,rep,name=annotations" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XXX_unrecognized []byte            `json:"-"`
 }
 
@@ -1730,6 +1733,13 @@ func (m *Container) GetState() ContainerState {
 func (m *Container) GetLabels() map[string]string {
 	if m != nil {
 		return m.Labels
+	}
+	return nil
+}
+
+func (m *Container) GetAnnotations() map[string]string {
+	if m != nil {
+		return m.Annotations
 	}
 	return nil
 }

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -169,7 +169,7 @@ message PodSandboxConfig {
     //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
     //     ContainerConfig.LogPath = `containerName_Instance#.log`
     //
-    // WARNING: Log managment and how kubelet should interface with the
+    // WARNING: Log management and how kubelet should interface with the
     // container logs are under active discussion in
     // https://issues.k8s.io/24677. There *may* be future change of direction
     // for logging as the discussion carries on.
@@ -182,7 +182,7 @@ message PodSandboxConfig {
     // aggregate cpu/memory resources limits of all containers).
     // Note: On a Linux host, kubelet will create a pod-level cgroup and pass
     // it as the cgroup parent for the PodSandbox. For some runtimes, this is
-    // sufficent. For others, e.g., hypervisor-based runtimes, explicit
+    // sufficient. For others, e.g., hypervisor-based runtimes, explicit
     // resource limits for the sandbox are needed at creation time.
     optional PodSandboxResources resources  = 6;
     // Labels are key value pairs that may be used to scope and select individual resources.
@@ -418,7 +418,7 @@ message ContainerConfig {
     //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
     //     ContainerConfig.LogPath = `containerName_Instance#.log`
     //
-    // WARNING: Log managment and how kubelet should interface with the
+    // WARNING: Log management and how kubelet should interface with the
     // container logs are under active discussion in
     // https://issues.k8s.io/24677. There *may* be future change of direction
     // for logging as the discussion carries on.
@@ -488,7 +488,7 @@ message ContainerFilter {
     optional string name = 1;
     // ID of the container.
     optional string id = 2;
-    // State of the contianer.
+    // State of the container.
     optional ContainerState state = 3;
     // The id of the pod sandbox
     optional string pod_sandbox_id = 4;
@@ -519,6 +519,9 @@ message Container {
     optional ContainerState state = 5;
     // Labels are key value pairs that may be used to scope and select individual resources.
     map<string, string> labels = 6;
+    // Annotations is an unstructured key value map that may be set by external
+    // tools to store and retrieve arbitrary metadata.
+    map<string, string> annotations = 7;
 }
 
 message ListContainersResponse {

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime.go
@@ -1,0 +1,480 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+var (
+	version                 = "0.1.0"
+	fakeImageSize    uint64 = 1
+	fakeRuntimeName         = "fakeRuntime"
+	fakePodSandboxIP        = "192.168.192.168"
+)
+
+type PodSandboxWithState struct {
+	// creation timestamp
+	createdAt int64
+	// the config of this pod sandbox
+	config *runtimeApi.PodSandboxConfig
+	// the state of this pod sandbox
+	state runtimeApi.PodSandBoxState
+}
+
+type ContainerWithState struct {
+	// creation timestamp
+	createdAt int64
+	// the id of this container
+	containerID string
+	// the sandbox id of this container
+	podSandboxID string
+	// the id of the image
+	imageID string
+	// the state of this container
+	state runtimeApi.ContainerState
+	// the config of this container
+	containerConfig *runtimeApi.ContainerConfig
+	// the sandbox config of this container
+	sandboxConfig *runtimeApi.PodSandboxConfig
+}
+
+type fakeKubeRuntime struct {
+	sync.Mutex
+
+	Images     map[string]*runtimeApi.Image
+	Containers map[string]*ContainerWithState
+	Sandboxes  map[string]*PodSandboxWithState
+
+	Called []string
+}
+
+func NewFakeKubeRuntime() *fakeKubeRuntime {
+	s := &fakeKubeRuntime{
+		Images:     make(map[string]*runtimeApi.Image),
+		Containers: make(map[string]*ContainerWithState),
+		Sandboxes:  make(map[string]*PodSandboxWithState),
+	}
+
+	return s
+}
+
+func stringInSlice(in string, list []string) bool {
+	for _, v := range list {
+		if v == in {
+			return true
+		}
+	}
+
+	return false
+}
+
+func makeFakeImage(image string) *runtimeApi.Image {
+	return &runtimeApi.Image{
+		Id:       &image,
+		Size_:    &fakeImageSize,
+		RepoTags: []string{image},
+	}
+}
+
+func (r *fakeKubeRuntime) SetFakeSandboxes(sandboxes []*PodSandboxWithState) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Sandboxes = make(map[string]*PodSandboxWithState)
+	for _, sandbox := range sandboxes {
+		sandboxID := sandbox.config.GetName()
+		r.Sandboxes[sandboxID] = sandbox
+	}
+}
+
+func (r *fakeKubeRuntime) SetFakeContainers(containers []*ContainerWithState) {
+	r.Lock()
+	defer r.Unlock()
+
+	images := sets.NewString()
+	r.Containers = make(map[string]*ContainerWithState)
+	for _, c := range containers {
+		containerID := c.containerConfig.GetName()
+		r.Containers[containerID] = c
+		images.Insert(c.containerConfig.Image.GetImage())
+	}
+
+	r.Images = make(map[string]*runtimeApi.Image)
+	for _, image := range images.List() {
+		r.Images[image] = makeFakeImage(image)
+	}
+}
+
+func (r *fakeKubeRuntime) SetFakeImages(images []string) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Images = make(map[string]*runtimeApi.Image)
+	for _, image := range images {
+		r.Images[image] = makeFakeImage(image)
+	}
+}
+
+func (r *fakeKubeRuntime) ListImages(filter *runtimeApi.ImageFilter) ([]*runtimeApi.Image, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListImages")
+
+	images := make([]*runtimeApi.Image, 0)
+	for _, img := range r.Images {
+		if filter != nil && filter.Image != nil {
+			if !stringInSlice(filter.Image.GetImage(), img.RepoTags) {
+				continue
+			}
+		}
+
+		images = append(images, img)
+	}
+	return images, nil
+}
+
+func (r *fakeKubeRuntime) ImageStatus(image *runtimeApi.ImageSpec) (*runtimeApi.Image, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ImageStatus")
+
+	if img, ok := r.Images[image.GetImage()]; ok {
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("image %q not found", image.GetImage())
+}
+
+func (r *fakeKubeRuntime) PullImage(image *runtimeApi.ImageSpec, auth *runtimeApi.AuthConfig) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PullImage")
+
+	// ImageID should be randomized for real container runtime, but here just use
+	// image's name for easily making fake images.
+	imageID := image.GetImage()
+	if _, ok := r.Images[imageID]; !ok {
+		r.Images[imageID] = makeFakeImage(image.GetImage())
+	}
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) RemoveImage(image *runtimeApi.ImageSpec) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveImage")
+
+	if _, ok := r.Images[image.GetImage()]; ok {
+		delete(r.Images, image.GetImage())
+	}
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) Version(apiVersion string) (*runtimeApi.VersionResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Version")
+
+	return &runtimeApi.VersionResponse{
+		Version:           &version,
+		RuntimeName:       &fakeRuntimeName,
+		RuntimeVersion:    &version,
+		RuntimeApiVersion: &version,
+	}, nil
+}
+
+func (r *fakeKubeRuntime) CreatePodSandbox(config *runtimeApi.PodSandboxConfig) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "CreatePodSandbox")
+
+	// PodSandboxID should be randomized for real container runtime, but here just use
+	// sandbox's name for easily making fake sandboxes.
+	podSandboxID := config.GetName()
+	r.Sandboxes[podSandboxID] = &PodSandboxWithState{
+		config:    config,
+		state:     runtimeApi.PodSandBoxState_READY,
+		createdAt: time.Now().Unix(),
+	}
+
+	return podSandboxID, nil
+}
+
+func (r *fakeKubeRuntime) StopPodSandbox(podSandboxID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopPodSandbox")
+
+	if s, ok := r.Sandboxes[podSandboxID]; ok {
+		s.state = runtimeApi.PodSandBoxState_NOTREADY
+	} else {
+		return fmt.Errorf("pod sandbox %s not found", podSandboxID)
+	}
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) DeletePodSandbox(podSandboxID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "DeletePodSandbox")
+
+	if _, ok := r.Sandboxes[podSandboxID]; ok {
+		delete(r.Sandboxes, podSandboxID)
+	}
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) PodSandboxStatus(podSandboxID string) (*runtimeApi.PodSandboxStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PodSandboxStatus")
+
+	s, ok := r.Sandboxes[podSandboxID]
+	if !ok {
+		return nil, fmt.Errorf("pod sandbox %s not found", podSandboxID)
+	}
+
+	return &runtimeApi.PodSandboxStatus{
+		Id:        &podSandboxID,
+		Name:      s.config.Name,
+		CreatedAt: &s.createdAt,
+		State:     &s.state,
+		Network: &runtimeApi.PodSandboxNetworkStatus{
+			Ip: &fakePodSandboxIP,
+		},
+		Labels:      s.config.Labels,
+		Annotations: s.config.Annotations,
+	}, nil
+}
+
+func filterInLabels(filter, labels map[string]string) bool {
+	for k, v := range filter {
+		if value, ok := labels[k]; ok {
+			if value != v {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *fakeKubeRuntime) ListPodSandbox(filter *runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListPodSandbox")
+
+	result := make([]*runtimeApi.PodSandbox, 0)
+	for id, s := range r.Sandboxes {
+		if filter != nil {
+			if filter.Id != nil && filter.GetId() != id {
+				continue
+			}
+			if filter.Name != nil && filter.GetName() != s.config.GetName() {
+				continue
+			}
+			if filter.State != nil && filter.GetState() != s.state {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.config.Labels) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeApi.PodSandbox{
+			Id:        &id,
+			Name:      s.config.Name,
+			State:     &s.state,
+			CreatedAt: &s.createdAt,
+			Labels:    s.config.Labels,
+		})
+	}
+
+	return result, nil
+}
+
+func (r *fakeKubeRuntime) CreateContainer(podSandboxID string, config *runtimeApi.ContainerConfig, sandboxConfig *runtimeApi.PodSandboxConfig) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "CreateContainer")
+
+	imageID := ""
+	for _, img := range r.Images {
+		if stringInSlice(config.Image.GetImage(), img.RepoTags) {
+			imageID = img.GetId()
+			break
+		}
+	}
+	if imageID == "" {
+		return "", fmt.Errorf("image %q not found", config.Image.GetImage())
+	}
+
+	// ContainerID should be randomized for real container runtime, but here just use
+	// container's name for easily making fake containers.
+	containerID := config.GetName()
+	r.Containers[containerID] = &ContainerWithState{
+		createdAt:       time.Now().Unix(),
+		containerID:     containerID,
+		podSandboxID:    podSandboxID,
+		containerConfig: config,
+		sandboxConfig:   sandboxConfig,
+		imageID:         imageID,
+		state:           runtimeApi.ContainerState_CREATED,
+	}
+
+	return containerID, nil
+}
+
+func (r *fakeKubeRuntime) StartContainer(rawContainerID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StartContainer")
+
+	c, ok := r.Containers[rawContainerID]
+	if !ok {
+		return fmt.Errorf("container %s not found", rawContainerID)
+	}
+
+	// Set container to running.
+	c.state = runtimeApi.ContainerState_RUNNING
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) StopContainer(rawContainerID string, timeout int64) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopContainer")
+
+	c, ok := r.Containers[rawContainerID]
+	if !ok {
+		return fmt.Errorf("container %s not found", rawContainerID)
+	}
+
+	// Set container to exited.
+	c.state = runtimeApi.ContainerState_EXITED
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) RemoveContainer(rawContainerID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveContainer")
+
+	if _, ok := r.Containers[rawContainerID]; ok {
+		delete(r.Containers, rawContainerID)
+	}
+
+	return nil
+}
+
+func (r *fakeKubeRuntime) ListContainers(filter *runtimeApi.ContainerFilter) ([]*runtimeApi.Container, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListContainers")
+
+	result := make([]*runtimeApi.Container, 0)
+	for _, s := range r.Containers {
+		if filter != nil {
+			if filter.Id != nil && filter.GetId() != s.containerID {
+				continue
+			}
+			if filter.Name != nil && filter.GetName() != s.containerConfig.GetName() {
+				continue
+			}
+			if filter.PodSandboxId != nil && filter.GetPodSandboxId() != s.podSandboxID {
+				continue
+			}
+			if filter.State != nil && filter.GetState() != s.state {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.containerConfig.Labels) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeApi.Container{
+			Id:       &s.containerID,
+			Name:     s.containerConfig.Name,
+			State:    &s.state,
+			Image:    s.containerConfig.Image,
+			ImageRef: &s.imageID,
+			Labels:   s.containerConfig.Labels,
+		})
+	}
+
+	return result, nil
+}
+
+func (r *fakeKubeRuntime) ContainerStatus(rawContainerID string) (*runtimeApi.ContainerStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ContainerStatus")
+
+	c, ok := r.Containers[rawContainerID]
+	if !ok {
+		return nil, fmt.Errorf("container %s not found", rawContainerID)
+	}
+
+	return &runtimeApi.ContainerStatus{
+		Id:        &c.containerID,
+		Name:      c.containerConfig.Name,
+		State:     &c.state,
+		CreatedAt: &c.createdAt,
+		Image:     c.containerConfig.Image,
+		ImageRef:  &c.imageID,
+		Labels:    c.containerConfig.Labels,
+	}, nil
+}
+
+func (r *fakeKubeRuntime) Exec(rawContainerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Exec")
+	return nil
+}

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	"k8s.io/kubernetes/pkg/client/record"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
+	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+	kubetypes "k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/flowcontrol"
+)
+
+type fakeHTTP struct {
+	url string
+	err error
+}
+
+func (f *fakeHTTP) Get(url string) (*http.Response, error) {
+	f.url = url
+	return nil, f.err
+}
+
+// fakeRuntimeHelper implements kubecontainer.RuntimeHelper interfaces for testing purposes.
+type fakeRuntimeHelper struct{}
+
+func (f *fakeRuntimeHelper) GenerateRunContainerOptions(pod *api.Pod, container *api.Container, podIP string) (*kubecontainer.RunContainerOptions, error) {
+	var opts kubecontainer.RunContainerOptions
+	if len(container.TerminationMessagePath) != 0 {
+		testPodContainerDir, err := ioutil.TempDir("", "fooPodContainerDir")
+		if err != nil {
+			return nil, err
+		}
+		opts.PodContainerDir = testPodContainerDir
+	}
+	return &opts, nil
+}
+
+func (f *fakeRuntimeHelper) GetClusterDNS(pod *api.Pod) ([]string, []string, error) {
+	return nil, nil, nil
+}
+
+// This is not used by docker runtime.
+func (f *fakeRuntimeHelper) GeneratePodHostNameAndDomain(pod *api.Pod) (string, string, error) {
+	return "", "", nil
+}
+
+func (f *fakeRuntimeHelper) GetPodDir(kubetypes.UID) string {
+	return ""
+}
+
+func (f *fakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *api.Pod) []int64 {
+	return nil
+}
+
+func NewFakeKubeRuntimeManager(runtime *fakeKubeRuntime) (*kubeGenericRuntimeManager, error) {
+	networkPlugin, _ := network.InitNetworkPlugin(
+		[]network.NetworkPlugin{},
+		"",
+		nettest.NewFakeHost(nil),
+		componentconfig.HairpinNone,
+		"10.0.0.0/8",
+	)
+
+	return NewKubeGenericRuntimeManager(
+		&record.FakeRecorder{},
+		proberesults.NewManager(),
+		kubecontainer.NewRefManager(),
+		&containertest.FakeOS{},
+		networkPlugin,
+		&fakeRuntimeHelper{},
+		&fakeHTTP{},
+		flowcontrol.NewBackOff(time.Second, 300*time.Second),
+		false,
+		false,
+		runtime,
+		runtime,
+	)
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/kubernetes/pkg/api"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/util/term"
+)
+
+// AttachContainer attaches to the container's console
+func (m *kubeGenericRuntimeManager) AttachContainer(id kubecontainer.ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size) (err error) {
+	return fmt.Errorf("Not implemented")
+}
+
+// GetContainerLogs returns logs of a specific container.
+func (m *kubeGenericRuntimeManager) GetContainerLogs(pod *api.Pod, containerID kubecontainer.ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error) {
+	return fmt.Errorf("Not implemented")
+}
+
+// Runs the command in the container of the specified pod using nsenter.
+// Attaches the processes stdin, stdout, and stderr. Optionally uses a
+// tty.
+// TODO: handle terminal resizing, refer https://github.com/kubernetes/kubernetes/issues/29579
+func (m *kubeGenericRuntimeManager) ExecInContainer(containerID kubecontainer.ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// DeleteContainer removes a container.
+func (m *kubeGenericRuntimeManager) DeleteContainer(containerID kubecontainer.ContainerID) error {
+	return m.runtimeService.RemoveContainer(containerID.ID)
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/parsers"
+)
+
+// PullImage pulls an image from the network to local storage using the supplied
+// secrets if necessary.
+// TODO: pull image with qps and burst, ref https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/docker.go#L120
+func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pullSecrets []api.Secret) error {
+	img := image.Image
+	repoToPull, _, _, err := parsers.ParseImageName(img)
+	if err != nil {
+		return err
+	}
+
+	keyring, err := credentialprovider.MakeDockerKeyring(pullSecrets, m.keyring)
+	if err != nil {
+		return err
+	}
+
+	imgSpec := &runtimeApi.ImageSpec{Image: &img}
+	creds, withCredentials := keyring.Lookup(repoToPull)
+	if !withCredentials {
+		glog.V(3).Infof("Pulling image %q without credentials", img)
+
+		err = m.imageService.PullImage(imgSpec, nil)
+		if err != nil {
+			glog.Errorf("Pull image %q failed: %v", img, err)
+			return err
+		}
+
+		return nil
+	}
+
+	var pullErrs []error
+	for _, currentCreds := range creds {
+		authConfig := credentialprovider.LazyProvide(currentCreds)
+		auth := &runtimeApi.AuthConfig{
+			Username:      &authConfig.Username,
+			Password:      &authConfig.Password,
+			Auth:          &authConfig.Auth,
+			ServerAddress: &authConfig.ServerAddress,
+			IdentityToken: &authConfig.IdentityToken,
+			RegistryToken: &authConfig.RegistryToken,
+		}
+
+		err = m.imageService.PullImage(imgSpec, auth)
+		// If there was no error, return success
+		if err == nil {
+			return nil
+		}
+
+		pullErrs = append(pullErrs, err)
+	}
+
+	return utilerrors.NewAggregate(pullErrs)
+}
+
+// IsImagePresent checks whether the container image is already in the local storage.
+func (m *kubeGenericRuntimeManager) IsImagePresent(image kubecontainer.ImageSpec) (bool, error) {
+	images, err := m.imageService.ListImages(&runtimeApi.ImageFilter{
+		Image: &runtimeApi.ImageSpec{
+			Image: &image.Image,
+		},
+	})
+	if err != nil {
+		glog.Errorf("ListImages failed: %v", err)
+		return false, err
+	}
+
+	return len(images) > 0, nil
+}
+
+// ListImages gets all images currently on the machine.
+func (m *kubeGenericRuntimeManager) ListImages() ([]kubecontainer.Image, error) {
+	var images []kubecontainer.Image
+
+	allImages, err := m.imageService.ListImages(nil)
+	if err != nil {
+		glog.Errorf("ListImages failed: %v", err)
+		return nil, err
+	}
+
+	for _, img := range allImages {
+		images = append(images, kubecontainer.Image{
+			ID:          img.GetId(),
+			Size:        int64(img.GetSize_()),
+			RepoTags:    img.RepoTags,
+			RepoDigests: img.RepoDigests,
+		})
+	}
+
+	return images, nil
+}
+
+// RemoveImage removes the specified image.
+func (m *kubeGenericRuntimeManager) RemoveImage(image kubecontainer.ImageSpec) error {
+	err := m.imageService.RemoveImage(&runtimeApi.ImageSpec{Image: &image.Image})
+	if err != nil {
+		glog.Errorf("Remove image %q failed: %v", image.Image, err)
+		return err
+	}
+
+	return nil
+}
+
+// ImageStats returns the statistics of the image.
+func (m *kubeGenericRuntimeManager) ImageStats() (*kubecontainer.ImageStats, error) {
+	// TODO: support image stats in new runtime interface
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func TestPullImage(t *testing.T) {
+	_, fakeManager, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	err = fakeManager.PullImage(kubecontainer.ImageSpec{Image: "busybox"}, nil)
+	assert.NoError(t, err)
+
+	images, err := fakeManager.ListImages()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(images))
+	assert.Equal(t, images[0].RepoTags, []string{"busybox"})
+}
+
+func TestListImages(t *testing.T) {
+	fakeRuntime, fakeManager, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	images := []string{"1111", "2222", "3333"}
+	expected := sets.NewString(images...)
+	fakeRuntime.SetFakeImages(images)
+
+	actualImages, err := fakeManager.ListImages()
+	assert.NoError(t, err)
+	actual := sets.NewString()
+	for _, i := range actualImages {
+		actual.Insert(i.ID)
+	}
+
+	assert.Equal(t, expected.List(), actual.List())
+}
+
+func TestIsImagePresent(t *testing.T) {
+	fakeRuntime, fakeManager, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	image := "busybox"
+	fakeRuntime.SetFakeImages([]string{image})
+	present, err := fakeManager.IsImagePresent(kubecontainer.ImageSpec{Image: image})
+	assert.NoError(t, err)
+	assert.Equal(t, true, present)
+}
+
+func TestRemoveImage(t *testing.T) {
+	fakeRuntime, fakeManager, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	err = fakeManager.PullImage(kubecontainer.ImageSpec{Image: "busybox"}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(fakeRuntime.Images))
+
+	err = fakeManager.RemoveImage(kubecontainer.ImageSpec{Image: "busybox"})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(fakeRuntime.Images))
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/images"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/flowcontrol"
+)
+
+const (
+	// The api version of kubelet runtime api
+	kubeRuntimeAPIVersion = "0.1.0"
+	// The root directory for pod logs
+	podLogsRootDirectory = "/var/log/pods"
+)
+
+var (
+	// ErrVersionNotSupported is returned when the api version of runtime interface is not supported
+	ErrVersionNotSupported = errors.New("Runtime api version is not supported")
+)
+
+type kubeGenericRuntimeManager struct {
+	runtimeName         string
+	recorder            record.EventRecorder
+	osInterface         kubecontainer.OSInterface
+	containerRefManager *kubecontainer.RefManager
+
+	// Keyring for pulling images
+	keyring credentialprovider.DockerKeyring
+
+	// Runner of lifecycle events.
+	runner kubecontainer.HandlerRunner
+
+	// RuntimeHelper that wraps kubelet to generate runtime container options.
+	runtimeHelper kubecontainer.RuntimeHelper
+
+	// Health check results.
+	livenessManager proberesults.Manager
+
+	// If true, enforce container cpu limits with CFS quota support
+	cpuCFSQuota bool
+
+	// Network plugin.
+	networkPlugin network.NetworkPlugin
+
+	// wrapped image puller.
+	imagePuller images.ImageManager
+
+	// gRPC service clients
+	runtimeService kubecontainer.RuntimeService
+	imageService   kubecontainer.ImageManagerService
+}
+
+// NewKubeGenericRuntimeManager creates a new kubeGenericRuntimeManager
+func NewKubeGenericRuntimeManager(
+	recorder record.EventRecorder,
+	livenessManager proberesults.Manager,
+	containerRefManager *kubecontainer.RefManager,
+	osInterface kubecontainer.OSInterface,
+	networkPlugin network.NetworkPlugin,
+	runtimeHelper kubecontainer.RuntimeHelper,
+	httpClient types.HttpGetter,
+	imageBackOff *flowcontrol.Backoff,
+	serializeImagePulls bool,
+	cpuCFSQuota bool,
+	runtimeService kubecontainer.RuntimeService,
+	imageService kubecontainer.ImageManagerService,
+) (*kubeGenericRuntimeManager, error) {
+	kubeRuntimeManager := &kubeGenericRuntimeManager{
+		recorder:            recorder,
+		cpuCFSQuota:         cpuCFSQuota,
+		livenessManager:     livenessManager,
+		containerRefManager: containerRefManager,
+		osInterface:         osInterface,
+		networkPlugin:       networkPlugin,
+		runtimeHelper:       runtimeHelper,
+		runtimeService:      runtimeService,
+		imageService:        imageService,
+		keyring:             credentialprovider.NewDockerKeyring(),
+	}
+
+	typedVersion, err := kubeRuntimeManager.runtimeService.Version(kubeRuntimeAPIVersion)
+	if err != nil {
+		glog.Errorf("Get runtime version failed: %v", err)
+		return nil, err
+	}
+
+	// Only matching kubeRuntimeAPIVersion is supported now
+	// TODO: Runtime API machinery is under discussion at https://github.com/kubernetes/kubernetes/issues/28642
+	if typedVersion.GetVersion() != kubeRuntimeAPIVersion {
+		glog.Errorf("Runtime api version %s is not supported, only %s is supported now",
+			typedVersion.GetVersion(),
+			kubeRuntimeAPIVersion)
+		return nil, ErrVersionNotSupported
+	}
+
+	kubeRuntimeManager.runtimeName = typedVersion.GetRuntimeName()
+	glog.Infof("Container runtime %s initialized, version: %s, apiVersion: %s",
+		typedVersion.GetRuntimeName(),
+		typedVersion.GetRuntimeVersion(),
+		typedVersion.GetRuntimeApiVersion())
+
+	// If the container logs directory does not exist, create it.
+	// TODO: create podLogsRootDirectory at kubelet.go when kubelet is refactored to
+	// new runtime interface
+	if _, err := osInterface.Stat(podLogsRootDirectory); os.IsNotExist(err) {
+		if err := osInterface.MkdirAll(podLogsRootDirectory, 0755); err != nil {
+			glog.Errorf("Failed to create directory %q: %v", podLogsRootDirectory, err)
+		}
+	}
+
+	kubeRuntimeManager.imagePuller = images.NewImageManager(
+		kubecontainer.FilterEventRecorder(recorder),
+		kubeRuntimeManager,
+		imageBackOff,
+		serializeImagePulls)
+	kubeRuntimeManager.runner = lifecycle.NewHandlerRunner(httpClient, kubeRuntimeManager, kubeRuntimeManager)
+
+	return kubeRuntimeManager, nil
+}
+
+// Type returns the type of the container runtime.
+func (m *kubeGenericRuntimeManager) Type() string {
+	return m.runtimeName
+}
+
+// runtimeVersion implements kubecontainer.Version interface by implementing
+// Compare() and String()
+type runtimeVersion struct {
+	*semver.Version
+}
+
+func newRuntimeVersion(version string) (runtimeVersion, error) {
+	sem, err := semver.NewVersion(version)
+	if err != nil {
+		return runtimeVersion{}, err
+	}
+	return runtimeVersion{sem}, nil
+}
+
+func (r runtimeVersion) Compare(other string) (int, error) {
+	v, err := semver.NewVersion(other)
+	if err != nil {
+		return -1, err
+	}
+
+	if r.LessThan(*v) {
+		return -1, nil
+	}
+	if v.LessThan(*r.Version) {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// Version returns the version information of the container runtime.
+func (m *kubeGenericRuntimeManager) Version() (kubecontainer.Version, error) {
+	typedVersion, err := m.runtimeService.Version(kubeRuntimeAPIVersion)
+	if err != nil {
+		glog.Errorf("Get remote runtime version failed: %v", err)
+		return nil, err
+	}
+
+	return newRuntimeVersion(typedVersion.GetVersion())
+}
+
+// APIVersion returns the cached API version information of the container
+// runtime. Implementation is expected to update this cache periodically.
+// This may be different from the runtime engine's version.
+func (m *kubeGenericRuntimeManager) APIVersion() (kubecontainer.Version, error) {
+	typedVersion, err := m.runtimeService.Version(kubeRuntimeAPIVersion)
+	if err != nil {
+		glog.Errorf("Get remote runtime version failed: %v", err)
+		return nil, err
+	}
+
+	return newRuntimeVersion(typedVersion.GetRuntimeApiVersion())
+}
+
+// Status returns error if the runtime is unhealthy; nil otherwise.
+func (m *kubeGenericRuntimeManager) Status() error {
+	_, err := m.runtimeService.Version(kubeRuntimeAPIVersion)
+	if err != nil {
+		glog.Errorf("Checkout remote runtime status failed: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// GetPods returns a list of containers grouped by pods. The boolean parameter
+// specifies whether the runtime returns all containers including those already
+// exited and dead containers (used for garbage collection).
+func (m *kubeGenericRuntimeManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
+
+// SyncPod syncs the running pod into the desired pod.
+func (m *kubeGenericRuntimeManager) SyncPod(pod *api.Pod, _ api.PodStatus,
+	podStatus *kubecontainer.PodStatus, pullSecrets []api.Secret,
+	backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
+	result.Fail(fmt.Errorf("Not implemented"))
+
+	return
+}
+
+// KillPod kills all the containers of a pod. Pod may be nil, running pod must not be.
+// gracePeriodOverride if specified allows the caller to override the pod default grace period.
+// only hard kill paths are allowed to specify a gracePeriodOverride in the kubelet in order to not corrupt user data.
+// it is useful when doing SIGKILL for hard eviction scenarios, or max grace period during soft eviction scenarios.
+func (m *kubeGenericRuntimeManager) KillPod(pod *api.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// GetPodStatus retrieves the status of the pod, including the
+// information of all containers in the pod that are visble in Runtime.
+func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
+
+// Returns the filesystem path of the pod's network namespace; if the
+// runtime does not handle namespace creation itself, or cannot return
+// the network namespace path, it should return an error.
+// TODO: Change ContainerID to a Pod ID since the namespace is shared
+// by all containers in the pod.
+func (m *kubeGenericRuntimeManager) GetNetNS(containerID kubecontainer.ContainerID) (string, error) {
+	return "", fmt.Errorf("Not implemented")
+}
+
+// GetPodContainerID gets pod sandbox ID
+func (m *kubeGenericRuntimeManager) GetPodContainerID(pod *kubecontainer.Pod) (kubecontainer.ContainerID, error) {
+	return kubecontainer.ContainerID{}, fmt.Errorf("Not implemented")
+}
+
+// Forward the specified port from the specified pod to the stream.
+func (m *kubeGenericRuntimeManager) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// GarbageCollect removes dead containers using the specified container gc policy
+func (m *kubeGenericRuntimeManager) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy, allSourcesReady bool) error {
+	return fmt.Errorf("Not implemented")
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestFakeRuntimeManager() (*fakeKubeRuntime, *kubeGenericRuntimeManager, error) {
+	fakeRuntime := NewFakeKubeRuntime()
+	manager, err := NewFakeKubeRuntimeManager(fakeRuntime)
+	return fakeRuntime, manager, err
+}
+
+func TestNewKubeRuntimeManager(t *testing.T) {
+	fakeRuntime := NewFakeKubeRuntime()
+	_, err := NewFakeKubeRuntimeManager(fakeRuntime)
+	assert.NoError(t, err)
+}
+
+func TestVersion(t *testing.T) {
+	_, m, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	version, err := m.Version()
+	assert.NoError(t, err)
+	assert.Equal(t, kubeRuntimeAPIVersion, version.String())
+}
+
+func TestContainerRuntimeType(t *testing.T) {
+	_, m, err := createTestFakeRuntimeManager()
+	assert.NoError(t, err)
+
+	runtimeType := m.Type()
+	assert.Equal(t, fakeRuntimeName, runtimeType)
+}


### PR DESCRIPTION
Part of #28789. Initial implementation of  kubelet client/server container runtime #17048.

To facilitate code reviewing, this function will be split into a few small PRs:
- Add `KubeGenericRuntimeManager` which conforms to kubelet Runtime interface and add a runtime plugin interface for `KubeGenericRuntimeManager` (this PR)
- fake runtime/manager and unit testing
- Add gRPC implementation and add options `--container-runtime-endpoint` and `--image-service-endpoint` to kubelet
- Garbage collection
- Init containers

This PR contains only first part. Other parts will be sent out after this one is in.

CC @dchen1107 @yujuhong  and @tmrts @yifan-gu 

Also CC @kubernetes/sig-node @kubernetes/sig-rktnetes 
