### PR TITLE
Make Rackspace deploy scripts compatible with Kubernetes v1.3.0

### DIFF
--- a/cluster/rackspace/cloud-config/master-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/master-cloud-config.yaml
@@ -42,25 +42,62 @@ write_files:
       KUBE_USER:KUBE_PASSWORD
 
 coreos:
-  etcd:
-    name: kubernetes-master
+  etcd2:
     discovery: https://discovery.etcd.io/DISCOVERY_ID
-    addr: $private_ipv4:4001
-    peer-addr: $private_ipv4:7001
-    peer-bind-addr: $private_ipv4:7001
+    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+
+  flannel:
+    ip_masq: true
+    interface: eth2
 
   fleet:
     public-ip: $private_ipv4
     metadata: kubernetes_role=master
 
   update:
-    reboot-strategy: etcd-lock
+    reboot-strategy: off
 
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start
+    - name: flanneld.service
+      drop-ins:
+        - name: 50-flannel.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            After=etcd2.service
+
+            [Service]
+            ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"KUBE_NETWORK", "Backend": {"Type": "host-gw"}}'
+      command: start
+    - name: generate-serviceaccount-key.service
+      command: start
+      content: |
+        [Unit]
+        Description=Generate service-account key file
+
+        [Service]
+        ExecStartPre=-/usr/bin/mkdir -p /var/run/kubernetes/
+        ExecStart=/bin/openssl genrsa -out /var/run/kubernetes/kube-serviceaccount.key 2048 2>/dev/null
+        RemainAfterExit=yes
+        Type=oneshot
+    - name: docker.service
+      command: start
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Unit]
+            # making sure that flanneld finished startup, otherwise containers
+            # won't land in flannel's network...
+            Requires=flanneld.service
+            After=flanneld.service
+            Restart=Always
     - name: download-release.service
       command: start
       content: |
@@ -82,6 +119,8 @@ coreos:
         Requires=network-online.target
         After=download-release.service
         Requires=download-release.service
+        Requires=generate-serviceaccount-key.service
+        After=generate-serviceaccount-key.service
         [Service]
         ExecStartPre=/usr/bin/ln -sf /opt/kubernetes/server/bin/kube-apiserver /opt/bin/kube-apiserver
         ExecStartPre=/usr/bin/mkdir -p /var/lib/kube-apiserver
@@ -94,7 +133,10 @@ coreos:
         --port=8080 \
         --service-cluster-ip-range=SERVICE_CLUSTER_IP_RANGE \
         --token-auth-file=/var/lib/kube-apiserver/known_tokens.csv \
-        --v=2
+        --v=2 \
+        --service-account-key-file=/var/run/kubernetes/kube-serviceaccount.key \
+        --service-account-lookup=false \
+        --admission-control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
         Restart=always
         RestartSec=5
     - name: apiserver-advertiser.service
@@ -102,8 +144,8 @@ coreos:
       content: |
         [Unit]
         Description=Kubernetes Apiserver Advertiser
-        After=etcd.service
-        Requires=etcd.service
+        After=etcd2.service
+        Requires=etcd2.service
         After=master-apiserver.service
         [Service]
         ExecStart=/bin/sh -c 'etcdctl set /corekube/apiservers/$public_ipv4 $public_ipv4'
@@ -126,7 +168,9 @@ coreos:
         --cloud-config=/etc/cloud.conf \
         --logtostderr=true \
         --master=127.0.0.1:8080 \
-        --v=2
+        --v=2 \
+        --service-account-private-key-file=/var/run/kubernetes/kube-serviceaccount.key \
+        --root-ca-file=/run/kubernetes/apiserver.crt
         Restart=always
         RestartSec=5
     - name: kube-scheduler.service

--- a/cluster/rackspace/cloud-config/node-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/node-cloud-config.yaml
@@ -76,12 +76,12 @@ write_files:
       EOF
 
 coreos:
-  etcd:
-    name: kubernetes-node-INDEX
+  etcd2:
     discovery: https://discovery.etcd.io/DISCOVERY_ID
-    addr: $private_ipv4:4001
-    peer-addr: $private_ipv4:7001
-    peer-bind-addr: $private_ipv4:7001
+    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
 
   flannel:
     ip_masq: true
@@ -92,10 +92,10 @@ coreos:
     metadata: kubernetes_role=minion
 
   update:
-    reboot-strategy: etcd-lock
+    reboot-strategy: off
 
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start
@@ -104,8 +104,8 @@ coreos:
         - name: 50-flannel.conf
           content: |
             [Unit]
-            Requires=etcd.service
-            After=etcd.service
+            Requires=etcd2.service
+            After=etcd2.service
 
             [Service]
             ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"KUBE_NETWORK", "Backend": {"Type": "host-gw"}}'
