### PR TITLE
Change storeToNodeConditionLister to return []*api.Node instead of api.NodeList for performance

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -151,11 +151,11 @@ type storeToNodeConditionLister struct {
 }
 
 // List returns a list of nodes that match the conditions defined by the predicate functions in the storeToNodeConditionLister.
-func (s storeToNodeConditionLister) List() (nodes api.NodeList, err error) {
+func (s storeToNodeConditionLister) List() (nodes []*api.Node, err error) {
 	for _, m := range s.store.List() {
 		node := m.(*api.Node)
 		if s.predicate(node) {
-			nodes.Items = append(nodes.Items, *node)
+			nodes = append(nodes, node)
 		} else {
 			glog.V(5).Infof("Node %s matches none of the conditions", node.Name)
 		}

--- a/pkg/client/cache/listers_test.go
+++ b/pkg/client/cache/listers_test.go
@@ -114,9 +114,9 @@ func TestStoreToNodeConditionLister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	got := make([]string, len(gotNodes.Items))
-	for ix := range gotNodes.Items {
-		got[ix] = gotNodes.Items[ix].Name
+	got := make([]string, len(gotNodes))
+	for ix := range gotNodes {
+		got[ix] = gotNodes[ix].Name
 	}
 	if !want.HasAll(got...) || len(got) != len(want) {
 		t.Errorf("Expected %v, got %v", want, got)

--- a/plugin/pkg/scheduler/algorithm/listers.go
+++ b/plugin/pkg/scheduler/algorithm/listers.go
@@ -27,20 +27,23 @@ import (
 
 // NodeLister interface represents anything that can list nodes for a scheduler.
 type NodeLister interface {
-	List() (list api.NodeList, err error)
+	// We explicitly return []*api.Node, instead of api.NodeList, to avoid
+	// performing expensive copies that are unneded.
+	List() ([]*api.Node, error)
 }
 
 // FakeNodeLister implements NodeLister on a []string for test purposes.
-type FakeNodeLister api.NodeList
+type FakeNodeLister []*api.Node
 
 // List returns nodes as a []string.
-func (f FakeNodeLister) List() (api.NodeList, error) {
-	return api.NodeList(f), nil
+func (f FakeNodeLister) List() ([]*api.Node, error) {
+	return f, nil
 }
 
 // PodLister interface represents anything that can list pods for a scheduler.
 type PodLister interface {
-	// TODO: make this exactly the same as client's Pods(ns).List() method, by returning a api.PodList
+	// We explicitly return []*api.Pod, instead of api.PodList, to avoid
+	// performing expensive copies that are unneded.
 	List(labels.Selector) ([]*api.Pod, error)
 }
 

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -101,12 +101,12 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 	var maxCount int
 	var minCount int
 	counts := map[string]int{}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		totalCount := 0
 		// count weights for the weighted pod affinity
 		if affinity.PodAffinity != nil {
 			for _, weightedTerm := range affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-				weightedCount, err := ipa.CountWeightByPodMatchAffinityTerm(pod, allPods, weightedTerm.Weight, weightedTerm.PodAffinityTerm, &node)
+				weightedCount, err := ipa.CountWeightByPodMatchAffinityTerm(pod, allPods, weightedTerm.Weight, weightedTerm.PodAffinityTerm, node)
 				if err != nil {
 					return nil, err
 				}
@@ -117,7 +117,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 		// count weights for the weighted pod anti-affinity
 		if affinity.PodAntiAffinity != nil {
 			for _, weightedTerm := range affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-				weightedCount, err := ipa.CountWeightByPodMatchAffinityTerm(pod, allPods, (0 - weightedTerm.Weight), weightedTerm.PodAffinityTerm, &node)
+				weightedCount, err := ipa.CountWeightByPodMatchAffinityTerm(pod, allPods, (0 - weightedTerm.Weight), weightedTerm.PodAffinityTerm, node)
 				if err != nil {
 					return nil, err
 				}
@@ -146,7 +146,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 					//}
 					for _, epAffinityTerm := range podAffinityTerms {
 						match, err := ipa.failureDomains.CheckIfPodMatchPodAffinityTerm(pod, ep, epAffinityTerm,
-							func(pod *api.Pod) (*api.Node, error) { return &node, nil },
+							func(pod *api.Pod) (*api.Node, error) { return node, nil },
 							func(ep *api.Pod) (*api.Node, error) { return ipa.info.GetNodeInfo(ep.Spec.NodeName) },
 						)
 						if err != nil {
@@ -161,7 +161,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 				// count weight for the weighted pod affinity indicated by the existing pod.
 				for _, epWeightedTerm := range epAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 					match, err := ipa.failureDomains.CheckIfPodMatchPodAffinityTerm(pod, ep, epWeightedTerm.PodAffinityTerm,
-						func(pod *api.Pod) (*api.Node, error) { return &node, nil },
+						func(pod *api.Pod) (*api.Node, error) { return node, nil },
 						func(ep *api.Pod) (*api.Node, error) { return ipa.info.GetNodeInfo(ep.Spec.NodeName) },
 					)
 					if err != nil {
@@ -177,7 +177,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 			if epAffinity.PodAntiAffinity != nil {
 				for _, epWeightedTerm := range epAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 					match, err := ipa.failureDomains.CheckIfPodMatchPodAffinityTerm(pod, ep, epWeightedTerm.PodAffinityTerm,
-						func(pod *api.Pod) (*api.Node, error) { return &node, nil },
+						func(pod *api.Pod) (*api.Node, error) { return node, nil },
 						func(ep *api.Pod) (*api.Node, error) { return ipa.info.GetNodeInfo(ep.Spec.NodeName) },
 					)
 					if err != nil {
@@ -201,7 +201,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *api.Pod, nod
 
 	// calculate final priority score for each node
 	result := []schedulerapi.HostPriority{}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		fScore := float64(0)
 		if (maxCount - minCount) > 0 {
 			fScore = 10 * (float64(counts[node.Name]-minCount) / float64(maxCount-minCount))

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -30,12 +30,12 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
-type FakeNodeListInfo []api.Node
+type FakeNodeListInfo []*api.Node
 
 func (nodes FakeNodeListInfo) GetNodeInfo(nodeName string) (*api.Node, error) {
 	for _, node := range nodes {
 		if node.Name == nodeName {
-			return &node, nil
+			return node, nil
 		}
 	}
 	return nil, fmt.Errorf("Unable to find node: %s", nodeName)
@@ -252,13 +252,13 @@ func TestInterPodAffinityPriority(t *testing.T) {
 	tests := []struct {
 		pod          *api.Pod
 		pods         []*api.Pod
-		nodes        []api.Node
+		nodes        []*api.Node
 		expectedList schedulerapi.HostPriorityList
 		test         string
 	}{
 		{
 			pod: &api.Pod{Spec: api.PodSpec{NodeName: ""}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1, Annotations: map[string]string{}}},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -276,7 +276,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 				{Spec: api.PodSpec{NodeName: "machine3"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -294,7 +294,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			pods: []*api.Pod{
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgChinaAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelRgIndia}},
@@ -316,7 +316,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine4"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 				{Spec: api.PodSpec{NodeName: "machine5"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelRgChina}},
@@ -334,7 +334,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 				{Spec: api.PodSpec{NodeName: "machine3"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -350,7 +350,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1, Annotations: stayWithS1InRegion}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2, Annotations: stayWithS2InRegion}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -364,7 +364,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1, Annotations: hardAffinity}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2, Annotations: hardAffinity}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -385,7 +385,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgChina}},
 			},
@@ -398,7 +398,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgChina}},
 			},
@@ -412,7 +412,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 			},
@@ -426,7 +426,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1, Annotations: awayFromS2InAz}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS2, Annotations: awayFromS1InAz}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelAzAz2}},
 			},
@@ -440,7 +440,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelAzAz1}},
 			},
@@ -462,7 +462,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine4"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 				{Spec: api.PodSpec{NodeName: "machine5"}, ObjectMeta: api.ObjectMeta{Labels: podLabelSecurityS1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChinaAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelRgChina}},
@@ -485,7 +485,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine3"}, ObjectMeta: api.ObjectMeta{Annotations: stayWithS1InRegionAwayFromS2InAz}},
 				{Spec: api.PodSpec{NodeName: "machine4"}, ObjectMeta: api.ObjectMeta{Annotations: awayFromS1InAz}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelAzAz1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelRgIndia}},
@@ -499,12 +499,12 @@ func TestInterPodAffinityPriority(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods)
 		interPodAffinity := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}),
