### PR TITLE
Update coreos node e2e image to a version that uses cgroupfs

### DIFF
--- a/test/e2e_node/jenkins/copy-e2e-image.sh
+++ b/test/e2e_node/jenkins/copy-e2e-image.sh
@@ -20,11 +20,25 @@
 # typically from kubernetes-node-e2e-images
 
 set -e
-set -x
 
-echo "Copying image $1 from project $2 to project $3..."
-gcloud compute --project $3 disks create $1 --image=https://www.googleapis.com/compute/v1/projects/$2/global/images/$1
-gcloud compute --project $3 images create $1 \
-  --source-disk=$1 \
+print_usage() {
+    echo "This script helps copy a GCE image from a source to a target project"
+    echo -e "\nUsage:\n$0 <from-image-name> <from-project-name> <to-project-name> <to-image-name>\n"
+}
+
+if [  $# -ne 4 ]; then
+    print_usage
+    exit 1
+fi
+
+FROM_IMAGE=$1
+FROM_PROJECT=$2
+TO_PROJECT=$3
+TO_IMAGE=$4
+
+echo "Copying image $FROM_IMAGE from project $FROM_PROJECT to project $TO_PROJECT as image $TO_IMAGE..."
+gcloud compute --project $TO_PROJECT disks create $TO_IMAGE --image=https://www.googleapis.com/compute/v1/projects/$FROM_PROJECT/global/images/$FROM_IMAGE
+gcloud compute --project $TO_PROJECT images create $TO_IMAGE \
+  --source-disk=$TO_IMAGE \
   --description="Cloned from projects/$2/global/images/$1 by $USER on $(date)"
-gcloud -q compute --project $3 disks delete $1
+gcloud -q compute --project $TO_PROJECT disks delete $TO_IMAGE

--- a/test/e2e_node/jenkins/jenkins-ci.properties
+++ b/test/e2e_node/jenkins/jenkins-ci.properties
@@ -3,7 +3,7 @@ GCE_HOSTS=
 # To copy an image between projects:
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
-GCE_IMAGES=e2e-node-ubuntu-trusty-docker9-v1-image,e2e-node-ubuntu-trusty-docker10-v1-image,e2e-node-coreos-stable20160622-image,e2e-node-containervm-v20160321-image
+GCE_IMAGES=e2e-node-ubuntu-trusty-docker9-v1-image,e2e-node-ubuntu-trusty-docker10-v1-image,e2e-node-coreos-alpha-1068-20160707-image,e2e-node-containervm-v20160321-image
 GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins
 GCE_IMAGE_PROJECT=kubernetes-node-e2e-images

--- a/test/e2e_node/jenkins/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/jenkins-pull.properties
@@ -3,7 +3,7 @@ GCE_HOSTS=
 # To copy an image between projects:
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
-GCE_IMAGES=e2e-node-ubuntu-trusty-docker9-v1-image,e2e-node-ubuntu-trusty-docker10-v1-image,e2e-node-coreos-stable20160622-image,e2e-node-containervm-v20160321-image
+GCE_IMAGES=e2e-node-ubuntu-trusty-docker9-v1-image,e2e-node-ubuntu-trusty-docker10-v1-image,e2e-node-coreos-alpha-1068-20160707-image,e2e-node-containervm-v20160321-image
 GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins-pull
 GCE_IMAGE_PROJECT=kubernetes-node-e2e-images


### PR DESCRIPTION
Temporary fix for #28192. This PR updates coreos node e2e image to a version that uses cgroupfs.

cc @vishh @yifan-gu 
