### PR TITLE
Removed invalid value

### DIFF
--- a/examples/volumes/glusterfs/glusterfs-pod.json
+++ b/examples/volumes/glusterfs/glusterfs-pod.json
@@ -1,6 +1,5 @@
 {
     "apiVersion": "v1",
-    "id": "glusterfs",
     "kind": "Pod",
     "metadata": {
         "name": "glusterfs"


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Id isn't a valid field in a Pod object so kubectl fails with: 

```
error validating "glusterfs-pod.json": error validating data: found invalid field id for v1.Pod; if you choose to ignore these errors, turn validation off with --validate=false
```