+			nodeLister:            algorithm.FakeNodeLister(test.nodes),
 			podLister:             algorithm.FakePodLister(test.pods),
 			hardPodAffinityWeight: api.DefaultHardPodAffinitySymmetricWeight,
 			failureDomains:        priorityutil.Topologies{DefaultKeys: strings.Split(api.DefaultFailureDomains, ",")},
 		}
-		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -548,7 +548,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 	tests := []struct {
 		pod                   *api.Pod
 		pods                  []*api.Pod
-		nodes                 []api.Node
+		nodes                 []*api.Node
 		hardPodAffinityWeight int
 		expectedList          schedulerapi.HostPriorityList
 		test                  string
@@ -559,7 +559,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Annotations: hardPodAffinity}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Annotations: hardPodAffinity}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -574,7 +574,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Annotations: hardPodAffinity}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Annotations: hardPodAffinity}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
@@ -588,11 +588,11 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods)
 		ipa := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}),
+			nodeLister:            algorithm.FakeNodeLister(test.nodes),
 			podLister:             algorithm.FakePodLister(test.pods),
 			hardPodAffinityWeight: test.hardPodAffinityWeight,
 		}
-		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -634,7 +634,7 @@ func TestSoftPodAntiAffinityWithFailureDomains(t *testing.T) {
 	tests := []struct {
 		pod            *api.Pod
 		pods           []*api.Pod
-		nodes          []api.Node
+		nodes          []*api.Node
 		failureDomains priorityutil.Topologies
 		expectedList   schedulerapi.HostPriorityList
 		test           string
@@ -645,7 +645,7 @@ func TestSoftPodAntiAffinityWithFailureDomains(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabel1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabel1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: LabelZoneFailureDomainAZ1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelAzAZ1}},
 			},
