### PR TITLE
cluster/ubuntu/download-release.sh: if $KUBE_VERSION is set, use it.

### DIFF
--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -64,7 +64,9 @@ function get_latest_version_number {
   fi
 }
 
-KUBE_VERSION=$(get_latest_version_number | sed 's/^v//')
+if [ -z "$KUBE_VERSION" ]; then
+  KUBE_VERSION=$(get_latest_version_number | sed 's/^v//')
+fi
 
 # k8s
 echo "Prepare kubernetes ${KUBE_VERSION} release ..."


### PR DESCRIPTION
``` release-note
If $KUBE_VERSION is set in cluster/ubuntu/download-release.sh use that version, 
otherwise set it to the result of `get_latest_version_number`.
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
