### PR TITLE
Fix quotes in documentation

### DIFF
--- a/_v1.0/docs/user-guide/configuring-containers.md
+++ b/_v1.0/docs/user-guide/configuring-containers.md
@@ -28,7 +28,7 @@ title: "Kubernetes User Guide: Managing Applications: Configuring and launching 
 
 In addition to the imperative-style commands, such as `kubectl run` and `kubectl expose`, described [elsewhere](quick-start.html), Kubernetes supports declarative configuration. Often times, configuration files are preferable to imperative commands, since they can be checked into version control and changes to the files can be code reviewed, which is especially important for more complex configurations, producing a more robust, reliable and archival system.
 
-In the declarative style, all configuration is stored in YAML or JSON configuration files, using Kubernetes's API resource schemas as the configuration schemas. `kubectl` can create, update, delete, and get API resources. The `apiVersion` (currently “v1”), resource `kind`, and resource `name` are used by `kubectl` to construct the appropriate API path to invoke for the specified operation. 
+In the declarative style, all configuration is stored in YAML or JSON configuration files, using Kubernetes's API resource schemas as the configuration schemas. `kubectl` can create, update, delete, and get API resources. The `apiVersion` (currently “v1”), resource `kind`, and resource `name` are used by `kubectl` to construct the appropriate API path to invoke for the specified operation.
 
 ## Launching a container using a configuration file
 
@@ -45,13 +45,13 @@ spec:  # specification of the pod’s contents
   containers:
   - name: hello
     image: "ubuntu:14.04"
-    command: ["/bin/echo","hello”,”world"]
+    command: ["/bin/echo","hello","world"]
 {% endraw %}
 {% endhighlight %}
 
 The value of `metadata.name`, `hello-world`, will be the name of the pod resource created, and must be unique within the cluster, whereas `containers[0].name` is just a nickname for the container within that pod. `image` is the name of the Docker image, which Kubernetes expects to be able to pull from a registry, the [Docker Hub](https://registry.hub.docker.com/) by default.
 
-`restartPolicy: Never` indicates that we just want to run the container once and then terminate the pod. 
+`restartPolicy: Never` indicates that we just want to run the container once and then terminate the pod.
 
 The [`command`](containers.html#containers-and-commands) overrides the Docker container’s `Entrypoint`. Command arguments (corresponding to Docker’s `Cmd`) may be specified using `args`, as follows:
 
@@ -132,7 +132,7 @@ However, a shell isn’t necessary just to expand environment variables. Kuberne
 
 ## Viewing pod status
 
-You can see the pod you created (actually all of your cluster's pods) using the `get` command. 
+You can see the pod you created (actually all of your cluster's pods) using the `get` command.
 
 If you’re quick, it will look as follows:
 
@@ -201,7 +201,7 @@ pods/hello-world
 {% endraw %}
 {% endhighlight %}
 
-Terminated pods aren’t currently automatically deleted, so that you can observe their final status, so be sure to clean up your dead pods. 
+Terminated pods aren’t currently automatically deleted, so that you can observe their final status, so be sure to clean up your dead pods.
 
 On the other hand, containers and their logs are eventually deleted automatically in order to free up disk space on the nodes.
 
@@ -218,4 +218,3 @@ On the other hand, containers and their logs are eventually deleted automaticall
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/configuring-containers.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->
-

--- a/_v1.0/docs/user-guide/managing-deployments.md
+++ b/_v1.0/docs/user-guide/managing-deployments.md
@@ -151,7 +151,7 @@ my-nginx-svc   app=nginx   app=nginx   10.0.152.174   80/TCP
 
 ## Using labels effectively
 
-The examples we’ve used so far apply at most a single label to any resource. There are many scenarios where multiple labels should be used to distinguish sets from one another. 
+The examples we’ve used so far apply at most a single label to any resource. There are many scenarios where multiple labels should be used to distinguish sets from one another.
 
 For instance, different applications would use different values for the `app` label, but a multi-tier application, such as the [guestbook example](../../examples/guestbook/), would additionally need to distinguish each tier. The frontend could carry the following labels:
 
@@ -291,7 +291,7 @@ my-nginx-o0ef1   1/1       Running   0          1h
 
 At some point, you’ll eventually need to update your deployed application, typically by specifying a new image or image tag, as in the canary deployment scenario above. `kubectl` supports several update operations, each of which is applicable to different scenarios.
 
-To update a service without an outage, `kubectl` supports what is called [“rolling update”](kubectl/kubectl_rolling-update.html), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](../design/simple-rolling-update.html) and the [example of rolling update](update-demo/) for more information. 
+To update a service without an outage, `kubectl` supports what is called [“rolling update”](kubectl/kubectl_rolling-update.html), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](../design/simple-rolling-update.html) and the [example of rolling update](update-demo/) for more information.
 
 Let’s say you were running version 1.7.9 of nginx:
 
@@ -401,7 +401,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.9.2
-        args: [“nginx”,”-T”]
+        args: ["nginx","-T"]
         ports:
         - containerPort: 80
 {% endraw %}
@@ -441,7 +441,7 @@ Sometimes it’s necessary to make narrow, non-disruptive updates to resources y
 
 {% highlight console %}
 {% raw %}
-$ kubectl patch rc my-nginx-v4 -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
+$ kubectl patch rc my-nginx-v4 -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}'
 my-nginx-v4
 $ kubectl get rc my-nginx-v4 -o yaml
 apiVersion: v1
@@ -495,4 +495,3 @@ replicationcontrollers/my-nginx-v4
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/managing-deployments.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->
-

--- a/_v1.1/docs/user-guide/configuring-containers.md
+++ b/_v1.1/docs/user-guide/configuring-containers.md
@@ -45,7 +45,7 @@ spec:  # specification of the pod’s contents
   containers:
   - name: hello
     image: "ubuntu:14.04"
-    command: ["/bin/echo","hello”,”world"]
+    command: ["/bin/echo","hello","world"]
 {% endraw %}
 {% endhighlight %}
 
@@ -220,4 +220,3 @@ On the other hand, containers and their logs are eventually deleted automaticall
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/configuring-containers.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->
-

--- a/_v1.1/docs/user-guide/managing-deployments.md
+++ b/_v1.1/docs/user-guide/managing-deployments.md
@@ -401,7 +401,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.9.2
-        args: [“nginx”,”-T”]
+        args: ["nginx","-T"]
         ports:
         - containerPort: 80
 {% endraw %}
@@ -441,7 +441,7 @@ Sometimes it’s necessary to make narrow, non-disruptive updates to resources y
 
 {% highlight console %}
 {% raw %}
-$ kubectl patch rc my-nginx-v4 -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}' 
+$ kubectl patch rc my-nginx-v4 -p '{"metadata": {"annotations": {"description": "my frontend running nginx"}}}'
 my-nginx-v4
 $ kubectl get rc my-nginx-v4 -o yaml
 apiVersion: v1
@@ -497,4 +497,3 @@ replicationcontrollers/my-nginx-v4
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/managing-deployments.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->
-


### PR DESCRIPTION
`”` are rendered as `'?`

![image](https://cloud.githubusercontent.com/assets/89186/16690159/77639972-451e-11e6-8b7f-4a56d9784de7.png)
