### PR TITLE
Finish migration of integration tests to separate namespaces

### DIFF
--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -71,7 +71,7 @@ type passthroughLogger struct{}
 
 // Addf logs info immediately.
 func (passthroughLogger) Addf(format string, data ...interface{}) {
-	glog.InfoDepth(1, fmt.Sprintf(format, data...))
+	glog.V(2).Info(fmt.Sprintf(format, data...))
 }
 
 // DefaultStacktracePred is the default implementation of StacktracePred.

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -791,14 +791,13 @@ func runSelfLinkTestOnNamespace(t *testing.T, c *client.Client, namespace string
 }
 
 func TestSelfLinkOnNamespace(t *testing.T) {
-	// TODO: Limit the test to a single non-default namespace and clean this up at the end.
-	framework.DeleteAllEtcdKeys()
-
 	_, s := framework.RunAMaster(nil)
 	defer s.Close()
 
+	ns := framework.CreateTestingNamespace("selflink", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
 	c := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
-	runSelfLinkTestOnNamespace(t, c, api.NamespaceDefault)
-	runSelfLinkTestOnNamespace(t, c, "other-namespace")
+	runSelfLinkTestOnNamespace(t, c, ns.Name)
 }

--- a/test/integration/framework/etcd_utils.go
+++ b/test/integration/framework/etcd_utils.go
@@ -62,21 +62,3 @@ func WithEtcdKey(f func(string)) {
 	defer etcd.NewKeysAPI(NewEtcdClient()).Delete(context.TODO(), prefix, &etcd.DeleteOptions{Recursive: true})
 	f(prefix)
 }
-
-// DeleteAllEtcdKeys deletes all keys from etcd.
-// TODO: Instead of sprinkling calls to this throughout the code, adjust the
-// prefix in etcdtest package; then just delete everything once at the end
-// of the test run.
-func DeleteAllEtcdKeys() {
-	glog.Infof("Deleting all etcd keys")
-	keysAPI := etcd.NewKeysAPI(NewEtcdClient())
-	keys, err := keysAPI.Get(context.TODO(), "/", nil)
-	if err != nil {
-		glog.Fatalf("Unable to list root etcd keys: %v", err)
-	}
-	for _, node := range keys.Node.Nodes {
-		if _, err := keysAPI.Delete(context.TODO(), node.Key, &etcd.DeleteOptions{Recursive: true}); err != nil {
-			glog.Fatalf("Unable delete key: %v", err)
-		}
-	}
-}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -91,8 +91,6 @@ type Config struct {
 	// If nil, a default is used, partially filled configs will not get populated.
 	MasterConfig            *master.Config
 	StartReplicationManager bool
-	// If true, all existing etcd keys are purged before starting master components
-	DeleteEtcdKeys bool
 	// Client throttling qps
 	QPS float32
 	// Client burst qps, also burst replicas allowed in rc manager
@@ -105,9 +103,6 @@ func NewMasterComponents(c *Config) *MasterComponents {
 	m, s := startMasterOrDie(c.MasterConfig)
 	// TODO: Allow callers to pipe through a different master url and create a client/start components using it.
 	glog.Infof("Master %+v", s.URL)
-	if c.DeleteEtcdKeys {
-		DeleteAllEtcdKeys()
-	}
 	// TODO: caesarxuchao: remove this client when the refactoring of client libraray is done.
 	restClient := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}, QPS: c.QPS, Burst: c.Burst})
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}, QPS: c.QPS, Burst: c.Burst})

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -67,7 +67,7 @@ func scrapeMetrics(s *httptest.Server) ([]*prometheuspb.MetricFamily, error) {
 		if err := proto.UnmarshalText(scanner.Text(), &metric); err != nil {
 			return nil, fmt.Errorf("Failed to unmarshal line of metrics response: %v", err)
 		}
-		glog.Infof("Got metric %q", metric.GetName())
+		glog.V(4).Infof("Got metric %q", metric.GetName())
 		metrics = append(metrics, &metric)
 	}
 	return metrics, nil


### PR DESCRIPTION
This is also making the logs from integration tests debuggable and understandable.
