### PR TITLE
Fix a problem with multiple APIs clobbering each other in registration.

### DIFF
--- a/pkg/apimachinery/registered/registered.go
+++ b/pkg/apimachinery/registered/registered.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/golang/glog"
 
@@ -207,11 +208,7 @@ func AddThirdPartyAPIGroupVersions(gvs ...unversioned.GroupVersion) []unversione
 	}
 	RegisterVersions(filteredGVs)
 	EnableVersions(filteredGVs...)
-	next := make([]unversioned.GroupVersion, len(gvs))
-	for ix := range filteredGVs {
-		next[ix] = filteredGVs[ix]
-	}
-	thirdPartyGroupVersions = next
+	thirdPartyGroupVersions = append(thirdPartyGroupVersions, filteredGVs...)
 
 	return skippedGVs
 }

--- a/pkg/apimachinery/registered/registered.go
+++ b/pkg/apimachinery/registered/registered.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/golang/glog"
 
@@ -56,6 +55,10 @@ var (
 )
 
 func init() {
+	loadKubeAPIVersions()
+}
+
+func loadKubeAPIVersions() {
 	// Env var KUBE_API_VERSIONS is a comma separated list of API versions that
 	// should be registered in the scheme.
 	kubeAPIVersions := os.Getenv("KUBE_API_VERSIONS")
@@ -69,6 +72,16 @@ func init() {
 			envRequestedVersions = append(envRequestedVersions, gv)
 		}
 	}
+}
+
+// Resets everything to clean room for the start of a test
+func clearForTesting() {
+	registeredVersions = map[unversioned.GroupVersion]struct{}{}
+	thirdPartyGroupVersions = []unversioned.GroupVersion{}
+	enabledVersions = map[unversioned.GroupVersion]struct{}{}
+	groupMetaMap = map[string]*apimachinery.GroupMeta{}
+	envRequestedVersions = []unversioned.GroupVersion{}
+	loadKubeAPIVersions()
 }
 
 // RegisterVersions adds the given group versions to the list of registered group versions.
@@ -209,7 +222,6 @@ func AddThirdPartyAPIGroupVersions(gvs ...unversioned.GroupVersion) []unversione
 	RegisterVersions(filteredGVs)
 	EnableVersions(filteredGVs...)
 	thirdPartyGroupVersions = append(thirdPartyGroupVersions, filteredGVs...)
-
 	return skippedGVs
 }
 

--- a/pkg/apimachinery/registered/registered_test.go
+++ b/pkg/apimachinery/registered/registered_test.go
@@ -23,6 +23,78 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery"
 )
 
+func TestAddThirdPartyVersionsBasic(t *testing.T) {
+	clearForTesting()
+
+	registered := []unversioned.GroupVersion{
+		{
+			Group:   "",
+			Version: "v1",
+		},
+	}
+	skipped := registered
+	thirdParty := []unversioned.GroupVersion{
+		{
+			Group:   "company.com",
+			Version: "v1",
+		},
+		{
+			Group:   "company.com",
+			Version: "v2",
+		},
+	}
+	gvs := append(registered, thirdParty...)
+
+	RegisterVersions(registered)
+	wasSkipped := AddThirdPartyAPIGroupVersions(gvs...)
+	if len(wasSkipped) != len(skipped) {
+		t.Errorf("Expected %v, found %v", skipped, wasSkipped)
+	}
+	for ix := range wasSkipped {
+		found := false
+		for _, gv := range skipped {
+			if gv.String() == wasSkipped[ix].String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Couldn't find %v in %v", wasSkipped[ix], skipped)
+		}
+	}
+	for _, gv := range thirdParty {
+		if !IsThirdPartyAPIGroupVersion(gv) {
+			t.Errorf("Expected %v to be third party.", gv)
+		}
+	}
+}
+
+func TestAddThirdPartyVersionsMultiple(t *testing.T) {
+	clearForTesting()
+
+	thirdParty := []unversioned.GroupVersion{
+		{
+			Group:   "company.com",
+			Version: "v1",
+		},
+		{
+			Group:   "company.com",
+			Version: "v2",
+		},
+	}
+	for _, gv := range thirdParty {
+		wasSkipped := AddThirdPartyAPIGroupVersions(gv)
+		if len(wasSkipped) != 0 {
+			t.Errorf("Expected length 0, found %v", wasSkipped)
+		}
+	}
+	for _, gv := range thirdParty {
+		if !IsThirdPartyAPIGroupVersion(gv) {
+			t.Errorf("Expected %v to be third party.", gv)
+		}
+	}
+}
+
 func TestAllPreferredGroupVersions(t *testing.T) {
 	testCases := []struct {
 		groupMetas []apimachinery.GroupMeta


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24392

@kubernetes/sig-api-machinery 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28431)

<!-- Reviewable:end -->
