### PR TITLE
kube-up: install new Docker pre-requisite (libltdl7) when not in image

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -376,11 +376,15 @@ purge-old-docker-package:
     - mode: 644
     - makedirs: true
 
+libltdl7:
+  pkg.installed
+
 docker-upgrade:
   cmd.run:
     - name: /opt/kubernetes/helpers/pkg install-no-start {{ docker_pkg_name }} {{ override_docker_ver }} /var/cache/docker-install/{{ override_deb }}
     - require:
       - file: /var/cache/docker-install/{{ override_deb }}
+      - pkg: libltdl7
 
 {% endif %} # end override_docker_ver != ''
 


### PR DESCRIPTION
Docker now has a dependency on libltdl7; we have to specify it manually
if we are installing docker using dpkg (vs using apt-get or similar,
which would pull it in automatically)

Fixes #28644

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28745)

<!-- Reviewable:end -->
