### PR TITLE
Fixed a little typo in Cassandra example Readme

### DIFF
--- a/examples/cassandra/README.md
+++ b/examples/cassandra/README.md
@@ -281,7 +281,7 @@ The `selector` attribute contains the controller's selector query. It can be
 explicitly specified, or applied automatically from the labels in the pod
 template if not set, as is done here.
 
-The pod template's label, `app:cassandra`, matches matches the Service selector
+The pod template's label, `app:cassandra`, matches the Service selector
 from Step 1. This is how pods created by this replication controller are picked up
 by the Service."
 


### PR DESCRIPTION
Just a little fix for a typo in the Cassandra Cluster Example.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
