### PR TITLE
Do not depend on metadata server for auth

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -226,7 +226,7 @@ fi
 if [[ -f "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
   echo 'Activating service account...'  # No harm in doing this multiple times.
   gcloud auth activate-service-account --key-file="${KUBEKINS_SERVICE_ACCOUNT_FILE}"
-  export GCE_SERVICE_ACCOUNT=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')
+  unset GCE_SERVICE_ACCOUNT  # Use checked in credentials, not the metadata server
   unset KUBEKINS_SERVICE_ACCOUNT_FILE
 elif [[ -n "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
   echo "ERROR: cannot access service account file at: ${KUBEKINS_SERVICE_ACCOUNT_FILE}"


### PR DESCRIPTION
If `GCE_SERVICE_ACCOUNT` is set then `ginkgo-e2e.sh` sets `--gce-service-account=$GCE_SERVICE_ACCOUNT`, which causes tests to use the metadata server for the account, which we do not want.

https://github.com/kubernetes/kubernetes/blob/master/hack/ginkgo-e2e.sh#L115

This causes e2e tests to blow up after starting the cluster: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-gce/20006/
