### PR TITLE
Check return value when calling ensureDnsRecords

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -724,22 +724,24 @@ func (s *ServiceController) lockedUpdateDNSRecords(service *cachedService, clust
 	if !wantsDNSRecords(service.appliedState) {
 		return nil
 	}
-	ensuredCount := 0
+
+	var err error
+	missedCount := 0
+	unensuredCount := 0
 	for key := range s.clusterCache.clientMap {
 		for _, clusterName := range clusterNames {
 			if key == clusterName {
-				err := s.ensureDnsRecords(clusterName, service)
-				if err != nil {
-					glog.Errorf("Failed to ensure DNS records for service %v in cluster %s due to %v", service, clusterName, err)
-				} else {
-					ensuredCount += 1
+				if err = s.ensureDnsRecords(clusterName, service); err != nil {
+					unensuredCount += 1
 				}
+			} else {
+				missedCount += 1
 			}
 		}
 	}
-	if ensuredCount < len(clusterNames) {
-		return fmt.Errorf("Failed to update DNS records for %d of %d clusters for service %v due to missing clients for those clusters",
-			len(clusterNames)-ensuredCount, len(clusterNames), service)
+	if missedCount > 0 || unensuredCount > 0 {
+		return fmt.Errorf("Failed to update DNS records for %d clusters for service %v due to missing clients[missed count: %d] or ensuring DNS records error[unensured count: %d] %v",
+			len(clusterNames), service, missedCount, unensuredCount, err)
 	}
 	return nil
 }

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -728,8 +728,12 @@ func (s *ServiceController) lockedUpdateDNSRecords(service *cachedService, clust
 	for key := range s.clusterCache.clientMap {
 		for _, clusterName := range clusterNames {
 			if key == clusterName {
-				s.ensureDnsRecords(clusterName, service)
-				ensuredCount += 1
+				err := s.ensureDnsRecords(clusterName, service)
+				if err != nil {
+					glog.Errorf("Failed to ensure DNS records for service %v in cluster %s due to %v", service, clusterName, err)
+				} else {
+					ensuredCount += 1
+				}
 			}
 		}
 	}

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -725,23 +725,25 @@ func (s *ServiceController) lockedUpdateDNSRecords(service *cachedService, clust
 		return nil
 	}
 
-	var err error
-	missedCount := 0
+	ensuredCount := 0
 	unensuredCount := 0
 	for key := range s.clusterCache.clientMap {
 		for _, clusterName := range clusterNames {
 			if key == clusterName {
-				if err = s.ensureDnsRecords(clusterName, service); err != nil {
+				err := s.ensureDnsRecords(clusterName, service)
+				if err != nil {
 					unensuredCount += 1
+					glog.V(4).Infof("Failed to update DNS records for service %v from cluster %s: %v", service, clusterName, err)
+				} else {
+					ensuredCount += 1
 				}
-			} else {
-				missedCount += 1
 			}
 		}
 	}
+	missedCount := len(clusterNames) - ensuredCount - unensuredCount
 	if missedCount > 0 || unensuredCount > 0 {
-		return fmt.Errorf("Failed to update DNS records for %d clusters for service %v due to missing clients[missed count: %d] or ensuring DNS records error[unensured count: %d] %v",
-			len(clusterNames), service, missedCount, unensuredCount, err)
+		return fmt.Errorf("Failed to update DNS records for %d clusters for service %v due to missing clients [missed count: %d] and/or failing to ensure DNS records [unensured count: %d]",
+			len(clusterNames), service, missedCount, unensuredCount)
 	}
 	return nil
 }


### PR DESCRIPTION
When [lockedUpdateDNSRecords](https://github.com/xiangpengzhao/kubernetes/blob/check_ensureDnsRecords_return_value/federation/pkg/federation-controller/service/servicecontroller.go#L723) calls `ensureDnsRecords`, it should check the return value. If it returns error, the `ensuredCount` should not increment.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28568)

<!-- Reviewable:end -->
