### PR TITLE
WIP - Handle map[]struct{} in DeepCopy

### DIFF
--- a/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
+++ b/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
@@ -356,10 +356,17 @@ func (g *genDeepCopy) doBuiltin(t *types.Type, sw *generator.SnippetWriter) {
 func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 	sw.Do("*out = make($.|raw$)\n", t)
 	if t.Key.IsAssignable() {
-		sw.Do("for key, val := range in {\n", nil)
-		if t.Elem.IsAssignable() {
+		switch {
+		case t.Elem.IsAnonymousStruct():
+			sw.Do("for key := range in {\n", nil)
+			sw.Do("(*out)[key] = struct{}{}\n", nil)
+			sw.Do("}\n", nil)
+		case t.Elem.IsAssignable():
+			sw.Do("for key, val := range in {\n", nil)
 			sw.Do("(*out)[key] = val\n", nil)
-		} else {
+			sw.Do("}\n", nil)
+		default:
+			sw.Do("for key, val := range in {\n", nil)
 			if g.canInlineTypeFn(g.context, t.Elem) {
 				sw.Do("newVal := new($.|raw$)\n", t.Elem)
 				funcName := g.funcNameTmpl(t.Elem)
@@ -374,13 +381,14 @@ func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 				sw.Do("(*out)[key] = newVal.($.|raw$)\n", t.Elem)
 				sw.Do("}\n", nil)
 			}
+			sw.Do("}\n", nil)
 		}
 	} else {
 		// TODO: Implement it when necessary.
 		sw.Do("for range in {\n", nil)
 		sw.Do("// FIXME: Copying unassignable keys unsupported $.|raw$\n", t.Key)
+		sw.Do("}\n", nil)
 	}
-	sw.Do("}\n", nil)
 }
 
 func (g *genDeepCopy) doSlice(t *types.Type, sw *generator.SnippetWriter) {

--- a/cmd/libs/go2idl/types/types.go
+++ b/cmd/libs/go2idl/types/types.go
@@ -290,6 +290,12 @@ func (t *Type) IsAssignable() bool {
 	return t.Kind == Builtin || (t.Kind == Alias && t.Underlying.Kind == Builtin)
 }
 
+// IsAnonymousStruct returns true if the type is an anonymous struct or an alias
+// to an anonymous struct.
+func (t *Type) IsAnonymousStruct() bool {
+	return (t.Kind == Struct && t.Name.Name == "struct{}") || (t.Kind == Alias && t.Underlying.IsAnonymousStruct())
+}
+
 // A single struct member
 type Member struct {
 	// The name of the member.


### PR DESCRIPTION
Deep copy was not properly handling the empty struct case we use for Sets.

@lavalamp I need your expertise when you have some time - the go2idl parser is turning sets.String into the following tree:

```
type:         sets.String           kind: Alias
  underlying: map[string]sets.Empty kind: Map
    key:      string                kind: Builtin
    elem:     set.Empty             kind: Struct
                                          ^
                                          should be Alias
```

Looking at tc.Named, I'm not sure what the expected outcome would be and why you flatten there.
