### PR TITLE
update resource builder error message to be more clear

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -333,7 +333,7 @@ func (b *Builder) ResourceTypeOrNameArgs(allowEmptySelector bool, args ...string
 		}
 	case len(args) == 0:
 	default:
-		b.errs = append(b.errs, fmt.Errorf("when passing arguments, must be resource or resource and name"))
+		b.errs = append(b.errs, fmt.Errorf("arguments must consist of a resource or a resource and name"))
 	}
 	return b
 }
@@ -362,7 +362,12 @@ func hasCombinedTypeArgs(args []string) (bool, error) {
 	case hasSlash > 0 && hasSlash == len(args):
 		return true, nil
 	case hasSlash > 0 && hasSlash != len(args):
-		return true, fmt.Errorf("when passing arguments in resource/name form, all arguments must include the resource")
+		baseCmd := "cmd"
+		if len(os.Args) > 0 {
+			baseCmdSlice := strings.Split(os.Args[0], "/")
+			baseCmd = baseCmdSlice[len(baseCmdSlice)-1]
+		}
+		return true, fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. '%s get resource/<resource_name>' instead of '%s get resource resource/<resource_name>'", baseCmd, baseCmd)
 	default:
 		return false, nil
 	}

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -1231,7 +1231,7 @@ func TestHasNames(t *testing.T) {
 		{
 			args:            []string{"rc/foo", "bar"},
 			expectedHasName: false,
-			expectedError:   fmt.Errorf("when passing arguments in resource/name form, all arguments must include the resource"),
+			expectedError:   fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'resource.test get resource/<resource_name>' instead of 'resource.test get resource resource/<resource_name>'"),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
release-note-none

The error message given by command line `kubectl get` is sometimes of no help / not clear on what must be corrected, e.g.：
`kubectl get pod pod/database-1-i10b9`
error: when passing arguments in resource/name form, all arguments must include the resource 
##### Steps to Reproduce:
1. Run command "$ kubectl get pod pod/database-1-i10b9"  
##### Actual Result:

Get unfriendly error message which is of no help:
"error: when passing arguments in resource/name form, all arguments must include the resource"
##### Expected Result:

Error message should recommend end user to run this cli in good grammar: "$ kubectl get pod database-1-i10b9" or "$ kubectl get pod/database-1-i10b9"
##### Before

"error: when passing arguments in resource/name form, all arguments must include the resource"
##### After

"error: there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. `kubectl get resource/<resource_name>` instead of `kubectl get resource resource/<resource_name>`"

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
