### PR TITLE
Log pod.Name when the scheduler schedules pods

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -93,11 +93,11 @@ func (s *Scheduler) Run() {
 func (s *Scheduler) scheduleOne() {
 	pod := s.config.NextPod()
 
-	glog.V(3).Infof("Attempting to schedule: %+v", pod)
+	glog.V(3).Infof("Attempting to schedule: %v", pod.Name)
 	start := time.Now()
 	dest, err := s.config.Algorithm.Schedule(pod, s.config.NodeLister)
 	if err != nil {
-		glog.V(1).Infof("Failed to schedule: %+v", pod)
+		glog.V(1).Infof("Failed to schedule: %v", pod.Name)
 		s.config.Error(pod, err)
 		s.config.Recorder.Eventf(pod, api.EventTypeWarning, "FailedScheduling", "%v", err)
 		s.config.PodConditionUpdater.Update(pod, &api.PodCondition{


### PR DESCRIPTION
When the scheduler schedules pods, one of the logs doesn't show the right info as follows:

```
I0609 15:18:17.934545   32560 factory.go:420] About to try and schedule pod mongo
I0609 15:18:17.934641   32560 scheduler.go:96] Attempting to schedule: kind:"" apiVersion:""
```

In fact, just log the pod name is enough.

```
I0702 01:02:55.352437    2062 factory.go:420] About to try and schedule pod mongo
I0702 01:02:55.352600    2062 scheduler.go:96] Attempting to schedule: mongo
```

BTW, maybe we should check how to make `%+v` of pod show more valuable info.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28412)

<!-- Reviewable:end -->
