### PR TITLE
Add known versions to release 1.4 clientset.

### DIFF
--- a/pkg/client/clientset_generated/release_1_4/import_known_versions.go
+++ b/pkg/client/clientset_generated/release_1_4/import_known_versions.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release_1_4
+
+// These imports are the API groups the client will support.
+import (
+	"fmt"
+
+	_ "k8s.io/kubernetes/pkg/api/install"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
+	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+)
+
+func init() {
+	if missingVersions := registered.ValidateEnvRequestedVersions(); len(missingVersions) != 0 {
+		panic(fmt.Sprintf("KUBE_API_VERSIONS contains versions that are not installed: %q.", missingVersions))
+	}
+}


### PR DESCRIPTION
These imports install the API groups and register them with the API machinery. The release_1_4 clientset cannot be used without these imports. 

Follow up for PR #26588

@kubernetes/sig-api-machinery

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
