### PR TITLE
Optimise the process of the CalculateSpreadPriority in selector_spreading.go

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
@@ -62,6 +62,11 @@ func NewSelectorSpreadPriority(podLister algorithm.PodLister, serviceLister algo
 // pods which match the same service selectors or RC selectors as the pod being scheduled.
 // Where zone information is included on the nodes, it favors nodes in zones with fewer existing matching pods.
 func (s *SelectorSpread) CalculateSpreadPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodeLister algorithm.NodeLister) (schedulerapi.HostPriorityList, error) {
+	nodes, err := nodeLister.List()
+	if err != nil {
+		return nil, err
+	}
+
 	selectors := make([]labels.Selector, 0, 3)
 	if services, err := s.serviceLister.GetPodServices(pod); err == nil {
 		for _, service := range services {
@@ -79,11 +84,6 @@ func (s *SelectorSpread) CalculateSpreadPriority(pod *api.Pod, nodeNameToInfo ma
 				selectors = append(selectors, selector)
 			}
 		}
-	}
-
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return nil, err
 	}
 
 	// Count similar pods by node

--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
@@ -195,6 +195,10 @@ func NewServiceAntiAffinityPriority(podLister algorithm.PodLister, serviceLister
 // The label to be considered is provided to the struct (ServiceAntiAffinity).
 func (s *ServiceAntiAffinity) CalculateAntiAffinityPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodeLister algorithm.NodeLister) (schedulerapi.HostPriorityList, error) {
 	var nsServicePods []*api.Pod
+	nodes, err := nodeLister.List()
+	if err != nil {
+		return nil, err
+	}
 
 	if services, err := s.serviceLister.GetPodServices(pod); err == nil {
 		// just use the first service and get the other pods within the service
@@ -210,11 +214,6 @@ func (s *ServiceAntiAffinity) CalculateAntiAffinityPriority(pod *api.Pod, nodeNa
 				nsServicePods = append(nsServicePods, nsPod)
 			}
 		}
-	}
-
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return nil, err
 	}
 
 	// separate out the nodes that have the label from the ones that don't


### PR DESCRIPTION
It had better inspect if the nodeLister is normal first in the CalculateSpreadPriority in selector_spreading.go. If the nodeLister.List return error, the function return directly, not need deal the serviceLister and controllerLister and replicaSetLister.
