### PR TITLE
add union registry for quota

### DIFF
--- a/pkg/quota/interfaces.go
+++ b/pkg/quota/interfaces.go
@@ -64,3 +64,19 @@ type Registry interface {
 	// Evaluators returns the set Evaluator objects registered to a groupKind
 	Evaluators() map[unversioned.GroupKind]Evaluator
 }
+
+// UnionRegistry combines multiple registries.  Order matters because first registry to claim a GroupKind
+// is the "winner"
+type UnionRegistry []Registry
+
+func (r UnionRegistry) Evaluators() map[unversioned.GroupKind]Evaluator {
+	ret := map[unversioned.GroupKind]Evaluator{}
+
+	for i := len(r) - 1; i >= 0; i-- {
+		for k, v := range r[i].Evaluators() {
+			ret[k] = v
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
Adds the ability to combine multiple quota registries together.  Kube needs this for other types.

@derekwaynecarr 
