### PR TITLE
Allow empty value for env in kubectl run

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -934,7 +934,7 @@ func parseEnvs(envArray []string) ([]api.EnvVar, error) {
 		}
 		name := env[:pos]
 		value := env[pos+1:]
-		if len(name) == 0 || len(value) == 0 {
+		if len(name) == 0 {
 			return nil, fmt.Errorf("invalid env: %v", env)
 		}
 		if len(validation.IsCIdentifier(name)) != 0 {
@@ -955,7 +955,7 @@ func parseV1Envs(envArray []string) ([]v1.EnvVar, error) {
 		}
 		name := env[:pos]
 		value := env[pos+1:]
-		if len(name) == 0 || len(validation.IsCIdentifier(name)) != 0 || len(value) == 0 {
+		if len(name) == 0 || len(validation.IsCIdentifier(name)) != 0 {
 			return nil, fmt.Errorf("invalid env: %v", env)
 		}
 		envVar := v1.EnvVar{Name: name, Value: value}

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -858,8 +858,13 @@ func TestParseEnv(t *testing.T) {
 			envArray: []string{
 				"WITH_OUT_VALUES=",
 			},
-			expected:  []api.EnvVar{},
-			expectErr: true,
+			expected: []api.EnvVar{
+				{
+					Name:  "WITH_OUT_VALUES",
+					Value: "",
+				},
+			},
+			expectErr: false,
 			test:      "test case 3",
 		},
 		{


### PR DESCRIPTION
Fixes #28734
