### PR TITLE
Add detect-master to local provider to get e2e working

### DIFF
--- a/cluster/local/util.sh
+++ b/cluster/local/util.sh
@@ -18,3 +18,10 @@ function prepare-e2e() {
   echo "Local doesn't need special preparations for e2e tests" 1>&2
 
 }
+
+detect-master() {
+  KUBE_MASTER=localhost
+  KUBE_MASTER_IP=127.0.0.1
+  KUBE_MASTER_URL="http://${KUBE_MASTER_IP}:8080"
+  echo "Using master: $KUBE_MASTER (external IP: $KUBE_MASTER_IP)"
+}

--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -397,13 +397,13 @@ at a custom host directly:
 
 ```sh
 export KUBECONFIG=/path/to/kubeconfig
-go run hack/e2e.go -v --test --check_node_count=false --test_args="--host=http://127.0.0.1:8080"
+go run hack/e2e.go -v --test --check_node_count=false
 ```
 
 To control the tests that are run:
 
 ```sh
-go run hack/e2e.go -v --test --check_node_count=false --test_args="--host=http://127.0.0.1:8080" --ginkgo.focus="Secrets"
+go run hack/e2e.go -v --test --check_node_count=false --test_args="--ginkgo.focus="Secrets"
 ```
 
 ## Kinds of tests


### PR DESCRIPTION
Make it possible to run some e2e tests using the local provider (./hack/local-up-cluster.sh)

This will now work for tests that don't need more than one node:
export  KUBERNETES_PROVIDER=local
go run hack/e2e.go -v -test --check_node_count=false --check_version_skew=false --test_args="--ginkgo.focus=Cadvisor"

Note: without this commit, the port and ip address are wrong and require the --host option (which is inconsistent with the other providers).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28469)

<!-- Reviewable:end -->
