### PR TITLE
AWS: Add ap-south-1 to list of known AWS regions

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -38,6 +38,7 @@ var AWSRegions = [...]string{
 	"us-west-2",
 	"eu-west-1",
 	"eu-central-1",
+	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",
 	"ap-northeast-1",


### PR DESCRIPTION
Adding the new ap-south-1 region (Mumbai)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28428)

<!-- Reviewable:end -->
