### PR TITLE
Update HumanResourcePrinter signature w single PrintOptions param

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -121,7 +121,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
 	allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
-	allKinds := cmdutil.GetFlagBool(cmd, "show-kind")
+	showKind := cmdutil.GetFlagBool(cmd, "show-kind")
 	mapper, typer := f.Object(cmdutil.GetIncludeThirdPartyAPIs(cmd))
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
@@ -301,28 +301,12 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	// use the default printer for each object
 	printer = nil
 	var lastMapping *meta.RESTMapping
-	var withKind bool = allKinds
 	w := kubectl.GetNewTabWriter(out)
 	defer w.Flush()
 
-	// determine if printing multiple kinds of
-	// objects and enforce "show-kinds" flag if so
-	for ix := range objs {
-		var mapping *meta.RESTMapping
-		if sorter != nil {
-			mapping = infos[sorter.OriginalPosition(ix)].Mapping
-		} else {
-			mapping = infos[ix].Mapping
-		}
-
-		// display "kind" column only if we have mixed resources
-		if lastMapping != nil && mapping.Resource != lastMapping.Resource {
-			withKind = true
-		}
-		lastMapping = mapping
+	if mustPrintWithKinds(objs, infos, sorter) {
+		showKind = true
 	}
-
-	lastMapping = nil
 
 	for ix := range objs {
 		var mapping *meta.RESTMapping
@@ -343,15 +327,24 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			lastMapping = mapping
 		}
 		if resourcePrinter, found := printer.(*kubectl.HumanReadablePrinter); found {
-			resourceName := mapping.Resource
-			if alias, ok := kubectl.ResourceShortFormFor(mapping.Resource); ok {
-				resourceName = alias
-			} else if resourceName == "" {
+			resourceName := resourcePrinter.GetResourceKind()
+			if mapping != nil {
+				if resourceName == "" {
+					resourceName = mapping.Resource
+				}
+				if alias, ok := kubectl.ResourceShortFormFor(mapping.Resource); ok {
+					resourceName = alias
+				} else if resourceName == "" {
+					resourceName = "none"
+				}
+			} else {
 				resourceName = "none"
 			}
 
-			resourcePrinter.Options.WithKind = withKind
-			resourcePrinter.Options.KindName = resourceName
+			if showKind {
+				resourcePrinter.EnsurePrintWithKind(resourceName)
+			}
+
 			if err := printer.PrintObj(original, w); err != nil {
 				allErrs = append(allErrs, err)
 			}
@@ -363,4 +356,29 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		}
 	}
 	return utilerrors.NewAggregate(allErrs)
+}
+
+// mustPrintWithKinds determines if printer is dealing
+// with multiple resource kinds, in which case it will
+// return true, indicating resource kind will be
+// included as part of printer output
+func mustPrintWithKinds(objs []runtime.Object, infos []*resource.Info, sorter *kubectl.RuntimeSort) bool {
+	var lastMap *meta.RESTMapping
+
+	for ix := range objs {
+		var mapping *meta.RESTMapping
+		if sorter != nil {
+			mapping = infos[sorter.OriginalPosition(ix)].Mapping
+		} else {
+			mapping = infos[ix].Mapping
+		}
+
+		// display "kind" only if we have mixed resources
+		if lastMap != nil && mapping.Resource != lastMap.Resource {
+			return true
+		}
+		lastMap = mapping
+	}
+
+	return false
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -1208,14 +1208,16 @@ func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMappin
 		if err != nil {
 			return nil, err
 		}
-		if version.IsEmpty() {
+		if version.IsEmpty() && mapping != nil {
 			version = mapping.GroupVersionKind.GroupVersion()
 		}
 		if version.IsEmpty() {
 			return nil, fmt.Errorf("you must specify an output-version when using this output format")
 		}
 
-		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.GroupVersionKind.GroupVersion())
+		if mapping != nil {
+			printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.GroupVersionKind.GroupVersion())
+		}
 
 	} else {
 		// Some callers do not have "label-columns" so we can't use the GetFlagStringSlice() helper

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -215,9 +215,26 @@ func TestJSONPrinter(t *testing.T) {
 	testPrinter(t, &JSONPrinter{}, json.Unmarshal)
 }
 
+func TestFormatResourceName(t *testing.T) {
+	tests := []struct {
+		kind, name string
+		want       string
+	}{
+		{"", "", ""},
+		{"", "name", "name"},
+		{"kind", "", "kind/"}, // should not happen in practice
+		{"kind", "name", "kind/name"},
+	}
+	for _, tt := range tests {
+		if got := formatResourceName(tt.kind, tt.name, true); got != tt.want {
+			t.Errorf("formatResourceName(%q, %q) = %q, want %q", tt.kind, tt.name, got, tt.want)
+		}
+	}
+}
+
 func PrintCustomType(obj *TestPrintType, w io.Writer, options PrintOptions) error {
 	data := obj.Data
-	kind := options.KindName
+	kind := options.Kind
 	if options.WithKind {
 		data = kind + "/" + data
 	}
@@ -254,8 +271,7 @@ func TestCustomTypePrintingWithKind(t *testing.T) {
 		ColumnLabels: []string{},
 	})
 	printer.Handler(columns, PrintCustomType)
-	printer.Options.WithKind = true
-	printer.Options.KindName = "test"
+	printer.EnsurePrintWithKind("test")
 
 	obj := TestPrintType{"test object"}
 	buffer := &bytes.Buffer{}


### PR DESCRIPTION
release-note-none
- Makes [HumanReadablePrinter options field non-exported again](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/resource_printer.go#L346-349)
- Adds test-case for HumanReadablePrinter resource printing with aliases.
- Better formatting for saving resource "kind" aliases

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28509)

<!-- Reviewable:end -->
