### PR TITLE
The notes are inconsistent with the code

### DIFF
--- a/pkg/client/cache/store.go
+++ b/pkg/client/cache/store.go
@@ -99,7 +99,7 @@ func SplitMetaNamespaceKey(key string) (namespace, name string, err error) {
 		// name only, no namespace
 		return "", parts[0], nil
 	case 2:
-		// name and namespace
+		// namespace and name
 		return parts[0], parts[1], nil
 	}
 


### PR DESCRIPTION
 In file "pkg/client/cache/store.go, the notes of line 102 "name and namespace" is inconsistent with line 103 "return parts[0], parts[1], nil", because parts[0] is namespace, and parts[1] is name, It is easy to be confused, and better to modify the notes to "namespace and name".
