### PR TITLE
Optimise the return of "LeastRequestedPriority" and "BalancedResourceAllocation" in priorities.go

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -81,7 +81,7 @@ func calculateResourceOccupancy(pod *api.Pod, node api.Node, nodeInfo *scheduler
 func LeastRequestedPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodeLister algorithm.NodeLister) (schedulerapi.HostPriorityList, error) {
 	nodes, err := nodeLister.List()
 	if err != nil {
-		return schedulerapi.HostPriorityList{}, err
+		return nil, err
 	}
 
 	list := schedulerapi.HostPriorityList{}
@@ -215,7 +215,7 @@ func calculateScoreFromSize(sumSize int64) int {
 func BalancedResourceAllocation(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodeLister algorithm.NodeLister) (schedulerapi.HostPriorityList, error) {
 	nodes, err := nodeLister.List()
 	if err != nil {
-		return schedulerapi.HostPriorityList{}, err
+		return nil, err
 	}
 
 	list := schedulerapi.HostPriorityList{}


### PR DESCRIPTION
In the "LeastRequestedPriority" and "BalancedResourceAllocation" function of priorities.go, when the nodeLister.List() return error, I think it had better return nil for HostPriorityList paramter, needn't schedulerapi.HostPriorityList{}, just like "CalculateInterPodAffinityPriority", "ImageLocalityPriority", "CalculateSpreadPriority", etc.
