### PR TITLE
Give sufficient permissions to kube-version-defs file to be able to source it during build.

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -29,6 +29,7 @@ RUN chmod -R a+rwx ${HOME}
 
 # Propagate the git tree version into the build image
 ADD kube-version-defs /kube-version-defs
+RUN chmod a+r /kube-version-defs
 ENV KUBE_GIT_VERSION_FILE /kube-version-defs
 
 # Make output from the dockerized build go someplace else


### PR DESCRIPTION
Without this change, I get 

``` shell
/go/src/k8s.io/kubernetes/hack/lib/version.sh: line 107: /kube-version-defs: Permission denied
```

and federation images aren't assigned the right version tags.

cc @mml 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
