### PR TITLE
AWS: Added experimental option to skip zone check

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -304,10 +304,10 @@ type CloudConfig struct {
 		//During the instantiation of an new AWS cloud provider, the detected region
 		//is validated against a known set of regions.
 		//
-		//In a non-standard, AWS like environment (e.g. Eucalyptus), this check may 
-		//be undesirable.  Setting this to true will disable the check and provide 
-		//a warning that the check was skipped.  Please note that this is an 
-		//experimental feature and work-in-progress for the moment.  If you find 
+		//In a non-standard, AWS like environment (e.g. Eucalyptus), this check may
+		//be undesirable.  Setting this to true will disable the check and provide
+		//a warning that the check was skipped.  Please note that this is an
+		//experimental feature and work-in-progress for the moment.  If you find
 		//yourself in an non-AWS cloud and open an issue, please indicate that in the
 		//issue body.
 		DisableStrictZoneCheck bool

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -300,7 +300,16 @@ type CloudConfig struct {
 		//has setup a rule that allows inbound traffic on kubelet ports from the
 		//local VPC subnet (so load balancers can access it). E.g. 10.82.0.0/16 30000-32000.
 		DisableSecurityGroupIngress bool
-		
+
+		//During the instantiation of an new AWS cloud provider, the detected region
+		//is validated against a known set of regions.
+		//
+		//In a non-standard, AWS like environment (e.g. Eucalyptus), this check may 
+		//be undesirable.  Setting this to true will disable the check and provide 
+		//a warning that the check was skipped.  Please note that this is an 
+		//experimental feature and work-in-progress for the moment.  If you find 
+		//yourself in an non-AWS cloud and open an issue, please indicate that in the
+		//issue body.
 		DisableStrictZoneCheck bool
 	}
 }

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -300,6 +300,8 @@ type CloudConfig struct {
 		//has setup a rule that allows inbound traffic on kubelet ports from the
 		//local VPC subnet (so load balancers can access it). E.g. 10.82.0.0/16 30000-32000.
 		DisableSecurityGroupIngress bool
+		
+		DisableStrictZoneCheck bool
 	}
 }
 
@@ -664,9 +666,13 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 		return nil, err
 	}
 
-	valid := isRegionValid(regionName)
-	if !valid {
-		return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", zone)
+	if !cfg.Global.DisableStrictZoneCheck {
+		valid := isRegionValid(regionName)
+		if !valid {
+			return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", zone)
+		}
+	} else {
+		glog.Warningf("Strict AWS zone checking is disabled.  Proceeding with zone: %s", zone)
 	}
 
 	ec2, err := awsServices.Compute(regionName)


### PR DESCRIPTION
This pull request resolves #28380.  In the vast majority of cases, it is appropriate to validate the AWS region against a known set of regions.  However, there is the edge case where this is undesirable as Kubernetes may be deployed in an AWS-like environment where the region is not one of the known regions.

By adding the optional **DisableStrictZoneCheck true** to the **[Global]** section in the aws.conf file (e.g. /etc/aws/aws.conf) one can bypass the ragion validation. 
