### PR TITLE
Fixes bad heuristic when calling "tc show" to check interface

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -255,7 +255,7 @@ func (t *tcShaper) ReconcileInterface() error {
 		return t.initializeInterface()
 	}
 	fields := strings.Split(output, " ")
-	if len(fields) != 12 || fields[1] != "htb" || fields[2] != "1:" {
+	if len(fields) < 12 || fields[1] != "htb" || fields[2] != "1:" {
 		if err := t.deleteInterface(fields[2]); err != nil {
 			return err
 		}


### PR DESCRIPTION
`tc` sometimes returns stuff that has more than 12 words in its response. The heuristic is bad, but this at least fixes the case when `tc` is returning too much.

Fixes #28571.
