### PR TITLE
Fix support for DNS in local-up-cluster.sh

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -34,9 +34,16 @@ kube::etcd::start() {
 
   version=$(etcd --version | head -n 1 | cut -d " " -f 3)
   if [[ "${version}" < "${ETCD_VERSION}" ]]; then
-   kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
-   kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
-   exit 1
+   export PATH=$KUBE_ROOT/third_party/etcd:$PATH
+   hash etcd
+   echo $PATH
+   ls $KUBE_ROOT/third_party/etcd
+   version=$(etcd --version | head -n 1 | cut -d " " -f 3)
+   if [[ "${version}" < "${ETCD_VERSION}" ]]; then
+    kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
+    exit 1
+   fi
   fi
 
   # Start etcd


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

The default appears to be gce now, so this tries to spawn a service in
gce... not the desired outcome for a local test setup.

We also need to sync the kubectl config in the script with the instructions for users, since if people don't test with DNS enabled, it bitrots (which this aims to fix).

To test manually, run something like
```
sudo KUBE_ENABLE_CLUSTER_DNS=true API_HOST_IP=0.0.0.0 ./hack/local-up-cluster.sh
```

The API_HOST_IP=0.0.0.0 is required, otherwise the master is not contactable by kubedns, and the dns pod will fail readychecking on the healthz pod.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28458)

<!-- Reviewable:end -->