@@ -659,7 +659,7 @@ func TestSoftPodAntiAffinityWithFailureDomains(t *testing.T) {
 				{Spec: api.PodSpec{NodeName: "machine1"}, ObjectMeta: api.ObjectMeta{Labels: podLabel1}},
 				{Spec: api.PodSpec{NodeName: "machine2"}, ObjectMeta: api.ObjectMeta{Labels: podLabel1}},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: LabelZoneFailureDomainAZ1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: labelAzAZ1}},
 			},
@@ -672,12 +672,12 @@ func TestSoftPodAntiAffinityWithFailureDomains(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods)
 		ipa := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}),
+			nodeLister:            algorithm.FakeNodeLister(test.nodes),
 			podLister:             algorithm.FakePodLister(test.pods),
 			hardPodAffinityWeight: api.DefaultHardPodAffinitySymmetricWeight,
 			failureDomains:        test.failureDomains,
 		}
-		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, algorithm.FakeNodeLister(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
@@ -37,7 +37,7 @@ func CalculateNodeAffinityPriority(pod *api.Pod, nodeNameToInfo map[string]*sche
 	}
 
 	var maxCount float64
-	counts := make(map[string]float64, len(nodes.Items))
+	counts := make(map[string]float64, len(nodes))
 
 	affinity, err := api.GetAffinityFromPodAnnotations(pod.Annotations)
 	if err != nil {
@@ -59,7 +59,7 @@ func CalculateNodeAffinityPriority(pod *api.Pod, nodeNameToInfo map[string]*sche
 				return nil, err
 			}
 
-			for _, node := range nodes.Items {
+			for _, node := range nodes {
 				if nodeSelector.Matches(labels.Set(node.Labels)) {
 					counts[node.Name] += float64(preferredSchedulingTerm.Weight)
 				}
@@ -71,9 +71,8 @@ func CalculateNodeAffinityPriority(pod *api.Pod, nodeNameToInfo map[string]*sche
 		}
 	}
 
-	result := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
+	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
+	for _, node := range nodes {
 		if maxCount > 0 {
 			fScore := 10 * (counts[node.Name] / maxCount)
 			result = append(result, schedulerapi.HostPriority{Host: node.Name, Score: int(fScore)})

--- a/plugin/pkg/scheduler/algorithm/priorities/node_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_affinity_test.go
@@ -93,7 +93,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 
 	tests := []struct {
 		pod          *api.Pod
-		nodes        []api.Node
+		nodes        []*api.Node
 		expectedList schedulerapi.HostPriorityList
 		test         string
 	}{
@@ -103,7 +103,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -117,7 +117,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 					Annotations: affinity1,
 				},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label4}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -131,7 +131,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 					Annotations: affinity1,
 				},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -145,7 +145,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 					Annotations: affinity2,
 				},
 			},
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine5", Labels: label5}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
@@ -156,7 +156,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		list, err := CalculateNodeAffinityPriority(test.pod, schedulercache.CreateNodeNameToInfoMap(nil), algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := CalculateNodeAffinityPriority(test.pod, schedulercache.CreateNodeNameToInfoMap(nil), algorithm.FakeNodeLister(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -86,9 +86,8 @@ func LeastRequestedPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulerca
 		return schedulerapi.HostPriorityList{}, err
 	}
 
-	list := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
+	list := make(schedulerapi.HostPriorityList, 0, len(nodes))
+	for _, node := range nodes {
 		list = append(list, calculateResourceOccupancy(pod, node, nodeNameToInfo[node.Name]))
 	}
 	return list, nil
@@ -118,12 +117,12 @@ func (n *NodeLabelPrioritizer) CalculateNodeLabelPriority(pod *api.Pod, nodeName
 	}
 
 	labeledNodes := map[string]bool{}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		exists := labels.Set(node.Labels).Has(n.label)
 		labeledNodes[node.Name] = (exists && n.presence) || (!exists && !n.presence)
 	}
 
-	result := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
+	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 	//score int - scale of 0-10
 	// 0 being the lowest priority and 10 being the highest
 	for nodeName, success := range labeledNodes {
@@ -158,8 +157,7 @@ func ImageLocalityPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercac
 	}
 
 	for i := range pod.Spec.Containers {
-		for j := range nodes.Items {
-			node := &nodes.Items[j]
+		for _, node := range nodes {
 			// Check if this container's image is present and get its size.
 			imageSize := checkContainerImageOnNode(node, &pod.Spec.Containers[i])
 			// Add this size to the total result of this node.
@@ -167,7 +165,7 @@ func ImageLocalityPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercac
 		}
 	}
 
-	result := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
+	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 	// score int - scale of 0-10
 	// 0 being the lowest priority and 10 being the highest.
 	for nodeName, sumSize := range sumSizeMap {
@@ -222,9 +220,8 @@ func BalancedResourceAllocation(pod *api.Pod, nodeNameToInfo map[string]*schedul
 		return schedulerapi.HostPriorityList{}, err
 	}
 
-	list := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
+	list := make(schedulerapi.HostPriorityList, 0, len(nodes))
+	for _, node := range nodes {
 		list = append(list, calculateBalancedResourceAllocation(pod, node, nodeNameToInfo[node.Name]))
 	}
 	return list, nil

--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -664,20 +664,18 @@ func TestZoneSpreadPriority(t *testing.T) {
 	}
 }
 
-func makeLabeledNodeList(nodeMap map[string]map[string]string) (result api.NodeList) {
-	nodes := []api.Node{}
+func makeLabeledNodeList(nodeMap map[string]map[string]string) []*api.Node {
+	nodes := make([]*api.Node, 0, len(nodeMap))
 	for nodeName, labels := range nodeMap {
-		nodes = append(nodes, api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName, Labels: labels}})
+		nodes = append(nodes, &api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName, Labels: labels}})
 	}
-	return api.NodeList{Items: nodes}
+	return nodes
 }
 
