### PR TITLE
Node E2E: Disable kubenet for local node e2e test.

### DIFF
--- a/hack/e2e-node-test.sh
+++ b/hack/e2e-node-test.sh
@@ -129,6 +129,6 @@ else
   # Test using the host the script was run on
   # Provided for backwards compatibility
   "${ginkgo}" --focus=$focus --skip=$skip "${KUBE_ROOT}/test/e2e_node/" --report-dir=${report} \
-    -- --alsologtostderr --v 2 --node-name $(hostname) --build-services=true --start-services=true --stop-services=true
+    -- --alsologtostderr --v 2 --node-name $(hostname) --disable-kubenet=true --build-services=true --start-services=true --stop-services=true
   exit $?
 fi

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -99,6 +99,7 @@ deployment-label-key
 deserialization-cache-size
 dest-file
 disable-filter
+disable-kubenet
 dns-port
 dns-provider
 dns-provider-config

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -26,6 +26,7 @@ import (
 var kubeletAddress = flag.String("kubelet-address", "http://127.0.0.1:10255", "Host and port of the kubelet")
 var apiServerAddress = flag.String("api-server-address", "http://127.0.0.1:8080", "Host and port of the api server")
 
+var disableKubenet = flag.Bool("disable-kubenet", false, "If true, start kubelet without kubenet")
 var buildServices = flag.Bool("build-services", true, "If true, build local executables")
 var startServices = flag.Bool("start-services", true, "If true, start local node services")
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/pull/28196, we must manually setup cni and nsenter in local node to run `make test_e2e_node`, which may not be necessary for local development.

I've tried to move cni downloading logic into `BeforeSuite`, however it is still hard to figure out who should install nsenter, manually installed by every developer? in the `setup_host.sh` script? in `BeforeSuite`?

This PR:
- Added a flag to disable kubenet and disabled kubenet in local test.
- Cleaned up the CNI installation logic a bit.

/cc @yujuhong @freehan 
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
