### PR TITLE
Add checks in Create and Update Cgroup methods

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -29,6 +29,10 @@ func NewCgroupManager(_ interface{}) CgroupManager {
 	return &unsupportedCgroupManager{}
 }
 
+func (m *unsupportedCgroupManager) Exists(_ string) bool {
+	return false
+}
+
 func (m *unsupportedCgroupManager) Destroy(_ *CgroupConfig) error {
 	return nil
 }

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -18,11 +18,8 @@ package cm
 
 import (
 	"fmt"
-	"path"
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
-	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
-	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
 )
 
 // cgroupSubsystems holds information about the mounted cgroup subsytems
@@ -57,42 +54,5 @@ func getCgroupSubsystems() (*cgroupSubsystems, error) {
 	return &cgroupSubsystems{
 		mounts:      allCgroups,
 		mountPoints: mountPoints,
-	}, nil
-}
-
-// getLibcontainerCgroupManager returns libcontainer's cgroups manager
-// object with the specified cgroup configuration
-func getLibcontainerCgroupManager(cgroupConfig *CgroupConfig, subsystems *cgroupSubsystems) (*cgroupfs.Manager, error) {
-	// get cgroup name
-	name := cgroupConfig.Name
-
-	// Get map of all cgroup paths on the system for the particular cgroup
-	cgroupPaths := make(map[string]string, len(subsystems.mountPoints))
-	for key, val := range subsystems.mountPoints {
-		cgroupPaths[key] = path.Join(val, name)
-	}
-
-	// Extract the cgroup resource parameters
-	resourceConfig := cgroupConfig.ResourceParameters
-	resources := &libcontainerconfigs.Resources{}
-	resources.AllowAllDevices = true
-	if resourceConfig.Memory != nil {
-		resources.Memory = *resourceConfig.Memory
-	}
-	if resourceConfig.CpuShares != nil {
-		resources.CpuShares = *resourceConfig.CpuShares
-	}
-	if resourceConfig.CpuQuota != nil {
-		resources.CpuQuota = *resourceConfig.CpuQuota
-	}
-	// Initialize libcontainer's cgroup config
-	libcontainerCgroupConfig := &libcontainerconfigs.Cgroup{
-		Name:      path.Base(name),
-		Parent:    path.Dir(name),
-		Resources: resources,
-	}
-	return &cgroupfs.Manager{
-		Cgroups: libcontainerCgroupConfig,
-		Paths:   cgroupPaths,
 	}, nil
 }

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -53,4 +53,6 @@ type CgroupManager interface {
 	Destroy(*CgroupConfig) error
 	// Update cgroup configuration.
 	Update(*CgroupConfig) error
+	// Exists checks if the cgroup already exists
+	Exists(string) bool
 }


### PR DESCRIPTION
This PR is connected to upstream issue for adding pod level cgroups in Kubernetes: #27204 
Libcontainer currently doesen't support updates to parent devices cgroups. Until we get libcontainer to support skipping devices cgroup we will have that logic on the kubelet side.
This PR includes:
1. Skip the devices cgroup when updating a cgroup. We only update the memory and cpu subsytems.
2. We explicitly pass all the cgroup paths that don't already exist to Apply() 
3. Adds an AlreadyExists() method which is a utility function to check if all the subsystems of a cgroup already exist. 
On cgroupManager.Update() we only call Set() and cgroupManager.Create() we only call Apply() method

@vishh PTAL
