### PR TITLE
Function closures in addConversionFuncs is bound to same 'kind' variable

### DIFF
--- a/federation/apis/core/v1/conversion.go
+++ b/federation/apis/core/v1/conversion.go
@@ -64,9 +64,10 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
-	for _, kind := range []string{
+	for _, k := range []string{
 		"Service",
 	} {
+		kind := k // don't close over range variables
 		err = scheme.AddFieldLabelConversionFunc("v1", kind,
 			func(label, value string) (string, string, error) {
 				switch label {


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Fixes #28614

This PR has a simple fix to move creating the field label conversion func
for ObjectMeta fields into another local method.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28621)

<!-- Reviewable:end -->
