### PR TITLE
Node E2E: Use waiting reason to figure out image pulling error.

### DIFF
--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -187,44 +188,44 @@ while true; do sleep 1; done
 				image       string
 				secret      bool
 				phase       api.PodPhase
-				state       ContainerState
+				waiting     bool
 			}{
 				{
 					description: "should not be able to pull image from invalid registry",
 					image:       "invalid.com/invalid/alpine:3.1",
 					phase:       api.PodPending,
-					state:       ContainerStateWaiting,
+					waiting:     true,
 				},
 				{
 					description: "should not be able to pull non-existing image from gcr.io",
 					image:       "gcr.io/google_containers/invalid-image:invalid-tag",
 					phase:       api.PodPending,
-					state:       ContainerStateWaiting,
+					waiting:     true,
 				},
 				{
 					description: "should be able to pull image from gcr.io",
 					image:       NoPullImageRegistry[pullTestAlpineWithBash],
 					phase:       api.PodRunning,
-					state:       ContainerStateRunning,
+					waiting:     false,
 				},
 				{
 					description: "should be able to pull image from docker hub",
 					image:       NoPullImageRegistry[pullTestAlpine],
 					phase:       api.PodRunning,
-					state:       ContainerStateRunning,
+					waiting:     false,
 				},
 				{
 					description: "should not be able to pull from private registry without secret",
 					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
 					phase:       api.PodPending,
-					state:       ContainerStateWaiting,
+					waiting:     true,
 				},
 				{
 					description: "should be able to pull from private registry with secret",
 					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
 					secret:      true,
 					phase:       api.PodRunning,
-					state:       ContainerStateRunning,
+					waiting:     false,
 				},
 			} {
 				testCase := testCase
@@ -259,15 +260,24 @@ while true; do sleep 1; done
 					// pod phase first, and the expected pod phase is Pending, the container status may not
 					// even show up when we check it.
 					By("check the container state")
-					getState := func() (ContainerState, error) {
+					checkContainerState := func() (bool, error) {
 						status, err := container.GetStatus()
 						if err != nil {
-							return ContainerStateUnknown, err
+							return false, err
 						}
-						return GetContainerState(status.State), nil
+						if !testCase.waiting && status.State.Running != nil {
+							return true, nil
+						}
+						if testCase.waiting && status.State.Waiting != nil {
+							reason := status.State.Waiting.Reason
+							return reason == kubecontainer.ErrImagePull.Error() ||
+								reason == kubecontainer.ErrImagePullBackOff.Error(), nil
+
+						}
+						return false, nil
 					}
-					Eventually(getState, retryTimeout, pollInterval).Should(Equal(testCase.state))
-					Consistently(getState, consistentCheckTimeout, pollInterval).Should(Equal(testCase.state))
+					Eventually(checkContainerState, retryTimeout, pollInterval).Should(BeTrue())
+					Consistently(checkContainerState, consistentCheckTimeout, pollInterval).Should(BeTrue())
 
 					By("check the pod phase")
 					Expect(container.GetPhase()).To(Equal(testCase.phase))


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kubernetes/pull/28323#issuecomment-230002158, using `Waiting` reason to check whether the image pulling failures as expected.

@yujuhong 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
