### PR TITLE
Do not skip check for cgroup creation in the systemd mount

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -54,10 +54,8 @@ func (m *cgroupManagerImpl) Exists(name string) bool {
 	}
 
 	// If even one cgroup doesn't exist we go on to create it
-	// @TODO(dubstack) We skip check for systemd until we update
-	// libcontainer in vendor
-	for key, path := range cgroupPaths {
-		if key != "systemd" && !libcontainercgroups.PathExists(path) {
+	for _, path := range cgroupPaths {
+		if !libcontainercgroups.PathExists(path) {
 			return false
 		}
 	}


### PR DESCRIPTION
As soon as libcontainer dependency is update in #28410, we can skip check for cgroup creation in the systemd mount. As the latest version of libcontainer should create cgroups in the sytemd mount aswell.

This is tied to the upstream issue: #27204

@vishh PTAL
