### PR TITLE
Node E2E: Make it possible to share test between e2e and node e2e

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -11,7 +11,6 @@ allow-privileged
 api-burst
 api-prefix
 api-rate
-api-server-address
 api-server-port
 api-servers
 api-token

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e_node
+package common
 
-import (
-	"flag"
+type Suite string
+
+const (
+	E2E     Suite = "e2e"
+	NodeE2E Suite = "node e2e"
 )
 
-var kubeletAddress = flag.String("kubelet-address", "http://127.0.0.1:10255", "Host and port of the kubelet")
-
-var disableKubenet = flag.Bool("disable-kubenet", false, "If true, start kubelet without kubenet")
-var buildServices = flag.Bool("build-services", true, "If true, build local executables")
-var startServices = flag.Bool("start-services", true, "If true, start local node services")
-var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
+var CurrentSuite Suite

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -81,7 +81,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key1=\"value1\"\n"))
 
 		//modify labels
-		f.UpdatePod(podName, func(pod *api.Pod) {
+		f.PodClient().Update(podName, func(pod *api.Pod) {
 			pod.Labels["key3"] = "value3"
 		})
 
@@ -116,7 +116,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"bar\"\n"))
 
 		//modify annotations
-		f.UpdatePod(podName, func(pod *api.Pod) {
+		f.PodClient().Update(podName, func(pod *api.Pod) {
 			pod.Annotations["builder"] = "foo"
 		})
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -36,6 +36,7 @@ import (
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/runtime"
+	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -145,6 +146,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		framework.Logf("Dumping network health container logs from all nodes")
 		framework.LogContainersInPodsWithLabels(c, api.NamespaceSystem, framework.ImagePullerLabels, "nethealth")
 	}
+
+	// Reference common test to make the import valid.
+	commontest.CurrentSuite = commontest.E2E
 
 	return nil
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -104,6 +104,7 @@ func RegisterCommonFlags() {
 	flag.BoolVar(&TestContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after each test.")
 	flag.StringVar(&TestContext.OutputPrintType, "output-print-type", "hr", "Comma separated list: 'hr' for human readable summaries 'json' for JSON ones.")
 	flag.BoolVar(&TestContext.DumpLogsOnFailure, "dump-logs-on-failure", true, "If set to true test will dump data about the namespace in which test was running.")
+	flag.StringVar(&TestContext.Host, "host", "http://127.0.0.1:8080", "The host, or apiserver, to connect to")
 }
 
 // Register flags specific to the cluster e2e test suite.
@@ -119,7 +120,6 @@ func RegisterClusterFlags() {
 
 	flag.StringVar(&TestContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
 	flag.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
-	flag.StringVar(&TestContext.Host, "host", "", "The host, or apiserver, to connect to")
 	flag.StringVar(&TestContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
 	flag.StringVar(&TestContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
 	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")

--- a/test/e2e/kubelet_etc_hosts.go
+++ b/test/e2e/kubelet_etc_hosts.go
@@ -24,7 +24,6 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -84,29 +83,12 @@ func (config *KubeletManagedHostConfig) setup() {
 
 func (config *KubeletManagedHostConfig) createPodWithoutHostNetwork() {
 	podSpec := config.createPodSpec(kubeletEtcHostsPodName)
-	config.pod = config.createPod(podSpec)
+	config.pod = config.f.PodClient().CreateSync(podSpec)
 }
 
 func (config *KubeletManagedHostConfig) createPodWithHostNetwork() {
 	podSpec := config.createPodSpecWithHostNetwork(kubeletEtcHostsHostNetworkPodName)
-	config.hostNetworkPod = config.createPod(podSpec)
-}
-
-func (config *KubeletManagedHostConfig) createPod(podSpec *api.Pod) *api.Pod {
-	createdPod, err := config.getPodClient().Create(podSpec)
-	if err != nil {
-		framework.Failf("Failed to create %s pod: %v", podSpec.Name, err)
-	}
-	framework.ExpectNoError(config.f.WaitForPodRunning(podSpec.Name))
-	createdPod, err = config.getPodClient().Get(podSpec.Name)
-	if err != nil {
-		framework.Failf("Failed to retrieve %s pod: %v", podSpec.Name, err)
-	}
-	return createdPod
-}
-
-func (config *KubeletManagedHostConfig) getPodClient() client.PodInterface {
-	return config.f.Client.Pods(config.f.Namespace.Name)
+	config.hostNetworkPod = config.f.PodClient().CreateSync(podSpec)
 }
 
 func assertEtcHostsIsKubeletManaged(etcHostsContent string) {

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -462,7 +462,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(1))
 
 		By("updating the pod")
-		f.UpdatePod(name, func(pod *api.Pod) {
+		f.PodClient().Update(name, func(pod *api.Pod) {
 			value = strconv.Itoa(time.Now().Nanosecond())
 			pod.Labels["time"] = value
 		})
@@ -530,7 +530,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(1))
 
 		By("updating the pod")
-		f.UpdatePod(name, func(pod *api.Pod) {
+		f.PodClient().Update(name, func(pod *api.Pod) {
 			newDeadline := int64(5)
 			pod.Spec.ActiveDeadlineSeconds = &newDeadline
 		})
@@ -1309,7 +1309,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		delay1, delay2 := startPodAndGetBackOffs(f, pod, podName, containerName, buildBackOffDuration)
 
 		By("updating the image")
-		f.UpdatePod(podName, func(pod *api.Pod) {
+		f.PodClient().Update(podName, func(pod *api.Pod) {
 			pod.Spec.Containers[0].Image = "gcr.io/google_containers/nginx-slim:0.7"
 		})
 

--- a/test/e2e_node/cgroup_manager_test.go
+++ b/test/e2e_node/cgroup_manager_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = framework.KubeDescribe("Kubelet Cgroup Manager", func() {
-	f := NewDefaultFramework("kubelet-cgroup-manager")
+	f := framework.NewDefaultFramework("kubelet-cgroup-manager")
 	Describe("QOS containers", func() {
 		Context("On enabling QOS cgroup hierarchy", func() {
 			It("Top level QoS containers should have been created", func() {
@@ -35,8 +35,7 @@ var _ = framework.KubeDescribe("Kubelet Cgroup Manager", func() {
 					contName := "qos-container" + string(util.NewUUID())
 					pod := &api.Pod{
 						ObjectMeta: api.ObjectMeta{
-							Name:      podName,
-							Namespace: f.Namespace.Name,
+							Name: podName,
 						},
 						Spec: api.PodSpec{
 							// Don't restart the Pod since it is expected to exit
@@ -64,11 +63,9 @@ var _ = framework.KubeDescribe("Kubelet Cgroup Manager", func() {
 							},
 						},
 					}
-					f.MungePodSpec(pod)
-					podClient := f.Client.Pods(f.Namespace.Name)
-					_, err := podClient.Create(pod)
-					Expect(err).NotTo(HaveOccurred())
-					err = framework.WaitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
+					podClient := f.PodClient()
+					podClient.Create(pod)
+					err := framework.WaitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
 					Expect(err).NotTo(HaveOccurred())
 				}
 			})

--- a/test/e2e_node/configmap.go
+++ b/test/e2e_node/configmap.go
@@ -30,7 +30,7 @@ import (
 
 var _ = framework.KubeDescribe("ConfigMap", func() {
 
-	f := NewDefaultFramework("configmap")
+	f := framework.NewDefaultFramework("configmap")
 
 	It("should be consumable from pods in volumpe [Conformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0)
@@ -122,7 +122,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		}
 
 		By("Creating the pod")
-		f.CreatePod(pod)
+		f.PodClient().CreateSync(pod)
 
 		pollLogs := func() (string, error) {
 			return framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
@@ -179,7 +179,8 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 			},
 		}
 
-		f.MungePodSpec(pod)
+		// TODO(random-liu): Change TestContainerOutput to use PodClient and avoid MungeSpec explicitly
+		f.PodClient().MungeSpec(pod)
 
 		framework.TestContainerOutput("consume configMaps", f.Client, pod, 0, []string{
 			"CONFIG_DATA_1=value-1",
@@ -260,7 +261,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64) {
 		pod.Spec.SecurityContext.FSGroup = &fsGroup
 	}
 
-	f.MungePodSpec(pod)
+	f.PodClient().MungeSpec(pod)
 
 	framework.TestContainerOutput("consume configMaps", f.Client, pod, 0, []string{
 		"content of file \"/etc/configmap-volume/data-1\": value-1",
@@ -333,7 +334,7 @@ func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64) {
 		pod.Spec.SecurityContext.FSGroup = &fsGroup
 	}
 
-	f.MungePodSpec(pod)
+	f.PodClient().MungeSpec(pod)
 
 	framework.TestContainerOutput("consume configMaps", f.Client, pod, 0, []string{
 		"content of file \"/etc/configmap-volume/path/to/data-2\": value-2",

--- a/test/e2e_node/container.go
+++ b/test/e2e_node/container.go
@@ -28,12 +28,12 @@ import (
 // One pod one container
 // TODO: This should be migrated to the e2e framework.
 type ConformanceContainer struct {
-	Framework        *framework.Framework
 	Container        api.Container
 	RestartPolicy    api.RestartPolicy
 	Volumes          []api.Volume
 	ImagePullSecrets []string
 
+	PodClient          *framework.PodClient
 	podName            string
 	PodSecurityContext *api.PodSecurityContext
 }
@@ -58,15 +58,15 @@ func (cc *ConformanceContainer) Create() {
 			ImagePullSecrets: imagePullSecrets,
 		},
 	}
-	cc.Framework.CreatePodAsync(pod)
+	cc.PodClient.Create(pod)
 }
 
 func (cc *ConformanceContainer) Delete() error {
-	return cc.Framework.PodClient().Delete(cc.podName, api.NewDeleteOptions(0))
+	return cc.PodClient.Delete(cc.podName, api.NewDeleteOptions(0))
 }
 
 func (cc *ConformanceContainer) IsReady() (bool, error) {
-	pod, err := cc.Framework.PodClient().Get(cc.podName)
+	pod, err := cc.PodClient.Get(cc.podName)
 	if err != nil {
 		return false, err
 	}
@@ -74,7 +74,7 @@ func (cc *ConformanceContainer) IsReady() (bool, error) {
 }
 
 func (cc *ConformanceContainer) GetPhase() (api.PodPhase, error) {
-	pod, err := cc.Framework.PodClient().Get(cc.podName)
+	pod, err := cc.PodClient.Get(cc.podName)
 	if err != nil {
 		return api.PodUnknown, err
 	}
@@ -82,7 +82,7 @@ func (cc *ConformanceContainer) GetPhase() (api.PodPhase, error) {
 }
 
 func (cc *ConformanceContainer) GetStatus() (api.ContainerStatus, error) {
-	pod, err := cc.Framework.PodClient().Get(cc.podName)
+	pod, err := cc.PodClient.Get(cc.podName)
 	if err != nil {
 		return api.ContainerStatus{}, err
 	}
@@ -94,7 +94,7 @@ func (cc *ConformanceContainer) GetStatus() (api.ContainerStatus, error) {
 }
 
 func (cc *ConformanceContainer) Present() (bool, error) {
-	_, err := cc.Framework.PodClient().Get(cc.podName)
+	_, err := cc.PodClient.Get(cc.podName)
 	if err == nil {
 		return true, nil
 	}

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -29,14 +29,20 @@ import (
 )
 
 var _ = framework.KubeDescribe("Kubelet Container Manager", func() {
-	f := NewDefaultFramework("kubelet-container-manager")
+	f := framework.NewDefaultFramework("kubelet-container-manager")
+	var podClient *framework.PodClient
+
+	BeforeEach(func() {
+		podClient = f.PodClient()
+	})
+
 	Describe("oom score adjusting", func() {
 		Context("when scheduling a busybox command that always fails in a pod", func() {
 			var podName string
 
 			BeforeEach(func() {
 				podName = "bin-false" + string(util.NewUUID())
-				f.CreatePodAsync(&api.Pod{
+				podClient.Create(&api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						Name: podName,
 					},
@@ -56,7 +62,7 @@ var _ = framework.KubeDescribe("Kubelet Container Manager", func() {
 
 			It("should have an error terminated reason", func() {
 				Eventually(func() error {
-					podData, err := f.PodClient().Get(podName)
+					podData, err := podClient.Get(podName)
 					if err != nil {
 						return err
 					}
@@ -75,7 +81,7 @@ var _ = framework.KubeDescribe("Kubelet Container Manager", func() {
 			})
 
 			It("should be possible to delete", func() {
-				err := f.PodClient().Delete(podName, &api.DeleteOptions{})
+				err := podClient.Delete(podName, &api.DeleteOptions{})
 				Expect(err).To(BeNil(), fmt.Sprintf("Error deleting Pod %v", err))
 			})
 		})

--- a/test/e2e_node/downward_api_test.go
+++ b/test/e2e_node/downward_api_test.go
@@ -30,7 +30,7 @@ import (
 // Ported from test/e2e/downard_api_test.go
 
 var _ = framework.KubeDescribe("Downward API", func() {
-	f := NewDefaultFramework("downward-api")
+	f := framework.NewDefaultFramework("downward-api")
 	It("should provide pod name and namespace as env vars [Conformance]", func() {
 		podName := "downward-api-" + string(util.NewUUID())
 		env := []api.EnvVar{
@@ -158,7 +158,8 @@ func testDownwardAPI(f *framework.Framework, podName string, env []api.EnvVar, e
 			RestartPolicy: api.RestartPolicyNever,
 		},
 	}
-	f.MungePodSpec(pod)
+	// TODO(random-liu): Change TestContainerOutputRegexp to use PodClient and avoid MungeSpec explicitly
+	f.PodClient().MungeSpec(pod)
 
 	f.TestContainerOutputRegexp("downward api env vars", pod, 0, expectations)
 }

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/golang/glog"
@@ -104,6 +105,9 @@ var _ = BeforeSuite(func() {
 	} else {
 		glog.Infof("Running tests without starting services.")
 	}
+
+	// Reference common test to make the import valid.
+	commontest.CurrentSuite = commontest.NodeE2E
 })
 
 // Tear down the kubelet on the node

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var _ = framework.KubeDescribe("MirrorPod", func() {
-	f := NewDefaultFramework("mirror-pod")
+	f := framework.NewDefaultFramework("mirror-pod")
 	Context("when create a mirror pod ", func() {
 		var staticPodName, mirrorPodName string
 		BeforeEach(func() {

--- a/test/e2e_node/privileged_test.go
+++ b/test/e2e_node/privileged_test.go
@@ -54,11 +54,13 @@ type PrivilegedPodTestConfig struct {
 	privilegedPod *api.Pod
 }
 
+// TODO(random-liu): Change the test to use framework and framework pod client.
 var _ = Describe("PrivilegedPod", func() {
 	var c *client.Client
-	restClientConfig := &restclient.Config{Host: *apiServerAddress}
+	var restClientConfig *restclient.Config
 	BeforeEach(func() {
 		// Setup the apiserver client
+		restClientConfig = &restclient.Config{Host: framework.TestContext.Host}
 		c = client.NewOrDie(restClientConfig)
 	})
 	It("should test privileged pod", func() {

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
-	f := NewDefaultFramework("runtime-conformance")
+	f := framework.NewDefaultFramework("runtime-conformance")
 
 	Describe("container runtime conformance blackbox test", func() {
 		Context("when starting a container that exits", func() {
@@ -91,7 +91,7 @@ while true; do sleep 1; done
 					testContainer.Name = testCase.Name
 					testContainer.Command = []string{"sh", "-c", tmpCmd}
 					terminateContainer := ConformanceContainer{
-						Framework:     f,
+						PodClient:     f.PodClient(),
 						Container:     testContainer,
 						RestartPolicy: testCase.RestartPolicy,
 						Volumes:       testVolumes,
@@ -134,7 +134,7 @@ while true; do sleep 1; done
 				terminationMessagePath := "/dev/termination-log"
 				priv := true
 				c := ConformanceContainer{
-					Framework: f,
+					PodClient: f.PodClient(),
 					Container: api.Container{
 						Image:   ImageRegistry[busyBoxImage],
 						Name:    name,
@@ -235,7 +235,7 @@ while true; do sleep 1; done
 					name := "image-pull-test"
 					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
 					container := ConformanceContainer{
-						Framework: f,
+						PodClient: f.PodClient(),
 						Container: api.Container{
 							Name:    name,
 							Image:   testCase.image,


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/29081.

This PR is part of the plan to improve node e2e test coverage.
- Now to improve test coverage, we have to copy test from e2e to node e2e.
- When adding a new test, we have to decide its destiny at the very beginning - whether it is a node e2e or e2e.

This PR makes it possible to share test between e2e and node e2e. 
By leveraging the mechanism of ginkgo, as long as we can import the test package in the test suite, the corresponding `Describe` will be run to initialize the global variable `_`, and the test will be inserted into the test suite. (See https://github.com/onsi/composition-ginkgo-example)

In the future, we just need to use the framework to write the test, and put the test into `test/e2e/node`, then it will be automatically shared by the 2 test suites.

This PR:
1) Refactored the framework to make it automatically differentiate e2e and node e2e (Mainly refactored the `PodClient` and the apiserver client initialization).
2) Created a new directory `test/e2e/node` and make it shared by e2e and node e2e.
3) Moved `container_probe.go` into `test/e2e/node` to verify the change.

@kubernetes/sig-node 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
