### PR TITLE
build: fixed ${KUBE_ROOT} prefix for build scripts

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -29,7 +29,7 @@ readonly DOCKER_MACHINE_DRIVER=${DOCKER_MACHINE_DRIVER:-"virtualbox --virtualbox
 # This will canonicalize the path
 KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd -P)
 
-source hack/lib/init.sh
+source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Incoming options
 #

--- a/build/copy-output.sh
+++ b/build/copy-output.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs
 kube::build::copy_output

--- a/build/make-build-image.sh
+++ b/build/make-build-image.sh
@@ -25,7 +25,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs
 kube::build::build_image

--- a/build/make-clean.sh
+++ b/build/make-clean.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs
 kube::build::clean_output

--- a/build/push-devel-build.sh
+++ b/build/push-devel-build.sh
@@ -29,6 +29,6 @@ KUBE_GCS_UPLOAD_RELEASE=y
 KUBE_GCS_RELEASE_PREFIX="devel/${LATEST}"
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::release::gcs::release

--- a/build/release.sh
+++ b/build/release.sh
@@ -24,7 +24,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 KUBE_RELEASE_RUN_TESTS=${KUBE_RELEASE_RUN_TESTS-y}
 

--- a/build/shell.sh
+++ b/build/shell.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs
 kube::build::build_image


### PR DESCRIPTION
Running `./make-build-image.sh` command inside the `build` directory doesn't work:

``` sh
$ cd build
$ ./make-build-image.sh 
./../build/common.sh: line 32: hack/lib/init.sh: No such file or directory
```

This PR adds `${KUBE_ROOT}` prefix for the `source` bash function. Also I added braces to unify the code style.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
