### PR TITLE
add default flannel configuration for cni

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -68,6 +68,9 @@ ADD https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz /
 # Copy the cni folder into /opt/
 COPY cni /opt/cni
 
+# Copy overlay configuration to default directory
+COPY cni-conf /etc/cni/net.d
+
 # Create symlinks for each hyperkube server
 # TODO: this is unreliable for now (e.g. running "/kubelet" panics)
 # Also, it doesn't work for other architectures

--- a/cluster/images/hyperkube/cni-conf/10-containernet.conf
+++ b/cluster/images/hyperkube/cni-conf/10-containernet.conf
@@ -1,0 +1,9 @@
+{
+  "name": "containernet",
+  "type": "flannel",
+  "delegate": {
+        "bridge": "cni0",
+        "mtu": 1450,
+        "isDefaultGateway": true
+    }
+}

--- a/cluster/images/hyperkube/cni-conf/99-loopback.conf
+++ b/cluster/images/hyperkube/cni-conf/99-loopback.conf
@@ -1,0 +1,3 @@
+{
+    "type": "loopback"
+}


### PR DESCRIPTION
I added a default flannel configuration for cni.

So hyperkube can be started with:

```
--network-plugin=kubenet
```

or with flannel:

```
--network-plugin=cni
--network-plugin-dir=/etc/cni/net.d
```

Requires update of cni binaries to 0.3.0 or later to work. See also https://github.com/kubernetes/kubernetes/issues/27603

This PR is intended to support multi-node Hyperkube 
https://github.com/kubernetes/kube-deploy/pull/115

CC @zreigz  

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
