### PR TITLE
PersistentVolumeClaim.Spec is immutable once created

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -740,9 +740,14 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		oldClaim          *api.PersistentVolumeClaim
 		newClaim          *api.PersistentVolumeClaim
 	}{
-		"valid-update": {
+		"valid-update-volumeName-only": {
 			isExpectedFailure: false,
 			oldClaim:          validClaim,
+			newClaim:          validUpdateClaim,
+		},
+		"valid-no-op-update": {
+			isExpectedFailure: false,
+			oldClaim:          validUpdateClaim,
 			newClaim:          validUpdateClaim,
 		},
 		"invalid-update-change-resources-on-bound-claim": {

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
@@ -86,11 +86,7 @@ func TestUpdate(t *testing.T) {
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*api.PersistentVolumeClaim)
-			object.Spec.Resources = api.ResourceRequirements{
-				Requests: api.ResourceList{
-					api.ResourceName(api.ResourceStorage): resource.MustParse("20G"),
-				},
-			}
+			object.Spec.VolumeName = "onlyVolumeNameUpdateAllowed"
 			return object
 		},
 	)


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/pull/28636, PVCs are immutable post-creation in order to enforce quota, limitRange, etc. without being able to game the system.

@derekwaynecarr @abhgupta @smarterclayton @kubernetes/sig-storage 

``` release-note
PersistentVolumeClaim.Spec was previously mutable until bound. This was change to immutability after initial creation. Updates to labels/annotation are allowed. Immutability is necessary to enforce quota, limitRange, etc. without gaming the system.
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
