### PR TITLE
Error info "scheduler" modify

### DIFF
--- a/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
@@ -46,7 +46,7 @@ func (st *schedulerTester) expectSchedule(pod *api.Pod, expected string) {
 func (st *schedulerTester) expectSuccess(pod *api.Pod) {
 	_, err := st.scheduler.Schedule(pod, st.nodeLister)
 	if err != nil {
-		st.t.Errorf("Unexpected error %v\nTried to scheduler: %#v", err, pod)
+		st.t.Errorf("Unexpected error %v\nTried to schedule: %#v", err, pod)
 		return
 	}
 }


### PR DESCRIPTION
File "plugin\pkg\scheduler\algorithm\scheduler_interface_test.go“, line 49, "st.t.Errorf("Unexpected error %v\nTried to scheduler: %#v", err, pod)", here "scheduler" should be "schedule" because it is to schedule pod.
