### PR TITLE
Only activate service account when file exists

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -151,9 +151,11 @@ if running_in_docker; then
     fi
 fi
 
-if [[ -n "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
+if [[ -f "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
   echo 'Activating service account...'  # No harm in doing this multiple times.
   gcloud auth activate-service-account --key-file="${KUBEKINS_SERVICE_ACCOUNT_FILE}"
+elif [[ -n "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
+  echo "ERROR: cannot access service account file at: ${KUBEKINS_SERVICE_ACCOUNT_FILE}"
 fi
 
 # Install gcloud from a custom path if provided. Used to test GKE with gcloud


### PR DESCRIPTION
fyi @krousey I'm going to manually merge this as https://github.com/kubernetes/kubernetes/pull/28634 makes life very unhappy.

To fix I need to add an additional -v mount on dockerized-e2e-runner.sh, but I'll figure this out next week.

/cc @spxtr 