-func makeNodeList(nodeNames []string) api.NodeList {
-	result := api.NodeList{
-		Items: make([]api.Node, len(nodeNames)),
+func makeNodeList(nodeNames []string) []*api.Node {
+	nodes := make([]*api.Node, 0, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		nodes = append(nodes, &api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName}})
 	}
-	for ix := range nodeNames {
-		result.Items[ix].Name = nodeNames[ix]
-	}
-	return result
+	return nodes
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/taint_toleration.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/taint_toleration.go
@@ -61,7 +61,7 @@ func ComputeTaintTolerationPriority(pod *api.Pod, nodeNameToInfo map[string]*sch
 	// the max value of counts
 	var maxCount float64
 	// counts hold the count of intolerable taints of a pod for a given node
-	counts := make(map[string]float64, len(nodes.Items))
+	counts := make(map[string]float64, len(nodes))
 
 	tolerations, err := api.GetTolerationsFromPodAnnotations(pod.Annotations)
 	if err != nil {
@@ -71,8 +71,7 @@ func ComputeTaintTolerationPriority(pod *api.Pod, nodeNameToInfo map[string]*sch
 	tolerationList := getAllTolerationPreferNoSchedule(tolerations)
 
 	// calculate the intolerable taints for all the nodes
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
+	for _, node := range nodes {
 		taints, err := api.GetTaintsFromNodeAnnotations(node.Annotations)
 		if err != nil {
 			return nil, err
@@ -88,9 +87,8 @@ func ComputeTaintTolerationPriority(pod *api.Pod, nodeNameToInfo map[string]*sch
 	// The maximum priority value to give to a node
 	// Priority values range from 0 - maxPriority
 	const maxPriority = float64(10)
-	result := make(schedulerapi.HostPriorityList, 0, len(nodes.Items))
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
+	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
+	for _, node := range nodes {
 		fScore := maxPriority
 		if maxCount > 0 {
 			fScore = (1.0 - counts[node.Name]/maxCount) * 10

--- a/plugin/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
-func nodeWithTaints(nodeName string, taints []api.Taint) api.Node {
+func nodeWithTaints(nodeName string, taints []api.Taint) *api.Node {
 	taintsData, _ := json.Marshal(taints)
-	return api.Node{
+	return &api.Node{
 		ObjectMeta: api.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
@@ -57,7 +57,7 @@ func podWithTolerations(tolerations []api.Toleration) *api.Pod {
 func TestTaintAndToleration(t *testing.T) {
 	tests := []struct {
 		pod          *api.Pod
-		nodes        []api.Node
+		nodes        []*api.Node
 		expectedList schedulerapi.HostPriorityList
 		test         string
 	}{
@@ -70,7 +70,7 @@ func TestTaintAndToleration(t *testing.T) {
 				Value:    "bar",
 				Effect:   api.TaintEffectPreferNoSchedule,
 			}}),
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				nodeWithTaints("nodeA", []api.Taint{{
 					Key:    "foo",
 					Value:  "bar",
@@ -103,7 +103,7 @@ func TestTaintAndToleration(t *testing.T) {
 					Effect:   api.TaintEffectPreferNoSchedule,
 				},
 			}),
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				nodeWithTaints("nodeA", []api.Taint{}),
 				nodeWithTaints("nodeB", []api.Taint{
 					{
@@ -139,7 +139,7 @@ func TestTaintAndToleration(t *testing.T) {
 				Value:    "bar",
 				Effect:   api.TaintEffectPreferNoSchedule,
 			}}),
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				nodeWithTaints("nodeA", []api.Taint{}),
 				nodeWithTaints("nodeB", []api.Taint{
 					{
@@ -182,7 +182,7 @@ func TestTaintAndToleration(t *testing.T) {
 					Effect:   api.TaintEffectNoSchedule,
 				},
 			}),
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				nodeWithTaints("nodeA", []api.Taint{}),
 				nodeWithTaints("nodeB", []api.Taint{
 					{
@@ -215,7 +215,7 @@ func TestTaintAndToleration(t *testing.T) {
 		list, err := ComputeTaintTolerationPriority(
 			test.pod,
 			nodeNameToInfo,
-			algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+			algorithm.FakeNodeLister(test.nodes))
 		if err != nil {
 			t.Errorf("%s, unexpected error: %v", test.test, err)
 		}

--- a/plugin/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface.go
@@ -27,12 +27,12 @@ import (
 type SchedulerExtender interface {
 	// Filter based on extender-implemented predicate functions. The filtered list is
 	// expected to be a subset of the supplied list.
-	Filter(pod *api.Pod, nodes *api.NodeList) (filteredNodes *api.NodeList, err error)
+	Filter(pod *api.Pod, nodes []*api.Node) (filteredNodes []*api.Node, err error)
 
 	// Prioritize based on extender-implemented priority functions. The returned scores & weight
 	// are used to compute the weighted score for an extender. The weighted scores are added to
 	// the scores computed  by Kubernetes scheduler. The total scores are used to do the host selection.
-	Prioritize(pod *api.Pod, nodes *api.NodeList) (hostPriorities *schedulerapi.HostPriorityList, weight int, err error)
+	Prioritize(pod *api.Pod, nodes []*api.Node) (hostPriorities *schedulerapi.HostPriorityList, weight int, err error)
 }
 
 // ScheduleAlgorithm is an interface implemented by things that know how to schedule pods

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -66,7 +66,7 @@ func numericPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.Nod
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %v", err)
 	}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		score, err := strconv.Atoi(node.Name)
 		if err != nil {
 			return nil, err
@@ -102,12 +102,10 @@ func reverseNumericPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulerca
 	return reverseResult, nil
 }
 
-func makeNodeList(nodeNames []string) api.NodeList {
-	result := api.NodeList{
-		Items: make([]api.Node, len(nodeNames)),
-	}
-	for ix := range nodeNames {
-		result.Items[ix].Name = nodeNames[ix]
+func makeNodeList(nodeNames []string) []*api.Node {
+	result := make([]*api.Node, 0, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		result = append(result, &api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName}})
 	}
 	return result
 }

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -125,7 +125,7 @@ func TestScheduler(t *testing.T) {
 				},
 			},
 			NodeLister: algorithm.FakeNodeLister(
-				api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
+				[]*api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}},
 			),
 			Algorithm: item.algo,
 			Binder: fakeBinder{func(b *api.Binding) error {
@@ -292,7 +292,7 @@ func setupTestSchedulerWithOnePod(t *testing.T, queuedPodStore *clientcache.FIFO
 	cfg := &Config{
 		SchedulerCache: scache,
 		NodeLister: algorithm.FakeNodeLister(
-			api.NodeList{Items: []api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}}},
+			[]*api.Node{{ObjectMeta: api.ObjectMeta{Name: "machine1"}}},
 		),
 		Algorithm: algo,
 		Binder: fakeBinder{func(b *api.Binding) error {


### PR DESCRIPTION
Currently copies that are made while copying/creating api.NodeList are significant part of scheduler profile, and a bunch of them are made in places, that are not-parallelizable.
Ref #28590
