### PR TITLE
Doc referrence "container-id" incorrect

### DIFF
--- a/docs/proposals/disk-accounting.md
+++ b/docs/proposals/disk-accounting.md
@@ -151,7 +151,7 @@ Identical files are hardlinked between images.
 
 The image layers contain all their data under a `root` subdirectory.
 
-Everything under  `/var/lib/docker/overlay/<container-id>` are files required for running the container, including its writable layer.
+Everything under  `/var/lib/docker/overlay/<id>` are files required for running the container, including its writable layer.
 
 ### Improve disk accounting
 


### PR DESCRIPTION
File "docs\proposals\disk-accounting.md", line 154, "Everything under  `/var/lib/docker/overlay/<container-id>` are files required for running the container", here "container-id" is incorrect because files under "/var/lib/docker/overlay" are layer files, and  "container-id"  should be "id" thus consistent with line 148 "Image layers and writable layers are stored under `/var/lib/docker/overlay/<id>`".
