### PR TITLE
Enable memory eviction by default

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -151,6 +151,7 @@ func NewKubeletServer() *KubeletServer {
 			OutOfDiskTransitionFrequency:     unversioned.Duration{Duration: 5 * time.Minute},
 			HairpinMode:                      componentconfig.PromiscuousBridge,
 			BabysitDaemons:                   false,
+			EvictionHard:                     "memory.available<100Mi",
 			EvictionPressureTransitionPeriod: unversioned.Duration{Duration: 5 * time.Minute},
 			PodsPerCore:                      0,
 		},


### PR DESCRIPTION
``` release-note
Enable memory based pod evictions by default on the kubelet.  

Trigger pod eviction when available memory falls below 100Mi.
```

See: https://github.com/kubernetes/kubernetes/issues/28552

/cc @kubernetes/rh-cluster-infra @kubernetes/sig-node 
