### PR TITLE
"was not created" should be "was created"

### DIFF
--- a/pkg/client/restclient/request_test.go
+++ b/pkg/client/restclient/request_test.go
@@ -1086,7 +1086,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
 	}
 	if wasCreated {
-		t.Errorf("expected object was not created")
+		t.Errorf("expected object was created")
 	}
 	tmpStr := string(reqBodyExpected)
 	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar/baz", "", "", "")


### PR DESCRIPTION
In file pkg\client\restclient/request_test.go, line #1089, "t.Errorf("expected object was not created")" , here "was not created" should be "was created" because the if condition is "if wasCreated".
