### PR TITLE
Better visibility to contributing docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing guidelines
 
+Want to hack on kubernetes? Yay!
+
+## Developer Guide
+
+We have a [Developer's Guide](docs/devel/README.md) that outlines everything you need to know from setting up your dev environment to how to get faster Pull Request reviews. And of course if you find something undocumented or incorrect along the way, feel free to send a PR!
+
 ## Filing issues
 
 If you have a question about Kubernetes or have a problem using Kubernetes, before filing an issue, please read the [troubleshooting guide](docs/troubleshooting.md).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For Q&A, our threads are at:
  * [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
  * [Slack](http://slack.k8s.io/)
 
-### Want to do more than just 'discuss' Kubernetes?
+### Want to contribute to Kubernetes?
 
 If you're interested in being a contributor and want to get involved in developing Kubernetes, start in the [Kubernetes Developer Guide](docs/devel/README.md) and also review the [contributor guidelines](CONTRIBUTING.md).
 


### PR DESCRIPTION
<!--
Checklist for submitting a Pull Request

Please remove this comment block before submitting.

1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. If you want this PR to automatically close an issue when it is merged,
   add `fixes #<issue number>` or `fixes #<issue number>, fixes #<issue number>`
   to close multiple issues (see: https://github.com/blog/1506-closing-issues-via-pull-requests).
4. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.
-->

``` release-note

```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
1. Updates the README.md to have a heading with the word "contribute", long
   time OSS contributors (or maybe I just do this) skim docs quickly and need
   a large call out to exactly what they are looking for.
2. The best resource I found was a developer guide that wasn't even linked in
   CONTRIBUTING.md, which seems like a shame so I made it right at the top!
