### PR TITLE
Scheduler adds NvidiaGPU comparision in getResourceRequest()

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -423,6 +423,9 @@ func getResourceRequest(pod *api.Pod) *resourceRequest {
 		if cpu := requests.Cpu().MilliValue(); cpu > result.milliCPU {
 			result.milliCPU = cpu
 		}
+		if gpu := requests.NvidiaGPU().Value(); gpu > result.nvidiaGPU {
+			result.nvidiaGPU = gpu
+		}
 	}
 	return &result
 }


### PR DESCRIPTION
In file "plugin\pkg\scheduler\algorithm\predicates\predicates.go", function getResourceRequest(), line 391, only mem and cpu handled, NvidiaGPU is required to add to compare:
        if gpu := requests.NvidiaGPU().Value(); gpu > result.nvidiaGPU {
            result.nvidiaGPU = gpu
        } 
