### PR TITLE
Allow proto tag to define field name

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
@@ -589,6 +589,8 @@ func protobufTagToField(tag string, field *protoField, m types.Member, t *types.
 			return fmt.Errorf("member %q of %q malformed 'protobuf' tag, tag %d should be key=value, got %q\n", m.Name, t.Name, i+4, extra)
 		}
 		switch parts[0] {
+		case "name":
+			protoExtra[parts[0]] = parts[1]
 		case "casttype", "castkey", "castvalue":
 			parts[0] = fmt.Sprintf("(gogoproto.%s)", parts[0])
 			protoExtra[parts[0]] = parts[1]


### PR DESCRIPTION
When we introduce a new field for backwards compatibility, we may want
to specify a different protobuf field name (one that matches JSON) than
the automatic transformation applied to the struct field. This allows an
API field to define the name of its protobuf tag.

@wojtek-t hit this while adding protobuf to OpenShift - we have fields we
keep for backward compatibility that need to be assigned a field by name.
Has no impact on existing (already tagged) fields.
