### PR TITLE
Add support to quota pvc storage requests

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -134,6 +134,7 @@ var standardQuotaResources = sets.NewString(
 	string(ResourceMemory),
 	string(ResourceRequestsCPU),
 	string(ResourceRequestsMemory),
+	string(ResourceRequestsStorage),
 	string(ResourceLimitsCPU),
 	string(ResourceLimitsMemory),
 	string(ResourcePods),

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2568,6 +2568,8 @@ const (
 	ResourceRequestsCPU ResourceName = "requests.cpu"
 	// Memory request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceRequestsMemory ResourceName = "requests.memory"
+	// Storage request, in bytes
+	ResourceRequestsStorage ResourceName = "requests.storage"
 	// CPU limit, in cores. (500m = .5 cores)
 	ResourceLimitsCPU ResourceName = "limits.cpu"
 	// Memory limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -3038,6 +3038,8 @@ const (
 	ResourceRequestsCPU ResourceName = "requests.cpu"
 	// Memory request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceRequestsMemory ResourceName = "requests.memory"
+	// Storage request, in bytes
+	ResourceRequestsStorage ResourceName = "requests.storage"
 	// CPU limit, in cores. (500m = .5 cores)
 	ResourceLimitsCPU ResourceName = "limits.cpu"
 	// Memory limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -278,6 +278,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		usedResources := api.ResourceList{}
 		usedResources[api.ResourceQuotas] = resource.MustParse("1")
 		usedResources[api.ResourcePersistentVolumeClaims] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsStorage] = resource.MustParse("0")
 		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -289,6 +290,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		By("Ensuring resource quota status captures persistent volume claimcreation")
 		usedResources = api.ResourceList{}
 		usedResources[api.ResourcePersistentVolumeClaims] = resource.MustParse("1")
+		usedResources[api.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -298,6 +300,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 
 		By("Ensuring resource quota status released usage")
 		usedResources[api.ResourcePersistentVolumeClaims] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsStorage] = resource.MustParse("0")
 		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -512,6 +515,7 @@ func newTestResourceQuota(name string) *api.ResourceQuota {
 	hard[api.ResourceConfigMaps] = resource.MustParse("2")
 	hard[api.ResourceSecrets] = resource.MustParse("10")
 	hard[api.ResourcePersistentVolumeClaims] = resource.MustParse("10")
+	hard[api.ResourceRequestsStorage] = resource.MustParse("10Gi")
 	return &api.ResourceQuota{
 		ObjectMeta: api.ObjectMeta{Name: name},
 		Spec:       api.ResourceQuotaSpec{Hard: hard},


### PR DESCRIPTION
Adds support to quota cumulative `PersistentVolumeClaim` storage requests in a namespace.

Per our chat today @markturansky @abhgupta - this is not done (lacks unit testing), but is functional.

This lets quota enforcement for `PersistentVolumeClaim` to occur at creation time.  Supporting bind time enforcement would require substantial more work.  It's possible this is sufficient for many, so I am opening it up for feedback.

In the future, I suspect we may want to treat local disk in a special manner, but that would have to be a different resource altogether (i.e. `requests.disk`) or something.

Example quota:

```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: quota
spec:
  hard:
    persistentvolumeclaims: "10"
    requests.storage: "40Gi"
```

/cc @kubernetes/rh-cluster-infra @deads2k 
