### PR TITLE
Fix build on OS X when GNU sed is present.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -242,11 +242,15 @@ function kube::build::is_osx() {
   [[ "$(uname)" == "Darwin" ]]
 }
 
+function kube::build::is_gnu_sed() {
+  [[ $(sed --version 2>&1) == *GNU* ]]
+}
+
 function kube::build::update_dockerfile() {
-  if kube::build::is_osx; then
-    sed_opts=(-i '')
-  else
+  if kube::build::is_gnu_sed; then
     sed_opts=(-i)
+  else
+    sed_opts=(-i '')
   fi
   sed "${sed_opts[@]}" "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
 }

--- a/build/common.sh
+++ b/build/common.sh
@@ -173,7 +173,7 @@ function kube::build::docker_available_on_osx() {
     
     kube::log::status "No docker host is set. Checking options for setting one..."
     if [[ -z "$(which docker-machine)" && -z "$(which boot2docker)" ]]; then
-      kube::log::status "It looks like you're running Mac OS X, and neither Docker for Mac, docker-machine or boot2docker are nowhere to be found."
+      kube::log::status "It looks like you're running Mac OS X, yet none of Docker for Mac, docker-machine or boot2docker are on the path."
       kube::log::status "See: https://docs.docker.com/machine/ for installation instructions."
       return 1
     elif [[ -n "$(which docker-machine)" ]]; then


### PR DESCRIPTION
See #20147, which fixed it when system default BSD sed was present but did not account for possibility of GNU sed on OS X.

See also http://unix.stackexchange.com/questions/92895/how-to-achieve-portability-with-sed-i-in-place-editing

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
