### PR TITLE
don't migrate files you can't access

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -230,14 +230,17 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 		if _, err := os.Stat(destination); err == nil {
 			// if the destination already exists, do nothing
 			continue
+		} else if os.IsPermission(err) {
+			// if we can't access the file, skip it
+			continue
 		} else if !os.IsNotExist(err) {
 			// if we had an error other than non-existence, fail
 			return err
 		}
 
 		if sourceInfo, err := os.Stat(source); err != nil {
-			if os.IsNotExist(err) {
-				// if the source file doesn't exist, there's no work to do.
+			if os.IsNotExist(err) || os.IsPermission(err) {
+				// if the source file doesn't exist or we can't access it, there's no work to do.
 				continue
 			}
 


### PR DESCRIPTION
If you can't access a file, you shouldn't try to migrate it.

Ref https://github.com/openshift/origin/issues/9581

@fabianofranz 
