### PR TITLE
delete the redundant word "a"

### DIFF
--- a/docs/reporting-security-issues.md
+++ b/docs/reporting-security-issues.md
@@ -34,7 +34,7 @@ Documentation for other releases can be found at
 
 # Security
 
-If you believe you have discovered a vulnerability or a have a security incident to report, please follow the steps below. This applies to Kubernetes releases v1.0 or later.
+If you believe you have discovered a vulnerability or have a security incident to report, please follow the steps below. This applies to Kubernetes releases v1.0 or later.
 
 To watch for security and major API announcements, please join our [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) group.
 


### PR DESCRIPTION
In file docs/reporting-security-issues.md, line #37, "If you believe you have discovered a vulnerability or a have a security incident to report", here the second "a" is redundant, should be deleted.
