### PR TITLE
Remove br_netfilter warning in kube-proxy

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -26,7 +26,6 @@ import (
 	"encoding/base32"
 	"fmt"
 	"net"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -198,15 +197,8 @@ func NewProxier(ipt utiliptables.Interface, exec utilexec.Interface, syncPeriod 
 	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers
 	// are connected to a Linux bridge (but not SDN bridges).  Until most
 	// plugins handle this, log when config is missing
-	warnBrNetfilter := false
-	if _, err := os.Stat("/sys/module/br_netfilter"); os.IsNotExist(err) {
-		warnBrNetfilter = true
-	}
 	if val, err := utilsysctl.GetSysctl(sysctlBridgeCallIptables); err == nil && val != 1 {
-		warnBrNetfilter = true
-	}
-	if warnBrNetfilter {
-		glog.Infof("missing br-netfilter module or unset br-nf-call-iptables; proxy may not work as intended")
+		glog.Infof("missing br-netfilter module or unset sysctl br-nf-call-iptables; proxy may not work as intended")
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.


### PR DESCRIPTION
Many distros have this module linked in, generating a spurious error.

Fixes #23385