@@ -144,6 +144,8 @@ coreos:
         Requires=docker.service
         After=download-release.service
         Requires=download-release.service
+        After=apiserver-finder.service
+        Requires=apiserver-finder.service
         [Service]
         EnvironmentFile=/run/kubelet/apiservers.env
         ExecStartPre=/run/config-kubelet.sh
@@ -172,6 +174,8 @@ coreos:
         Requires=docker.service
         After=download-release.service
         Requires=download-release.service
+        After=apiserver-finder.service
+        Requires=apiserver-finder.service
         [Service]
         EnvironmentFile=/run/kubelet/apiservers.env
         ExecStartPre=/run/config-kube-proxy.sh
@@ -184,26 +188,6 @@ coreos:
         --master=${FIRST_APISERVER_URL}
         Restart=always
         RestartSec=5
-    - name: kubelet-sighup.path
-      command: start
-      content: |
-        [Path]
-        PathChanged=/run/kubelet/apiservers.env
-    - name: kubelet-sighup.service
-      command: start
-      content: |
-        [Service]
-        ExecStart=/usr/bin/pkill -SIGHUP -f kubelet
-    - name: kube-proxy-sighup.path
-      command: start
-      content: |
-        [Path]
-        PathChanged=/run/kubelet/apiservers.env
-    - name: kube-proxy-sighup.service
-      command: start
-      content: |
-        [Service]
-        ExecStart=/usr/bin/pkill -SIGHUP -f kube-proxy
     - name: apiserver-finder.service
       command: start
       content: |
@@ -211,8 +195,8 @@ coreos:
         Description=Kubernetes Apiserver finder
         After=network-online.target
         Requires=network-online.target
-        After=etcd.service
-        Requires=etcd.service
+        After=etcd2.service
+        Requires=etcd2.service
         [Service]
         ExecStartPre=/opt/bin/regen-apiserver-list.sh
         ExecStart=/usr/bin/etcdctl exec-watch --recursive /corekube/apiservers -- /opt/bin/regen-apiserver-list.sh

--- a/cluster/rackspace/config-default.sh
+++ b/cluster/rackspace/config-default.sh
@@ -19,7 +19,7 @@
 # KUBE_IMAGE, KUBE_MASTER_FLAVOR, KUBE_NODE_FLAVOR, NUM_NODES, NOVA_NETWORK and SSH_KEY_NAME
 
 # Shared
-KUBE_IMAGE="${KUBE_IMAGE-f2a71670-ced3-4274-80b6-0efcd0f8f91b}" # CoreOS(Beta)
+KUBE_IMAGE="${KUBE_IMAGE-3eba4fbb-51da-4233-b699-8a4030561add}" # CoreOS (Stable)
 SSH_KEY_NAME="${SSH_KEY_NAME-id_kubernetes}"
 NOVA_NETWORK_LABEL="kubernetes-pool-net"
 NOVA_NETWORK_CIDR="${NOVA_NETWORK-192.168.0.0/24}"
@@ -47,8 +47,8 @@ ENABLE_CLUSTER_LOGGING=false
 ELASTICSEARCH_LOGGING_REPLICAS=1
 
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
-#   none     - No cluster monitoring setup 
-#   influxdb - Heapster, InfluxDB, and Grafana 
+#   none     - No cluster monitoring setup
+#   influxdb - Heapster, InfluxDB, and Grafana
 #   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
 

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -128,7 +128,7 @@ prep_known_tokens() {
 
 rax-boot-master() {
 
-  DISCOVERY_URL=$(curl https://discovery.etcd.io/new)
+  DISCOVERY_URL=$(curl https://discovery.etcd.io/new?size=1)
   DISCOVERY_ID=$(echo "${DISCOVERY_URL}" | cut -f 4 -d /)
   echo "cluster/rackspace/util.sh: etcd discovery URL: ${DISCOVERY_URL}"
 
@@ -138,6 +138,7 @@ rax-boot-master() {
       -e "s|KUBE_USER|${KUBE_USER}|" \
       -e "s|KUBE_PASSWORD|${KUBE_PASSWORD}|" \
       -e "s|SERVICE_CLUSTER_IP_RANGE|${SERVICE_CLUSTER_IP_RANGE}|" \
+      -e "s|KUBE_NETWORK|${KUBE_NETWORK}|" \
       -e "s|OS_AUTH_URL|${OS_AUTH_URL}|" \
       -e "s|OS_USERNAME|${OS_USERNAME}|" \
       -e "s|OS_PASSWORD|${OS_PASSWORD}|" \


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
- Use the current stable CoreOS image
- Switch to etcd2
- Launch flanneld on master to make nodes accessible
- Generate Service Account certificate and enable admission controls

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28676)

<!-- Reviewable:end -->
