### PR TITLE
Generate a better Stringer method for proto types

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
@@ -53,6 +53,8 @@ func (g *genProtoIDL) PackageVars(c *generator.Context) []string {
 	return []string{
 		"option (gogoproto.marshaler_all) = true;",
 		"option (gogoproto.sizer_all) = true;",
+		"option (gogoproto.goproto_stringer_all) = false;",
+		"option (gogoproto.stringer_all) = true;",
 		"option (gogoproto.unmarshaler_all) = true;",
 		"option (gogoproto.goproto_unrecognized_all) = false;",
 		"option (gogoproto.goproto_enum_prefix_all) = false;",
@@ -316,6 +318,9 @@ func (b bodyGen) doStruct(sw *generator.SnippetWriter) error {
 				}
 			default:
 				if !b.omitGogo || !strings.HasPrefix(key, "(gogoproto.") {
+					if key == "(gogoproto.goproto_stringer)" && v[0] == "false" {
+						options = append(options, "(gogoproto.stringer) = false")
+					}
 					options = append(options, fmt.Sprintf("%s = %s", key, v[0]))
 				}
 			}

--- a/federation/apis/federation/v1beta1/generated.pb.go
+++ b/federation/apis/federation/v1beta1/generated.pb.go
@@ -40,6 +40,9 @@ import math "math"
 
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -47,29 +50,23 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *Cluster) Reset()         { *m = Cluster{} }
-func (m *Cluster) String() string { return proto.CompactTextString(m) }
-func (*Cluster) ProtoMessage()    {}
+func (m *Cluster) Reset()      { *m = Cluster{} }
+func (*Cluster) ProtoMessage() {}
 
-func (m *ClusterCondition) Reset()         { *m = ClusterCondition{} }
-func (m *ClusterCondition) String() string { return proto.CompactTextString(m) }
-func (*ClusterCondition) ProtoMessage()    {}
+func (m *ClusterCondition) Reset()      { *m = ClusterCondition{} }
+func (*ClusterCondition) ProtoMessage() {}
 
-func (m *ClusterList) Reset()         { *m = ClusterList{} }
-func (m *ClusterList) String() string { return proto.CompactTextString(m) }
-func (*ClusterList) ProtoMessage()    {}
+func (m *ClusterList) Reset()      { *m = ClusterList{} }
+func (*ClusterList) ProtoMessage() {}
 
-func (m *ClusterSpec) Reset()         { *m = ClusterSpec{} }
-func (m *ClusterSpec) String() string { return proto.CompactTextString(m) }
-func (*ClusterSpec) ProtoMessage()    {}
+func (m *ClusterSpec) Reset()      { *m = ClusterSpec{} }
+func (*ClusterSpec) ProtoMessage() {}
 
-func (m *ClusterStatus) Reset()         { *m = ClusterStatus{} }
-func (m *ClusterStatus) String() string { return proto.CompactTextString(m) }
-func (*ClusterStatus) ProtoMessage()    {}
+func (m *ClusterStatus) Reset()      { *m = ClusterStatus{} }
+func (*ClusterStatus) ProtoMessage() {}
 
-func (m *ServerAddressByClientCIDR) Reset()         { *m = ServerAddressByClientCIDR{} }
-func (m *ServerAddressByClientCIDR) String() string { return proto.CompactTextString(m) }
-func (*ServerAddressByClientCIDR) ProtoMessage()    {}
+func (m *ServerAddressByClientCIDR) Reset()      { *m = ServerAddressByClientCIDR{} }
+func (*ServerAddressByClientCIDR) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*Cluster)(nil), "k8s.io.kubernetes.federation.apis.federation.v1beta1.Cluster")
@@ -453,6 +450,86 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *Cluster) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Cluster{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ClusterSpec", "ClusterSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ClusterStatus", "ClusterStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastProbeTime:` + strings.Replace(strings.Replace(this.LastProbeTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Cluster", "Cluster", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterSpec{`,
+		`ServerAddressByClientCIDRs:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ServerAddressByClientCIDRs), "ServerAddressByClientCIDR", "ServerAddressByClientCIDR", 1), `&`, ``, 1) + `,`,
+		`SecretRef:` + strings.Replace(fmt.Sprintf("%v", this.SecretRef), "LocalObjectReference", "k8s_io_kubernetes_pkg_api_v1.LocalObjectReference", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterStatus{`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "ClusterCondition", "ClusterCondition", 1), `&`, ``, 1) + `,`,
+		`Zones:` + fmt.Sprintf("%v", this.Zones) + `,`,
+		`Region:` + fmt.Sprintf("%v", this.Region) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServerAddressByClientCIDR) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServerAddressByClientCIDR{`,
+		`ClientCIDR:` + fmt.Sprintf("%v", this.ClientCIDR) + `,`,
+		`ServerAddress:` + fmt.Sprintf("%v", this.ServerAddress) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *Cluster) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/api/unversioned/generated.pb.go
+++ b/pkg/api/unversioned/generated.pb.go
@@ -58,6 +58,10 @@ import math "math"
 
 import time "time"
 
+import strings "strings"
+import reflect "reflect"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -65,32 +69,26 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *APIGroup) Reset()         { *m = APIGroup{} }
-func (m *APIGroup) String() string { return proto.CompactTextString(m) }
-func (*APIGroup) ProtoMessage()    {}
+func (m *APIGroup) Reset()      { *m = APIGroup{} }
+func (*APIGroup) ProtoMessage() {}
 
-func (m *APIGroupList) Reset()         { *m = APIGroupList{} }
-func (m *APIGroupList) String() string { return proto.CompactTextString(m) }
-func (*APIGroupList) ProtoMessage()    {}
+func (m *APIGroupList) Reset()      { *m = APIGroupList{} }
+func (*APIGroupList) ProtoMessage() {}
 
-func (m *APIResource) Reset()         { *m = APIResource{} }
-func (m *APIResource) String() string { return proto.CompactTextString(m) }
-func (*APIResource) ProtoMessage()    {}
+func (m *APIResource) Reset()      { *m = APIResource{} }
+func (*APIResource) ProtoMessage() {}
 
-func (m *APIResourceList) Reset()         { *m = APIResourceList{} }
-func (m *APIResourceList) String() string { return proto.CompactTextString(m) }
-func (*APIResourceList) ProtoMessage()    {}
+func (m *APIResourceList) Reset()      { *m = APIResourceList{} }
+func (*APIResourceList) ProtoMessage() {}
 
 func (m *APIVersions) Reset()      { *m = APIVersions{} }
 func (*APIVersions) ProtoMessage() {}
 
-func (m *Duration) Reset()         { *m = Duration{} }
-func (m *Duration) String() string { return proto.CompactTextString(m) }
-func (*Duration) ProtoMessage()    {}
+func (m *Duration) Reset()      { *m = Duration{} }
+func (*Duration) ProtoMessage() {}
 
-func (m *ExportOptions) Reset()         { *m = ExportOptions{} }
-func (m *ExportOptions) String() string { return proto.CompactTextString(m) }
-func (*ExportOptions) ProtoMessage()    {}
+func (m *ExportOptions) Reset()      { *m = ExportOptions{} }
+func (*ExportOptions) ProtoMessage() {}
 
 func (m *GroupKind) Reset()      { *m = GroupKind{} }
 func (*GroupKind) ProtoMessage() {}
@@ -101,9 +99,8 @@ func (*GroupResource) ProtoMessage() {}
 func (m *GroupVersion) Reset()      { *m = GroupVersion{} }
 func (*GroupVersion) ProtoMessage() {}
 
-func (m *GroupVersionForDiscovery) Reset()         { *m = GroupVersionForDiscovery{} }
-func (m *GroupVersionForDiscovery) String() string { return proto.CompactTextString(m) }
-func (*GroupVersionForDiscovery) ProtoMessage()    {}
+func (m *GroupVersionForDiscovery) Reset()      { *m = GroupVersionForDiscovery{} }
+func (*GroupVersionForDiscovery) ProtoMessage() {}
 
 func (m *GroupVersionKind) Reset()      { *m = GroupVersionKind{} }
 func (*GroupVersionKind) ProtoMessage() {}
@@ -111,49 +108,38 @@ func (*GroupVersionKind) ProtoMessage() {}
 func (m *GroupVersionResource) Reset()      { *m = GroupVersionResource{} }
 func (*GroupVersionResource) ProtoMessage() {}
 
-func (m *LabelSelector) Reset()         { *m = LabelSelector{} }
-func (m *LabelSelector) String() string { return proto.CompactTextString(m) }
-func (*LabelSelector) ProtoMessage()    {}
+func (m *LabelSelector) Reset()      { *m = LabelSelector{} }
+func (*LabelSelector) ProtoMessage() {}
 
-func (m *LabelSelectorRequirement) Reset()         { *m = LabelSelectorRequirement{} }
-func (m *LabelSelectorRequirement) String() string { return proto.CompactTextString(m) }
-func (*LabelSelectorRequirement) ProtoMessage()    {}
+func (m *LabelSelectorRequirement) Reset()      { *m = LabelSelectorRequirement{} }
+func (*LabelSelectorRequirement) ProtoMessage() {}
 
-func (m *ListMeta) Reset()         { *m = ListMeta{} }
-func (m *ListMeta) String() string { return proto.CompactTextString(m) }
-func (*ListMeta) ProtoMessage()    {}
+func (m *ListMeta) Reset()      { *m = ListMeta{} }
+func (*ListMeta) ProtoMessage() {}
 
-func (m *RootPaths) Reset()         { *m = RootPaths{} }
-func (m *RootPaths) String() string { return proto.CompactTextString(m) }
-func (*RootPaths) ProtoMessage()    {}
+func (m *RootPaths) Reset()      { *m = RootPaths{} }
+func (*RootPaths) ProtoMessage() {}
 
-func (m *ServerAddressByClientCIDR) Reset()         { *m = ServerAddressByClientCIDR{} }
-func (m *ServerAddressByClientCIDR) String() string { return proto.CompactTextString(m) }
-func (*ServerAddressByClientCIDR) ProtoMessage()    {}
+func (m *ServerAddressByClientCIDR) Reset()      { *m = ServerAddressByClientCIDR{} }
+func (*ServerAddressByClientCIDR) ProtoMessage() {}
 
-func (m *Status) Reset()         { *m = Status{} }
-func (m *Status) String() string { return proto.CompactTextString(m) }
-func (*Status) ProtoMessage()    {}
+func (m *Status) Reset()      { *m = Status{} }
+func (*Status) ProtoMessage() {}
 
-func (m *StatusCause) Reset()         { *m = StatusCause{} }
-func (m *StatusCause) String() string { return proto.CompactTextString(m) }
-func (*StatusCause) ProtoMessage()    {}
+func (m *StatusCause) Reset()      { *m = StatusCause{} }
+func (*StatusCause) ProtoMessage() {}
 
-func (m *StatusDetails) Reset()         { *m = StatusDetails{} }
-func (m *StatusDetails) String() string { return proto.CompactTextString(m) }
-func (*StatusDetails) ProtoMessage()    {}
+func (m *StatusDetails) Reset()      { *m = StatusDetails{} }
+func (*StatusDetails) ProtoMessage() {}
 
-func (m *Time) Reset()         { *m = Time{} }
-func (m *Time) String() string { return proto.CompactTextString(m) }
-func (*Time) ProtoMessage()    {}
+func (m *Time) Reset()      { *m = Time{} }
+func (*Time) ProtoMessage() {}
 
-func (m *Timestamp) Reset()         { *m = Timestamp{} }
-func (m *Timestamp) String() string { return proto.CompactTextString(m) }
-func (*Timestamp) ProtoMessage()    {}
+func (m *Timestamp) Reset()      { *m = Timestamp{} }
+func (*Timestamp) ProtoMessage() {}
 
-func (m *TypeMeta) Reset()         { *m = TypeMeta{} }
-func (m *TypeMeta) String() string { return proto.CompactTextString(m) }
-func (*TypeMeta) ProtoMessage()    {}
+func (m *TypeMeta) Reset()      { *m = TypeMeta{} }
+func (*TypeMeta) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*APIGroup)(nil), "k8s.io.kubernetes.pkg.api.unversioned.APIGroup")
@@ -1277,6 +1263,220 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *APIGroup) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&APIGroup{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Versions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Versions), "GroupVersionForDiscovery", "GroupVersionForDiscovery", 1), `&`, ``, 1) + `,`,
+		`PreferredVersion:` + strings.Replace(strings.Replace(this.PreferredVersion.String(), "GroupVersionForDiscovery", "GroupVersionForDiscovery", 1), `&`, ``, 1) + `,`,
+		`ServerAddressByClientCIDRs:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ServerAddressByClientCIDRs), "ServerAddressByClientCIDR", "ServerAddressByClientCIDR", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *APIGroupList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&APIGroupList{`,
+		`Groups:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Groups), "APIGroup", "APIGroup", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *APIResource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&APIResource{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Namespaced:` + fmt.Sprintf("%v", this.Namespaced) + `,`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *APIResourceList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&APIResourceList{`,
+		`GroupVersion:` + fmt.Sprintf("%v", this.GroupVersion) + `,`,
+		`APIResources:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.APIResources), "APIResource", "APIResource", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Duration) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Duration{`,
+		`Duration:` + fmt.Sprintf("%v", this.Duration) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ExportOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ExportOptions{`,
+		`Export:` + fmt.Sprintf("%v", this.Export) + `,`,
+		`Exact:` + fmt.Sprintf("%v", this.Exact) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GroupVersionForDiscovery) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GroupVersionForDiscovery{`,
+		`GroupVersion:` + fmt.Sprintf("%v", this.GroupVersion) + `,`,
+		`Version:` + fmt.Sprintf("%v", this.Version) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForMatchLabels := make([]string, 0, len(this.MatchLabels))
+	for k := range this.MatchLabels {
+		keysForMatchLabels = append(keysForMatchLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMatchLabels)
+	mapStringForMatchLabels := "map[string]string{"
+	for _, k := range keysForMatchLabels {
+		mapStringForMatchLabels += fmt.Sprintf("%v: %v,", k, this.MatchLabels[k])
+	}
+	mapStringForMatchLabels += "}"
+	s := strings.Join([]string{`&LabelSelector{`,
+		`MatchLabels:` + mapStringForMatchLabels + `,`,
+		`MatchExpressions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.MatchExpressions), "LabelSelectorRequirement", "LabelSelectorRequirement", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelectorRequirement) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LabelSelectorRequirement{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", this.Values) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListMeta) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListMeta{`,
+		`SelfLink:` + fmt.Sprintf("%v", this.SelfLink) + `,`,
+		`ResourceVersion:` + fmt.Sprintf("%v", this.ResourceVersion) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RootPaths) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RootPaths{`,
+		`Paths:` + fmt.Sprintf("%v", this.Paths) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServerAddressByClientCIDR) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServerAddressByClientCIDR{`,
+		`ClientCIDR:` + fmt.Sprintf("%v", this.ClientCIDR) + `,`,
+		`ServerAddress:` + fmt.Sprintf("%v", this.ServerAddress) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Status) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Status{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "ListMeta", 1), `&`, ``, 1) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Details:` + strings.Replace(fmt.Sprintf("%v", this.Details), "StatusDetails", "StatusDetails", 1) + `,`,
+		`Code:` + fmt.Sprintf("%v", this.Code) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StatusCause) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StatusCause{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Field:` + fmt.Sprintf("%v", this.Field) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StatusDetails) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StatusDetails{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Group:` + fmt.Sprintf("%v", this.Group) + `,`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`Causes:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Causes), "StatusCause", "StatusCause", 1), `&`, ``, 1) + `,`,
+		`RetryAfterSeconds:` + fmt.Sprintf("%v", this.RetryAfterSeconds) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Timestamp) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Timestamp{`,
+		`Seconds:` + fmt.Sprintf("%v", this.Seconds) + `,`,
+		`Nanos:` + fmt.Sprintf("%v", this.Nanos) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TypeMeta) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TypeMeta{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *APIGroup) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/api/unversioned/generated.proto
+++ b/pkg/api/unversioned/generated.proto
@@ -328,6 +328,7 @@ message StatusDetails {
 // 
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
+// +protobuf.options.(gogoproto.goproto_stringer)=false
 message Time {
   // Represents seconds of UTC time since Unix epoch
   // 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to

--- a/pkg/api/unversioned/time.go
+++ b/pkg/api/unversioned/time.go
@@ -29,6 +29,7 @@ import (
 //
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
+// +protobuf.options.(gogoproto.goproto_stringer)=false
 type Time struct {
 	time.Time `protobuf:"-"`
 }
@@ -38,6 +39,11 @@ type Time struct {
 // copy-by-assign, despite the presence of (unexported) Pointer fields.
 func (t Time) DeepCopy() Time {
 	return t
+}
+
+// String returns the representation of the time.
+func (t Time) String() string {
+	return t.Time.String()
 }
 
 // NewTime returns a wrapped instance of the provided time

--- a/pkg/api/v1/generated.pb.go
+++ b/pkg/api/v1/generated.pb.go
@@ -190,6 +190,10 @@ import k8s_io_kubernetes_pkg_runtime "k8s.io/kubernetes/pkg/runtime"
 
 import k8s_io_kubernetes_pkg_types "k8s.io/kubernetes/pkg/types"
 
+import strings "strings"
+import reflect "reflect"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -197,613 +201,461 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *AWSElasticBlockStoreVolumeSource) Reset()         { *m = AWSElasticBlockStoreVolumeSource{} }
-func (m *AWSElasticBlockStoreVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*AWSElasticBlockStoreVolumeSource) ProtoMessage()    {}
-
-func (m *Affinity) Reset()         { *m = Affinity{} }
-func (m *Affinity) String() string { return proto.CompactTextString(m) }
-func (*Affinity) ProtoMessage()    {}
-
-func (m *AttachedVolume) Reset()         { *m = AttachedVolume{} }
-func (m *AttachedVolume) String() string { return proto.CompactTextString(m) }
-func (*AttachedVolume) ProtoMessage()    {}
-
-func (m *AvoidPods) Reset()         { *m = AvoidPods{} }
-func (m *AvoidPods) String() string { return proto.CompactTextString(m) }
-func (*AvoidPods) ProtoMessage()    {}
-
-func (m *AzureFileVolumeSource) Reset()         { *m = AzureFileVolumeSource{} }
-func (m *AzureFileVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*AzureFileVolumeSource) ProtoMessage()    {}
-
-func (m *Binding) Reset()         { *m = Binding{} }
-func (m *Binding) String() string { return proto.CompactTextString(m) }
-func (*Binding) ProtoMessage()    {}
-
-func (m *Capabilities) Reset()         { *m = Capabilities{} }
-func (m *Capabilities) String() string { return proto.CompactTextString(m) }
-func (*Capabilities) ProtoMessage()    {}
-
-func (m *CephFSVolumeSource) Reset()         { *m = CephFSVolumeSource{} }
-func (m *CephFSVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*CephFSVolumeSource) ProtoMessage()    {}
-
-func (m *CinderVolumeSource) Reset()         { *m = CinderVolumeSource{} }
-func (m *CinderVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*CinderVolumeSource) ProtoMessage()    {}
-
-func (m *ComponentCondition) Reset()         { *m = ComponentCondition{} }
-func (m *ComponentCondition) String() string { return proto.CompactTextString(m) }
-func (*ComponentCondition) ProtoMessage()    {}
-
-func (m *ComponentStatus) Reset()         { *m = ComponentStatus{} }
-func (m *ComponentStatus) String() string { return proto.CompactTextString(m) }
-func (*ComponentStatus) ProtoMessage()    {}
-
-func (m *ComponentStatusList) Reset()         { *m = ComponentStatusList{} }
-func (m *ComponentStatusList) String() string { return proto.CompactTextString(m) }
-func (*ComponentStatusList) ProtoMessage()    {}
-
-func (m *ConfigMap) Reset()         { *m = ConfigMap{} }
-func (m *ConfigMap) String() string { return proto.CompactTextString(m) }
-func (*ConfigMap) ProtoMessage()    {}
-
-func (m *ConfigMapKeySelector) Reset()         { *m = ConfigMapKeySelector{} }
-func (m *ConfigMapKeySelector) String() string { return proto.CompactTextString(m) }
-func (*ConfigMapKeySelector) ProtoMessage()    {}
-
-func (m *ConfigMapList) Reset()         { *m = ConfigMapList{} }
-func (m *ConfigMapList) String() string { return proto.CompactTextString(m) }
-func (*ConfigMapList) ProtoMessage()    {}
-
-func (m *ConfigMapVolumeSource) Reset()         { *m = ConfigMapVolumeSource{} }
-func (m *ConfigMapVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*ConfigMapVolumeSource) ProtoMessage()    {}
-
-func (m *Container) Reset()         { *m = Container{} }
-func (m *Container) String() string { return proto.CompactTextString(m) }
-func (*Container) ProtoMessage()    {}
-
-func (m *ContainerImage) Reset()         { *m = ContainerImage{} }
-func (m *ContainerImage) String() string { return proto.CompactTextString(m) }
-func (*ContainerImage) ProtoMessage()    {}
-
-func (m *ContainerPort) Reset()         { *m = ContainerPort{} }
-func (m *ContainerPort) String() string { return proto.CompactTextString(m) }
-func (*ContainerPort) ProtoMessage()    {}
-
-func (m *ContainerState) Reset()         { *m = ContainerState{} }
-func (m *ContainerState) String() string { return proto.CompactTextString(m) }
-func (*ContainerState) ProtoMessage()    {}
-
-func (m *ContainerStateRunning) Reset()         { *m = ContainerStateRunning{} }
-func (m *ContainerStateRunning) String() string { return proto.CompactTextString(m) }
-func (*ContainerStateRunning) ProtoMessage()    {}
-
-func (m *ContainerStateTerminated) Reset()         { *m = ContainerStateTerminated{} }
-func (m *ContainerStateTerminated) String() string { return proto.CompactTextString(m) }
-func (*ContainerStateTerminated) ProtoMessage()    {}
-
-func (m *ContainerStateWaiting) Reset()         { *m = ContainerStateWaiting{} }
-func (m *ContainerStateWaiting) String() string { return proto.CompactTextString(m) }
-func (*ContainerStateWaiting) ProtoMessage()    {}
-
-func (m *ContainerStatus) Reset()         { *m = ContainerStatus{} }
-func (m *ContainerStatus) String() string { return proto.CompactTextString(m) }
-func (*ContainerStatus) ProtoMessage()    {}
-
-func (m *DaemonEndpoint) Reset()         { *m = DaemonEndpoint{} }
-func (m *DaemonEndpoint) String() string { return proto.CompactTextString(m) }
-func (*DaemonEndpoint) ProtoMessage()    {}
-
-func (m *DeleteOptions) Reset()         { *m = DeleteOptions{} }
-func (m *DeleteOptions) String() string { return proto.CompactTextString(m) }
-func (*DeleteOptions) ProtoMessage()    {}
-
-func (m *DownwardAPIVolumeFile) Reset()         { *m = DownwardAPIVolumeFile{} }
-func (m *DownwardAPIVolumeFile) String() string { return proto.CompactTextString(m) }
-func (*DownwardAPIVolumeFile) ProtoMessage()    {}
-
-func (m *DownwardAPIVolumeSource) Reset()         { *m = DownwardAPIVolumeSource{} }
-func (m *DownwardAPIVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*DownwardAPIVolumeSource) ProtoMessage()    {}
-
-func (m *EmptyDirVolumeSource) Reset()         { *m = EmptyDirVolumeSource{} }
-func (m *EmptyDirVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*EmptyDirVolumeSource) ProtoMessage()    {}
-
-func (m *EndpointAddress) Reset()         { *m = EndpointAddress{} }
-func (m *EndpointAddress) String() string { return proto.CompactTextString(m) }
-func (*EndpointAddress) ProtoMessage()    {}
-
-func (m *EndpointPort) Reset()         { *m = EndpointPort{} }
-func (m *EndpointPort) String() string { return proto.CompactTextString(m) }
-func (*EndpointPort) ProtoMessage()    {}
-
-func (m *EndpointSubset) Reset()         { *m = EndpointSubset{} }
-func (m *EndpointSubset) String() string { return proto.CompactTextString(m) }
-func (*EndpointSubset) ProtoMessage()    {}
-
-func (m *Endpoints) Reset()         { *m = Endpoints{} }
-func (m *Endpoints) String() string { return proto.CompactTextString(m) }
-func (*Endpoints) ProtoMessage()    {}
-
-func (m *EndpointsList) Reset()         { *m = EndpointsList{} }
-func (m *EndpointsList) String() string { return proto.CompactTextString(m) }
-func (*EndpointsList) ProtoMessage()    {}
-
-func (m *EnvVar) Reset()         { *m = EnvVar{} }
-func (m *EnvVar) String() string { return proto.CompactTextString(m) }
-func (*EnvVar) ProtoMessage()    {}
-
-func (m *EnvVarSource) Reset()         { *m = EnvVarSource{} }
-func (m *EnvVarSource) String() string { return proto.CompactTextString(m) }
-func (*EnvVarSource) ProtoMessage()    {}
-
-func (m *Event) Reset()         { *m = Event{} }
-func (m *Event) String() string { return proto.CompactTextString(m) }
-func (*Event) ProtoMessage()    {}
-
-func (m *EventList) Reset()         { *m = EventList{} }
-func (m *EventList) String() string { return proto.CompactTextString(m) }
-func (*EventList) ProtoMessage()    {}
-
-func (m *EventSource) Reset()         { *m = EventSource{} }
-func (m *EventSource) String() string { return proto.CompactTextString(m) }
-func (*EventSource) ProtoMessage()    {}
-
-func (m *ExecAction) Reset()         { *m = ExecAction{} }
-func (m *ExecAction) String() string { return proto.CompactTextString(m) }
-func (*ExecAction) ProtoMessage()    {}
-
-func (m *ExportOptions) Reset()         { *m = ExportOptions{} }
-func (m *ExportOptions) String() string { return proto.CompactTextString(m) }
-func (*ExportOptions) ProtoMessage()    {}
-
-func (m *FCVolumeSource) Reset()         { *m = FCVolumeSource{} }
-func (m *FCVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*FCVolumeSource) ProtoMessage()    {}
-
-func (m *FlexVolumeSource) Reset()         { *m = FlexVolumeSource{} }
-func (m *FlexVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*FlexVolumeSource) ProtoMessage()    {}
-
-func (m *FlockerVolumeSource) Reset()         { *m = FlockerVolumeSource{} }
-func (m *FlockerVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*FlockerVolumeSource) ProtoMessage()    {}
-
-func (m *GCEPersistentDiskVolumeSource) Reset()         { *m = GCEPersistentDiskVolumeSource{} }
-func (m *GCEPersistentDiskVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*GCEPersistentDiskVolumeSource) ProtoMessage()    {}
-
-func (m *GitRepoVolumeSource) Reset()         { *m = GitRepoVolumeSource{} }
-func (m *GitRepoVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*GitRepoVolumeSource) ProtoMessage()    {}
-
-func (m *GlusterfsVolumeSource) Reset()         { *m = GlusterfsVolumeSource{} }
-func (m *GlusterfsVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*GlusterfsVolumeSource) ProtoMessage()    {}
-
-func (m *HTTPGetAction) Reset()         { *m = HTTPGetAction{} }
-func (m *HTTPGetAction) String() string { return proto.CompactTextString(m) }
-func (*HTTPGetAction) ProtoMessage()    {}
-
-func (m *HTTPHeader) Reset()         { *m = HTTPHeader{} }
-func (m *HTTPHeader) String() string { return proto.CompactTextString(m) }
-func (*HTTPHeader) ProtoMessage()    {}
-
-func (m *Handler) Reset()         { *m = Handler{} }
-func (m *Handler) String() string { return proto.CompactTextString(m) }
-func (*Handler) ProtoMessage()    {}
-
-func (m *HostPathVolumeSource) Reset()         { *m = HostPathVolumeSource{} }
-func (m *HostPathVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*HostPathVolumeSource) ProtoMessage()    {}
-
-func (m *ISCSIVolumeSource) Reset()         { *m = ISCSIVolumeSource{} }
-func (m *ISCSIVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*ISCSIVolumeSource) ProtoMessage()    {}
-
-func (m *KeyToPath) Reset()         { *m = KeyToPath{} }
-func (m *KeyToPath) String() string { return proto.CompactTextString(m) }
-func (*KeyToPath) ProtoMessage()    {}
-
-func (m *Lifecycle) Reset()         { *m = Lifecycle{} }
-func (m *Lifecycle) String() string { return proto.CompactTextString(m) }
-func (*Lifecycle) ProtoMessage()    {}
-
-func (m *LimitRange) Reset()         { *m = LimitRange{} }
-func (m *LimitRange) String() string { return proto.CompactTextString(m) }
-func (*LimitRange) ProtoMessage()    {}
-
-func (m *LimitRangeItem) Reset()         { *m = LimitRangeItem{} }
-func (m *LimitRangeItem) String() string { return proto.CompactTextString(m) }
-func (*LimitRangeItem) ProtoMessage()    {}
-
-func (m *LimitRangeList) Reset()         { *m = LimitRangeList{} }
-func (m *LimitRangeList) String() string { return proto.CompactTextString(m) }
-func (*LimitRangeList) ProtoMessage()    {}
-
-func (m *LimitRangeSpec) Reset()         { *m = LimitRangeSpec{} }
-func (m *LimitRangeSpec) String() string { return proto.CompactTextString(m) }
-func (*LimitRangeSpec) ProtoMessage()    {}
-
-func (m *List) Reset()         { *m = List{} }
-func (m *List) String() string { return proto.CompactTextString(m) }
-func (*List) ProtoMessage()    {}
-
-func (m *ListOptions) Reset()         { *m = ListOptions{} }
-func (m *ListOptions) String() string { return proto.CompactTextString(m) }
-func (*ListOptions) ProtoMessage()    {}
-
-func (m *LoadBalancerIngress) Reset()         { *m = LoadBalancerIngress{} }
-func (m *LoadBalancerIngress) String() string { return proto.CompactTextString(m) }
-func (*LoadBalancerIngress) ProtoMessage()    {}
-
-func (m *LoadBalancerStatus) Reset()         { *m = LoadBalancerStatus{} }
-func (m *LoadBalancerStatus) String() string { return proto.CompactTextString(m) }
-func (*LoadBalancerStatus) ProtoMessage()    {}
-
-func (m *LocalObjectReference) Reset()         { *m = LocalObjectReference{} }
-func (m *LocalObjectReference) String() string { return proto.CompactTextString(m) }
-func (*LocalObjectReference) ProtoMessage()    {}
-
-func (m *NFSVolumeSource) Reset()         { *m = NFSVolumeSource{} }
-func (m *NFSVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*NFSVolumeSource) ProtoMessage()    {}
-
-func (m *Namespace) Reset()         { *m = Namespace{} }
-func (m *Namespace) String() string { return proto.CompactTextString(m) }
-func (*Namespace) ProtoMessage()    {}
-
-func (m *NamespaceList) Reset()         { *m = NamespaceList{} }
-func (m *NamespaceList) String() string { return proto.CompactTextString(m) }
-func (*NamespaceList) ProtoMessage()    {}
-
-func (m *NamespaceSpec) Reset()         { *m = NamespaceSpec{} }
-func (m *NamespaceSpec) String() string { return proto.CompactTextString(m) }
-func (*NamespaceSpec) ProtoMessage()    {}
-
-func (m *NamespaceStatus) Reset()         { *m = NamespaceStatus{} }
-func (m *NamespaceStatus) String() string { return proto.CompactTextString(m) }
-func (*NamespaceStatus) ProtoMessage()    {}
-
-func (m *Node) Reset()         { *m = Node{} }
-func (m *Node) String() string { return proto.CompactTextString(m) }
-func (*Node) ProtoMessage()    {}
-
-func (m *NodeAddress) Reset()         { *m = NodeAddress{} }
-func (m *NodeAddress) String() string { return proto.CompactTextString(m) }
-func (*NodeAddress) ProtoMessage()    {}
-
-func (m *NodeAffinity) Reset()         { *m = NodeAffinity{} }
-func (m *NodeAffinity) String() string { return proto.CompactTextString(m) }
-func (*NodeAffinity) ProtoMessage()    {}
-
-func (m *NodeCondition) Reset()         { *m = NodeCondition{} }
-func (m *NodeCondition) String() string { return proto.CompactTextString(m) }
-func (*NodeCondition) ProtoMessage()    {}
-
-func (m *NodeDaemonEndpoints) Reset()         { *m = NodeDaemonEndpoints{} }
-func (m *NodeDaemonEndpoints) String() string { return proto.CompactTextString(m) }
-func (*NodeDaemonEndpoints) ProtoMessage()    {}
-
-func (m *NodeList) Reset()         { *m = NodeList{} }
-func (m *NodeList) String() string { return proto.CompactTextString(m) }
-func (*NodeList) ProtoMessage()    {}
-
-func (m *NodeProxyOptions) Reset()         { *m = NodeProxyOptions{} }
-func (m *NodeProxyOptions) String() string { return proto.CompactTextString(m) }
-func (*NodeProxyOptions) ProtoMessage()    {}
-
-func (m *NodeSelector) Reset()         { *m = NodeSelector{} }
-func (m *NodeSelector) String() string { return proto.CompactTextString(m) }
-func (*NodeSelector) ProtoMessage()    {}
-
-func (m *NodeSelectorRequirement) Reset()         { *m = NodeSelectorRequirement{} }
-func (m *NodeSelectorRequirement) String() string { return proto.CompactTextString(m) }
-func (*NodeSelectorRequirement) ProtoMessage()    {}
-
-func (m *NodeSelectorTerm) Reset()         { *m = NodeSelectorTerm{} }
-func (m *NodeSelectorTerm) String() string { return proto.CompactTextString(m) }
-func (*NodeSelectorTerm) ProtoMessage()    {}
-
-func (m *NodeSpec) Reset()         { *m = NodeSpec{} }
-func (m *NodeSpec) String() string { return proto.CompactTextString(m) }
-func (*NodeSpec) ProtoMessage()    {}
-
-func (m *NodeStatus) Reset()         { *m = NodeStatus{} }
-func (m *NodeStatus) String() string { return proto.CompactTextString(m) }
-func (*NodeStatus) ProtoMessage()    {}
-
-func (m *NodeSystemInfo) Reset()         { *m = NodeSystemInfo{} }
-func (m *NodeSystemInfo) String() string { return proto.CompactTextString(m) }
-func (*NodeSystemInfo) ProtoMessage()    {}
-
-func (m *ObjectFieldSelector) Reset()         { *m = ObjectFieldSelector{} }
-func (m *ObjectFieldSelector) String() string { return proto.CompactTextString(m) }
-func (*ObjectFieldSelector) ProtoMessage()    {}
-
-func (m *ObjectMeta) Reset()         { *m = ObjectMeta{} }
-func (m *ObjectMeta) String() string { return proto.CompactTextString(m) }
-func (*ObjectMeta) ProtoMessage()    {}
-
-func (m *ObjectReference) Reset()         { *m = ObjectReference{} }
-func (m *ObjectReference) String() string { return proto.CompactTextString(m) }
-func (*ObjectReference) ProtoMessage()    {}
-
-func (m *OwnerReference) Reset()         { *m = OwnerReference{} }
-func (m *OwnerReference) String() string { return proto.CompactTextString(m) }
-func (*OwnerReference) ProtoMessage()    {}
-
-func (m *PersistentVolume) Reset()         { *m = PersistentVolume{} }
-func (m *PersistentVolume) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolume) ProtoMessage()    {}
-
-func (m *PersistentVolumeClaim) Reset()         { *m = PersistentVolumeClaim{} }
-func (m *PersistentVolumeClaim) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeClaim) ProtoMessage()    {}
-
-func (m *PersistentVolumeClaimList) Reset()         { *m = PersistentVolumeClaimList{} }
-func (m *PersistentVolumeClaimList) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeClaimList) ProtoMessage()    {}
-
-func (m *PersistentVolumeClaimSpec) Reset()         { *m = PersistentVolumeClaimSpec{} }
-func (m *PersistentVolumeClaimSpec) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeClaimSpec) ProtoMessage()    {}
-
-func (m *PersistentVolumeClaimStatus) Reset()         { *m = PersistentVolumeClaimStatus{} }
-func (m *PersistentVolumeClaimStatus) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeClaimStatus) ProtoMessage()    {}
-
-func (m *PersistentVolumeClaimVolumeSource) Reset()         { *m = PersistentVolumeClaimVolumeSource{} }
-func (m *PersistentVolumeClaimVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeClaimVolumeSource) ProtoMessage()    {}
-
-func (m *PersistentVolumeList) Reset()         { *m = PersistentVolumeList{} }
-func (m *PersistentVolumeList) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeList) ProtoMessage()    {}
-
-func (m *PersistentVolumeSource) Reset()         { *m = PersistentVolumeSource{} }
-func (m *PersistentVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeSource) ProtoMessage()    {}
-
-func (m *PersistentVolumeSpec) Reset()         { *m = PersistentVolumeSpec{} }
-func (m *PersistentVolumeSpec) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeSpec) ProtoMessage()    {}
-
-func (m *PersistentVolumeStatus) Reset()         { *m = PersistentVolumeStatus{} }
-func (m *PersistentVolumeStatus) String() string { return proto.CompactTextString(m) }
-func (*PersistentVolumeStatus) ProtoMessage()    {}
-
-func (m *Pod) Reset()         { *m = Pod{} }
-func (m *Pod) String() string { return proto.CompactTextString(m) }
-func (*Pod) ProtoMessage()    {}
-
-func (m *PodAffinity) Reset()         { *m = PodAffinity{} }
-func (m *PodAffinity) String() string { return proto.CompactTextString(m) }
-func (*PodAffinity) ProtoMessage()    {}
-
-func (m *PodAffinityTerm) Reset()         { *m = PodAffinityTerm{} }
-func (m *PodAffinityTerm) String() string { return proto.CompactTextString(m) }
-func (*PodAffinityTerm) ProtoMessage()    {}
-
-func (m *PodAntiAffinity) Reset()         { *m = PodAntiAffinity{} }
-func (m *PodAntiAffinity) String() string { return proto.CompactTextString(m) }
-func (*PodAntiAffinity) ProtoMessage()    {}
-
-func (m *PodAttachOptions) Reset()         { *m = PodAttachOptions{} }
-func (m *PodAttachOptions) String() string { return proto.CompactTextString(m) }
-func (*PodAttachOptions) ProtoMessage()    {}
-
-func (m *PodCondition) Reset()         { *m = PodCondition{} }
-func (m *PodCondition) String() string { return proto.CompactTextString(m) }
-func (*PodCondition) ProtoMessage()    {}
-
-func (m *PodExecOptions) Reset()         { *m = PodExecOptions{} }
-func (m *PodExecOptions) String() string { return proto.CompactTextString(m) }
-func (*PodExecOptions) ProtoMessage()    {}
-
-func (m *PodList) Reset()         { *m = PodList{} }
-func (m *PodList) String() string { return proto.CompactTextString(m) }
-func (*PodList) ProtoMessage()    {}
-
-func (m *PodLogOptions) Reset()         { *m = PodLogOptions{} }
-func (m *PodLogOptions) String() string { return proto.CompactTextString(m) }
-func (*PodLogOptions) ProtoMessage()    {}
-
-func (m *PodProxyOptions) Reset()         { *m = PodProxyOptions{} }
-func (m *PodProxyOptions) String() string { return proto.CompactTextString(m) }
-func (*PodProxyOptions) ProtoMessage()    {}
-
-func (m *PodSecurityContext) Reset()         { *m = PodSecurityContext{} }
-func (m *PodSecurityContext) String() string { return proto.CompactTextString(m) }
-func (*PodSecurityContext) ProtoMessage()    {}
-
-func (m *PodSignature) Reset()         { *m = PodSignature{} }
-func (m *PodSignature) String() string { return proto.CompactTextString(m) }
-func (*PodSignature) ProtoMessage()    {}
-
-func (m *PodSpec) Reset()         { *m = PodSpec{} }
-func (m *PodSpec) String() string { return proto.CompactTextString(m) }
-func (*PodSpec) ProtoMessage()    {}
-
-func (m *PodStatus) Reset()         { *m = PodStatus{} }
-func (m *PodStatus) String() string { return proto.CompactTextString(m) }
-func (*PodStatus) ProtoMessage()    {}
-
-func (m *PodStatusResult) Reset()         { *m = PodStatusResult{} }
-func (m *PodStatusResult) String() string { return proto.CompactTextString(m) }
-func (*PodStatusResult) ProtoMessage()    {}
-
-func (m *PodTemplate) Reset()         { *m = PodTemplate{} }
-func (m *PodTemplate) String() string { return proto.CompactTextString(m) }
-func (*PodTemplate) ProtoMessage()    {}
-
-func (m *PodTemplateList) Reset()         { *m = PodTemplateList{} }
-func (m *PodTemplateList) String() string { return proto.CompactTextString(m) }
-func (*PodTemplateList) ProtoMessage()    {}
-
-func (m *PodTemplateSpec) Reset()         { *m = PodTemplateSpec{} }
-func (m *PodTemplateSpec) String() string { return proto.CompactTextString(m) }
-func (*PodTemplateSpec) ProtoMessage()    {}
-
-func (m *Preconditions) Reset()         { *m = Preconditions{} }
-func (m *Preconditions) String() string { return proto.CompactTextString(m) }
-func (*Preconditions) ProtoMessage()    {}
-
-func (m *PreferAvoidPodsEntry) Reset()         { *m = PreferAvoidPodsEntry{} }
-func (m *PreferAvoidPodsEntry) String() string { return proto.CompactTextString(m) }
-func (*PreferAvoidPodsEntry) ProtoMessage()    {}
-
-func (m *PreferredSchedulingTerm) Reset()         { *m = PreferredSchedulingTerm{} }
-func (m *PreferredSchedulingTerm) String() string { return proto.CompactTextString(m) }
-func (*PreferredSchedulingTerm) ProtoMessage()    {}
-
-func (m *Probe) Reset()         { *m = Probe{} }
-func (m *Probe) String() string { return proto.CompactTextString(m) }
-func (*Probe) ProtoMessage()    {}
-
-func (m *RBDVolumeSource) Reset()         { *m = RBDVolumeSource{} }
-func (m *RBDVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*RBDVolumeSource) ProtoMessage()    {}
-
-func (m *RangeAllocation) Reset()         { *m = RangeAllocation{} }
-func (m *RangeAllocation) String() string { return proto.CompactTextString(m) }
-func (*RangeAllocation) ProtoMessage()    {}
-
-func (m *ReplicationController) Reset()         { *m = ReplicationController{} }
-func (m *ReplicationController) String() string { return proto.CompactTextString(m) }
-func (*ReplicationController) ProtoMessage()    {}
-
-func (m *ReplicationControllerList) Reset()         { *m = ReplicationControllerList{} }
-func (m *ReplicationControllerList) String() string { return proto.CompactTextString(m) }
-func (*ReplicationControllerList) ProtoMessage()    {}
-
-func (m *ReplicationControllerSpec) Reset()         { *m = ReplicationControllerSpec{} }
-func (m *ReplicationControllerSpec) String() string { return proto.CompactTextString(m) }
-func (*ReplicationControllerSpec) ProtoMessage()    {}
-
-func (m *ReplicationControllerStatus) Reset()         { *m = ReplicationControllerStatus{} }
-func (m *ReplicationControllerStatus) String() string { return proto.CompactTextString(m) }
-func (*ReplicationControllerStatus) ProtoMessage()    {}
-
-func (m *ResourceFieldSelector) Reset()         { *m = ResourceFieldSelector{} }
-func (m *ResourceFieldSelector) String() string { return proto.CompactTextString(m) }
-func (*ResourceFieldSelector) ProtoMessage()    {}
-
-func (m *ResourceQuota) Reset()         { *m = ResourceQuota{} }
-func (m *ResourceQuota) String() string { return proto.CompactTextString(m) }
-func (*ResourceQuota) ProtoMessage()    {}
-
-func (m *ResourceQuotaList) Reset()         { *m = ResourceQuotaList{} }
-func (m *ResourceQuotaList) String() string { return proto.CompactTextString(m) }
-func (*ResourceQuotaList) ProtoMessage()    {}
-
-func (m *ResourceQuotaSpec) Reset()         { *m = ResourceQuotaSpec{} }
-func (m *ResourceQuotaSpec) String() string { return proto.CompactTextString(m) }
-func (*ResourceQuotaSpec) ProtoMessage()    {}
-
-func (m *ResourceQuotaStatus) Reset()         { *m = ResourceQuotaStatus{} }
-func (m *ResourceQuotaStatus) String() string { return proto.CompactTextString(m) }
-func (*ResourceQuotaStatus) ProtoMessage()    {}
-
-func (m *ResourceRequirements) Reset()         { *m = ResourceRequirements{} }
-func (m *ResourceRequirements) String() string { return proto.CompactTextString(m) }
-func (*ResourceRequirements) ProtoMessage()    {}
-
-func (m *SELinuxOptions) Reset()         { *m = SELinuxOptions{} }
-func (m *SELinuxOptions) String() string { return proto.CompactTextString(m) }
-func (*SELinuxOptions) ProtoMessage()    {}
-
-func (m *Secret) Reset()         { *m = Secret{} }
-func (m *Secret) String() string { return proto.CompactTextString(m) }
-func (*Secret) ProtoMessage()    {}
-
-func (m *SecretKeySelector) Reset()         { *m = SecretKeySelector{} }
-func (m *SecretKeySelector) String() string { return proto.CompactTextString(m) }
-func (*SecretKeySelector) ProtoMessage()    {}
-
-func (m *SecretList) Reset()         { *m = SecretList{} }
-func (m *SecretList) String() string { return proto.CompactTextString(m) }
-func (*SecretList) ProtoMessage()    {}
-
-func (m *SecretVolumeSource) Reset()         { *m = SecretVolumeSource{} }
-func (m *SecretVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*SecretVolumeSource) ProtoMessage()    {}
-
-func (m *SecurityContext) Reset()         { *m = SecurityContext{} }
-func (m *SecurityContext) String() string { return proto.CompactTextString(m) }
-func (*SecurityContext) ProtoMessage()    {}
-
-func (m *SerializedReference) Reset()         { *m = SerializedReference{} }
-func (m *SerializedReference) String() string { return proto.CompactTextString(m) }
-func (*SerializedReference) ProtoMessage()    {}
-
-func (m *Service) Reset()         { *m = Service{} }
-func (m *Service) String() string { return proto.CompactTextString(m) }
-func (*Service) ProtoMessage()    {}
-
-func (m *ServiceAccount) Reset()         { *m = ServiceAccount{} }
-func (m *ServiceAccount) String() string { return proto.CompactTextString(m) }
-func (*ServiceAccount) ProtoMessage()    {}
-
-func (m *ServiceAccountList) Reset()         { *m = ServiceAccountList{} }
-func (m *ServiceAccountList) String() string { return proto.CompactTextString(m) }
-func (*ServiceAccountList) ProtoMessage()    {}
-
-func (m *ServiceList) Reset()         { *m = ServiceList{} }
-func (m *ServiceList) String() string { return proto.CompactTextString(m) }
-func (*ServiceList) ProtoMessage()    {}
-
-func (m *ServicePort) Reset()         { *m = ServicePort{} }
-func (m *ServicePort) String() string { return proto.CompactTextString(m) }
-func (*ServicePort) ProtoMessage()    {}
-
-func (m *ServiceProxyOptions) Reset()         { *m = ServiceProxyOptions{} }
-func (m *ServiceProxyOptions) String() string { return proto.CompactTextString(m) }
-func (*ServiceProxyOptions) ProtoMessage()    {}
-
-func (m *ServiceSpec) Reset()         { *m = ServiceSpec{} }
-func (m *ServiceSpec) String() string { return proto.CompactTextString(m) }
-func (*ServiceSpec) ProtoMessage()    {}
-
-func (m *ServiceStatus) Reset()         { *m = ServiceStatus{} }
-func (m *ServiceStatus) String() string { return proto.CompactTextString(m) }
-func (*ServiceStatus) ProtoMessage()    {}
-
-func (m *TCPSocketAction) Reset()         { *m = TCPSocketAction{} }
-func (m *TCPSocketAction) String() string { return proto.CompactTextString(m) }
-func (*TCPSocketAction) ProtoMessage()    {}
-
-func (m *Taint) Reset()         { *m = Taint{} }
-func (m *Taint) String() string { return proto.CompactTextString(m) }
-func (*Taint) ProtoMessage()    {}
-
-func (m *Toleration) Reset()         { *m = Toleration{} }
-func (m *Toleration) String() string { return proto.CompactTextString(m) }
-func (*Toleration) ProtoMessage()    {}
-
-func (m *Volume) Reset()         { *m = Volume{} }
-func (m *Volume) String() string { return proto.CompactTextString(m) }
-func (*Volume) ProtoMessage()    {}
-
-func (m *VolumeMount) Reset()         { *m = VolumeMount{} }
-func (m *VolumeMount) String() string { return proto.CompactTextString(m) }
-func (*VolumeMount) ProtoMessage()    {}
-
-func (m *VolumeSource) Reset()         { *m = VolumeSource{} }
-func (m *VolumeSource) String() string { return proto.CompactTextString(m) }
-func (*VolumeSource) ProtoMessage()    {}
-
-func (m *VsphereVirtualDiskVolumeSource) Reset()         { *m = VsphereVirtualDiskVolumeSource{} }
-func (m *VsphereVirtualDiskVolumeSource) String() string { return proto.CompactTextString(m) }
-func (*VsphereVirtualDiskVolumeSource) ProtoMessage()    {}
-
-func (m *WeightedPodAffinityTerm) Reset()         { *m = WeightedPodAffinityTerm{} }
-func (m *WeightedPodAffinityTerm) String() string { return proto.CompactTextString(m) }
-func (*WeightedPodAffinityTerm) ProtoMessage()    {}
+func (m *AWSElasticBlockStoreVolumeSource) Reset()      { *m = AWSElasticBlockStoreVolumeSource{} }
+func (*AWSElasticBlockStoreVolumeSource) ProtoMessage() {}
+
+func (m *Affinity) Reset()      { *m = Affinity{} }
+func (*Affinity) ProtoMessage() {}
+
+func (m *AttachedVolume) Reset()      { *m = AttachedVolume{} }
+func (*AttachedVolume) ProtoMessage() {}
+
+func (m *AvoidPods) Reset()      { *m = AvoidPods{} }
+func (*AvoidPods) ProtoMessage() {}
+
+func (m *AzureFileVolumeSource) Reset()      { *m = AzureFileVolumeSource{} }
+func (*AzureFileVolumeSource) ProtoMessage() {}
+
+func (m *Binding) Reset()      { *m = Binding{} }
+func (*Binding) ProtoMessage() {}
+
+func (m *Capabilities) Reset()      { *m = Capabilities{} }
+func (*Capabilities) ProtoMessage() {}
+
+func (m *CephFSVolumeSource) Reset()      { *m = CephFSVolumeSource{} }
+func (*CephFSVolumeSource) ProtoMessage() {}
+
+func (m *CinderVolumeSource) Reset()      { *m = CinderVolumeSource{} }
+func (*CinderVolumeSource) ProtoMessage() {}
+
+func (m *ComponentCondition) Reset()      { *m = ComponentCondition{} }
+func (*ComponentCondition) ProtoMessage() {}
+
+func (m *ComponentStatus) Reset()      { *m = ComponentStatus{} }
+func (*ComponentStatus) ProtoMessage() {}
+
+func (m *ComponentStatusList) Reset()      { *m = ComponentStatusList{} }
+func (*ComponentStatusList) ProtoMessage() {}
+
+func (m *ConfigMap) Reset()      { *m = ConfigMap{} }
+func (*ConfigMap) ProtoMessage() {}
+
+func (m *ConfigMapKeySelector) Reset()      { *m = ConfigMapKeySelector{} }
+func (*ConfigMapKeySelector) ProtoMessage() {}
+
+func (m *ConfigMapList) Reset()      { *m = ConfigMapList{} }
+func (*ConfigMapList) ProtoMessage() {}
+
+func (m *ConfigMapVolumeSource) Reset()      { *m = ConfigMapVolumeSource{} }
+func (*ConfigMapVolumeSource) ProtoMessage() {}
+
+func (m *Container) Reset()      { *m = Container{} }
+func (*Container) ProtoMessage() {}
+
+func (m *ContainerImage) Reset()      { *m = ContainerImage{} }
+func (*ContainerImage) ProtoMessage() {}
+
+func (m *ContainerPort) Reset()      { *m = ContainerPort{} }
+func (*ContainerPort) ProtoMessage() {}
+
+func (m *ContainerState) Reset()      { *m = ContainerState{} }
+func (*ContainerState) ProtoMessage() {}
+
+func (m *ContainerStateRunning) Reset()      { *m = ContainerStateRunning{} }
+func (*ContainerStateRunning) ProtoMessage() {}
+
+func (m *ContainerStateTerminated) Reset()      { *m = ContainerStateTerminated{} }
+func (*ContainerStateTerminated) ProtoMessage() {}
+
+func (m *ContainerStateWaiting) Reset()      { *m = ContainerStateWaiting{} }
+func (*ContainerStateWaiting) ProtoMessage() {}
+
+func (m *ContainerStatus) Reset()      { *m = ContainerStatus{} }
+func (*ContainerStatus) ProtoMessage() {}
+
+func (m *DaemonEndpoint) Reset()      { *m = DaemonEndpoint{} }
+func (*DaemonEndpoint) ProtoMessage() {}
+
+func (m *DeleteOptions) Reset()      { *m = DeleteOptions{} }
+func (*DeleteOptions) ProtoMessage() {}
+
+func (m *DownwardAPIVolumeFile) Reset()      { *m = DownwardAPIVolumeFile{} }
+func (*DownwardAPIVolumeFile) ProtoMessage() {}
+
+func (m *DownwardAPIVolumeSource) Reset()      { *m = DownwardAPIVolumeSource{} }
+func (*DownwardAPIVolumeSource) ProtoMessage() {}
+
+func (m *EmptyDirVolumeSource) Reset()      { *m = EmptyDirVolumeSource{} }
+func (*EmptyDirVolumeSource) ProtoMessage() {}
+
+func (m *EndpointAddress) Reset()      { *m = EndpointAddress{} }
+func (*EndpointAddress) ProtoMessage() {}
+
+func (m *EndpointPort) Reset()      { *m = EndpointPort{} }
+func (*EndpointPort) ProtoMessage() {}
+
+func (m *EndpointSubset) Reset()      { *m = EndpointSubset{} }
+func (*EndpointSubset) ProtoMessage() {}
+
+func (m *Endpoints) Reset()      { *m = Endpoints{} }
+func (*Endpoints) ProtoMessage() {}
+
+func (m *EndpointsList) Reset()      { *m = EndpointsList{} }
+func (*EndpointsList) ProtoMessage() {}
+
+func (m *EnvVar) Reset()      { *m = EnvVar{} }
+func (*EnvVar) ProtoMessage() {}
+
+func (m *EnvVarSource) Reset()      { *m = EnvVarSource{} }
+func (*EnvVarSource) ProtoMessage() {}
+
+func (m *Event) Reset()      { *m = Event{} }
+func (*Event) ProtoMessage() {}
+
+func (m *EventList) Reset()      { *m = EventList{} }
+func (*EventList) ProtoMessage() {}
+
+func (m *EventSource) Reset()      { *m = EventSource{} }
+func (*EventSource) ProtoMessage() {}
+
+func (m *ExecAction) Reset()      { *m = ExecAction{} }
+func (*ExecAction) ProtoMessage() {}
+
+func (m *ExportOptions) Reset()      { *m = ExportOptions{} }
+func (*ExportOptions) ProtoMessage() {}
+
+func (m *FCVolumeSource) Reset()      { *m = FCVolumeSource{} }
+func (*FCVolumeSource) ProtoMessage() {}
+
+func (m *FlexVolumeSource) Reset()      { *m = FlexVolumeSource{} }
+func (*FlexVolumeSource) ProtoMessage() {}
+
+func (m *FlockerVolumeSource) Reset()      { *m = FlockerVolumeSource{} }
+func (*FlockerVolumeSource) ProtoMessage() {}
+
+func (m *GCEPersistentDiskVolumeSource) Reset()      { *m = GCEPersistentDiskVolumeSource{} }
+func (*GCEPersistentDiskVolumeSource) ProtoMessage() {}
+
+func (m *GitRepoVolumeSource) Reset()      { *m = GitRepoVolumeSource{} }
+func (*GitRepoVolumeSource) ProtoMessage() {}
+
+func (m *GlusterfsVolumeSource) Reset()      { *m = GlusterfsVolumeSource{} }
+func (*GlusterfsVolumeSource) ProtoMessage() {}
+
+func (m *HTTPGetAction) Reset()      { *m = HTTPGetAction{} }
+func (*HTTPGetAction) ProtoMessage() {}
+
+func (m *HTTPHeader) Reset()      { *m = HTTPHeader{} }
+func (*HTTPHeader) ProtoMessage() {}
+
+func (m *Handler) Reset()      { *m = Handler{} }
+func (*Handler) ProtoMessage() {}
+
+func (m *HostPathVolumeSource) Reset()      { *m = HostPathVolumeSource{} }
+func (*HostPathVolumeSource) ProtoMessage() {}
+
+func (m *ISCSIVolumeSource) Reset()      { *m = ISCSIVolumeSource{} }
+func (*ISCSIVolumeSource) ProtoMessage() {}
+
+func (m *KeyToPath) Reset()      { *m = KeyToPath{} }
+func (*KeyToPath) ProtoMessage() {}
+
+func (m *Lifecycle) Reset()      { *m = Lifecycle{} }
+func (*Lifecycle) ProtoMessage() {}
+
+func (m *LimitRange) Reset()      { *m = LimitRange{} }
+func (*LimitRange) ProtoMessage() {}
+
+func (m *LimitRangeItem) Reset()      { *m = LimitRangeItem{} }
+func (*LimitRangeItem) ProtoMessage() {}
+
+func (m *LimitRangeList) Reset()      { *m = LimitRangeList{} }
+func (*LimitRangeList) ProtoMessage() {}
+
+func (m *LimitRangeSpec) Reset()      { *m = LimitRangeSpec{} }
+func (*LimitRangeSpec) ProtoMessage() {}
+
+func (m *List) Reset()      { *m = List{} }
+func (*List) ProtoMessage() {}
+
+func (m *ListOptions) Reset()      { *m = ListOptions{} }
+func (*ListOptions) ProtoMessage() {}
+
+func (m *LoadBalancerIngress) Reset()      { *m = LoadBalancerIngress{} }
+func (*LoadBalancerIngress) ProtoMessage() {}
+
+func (m *LoadBalancerStatus) Reset()      { *m = LoadBalancerStatus{} }
+func (*LoadBalancerStatus) ProtoMessage() {}
+
+func (m *LocalObjectReference) Reset()      { *m = LocalObjectReference{} }
+func (*LocalObjectReference) ProtoMessage() {}
+
+func (m *NFSVolumeSource) Reset()      { *m = NFSVolumeSource{} }
+func (*NFSVolumeSource) ProtoMessage() {}
+
+func (m *Namespace) Reset()      { *m = Namespace{} }
+func (*Namespace) ProtoMessage() {}
+
+func (m *NamespaceList) Reset()      { *m = NamespaceList{} }
+func (*NamespaceList) ProtoMessage() {}
+
+func (m *NamespaceSpec) Reset()      { *m = NamespaceSpec{} }
+func (*NamespaceSpec) ProtoMessage() {}
+
+func (m *NamespaceStatus) Reset()      { *m = NamespaceStatus{} }
+func (*NamespaceStatus) ProtoMessage() {}
+
+func (m *Node) Reset()      { *m = Node{} }
+func (*Node) ProtoMessage() {}
+
+func (m *NodeAddress) Reset()      { *m = NodeAddress{} }
+func (*NodeAddress) ProtoMessage() {}
+
+func (m *NodeAffinity) Reset()      { *m = NodeAffinity{} }
+func (*NodeAffinity) ProtoMessage() {}
+
+func (m *NodeCondition) Reset()      { *m = NodeCondition{} }
+func (*NodeCondition) ProtoMessage() {}
+
+func (m *NodeDaemonEndpoints) Reset()      { *m = NodeDaemonEndpoints{} }
+func (*NodeDaemonEndpoints) ProtoMessage() {}
+
+func (m *NodeList) Reset()      { *m = NodeList{} }
+func (*NodeList) ProtoMessage() {}
+
+func (m *NodeProxyOptions) Reset()      { *m = NodeProxyOptions{} }
+func (*NodeProxyOptions) ProtoMessage() {}
+
+func (m *NodeSelector) Reset()      { *m = NodeSelector{} }
+func (*NodeSelector) ProtoMessage() {}
+
+func (m *NodeSelectorRequirement) Reset()      { *m = NodeSelectorRequirement{} }
+func (*NodeSelectorRequirement) ProtoMessage() {}
+
+func (m *NodeSelectorTerm) Reset()      { *m = NodeSelectorTerm{} }
+func (*NodeSelectorTerm) ProtoMessage() {}
+
+func (m *NodeSpec) Reset()      { *m = NodeSpec{} }
+func (*NodeSpec) ProtoMessage() {}
+
+func (m *NodeStatus) Reset()      { *m = NodeStatus{} }
+func (*NodeStatus) ProtoMessage() {}
+
+func (m *NodeSystemInfo) Reset()      { *m = NodeSystemInfo{} }
+func (*NodeSystemInfo) ProtoMessage() {}
+
+func (m *ObjectFieldSelector) Reset()      { *m = ObjectFieldSelector{} }
+func (*ObjectFieldSelector) ProtoMessage() {}
+
+func (m *ObjectMeta) Reset()      { *m = ObjectMeta{} }
+func (*ObjectMeta) ProtoMessage() {}
+
+func (m *ObjectReference) Reset()      { *m = ObjectReference{} }
+func (*ObjectReference) ProtoMessage() {}
+
+func (m *OwnerReference) Reset()      { *m = OwnerReference{} }
+func (*OwnerReference) ProtoMessage() {}
+
+func (m *PersistentVolume) Reset()      { *m = PersistentVolume{} }
+func (*PersistentVolume) ProtoMessage() {}
+
+func (m *PersistentVolumeClaim) Reset()      { *m = PersistentVolumeClaim{} }
+func (*PersistentVolumeClaim) ProtoMessage() {}
+
+func (m *PersistentVolumeClaimList) Reset()      { *m = PersistentVolumeClaimList{} }
+func (*PersistentVolumeClaimList) ProtoMessage() {}
+
+func (m *PersistentVolumeClaimSpec) Reset()      { *m = PersistentVolumeClaimSpec{} }
+func (*PersistentVolumeClaimSpec) ProtoMessage() {}
+
+func (m *PersistentVolumeClaimStatus) Reset()      { *m = PersistentVolumeClaimStatus{} }
+func (*PersistentVolumeClaimStatus) ProtoMessage() {}
+
+func (m *PersistentVolumeClaimVolumeSource) Reset()      { *m = PersistentVolumeClaimVolumeSource{} }
+func (*PersistentVolumeClaimVolumeSource) ProtoMessage() {}
+
+func (m *PersistentVolumeList) Reset()      { *m = PersistentVolumeList{} }
+func (*PersistentVolumeList) ProtoMessage() {}
+
+func (m *PersistentVolumeSource) Reset()      { *m = PersistentVolumeSource{} }
+func (*PersistentVolumeSource) ProtoMessage() {}
+
+func (m *PersistentVolumeSpec) Reset()      { *m = PersistentVolumeSpec{} }
+func (*PersistentVolumeSpec) ProtoMessage() {}
+
+func (m *PersistentVolumeStatus) Reset()      { *m = PersistentVolumeStatus{} }
+func (*PersistentVolumeStatus) ProtoMessage() {}
+
+func (m *Pod) Reset()      { *m = Pod{} }
+func (*Pod) ProtoMessage() {}
+
+func (m *PodAffinity) Reset()      { *m = PodAffinity{} }
+func (*PodAffinity) ProtoMessage() {}
+
+func (m *PodAffinityTerm) Reset()      { *m = PodAffinityTerm{} }
+func (*PodAffinityTerm) ProtoMessage() {}
+
+func (m *PodAntiAffinity) Reset()      { *m = PodAntiAffinity{} }
+func (*PodAntiAffinity) ProtoMessage() {}
+
+func (m *PodAttachOptions) Reset()      { *m = PodAttachOptions{} }
+func (*PodAttachOptions) ProtoMessage() {}
+
+func (m *PodCondition) Reset()      { *m = PodCondition{} }
+func (*PodCondition) ProtoMessage() {}
+
+func (m *PodExecOptions) Reset()      { *m = PodExecOptions{} }
+func (*PodExecOptions) ProtoMessage() {}
+
+func (m *PodList) Reset()      { *m = PodList{} }
+func (*PodList) ProtoMessage() {}
+
+func (m *PodLogOptions) Reset()      { *m = PodLogOptions{} }
+func (*PodLogOptions) ProtoMessage() {}
+
+func (m *PodProxyOptions) Reset()      { *m = PodProxyOptions{} }
+func (*PodProxyOptions) ProtoMessage() {}
+
+func (m *PodSecurityContext) Reset()      { *m = PodSecurityContext{} }
+func (*PodSecurityContext) ProtoMessage() {}
+
+func (m *PodSignature) Reset()      { *m = PodSignature{} }
+func (*PodSignature) ProtoMessage() {}
+
+func (m *PodSpec) Reset()      { *m = PodSpec{} }
+func (*PodSpec) ProtoMessage() {}
+
+func (m *PodStatus) Reset()      { *m = PodStatus{} }
+func (*PodStatus) ProtoMessage() {}
+
+func (m *PodStatusResult) Reset()      { *m = PodStatusResult{} }
+func (*PodStatusResult) ProtoMessage() {}
+
+func (m *PodTemplate) Reset()      { *m = PodTemplate{} }
+func (*PodTemplate) ProtoMessage() {}
+
+func (m *PodTemplateList) Reset()      { *m = PodTemplateList{} }
+func (*PodTemplateList) ProtoMessage() {}
+
+func (m *PodTemplateSpec) Reset()      { *m = PodTemplateSpec{} }
+func (*PodTemplateSpec) ProtoMessage() {}
+
+func (m *Preconditions) Reset()      { *m = Preconditions{} }
+func (*Preconditions) ProtoMessage() {}
+
+func (m *PreferAvoidPodsEntry) Reset()      { *m = PreferAvoidPodsEntry{} }
+func (*PreferAvoidPodsEntry) ProtoMessage() {}
+
+func (m *PreferredSchedulingTerm) Reset()      { *m = PreferredSchedulingTerm{} }
+func (*PreferredSchedulingTerm) ProtoMessage() {}
+
+func (m *Probe) Reset()      { *m = Probe{} }
+func (*Probe) ProtoMessage() {}
+
+func (m *RBDVolumeSource) Reset()      { *m = RBDVolumeSource{} }
+func (*RBDVolumeSource) ProtoMessage() {}
+
+func (m *RangeAllocation) Reset()      { *m = RangeAllocation{} }
+func (*RangeAllocation) ProtoMessage() {}
+
+func (m *ReplicationController) Reset()      { *m = ReplicationController{} }
+func (*ReplicationController) ProtoMessage() {}
+
+func (m *ReplicationControllerList) Reset()      { *m = ReplicationControllerList{} }
+func (*ReplicationControllerList) ProtoMessage() {}
+
+func (m *ReplicationControllerSpec) Reset()      { *m = ReplicationControllerSpec{} }
+func (*ReplicationControllerSpec) ProtoMessage() {}
+
+func (m *ReplicationControllerStatus) Reset()      { *m = ReplicationControllerStatus{} }
+func (*ReplicationControllerStatus) ProtoMessage() {}
+
+func (m *ResourceFieldSelector) Reset()      { *m = ResourceFieldSelector{} }
+func (*ResourceFieldSelector) ProtoMessage() {}
+
+func (m *ResourceQuota) Reset()      { *m = ResourceQuota{} }
+func (*ResourceQuota) ProtoMessage() {}
+
+func (m *ResourceQuotaList) Reset()      { *m = ResourceQuotaList{} }
+func (*ResourceQuotaList) ProtoMessage() {}
+
+func (m *ResourceQuotaSpec) Reset()      { *m = ResourceQuotaSpec{} }
+func (*ResourceQuotaSpec) ProtoMessage() {}
+
+func (m *ResourceQuotaStatus) Reset()      { *m = ResourceQuotaStatus{} }
+func (*ResourceQuotaStatus) ProtoMessage() {}
+
+func (m *ResourceRequirements) Reset()      { *m = ResourceRequirements{} }
+func (*ResourceRequirements) ProtoMessage() {}
+
+func (m *SELinuxOptions) Reset()      { *m = SELinuxOptions{} }
+func (*SELinuxOptions) ProtoMessage() {}
+
+func (m *Secret) Reset()      { *m = Secret{} }
+func (*Secret) ProtoMessage() {}
+
+func (m *SecretKeySelector) Reset()      { *m = SecretKeySelector{} }
+func (*SecretKeySelector) ProtoMessage() {}
+
+func (m *SecretList) Reset()      { *m = SecretList{} }
+func (*SecretList) ProtoMessage() {}
+
+func (m *SecretVolumeSource) Reset()      { *m = SecretVolumeSource{} }
+func (*SecretVolumeSource) ProtoMessage() {}
+
+func (m *SecurityContext) Reset()      { *m = SecurityContext{} }
+func (*SecurityContext) ProtoMessage() {}
+
+func (m *SerializedReference) Reset()      { *m = SerializedReference{} }
+func (*SerializedReference) ProtoMessage() {}
+
+func (m *Service) Reset()      { *m = Service{} }
+func (*Service) ProtoMessage() {}
+
+func (m *ServiceAccount) Reset()      { *m = ServiceAccount{} }
+func (*ServiceAccount) ProtoMessage() {}
+
+func (m *ServiceAccountList) Reset()      { *m = ServiceAccountList{} }
+func (*ServiceAccountList) ProtoMessage() {}
+
+func (m *ServiceList) Reset()      { *m = ServiceList{} }
+func (*ServiceList) ProtoMessage() {}
+
+func (m *ServicePort) Reset()      { *m = ServicePort{} }
+func (*ServicePort) ProtoMessage() {}
+
+func (m *ServiceProxyOptions) Reset()      { *m = ServiceProxyOptions{} }
+func (*ServiceProxyOptions) ProtoMessage() {}
+
+func (m *ServiceSpec) Reset()      { *m = ServiceSpec{} }
+func (*ServiceSpec) ProtoMessage() {}
+
+func (m *ServiceStatus) Reset()      { *m = ServiceStatus{} }
+func (*ServiceStatus) ProtoMessage() {}
+
+func (m *TCPSocketAction) Reset()      { *m = TCPSocketAction{} }
+func (*TCPSocketAction) ProtoMessage() {}
+
+func (m *Taint) Reset()      { *m = Taint{} }
+func (*Taint) ProtoMessage() {}
+
+func (m *Toleration) Reset()      { *m = Toleration{} }
+func (*Toleration) ProtoMessage() {}
+
+func (m *Volume) Reset()      { *m = Volume{} }
+func (*Volume) ProtoMessage() {}
+
+func (m *VolumeMount) Reset()      { *m = VolumeMount{} }
+func (*VolumeMount) ProtoMessage() {}
+
+func (m *VolumeSource) Reset()      { *m = VolumeSource{} }
+func (*VolumeSource) ProtoMessage() {}
+
+func (m *VsphereVirtualDiskVolumeSource) Reset()      { *m = VsphereVirtualDiskVolumeSource{} }
+func (*VsphereVirtualDiskVolumeSource) ProtoMessage() {}
+
+func (m *WeightedPodAffinityTerm) Reset()      { *m = WeightedPodAffinityTerm{} }
+func (*WeightedPodAffinityTerm) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*AWSElasticBlockStoreVolumeSource)(nil), "k8s.io.kubernetes.pkg.api.v1.AWSElasticBlockStoreVolumeSource")
@@ -10434,6 +10286,2144 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *AWSElasticBlockStoreVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&AWSElasticBlockStoreVolumeSource{`,
+		`VolumeID:` + fmt.Sprintf("%v", this.VolumeID) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`Partition:` + fmt.Sprintf("%v", this.Partition) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Affinity) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Affinity{`,
+		`NodeAffinity:` + strings.Replace(fmt.Sprintf("%v", this.NodeAffinity), "NodeAffinity", "NodeAffinity", 1) + `,`,
+		`PodAffinity:` + strings.Replace(fmt.Sprintf("%v", this.PodAffinity), "PodAffinity", "PodAffinity", 1) + `,`,
+		`PodAntiAffinity:` + strings.Replace(fmt.Sprintf("%v", this.PodAntiAffinity), "PodAntiAffinity", "PodAntiAffinity", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *AttachedVolume) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&AttachedVolume{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`DevicePath:` + fmt.Sprintf("%v", this.DevicePath) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *AvoidPods) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&AvoidPods{`,
+		`PreferAvoidPods:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.PreferAvoidPods), "PreferAvoidPodsEntry", "PreferAvoidPodsEntry", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *AzureFileVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&AzureFileVolumeSource{`,
+		`SecretName:` + fmt.Sprintf("%v", this.SecretName) + `,`,
+		`ShareName:` + fmt.Sprintf("%v", this.ShareName) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Binding) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Binding{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Target:` + strings.Replace(strings.Replace(this.Target.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Capabilities) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Capabilities{`,
+		`Add:` + fmt.Sprintf("%v", this.Add) + `,`,
+		`Drop:` + fmt.Sprintf("%v", this.Drop) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CephFSVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CephFSVolumeSource{`,
+		`Monitors:` + fmt.Sprintf("%v", this.Monitors) + `,`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`User:` + fmt.Sprintf("%v", this.User) + `,`,
+		`SecretFile:` + fmt.Sprintf("%v", this.SecretFile) + `,`,
+		`SecretRef:` + strings.Replace(fmt.Sprintf("%v", this.SecretRef), "LocalObjectReference", "LocalObjectReference", 1) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CinderVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CinderVolumeSource{`,
+		`VolumeID:` + fmt.Sprintf("%v", this.VolumeID) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ComponentCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ComponentCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Error:` + fmt.Sprintf("%v", this.Error) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ComponentStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ComponentStatus{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "ComponentCondition", "ComponentCondition", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ComponentStatusList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ComponentStatusList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ComponentStatus", "ComponentStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ConfigMap) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForData := make([]string, 0, len(this.Data))
+	for k := range this.Data {
+		keysForData = append(keysForData, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForData)
+	mapStringForData := "map[string]string{"
+	for _, k := range keysForData {
+		mapStringForData += fmt.Sprintf("%v: %v,", k, this.Data[k])
+	}
+	mapStringForData += "}"
+	s := strings.Join([]string{`&ConfigMap{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Data:` + mapStringForData + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ConfigMapKeySelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ConfigMapKeySelector{`,
+		`LocalObjectReference:` + strings.Replace(strings.Replace(this.LocalObjectReference.String(), "LocalObjectReference", "LocalObjectReference", 1), `&`, ``, 1) + `,`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ConfigMapList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ConfigMapList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ConfigMap", "ConfigMap", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ConfigMapVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ConfigMapVolumeSource{`,
+		`LocalObjectReference:` + strings.Replace(strings.Replace(this.LocalObjectReference.String(), "LocalObjectReference", "LocalObjectReference", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "KeyToPath", "KeyToPath", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Container) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Container{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Image:` + fmt.Sprintf("%v", this.Image) + `,`,
+		`Command:` + fmt.Sprintf("%v", this.Command) + `,`,
+		`Args:` + fmt.Sprintf("%v", this.Args) + `,`,
+		`WorkingDir:` + fmt.Sprintf("%v", this.WorkingDir) + `,`,
+		`Ports:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ports), "ContainerPort", "ContainerPort", 1), `&`, ``, 1) + `,`,
+		`Env:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Env), "EnvVar", "EnvVar", 1), `&`, ``, 1) + `,`,
+		`Resources:` + strings.Replace(strings.Replace(this.Resources.String(), "ResourceRequirements", "ResourceRequirements", 1), `&`, ``, 1) + `,`,
+		`VolumeMounts:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.VolumeMounts), "VolumeMount", "VolumeMount", 1), `&`, ``, 1) + `,`,
+		`LivenessProbe:` + strings.Replace(fmt.Sprintf("%v", this.LivenessProbe), "Probe", "Probe", 1) + `,`,
+		`ReadinessProbe:` + strings.Replace(fmt.Sprintf("%v", this.ReadinessProbe), "Probe", "Probe", 1) + `,`,
+		`Lifecycle:` + strings.Replace(fmt.Sprintf("%v", this.Lifecycle), "Lifecycle", "Lifecycle", 1) + `,`,
+		`TerminationMessagePath:` + fmt.Sprintf("%v", this.TerminationMessagePath) + `,`,
+		`ImagePullPolicy:` + fmt.Sprintf("%v", this.ImagePullPolicy) + `,`,
+		`SecurityContext:` + strings.Replace(fmt.Sprintf("%v", this.SecurityContext), "SecurityContext", "SecurityContext", 1) + `,`,
+		`Stdin:` + fmt.Sprintf("%v", this.Stdin) + `,`,
+		`StdinOnce:` + fmt.Sprintf("%v", this.StdinOnce) + `,`,
+		`TTY:` + fmt.Sprintf("%v", this.TTY) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerImage) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerImage{`,
+		`Names:` + fmt.Sprintf("%v", this.Names) + `,`,
+		`SizeBytes:` + fmt.Sprintf("%v", this.SizeBytes) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerPort) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerPort{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`HostPort:` + fmt.Sprintf("%v", this.HostPort) + `,`,
+		`ContainerPort:` + fmt.Sprintf("%v", this.ContainerPort) + `,`,
+		`Protocol:` + fmt.Sprintf("%v", this.Protocol) + `,`,
+		`HostIP:` + fmt.Sprintf("%v", this.HostIP) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerState) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerState{`,
+		`Waiting:` + strings.Replace(fmt.Sprintf("%v", this.Waiting), "ContainerStateWaiting", "ContainerStateWaiting", 1) + `,`,
+		`Running:` + strings.Replace(fmt.Sprintf("%v", this.Running), "ContainerStateRunning", "ContainerStateRunning", 1) + `,`,
+		`Terminated:` + strings.Replace(fmt.Sprintf("%v", this.Terminated), "ContainerStateTerminated", "ContainerStateTerminated", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerStateRunning) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerStateRunning{`,
+		`StartedAt:` + strings.Replace(strings.Replace(this.StartedAt.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerStateTerminated) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerStateTerminated{`,
+		`ExitCode:` + fmt.Sprintf("%v", this.ExitCode) + `,`,
+		`Signal:` + fmt.Sprintf("%v", this.Signal) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`StartedAt:` + strings.Replace(strings.Replace(this.StartedAt.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`FinishedAt:` + strings.Replace(strings.Replace(this.FinishedAt.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`ContainerID:` + fmt.Sprintf("%v", this.ContainerID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerStateWaiting) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerStateWaiting{`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ContainerStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ContainerStatus{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`State:` + strings.Replace(strings.Replace(this.State.String(), "ContainerState", "ContainerState", 1), `&`, ``, 1) + `,`,
+		`LastTerminationState:` + strings.Replace(strings.Replace(this.LastTerminationState.String(), "ContainerState", "ContainerState", 1), `&`, ``, 1) + `,`,
+		`Ready:` + fmt.Sprintf("%v", this.Ready) + `,`,
+		`RestartCount:` + fmt.Sprintf("%v", this.RestartCount) + `,`,
+		`Image:` + fmt.Sprintf("%v", this.Image) + `,`,
+		`ImageID:` + fmt.Sprintf("%v", this.ImageID) + `,`,
+		`ContainerID:` + fmt.Sprintf("%v", this.ContainerID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DaemonEndpoint) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DaemonEndpoint{`,
+		`Port:` + fmt.Sprintf("%v", this.Port) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeleteOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeleteOptions{`,
+		`GracePeriodSeconds:` + valueToStringGenerated(this.GracePeriodSeconds) + `,`,
+		`Preconditions:` + strings.Replace(fmt.Sprintf("%v", this.Preconditions), "Preconditions", "Preconditions", 1) + `,`,
+		`OrphanDependents:` + valueToStringGenerated(this.OrphanDependents) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DownwardAPIVolumeFile) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DownwardAPIVolumeFile{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`FieldRef:` + strings.Replace(fmt.Sprintf("%v", this.FieldRef), "ObjectFieldSelector", "ObjectFieldSelector", 1) + `,`,
+		`ResourceFieldRef:` + strings.Replace(fmt.Sprintf("%v", this.ResourceFieldRef), "ResourceFieldSelector", "ResourceFieldSelector", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DownwardAPIVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DownwardAPIVolumeSource{`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "DownwardAPIVolumeFile", "DownwardAPIVolumeFile", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EmptyDirVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EmptyDirVolumeSource{`,
+		`Medium:` + fmt.Sprintf("%v", this.Medium) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EndpointAddress) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EndpointAddress{`,
+		`IP:` + fmt.Sprintf("%v", this.IP) + `,`,
+		`TargetRef:` + strings.Replace(fmt.Sprintf("%v", this.TargetRef), "ObjectReference", "ObjectReference", 1) + `,`,
+		`Hostname:` + fmt.Sprintf("%v", this.Hostname) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EndpointPort) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EndpointPort{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Port:` + fmt.Sprintf("%v", this.Port) + `,`,
+		`Protocol:` + fmt.Sprintf("%v", this.Protocol) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EndpointSubset) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EndpointSubset{`,
+		`Addresses:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Addresses), "EndpointAddress", "EndpointAddress", 1), `&`, ``, 1) + `,`,
+		`NotReadyAddresses:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.NotReadyAddresses), "EndpointAddress", "EndpointAddress", 1), `&`, ``, 1) + `,`,
+		`Ports:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ports), "EndpointPort", "EndpointPort", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Endpoints) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Endpoints{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Subsets:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Subsets), "EndpointSubset", "EndpointSubset", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EndpointsList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EndpointsList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Endpoints", "Endpoints", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EnvVar) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EnvVar{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Value:` + fmt.Sprintf("%v", this.Value) + `,`,
+		`ValueFrom:` + strings.Replace(fmt.Sprintf("%v", this.ValueFrom), "EnvVarSource", "EnvVarSource", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EnvVarSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EnvVarSource{`,
+		`FieldRef:` + strings.Replace(fmt.Sprintf("%v", this.FieldRef), "ObjectFieldSelector", "ObjectFieldSelector", 1) + `,`,
+		`ResourceFieldRef:` + strings.Replace(fmt.Sprintf("%v", this.ResourceFieldRef), "ResourceFieldSelector", "ResourceFieldSelector", 1) + `,`,
+		`ConfigMapKeyRef:` + strings.Replace(fmt.Sprintf("%v", this.ConfigMapKeyRef), "ConfigMapKeySelector", "ConfigMapKeySelector", 1) + `,`,
+		`SecretKeyRef:` + strings.Replace(fmt.Sprintf("%v", this.SecretKeyRef), "SecretKeySelector", "SecretKeySelector", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Event) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Event{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`InvolvedObject:` + strings.Replace(strings.Replace(this.InvolvedObject.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Source:` + strings.Replace(strings.Replace(this.Source.String(), "EventSource", "EventSource", 1), `&`, ``, 1) + `,`,
+		`FirstTimestamp:` + strings.Replace(strings.Replace(this.FirstTimestamp.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTimestamp:` + strings.Replace(strings.Replace(this.LastTimestamp.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Count:` + fmt.Sprintf("%v", this.Count) + `,`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EventList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EventList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Event", "Event", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *EventSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&EventSource{`,
+		`Component:` + fmt.Sprintf("%v", this.Component) + `,`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ExecAction) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ExecAction{`,
+		`Command:` + fmt.Sprintf("%v", this.Command) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ExportOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ExportOptions{`,
+		`Export:` + fmt.Sprintf("%v", this.Export) + `,`,
+		`Exact:` + fmt.Sprintf("%v", this.Exact) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FCVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&FCVolumeSource{`,
+		`TargetWWNs:` + fmt.Sprintf("%v", this.TargetWWNs) + `,`,
+		`Lun:` + valueToStringGenerated(this.Lun) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FlexVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForOptions := make([]string, 0, len(this.Options))
+	for k := range this.Options {
+		keysForOptions = append(keysForOptions, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForOptions)
+	mapStringForOptions := "map[string]string{"
+	for _, k := range keysForOptions {
+		mapStringForOptions += fmt.Sprintf("%v: %v,", k, this.Options[k])
+	}
+	mapStringForOptions += "}"
+	s := strings.Join([]string{`&FlexVolumeSource{`,
+		`Driver:` + fmt.Sprintf("%v", this.Driver) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`SecretRef:` + strings.Replace(fmt.Sprintf("%v", this.SecretRef), "LocalObjectReference", "LocalObjectReference", 1) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`Options:` + mapStringForOptions + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FlockerVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&FlockerVolumeSource{`,
+		`DatasetName:` + fmt.Sprintf("%v", this.DatasetName) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GCEPersistentDiskVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GCEPersistentDiskVolumeSource{`,
+		`PDName:` + fmt.Sprintf("%v", this.PDName) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`Partition:` + fmt.Sprintf("%v", this.Partition) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GitRepoVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GitRepoVolumeSource{`,
+		`Repository:` + fmt.Sprintf("%v", this.Repository) + `,`,
+		`Revision:` + fmt.Sprintf("%v", this.Revision) + `,`,
+		`Directory:` + fmt.Sprintf("%v", this.Directory) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GlusterfsVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GlusterfsVolumeSource{`,
+		`EndpointsName:` + fmt.Sprintf("%v", this.EndpointsName) + `,`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HTTPGetAction) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HTTPGetAction{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`Port:` + strings.Replace(strings.Replace(this.Port.String(), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1), `&`, ``, 1) + `,`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`Scheme:` + fmt.Sprintf("%v", this.Scheme) + `,`,
+		`HTTPHeaders:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.HTTPHeaders), "HTTPHeader", "HTTPHeader", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HTTPHeader) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HTTPHeader{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Value:` + fmt.Sprintf("%v", this.Value) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Handler) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Handler{`,
+		`Exec:` + strings.Replace(fmt.Sprintf("%v", this.Exec), "ExecAction", "ExecAction", 1) + `,`,
+		`HTTPGet:` + strings.Replace(fmt.Sprintf("%v", this.HTTPGet), "HTTPGetAction", "HTTPGetAction", 1) + `,`,
+		`TCPSocket:` + strings.Replace(fmt.Sprintf("%v", this.TCPSocket), "TCPSocketAction", "TCPSocketAction", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HostPathVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HostPathVolumeSource{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ISCSIVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ISCSIVolumeSource{`,
+		`TargetPortal:` + fmt.Sprintf("%v", this.TargetPortal) + `,`,
+		`IQN:` + fmt.Sprintf("%v", this.IQN) + `,`,
+		`Lun:` + fmt.Sprintf("%v", this.Lun) + `,`,
+		`ISCSIInterface:` + fmt.Sprintf("%v", this.ISCSIInterface) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *KeyToPath) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&KeyToPath{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Lifecycle) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Lifecycle{`,
+		`PostStart:` + strings.Replace(fmt.Sprintf("%v", this.PostStart), "Handler", "Handler", 1) + `,`,
+		`PreStop:` + strings.Replace(fmt.Sprintf("%v", this.PreStop), "Handler", "Handler", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LimitRange) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LimitRange{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "LimitRangeSpec", "LimitRangeSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LimitRangeItem) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForMax := make([]string, 0, len(this.Max))
+	for k := range this.Max {
+		keysForMax = append(keysForMax, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMax)
+	mapStringForMax := "ResourceList{"
+	for _, k := range keysForMax {
+		mapStringForMax += fmt.Sprintf("%v: %v,", k, this.Max[ResourceName(k)])
+	}
+	mapStringForMax += "}"
+	keysForMin := make([]string, 0, len(this.Min))
+	for k := range this.Min {
+		keysForMin = append(keysForMin, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMin)
+	mapStringForMin := "ResourceList{"
+	for _, k := range keysForMin {
+		mapStringForMin += fmt.Sprintf("%v: %v,", k, this.Min[ResourceName(k)])
+	}
+	mapStringForMin += "}"
+	keysForDefault := make([]string, 0, len(this.Default))
+	for k := range this.Default {
+		keysForDefault = append(keysForDefault, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForDefault)
+	mapStringForDefault := "ResourceList{"
+	for _, k := range keysForDefault {
+		mapStringForDefault += fmt.Sprintf("%v: %v,", k, this.Default[ResourceName(k)])
+	}
+	mapStringForDefault += "}"
+	keysForDefaultRequest := make([]string, 0, len(this.DefaultRequest))
+	for k := range this.DefaultRequest {
+		keysForDefaultRequest = append(keysForDefaultRequest, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForDefaultRequest)
+	mapStringForDefaultRequest := "ResourceList{"
+	for _, k := range keysForDefaultRequest {
+		mapStringForDefaultRequest += fmt.Sprintf("%v: %v,", k, this.DefaultRequest[ResourceName(k)])
+	}
+	mapStringForDefaultRequest += "}"
+	keysForMaxLimitRequestRatio := make([]string, 0, len(this.MaxLimitRequestRatio))
+	for k := range this.MaxLimitRequestRatio {
+		keysForMaxLimitRequestRatio = append(keysForMaxLimitRequestRatio, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMaxLimitRequestRatio)
+	mapStringForMaxLimitRequestRatio := "ResourceList{"
+	for _, k := range keysForMaxLimitRequestRatio {
+		mapStringForMaxLimitRequestRatio += fmt.Sprintf("%v: %v,", k, this.MaxLimitRequestRatio[ResourceName(k)])
+	}
+	mapStringForMaxLimitRequestRatio += "}"
+	s := strings.Join([]string{`&LimitRangeItem{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Max:` + mapStringForMax + `,`,
+		`Min:` + mapStringForMin + `,`,
+		`Default:` + mapStringForDefault + `,`,
+		`DefaultRequest:` + mapStringForDefaultRequest + `,`,
+		`MaxLimitRequestRatio:` + mapStringForMaxLimitRequestRatio + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LimitRangeList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LimitRangeList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "LimitRange", "LimitRange", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LimitRangeSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LimitRangeSpec{`,
+		`Limits:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Limits), "LimitRangeItem", "LimitRangeItem", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *List) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&List{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "RawExtension", "k8s_io_kubernetes_pkg_runtime.RawExtension", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListOptions{`,
+		`LabelSelector:` + fmt.Sprintf("%v", this.LabelSelector) + `,`,
+		`FieldSelector:` + fmt.Sprintf("%v", this.FieldSelector) + `,`,
+		`Watch:` + fmt.Sprintf("%v", this.Watch) + `,`,
+		`ResourceVersion:` + fmt.Sprintf("%v", this.ResourceVersion) + `,`,
+		`TimeoutSeconds:` + valueToStringGenerated(this.TimeoutSeconds) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LoadBalancerIngress) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LoadBalancerIngress{`,
+		`IP:` + fmt.Sprintf("%v", this.IP) + `,`,
+		`Hostname:` + fmt.Sprintf("%v", this.Hostname) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LoadBalancerStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LoadBalancerStatus{`,
+		`Ingress:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ingress), "LoadBalancerIngress", "LoadBalancerIngress", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LocalObjectReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LocalObjectReference{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NFSVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NFSVolumeSource{`,
+		`Server:` + fmt.Sprintf("%v", this.Server) + `,`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Namespace) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Namespace{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "NamespaceSpec", "NamespaceSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "NamespaceStatus", "NamespaceStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NamespaceList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NamespaceList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Namespace", "Namespace", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NamespaceSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NamespaceSpec{`,
+		`Finalizers:` + fmt.Sprintf("%v", this.Finalizers) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NamespaceStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NamespaceStatus{`,
+		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Node) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Node{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "NodeSpec", "NodeSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "NodeStatus", "NodeStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeAddress) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeAddress{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Address:` + fmt.Sprintf("%v", this.Address) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeAffinity) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeAffinity{`,
+		`RequiredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(fmt.Sprintf("%v", this.RequiredDuringSchedulingIgnoredDuringExecution), "NodeSelector", "NodeSelector", 1) + `,`,
+		`PreferredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.PreferredDuringSchedulingIgnoredDuringExecution), "PreferredSchedulingTerm", "PreferredSchedulingTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastHeartbeatTime:` + strings.Replace(strings.Replace(this.LastHeartbeatTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeDaemonEndpoints) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeDaemonEndpoints{`,
+		`KubeletEndpoint:` + strings.Replace(strings.Replace(this.KubeletEndpoint.String(), "DaemonEndpoint", "DaemonEndpoint", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Node", "Node", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeProxyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeProxyOptions{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeSelector{`,
+		`NodeSelectorTerms:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.NodeSelectorTerms), "NodeSelectorTerm", "NodeSelectorTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeSelectorRequirement) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeSelectorRequirement{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", this.Values) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeSelectorTerm) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeSelectorTerm{`,
+		`MatchExpressions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.MatchExpressions), "NodeSelectorRequirement", "NodeSelectorRequirement", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeSpec{`,
+		`PodCIDR:` + fmt.Sprintf("%v", this.PodCIDR) + `,`,
+		`ExternalID:` + fmt.Sprintf("%v", this.ExternalID) + `,`,
+		`ProviderID:` + fmt.Sprintf("%v", this.ProviderID) + `,`,
+		`Unschedulable:` + fmt.Sprintf("%v", this.Unschedulable) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForCapacity := make([]string, 0, len(this.Capacity))
+	for k := range this.Capacity {
+		keysForCapacity = append(keysForCapacity, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForCapacity)
+	mapStringForCapacity := "ResourceList{"
+	for _, k := range keysForCapacity {
+		mapStringForCapacity += fmt.Sprintf("%v: %v,", k, this.Capacity[ResourceName(k)])
+	}
+	mapStringForCapacity += "}"
+	keysForAllocatable := make([]string, 0, len(this.Allocatable))
+	for k := range this.Allocatable {
+		keysForAllocatable = append(keysForAllocatable, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForAllocatable)
+	mapStringForAllocatable := "ResourceList{"
+	for _, k := range keysForAllocatable {
+		mapStringForAllocatable += fmt.Sprintf("%v: %v,", k, this.Allocatable[ResourceName(k)])
+	}
+	mapStringForAllocatable += "}"
+	s := strings.Join([]string{`&NodeStatus{`,
+		`Capacity:` + mapStringForCapacity + `,`,
+		`Allocatable:` + mapStringForAllocatable + `,`,
+		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "NodeCondition", "NodeCondition", 1), `&`, ``, 1) + `,`,
+		`Addresses:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Addresses), "NodeAddress", "NodeAddress", 1), `&`, ``, 1) + `,`,
+		`DaemonEndpoints:` + strings.Replace(strings.Replace(this.DaemonEndpoints.String(), "NodeDaemonEndpoints", "NodeDaemonEndpoints", 1), `&`, ``, 1) + `,`,
+		`NodeInfo:` + strings.Replace(strings.Replace(this.NodeInfo.String(), "NodeSystemInfo", "NodeSystemInfo", 1), `&`, ``, 1) + `,`,
+		`Images:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Images), "ContainerImage", "ContainerImage", 1), `&`, ``, 1) + `,`,
+		`VolumesInUse:` + fmt.Sprintf("%v", this.VolumesInUse) + `,`,
+		`VolumesAttached:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.VolumesAttached), "AttachedVolume", "AttachedVolume", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NodeSystemInfo) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NodeSystemInfo{`,
+		`MachineID:` + fmt.Sprintf("%v", this.MachineID) + `,`,
+		`SystemUUID:` + fmt.Sprintf("%v", this.SystemUUID) + `,`,
+		`BootID:` + fmt.Sprintf("%v", this.BootID) + `,`,
+		`KernelVersion:` + fmt.Sprintf("%v", this.KernelVersion) + `,`,
+		`OSImage:` + fmt.Sprintf("%v", this.OSImage) + `,`,
+		`ContainerRuntimeVersion:` + fmt.Sprintf("%v", this.ContainerRuntimeVersion) + `,`,
+		`KubeletVersion:` + fmt.Sprintf("%v", this.KubeletVersion) + `,`,
+		`KubeProxyVersion:` + fmt.Sprintf("%v", this.KubeProxyVersion) + `,`,
+		`OperatingSystem:` + fmt.Sprintf("%v", this.OperatingSystem) + `,`,
+		`Architecture:` + fmt.Sprintf("%v", this.Architecture) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ObjectFieldSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ObjectFieldSelector{`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`FieldPath:` + fmt.Sprintf("%v", this.FieldPath) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ObjectMeta) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForLabels := make([]string, 0, len(this.Labels))
+	for k := range this.Labels {
+		keysForLabels = append(keysForLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForLabels)
+	mapStringForLabels := "map[string]string{"
+	for _, k := range keysForLabels {
+		mapStringForLabels += fmt.Sprintf("%v: %v,", k, this.Labels[k])
+	}
+	mapStringForLabels += "}"
+	keysForAnnotations := make([]string, 0, len(this.Annotations))
+	for k := range this.Annotations {
+		keysForAnnotations = append(keysForAnnotations, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForAnnotations)
+	mapStringForAnnotations := "map[string]string{"
+	for _, k := range keysForAnnotations {
+		mapStringForAnnotations += fmt.Sprintf("%v: %v,", k, this.Annotations[k])
+	}
+	mapStringForAnnotations += "}"
+	s := strings.Join([]string{`&ObjectMeta{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`GenerateName:` + fmt.Sprintf("%v", this.GenerateName) + `,`,
+		`Namespace:` + fmt.Sprintf("%v", this.Namespace) + `,`,
+		`SelfLink:` + fmt.Sprintf("%v", this.SelfLink) + `,`,
+		`UID:` + fmt.Sprintf("%v", this.UID) + `,`,
+		`ResourceVersion:` + fmt.Sprintf("%v", this.ResourceVersion) + `,`,
+		`Generation:` + fmt.Sprintf("%v", this.Generation) + `,`,
+		`CreationTimestamp:` + strings.Replace(strings.Replace(this.CreationTimestamp.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`DeletionTimestamp:` + strings.Replace(fmt.Sprintf("%v", this.DeletionTimestamp), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`DeletionGracePeriodSeconds:` + valueToStringGenerated(this.DeletionGracePeriodSeconds) + `,`,
+		`Labels:` + mapStringForLabels + `,`,
+		`Annotations:` + mapStringForAnnotations + `,`,
+		`OwnerReferences:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.OwnerReferences), "OwnerReference", "OwnerReference", 1), `&`, ``, 1) + `,`,
+		`Finalizers:` + fmt.Sprintf("%v", this.Finalizers) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ObjectReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ObjectReference{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`Namespace:` + fmt.Sprintf("%v", this.Namespace) + `,`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`UID:` + fmt.Sprintf("%v", this.UID) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`ResourceVersion:` + fmt.Sprintf("%v", this.ResourceVersion) + `,`,
+		`FieldPath:` + fmt.Sprintf("%v", this.FieldPath) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *OwnerReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&OwnerReference{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`UID:` + fmt.Sprintf("%v", this.UID) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`Controller:` + valueToStringGenerated(this.Controller) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolume) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolume{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PersistentVolumeSpec", "PersistentVolumeSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PersistentVolumeStatus", "PersistentVolumeStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeClaim) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeClaim{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PersistentVolumeClaimSpec", "PersistentVolumeClaimSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PersistentVolumeClaimStatus", "PersistentVolumeClaimStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeClaimList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeClaimList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PersistentVolumeClaim", "PersistentVolumeClaim", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeClaimSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeClaimSpec{`,
+		`AccessModes:` + fmt.Sprintf("%v", this.AccessModes) + `,`,
+		`Resources:` + strings.Replace(strings.Replace(this.Resources.String(), "ResourceRequirements", "ResourceRequirements", 1), `&`, ``, 1) + `,`,
+		`VolumeName:` + fmt.Sprintf("%v", this.VolumeName) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "k8s_io_kubernetes_pkg_api_unversioned.LabelSelector", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeClaimStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForCapacity := make([]string, 0, len(this.Capacity))
+	for k := range this.Capacity {
+		keysForCapacity = append(keysForCapacity, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForCapacity)
+	mapStringForCapacity := "ResourceList{"
+	for _, k := range keysForCapacity {
+		mapStringForCapacity += fmt.Sprintf("%v: %v,", k, this.Capacity[ResourceName(k)])
+	}
+	mapStringForCapacity += "}"
+	s := strings.Join([]string{`&PersistentVolumeClaimStatus{`,
+		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
+		`AccessModes:` + fmt.Sprintf("%v", this.AccessModes) + `,`,
+		`Capacity:` + mapStringForCapacity + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeClaimVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeClaimVolumeSource{`,
+		`ClaimName:` + fmt.Sprintf("%v", this.ClaimName) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PersistentVolume", "PersistentVolume", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeSource{`,
+		`GCEPersistentDisk:` + strings.Replace(fmt.Sprintf("%v", this.GCEPersistentDisk), "GCEPersistentDiskVolumeSource", "GCEPersistentDiskVolumeSource", 1) + `,`,
+		`AWSElasticBlockStore:` + strings.Replace(fmt.Sprintf("%v", this.AWSElasticBlockStore), "AWSElasticBlockStoreVolumeSource", "AWSElasticBlockStoreVolumeSource", 1) + `,`,
+		`HostPath:` + strings.Replace(fmt.Sprintf("%v", this.HostPath), "HostPathVolumeSource", "HostPathVolumeSource", 1) + `,`,
+		`Glusterfs:` + strings.Replace(fmt.Sprintf("%v", this.Glusterfs), "GlusterfsVolumeSource", "GlusterfsVolumeSource", 1) + `,`,
+		`NFS:` + strings.Replace(fmt.Sprintf("%v", this.NFS), "NFSVolumeSource", "NFSVolumeSource", 1) + `,`,
+		`RBD:` + strings.Replace(fmt.Sprintf("%v", this.RBD), "RBDVolumeSource", "RBDVolumeSource", 1) + `,`,
+		`ISCSI:` + strings.Replace(fmt.Sprintf("%v", this.ISCSI), "ISCSIVolumeSource", "ISCSIVolumeSource", 1) + `,`,
+		`Cinder:` + strings.Replace(fmt.Sprintf("%v", this.Cinder), "CinderVolumeSource", "CinderVolumeSource", 1) + `,`,
+		`CephFS:` + strings.Replace(fmt.Sprintf("%v", this.CephFS), "CephFSVolumeSource", "CephFSVolumeSource", 1) + `,`,
+		`FC:` + strings.Replace(fmt.Sprintf("%v", this.FC), "FCVolumeSource", "FCVolumeSource", 1) + `,`,
+		`Flocker:` + strings.Replace(fmt.Sprintf("%v", this.Flocker), "FlockerVolumeSource", "FlockerVolumeSource", 1) + `,`,
+		`FlexVolume:` + strings.Replace(fmt.Sprintf("%v", this.FlexVolume), "FlexVolumeSource", "FlexVolumeSource", 1) + `,`,
+		`AzureFile:` + strings.Replace(fmt.Sprintf("%v", this.AzureFile), "AzureFileVolumeSource", "AzureFileVolumeSource", 1) + `,`,
+		`VsphereVolume:` + strings.Replace(fmt.Sprintf("%v", this.VsphereVolume), "VsphereVirtualDiskVolumeSource", "VsphereVirtualDiskVolumeSource", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForCapacity := make([]string, 0, len(this.Capacity))
+	for k := range this.Capacity {
+		keysForCapacity = append(keysForCapacity, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForCapacity)
+	mapStringForCapacity := "ResourceList{"
+	for _, k := range keysForCapacity {
+		mapStringForCapacity += fmt.Sprintf("%v: %v,", k, this.Capacity[ResourceName(k)])
+	}
+	mapStringForCapacity += "}"
+	s := strings.Join([]string{`&PersistentVolumeSpec{`,
+		`Capacity:` + mapStringForCapacity + `,`,
+		`PersistentVolumeSource:` + strings.Replace(strings.Replace(this.PersistentVolumeSource.String(), "PersistentVolumeSource", "PersistentVolumeSource", 1), `&`, ``, 1) + `,`,
+		`AccessModes:` + fmt.Sprintf("%v", this.AccessModes) + `,`,
+		`ClaimRef:` + strings.Replace(fmt.Sprintf("%v", this.ClaimRef), "ObjectReference", "ObjectReference", 1) + `,`,
+		`PersistentVolumeReclaimPolicy:` + fmt.Sprintf("%v", this.PersistentVolumeReclaimPolicy) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PersistentVolumeStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PersistentVolumeStatus{`,
+		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Pod) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Pod{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PodSpec", "PodSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PodStatus", "PodStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodAffinity) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodAffinity{`,
+		`RequiredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.RequiredDuringSchedulingIgnoredDuringExecution), "PodAffinityTerm", "PodAffinityTerm", 1), `&`, ``, 1) + `,`,
+		`PreferredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.PreferredDuringSchedulingIgnoredDuringExecution), "WeightedPodAffinityTerm", "WeightedPodAffinityTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodAffinityTerm) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodAffinityTerm{`,
+		`LabelSelector:` + strings.Replace(fmt.Sprintf("%v", this.LabelSelector), "LabelSelector", "k8s_io_kubernetes_pkg_api_unversioned.LabelSelector", 1) + `,`,
+		`Namespaces:` + fmt.Sprintf("%v", this.Namespaces) + `,`,
+		`TopologyKey:` + fmt.Sprintf("%v", this.TopologyKey) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodAntiAffinity) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodAntiAffinity{`,
+		`RequiredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.RequiredDuringSchedulingIgnoredDuringExecution), "PodAffinityTerm", "PodAffinityTerm", 1), `&`, ``, 1) + `,`,
+		`PreferredDuringSchedulingIgnoredDuringExecution:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.PreferredDuringSchedulingIgnoredDuringExecution), "WeightedPodAffinityTerm", "WeightedPodAffinityTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodAttachOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodAttachOptions{`,
+		`Stdin:` + fmt.Sprintf("%v", this.Stdin) + `,`,
+		`Stdout:` + fmt.Sprintf("%v", this.Stdout) + `,`,
+		`Stderr:` + fmt.Sprintf("%v", this.Stderr) + `,`,
+		`TTY:` + fmt.Sprintf("%v", this.TTY) + `,`,
+		`Container:` + fmt.Sprintf("%v", this.Container) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastProbeTime:` + strings.Replace(strings.Replace(this.LastProbeTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodExecOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodExecOptions{`,
+		`Stdin:` + fmt.Sprintf("%v", this.Stdin) + `,`,
+		`Stdout:` + fmt.Sprintf("%v", this.Stdout) + `,`,
+		`Stderr:` + fmt.Sprintf("%v", this.Stderr) + `,`,
+		`TTY:` + fmt.Sprintf("%v", this.TTY) + `,`,
+		`Container:` + fmt.Sprintf("%v", this.Container) + `,`,
+		`Command:` + fmt.Sprintf("%v", this.Command) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Pod", "Pod", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodLogOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodLogOptions{`,
+		`Container:` + fmt.Sprintf("%v", this.Container) + `,`,
+		`Follow:` + fmt.Sprintf("%v", this.Follow) + `,`,
+		`Previous:` + fmt.Sprintf("%v", this.Previous) + `,`,
+		`SinceSeconds:` + valueToStringGenerated(this.SinceSeconds) + `,`,
+		`SinceTime:` + strings.Replace(fmt.Sprintf("%v", this.SinceTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`Timestamps:` + fmt.Sprintf("%v", this.Timestamps) + `,`,
+		`TailLines:` + valueToStringGenerated(this.TailLines) + `,`,
+		`LimitBytes:` + valueToStringGenerated(this.LimitBytes) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodProxyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodProxyOptions{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSecurityContext) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodSecurityContext{`,
+		`SELinuxOptions:` + strings.Replace(fmt.Sprintf("%v", this.SELinuxOptions), "SELinuxOptions", "SELinuxOptions", 1) + `,`,
+		`RunAsUser:` + valueToStringGenerated(this.RunAsUser) + `,`,
+		`RunAsNonRoot:` + valueToStringGenerated(this.RunAsNonRoot) + `,`,
+		`SupplementalGroups:` + fmt.Sprintf("%v", this.SupplementalGroups) + `,`,
+		`FSGroup:` + valueToStringGenerated(this.FSGroup) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSignature) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodSignature{`,
+		`PodController:` + strings.Replace(fmt.Sprintf("%v", this.PodController), "OwnerReference", "OwnerReference", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForNodeSelector := make([]string, 0, len(this.NodeSelector))
+	for k := range this.NodeSelector {
+		keysForNodeSelector = append(keysForNodeSelector, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForNodeSelector)
+	mapStringForNodeSelector := "map[string]string{"
+	for _, k := range keysForNodeSelector {
+		mapStringForNodeSelector += fmt.Sprintf("%v: %v,", k, this.NodeSelector[k])
+	}
+	mapStringForNodeSelector += "}"
+	s := strings.Join([]string{`&PodSpec{`,
+		`Volumes:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Volumes), "Volume", "Volume", 1), `&`, ``, 1) + `,`,
+		`Containers:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Containers), "Container", "Container", 1), `&`, ``, 1) + `,`,
+		`RestartPolicy:` + fmt.Sprintf("%v", this.RestartPolicy) + `,`,
+		`TerminationGracePeriodSeconds:` + valueToStringGenerated(this.TerminationGracePeriodSeconds) + `,`,
+		`ActiveDeadlineSeconds:` + valueToStringGenerated(this.ActiveDeadlineSeconds) + `,`,
+		`DNSPolicy:` + fmt.Sprintf("%v", this.DNSPolicy) + `,`,
+		`NodeSelector:` + mapStringForNodeSelector + `,`,
+		`ServiceAccountName:` + fmt.Sprintf("%v", this.ServiceAccountName) + `,`,
+		`DeprecatedServiceAccount:` + fmt.Sprintf("%v", this.DeprecatedServiceAccount) + `,`,
+		`NodeName:` + fmt.Sprintf("%v", this.NodeName) + `,`,
+		`HostNetwork:` + fmt.Sprintf("%v", this.HostNetwork) + `,`,
+		`HostPID:` + fmt.Sprintf("%v", this.HostPID) + `,`,
+		`HostIPC:` + fmt.Sprintf("%v", this.HostIPC) + `,`,
+		`SecurityContext:` + strings.Replace(fmt.Sprintf("%v", this.SecurityContext), "PodSecurityContext", "PodSecurityContext", 1) + `,`,
+		`ImagePullSecrets:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ImagePullSecrets), "LocalObjectReference", "LocalObjectReference", 1), `&`, ``, 1) + `,`,
+		`Hostname:` + fmt.Sprintf("%v", this.Hostname) + `,`,
+		`Subdomain:` + fmt.Sprintf("%v", this.Subdomain) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodStatus{`,
+		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "PodCondition", "PodCondition", 1), `&`, ``, 1) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`HostIP:` + fmt.Sprintf("%v", this.HostIP) + `,`,
+		`PodIP:` + fmt.Sprintf("%v", this.PodIP) + `,`,
+		`StartTime:` + strings.Replace(fmt.Sprintf("%v", this.StartTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`ContainerStatuses:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ContainerStatuses), "ContainerStatus", "ContainerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodStatusResult) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodStatusResult{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PodStatus", "PodStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodTemplate) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodTemplate{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodTemplateList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodTemplateList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PodTemplate", "PodTemplate", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodTemplateSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodTemplateSpec{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PodSpec", "PodSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Preconditions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Preconditions{`,
+		`UID:` + valueToStringGenerated(this.UID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PreferAvoidPodsEntry) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PreferAvoidPodsEntry{`,
+		`PodSignature:` + strings.Replace(strings.Replace(this.PodSignature.String(), "PodSignature", "PodSignature", 1), `&`, ``, 1) + `,`,
+		`EvictionTime:` + strings.Replace(strings.Replace(this.EvictionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PreferredSchedulingTerm) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PreferredSchedulingTerm{`,
+		`Weight:` + fmt.Sprintf("%v", this.Weight) + `,`,
+		`Preference:` + strings.Replace(strings.Replace(this.Preference.String(), "NodeSelectorTerm", "NodeSelectorTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Probe) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Probe{`,
+		`Handler:` + strings.Replace(strings.Replace(this.Handler.String(), "Handler", "Handler", 1), `&`, ``, 1) + `,`,
+		`InitialDelaySeconds:` + fmt.Sprintf("%v", this.InitialDelaySeconds) + `,`,
+		`TimeoutSeconds:` + fmt.Sprintf("%v", this.TimeoutSeconds) + `,`,
+		`PeriodSeconds:` + fmt.Sprintf("%v", this.PeriodSeconds) + `,`,
+		`SuccessThreshold:` + fmt.Sprintf("%v", this.SuccessThreshold) + `,`,
+		`FailureThreshold:` + fmt.Sprintf("%v", this.FailureThreshold) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RBDVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RBDVolumeSource{`,
+		`CephMonitors:` + fmt.Sprintf("%v", this.CephMonitors) + `,`,
+		`RBDImage:` + fmt.Sprintf("%v", this.RBDImage) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`RBDPool:` + fmt.Sprintf("%v", this.RBDPool) + `,`,
+		`RadosUser:` + fmt.Sprintf("%v", this.RadosUser) + `,`,
+		`Keyring:` + fmt.Sprintf("%v", this.Keyring) + `,`,
+		`SecretRef:` + strings.Replace(fmt.Sprintf("%v", this.SecretRef), "LocalObjectReference", "LocalObjectReference", 1) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RangeAllocation) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RangeAllocation{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Range:` + fmt.Sprintf("%v", this.Range) + `,`,
+		`Data:` + valueToStringGenerated(this.Data) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicationController) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicationController{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ReplicationControllerSpec", "ReplicationControllerSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ReplicationControllerStatus", "ReplicationControllerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicationControllerList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicationControllerList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ReplicationController", "ReplicationController", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicationControllerSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForSelector := make([]string, 0, len(this.Selector))
+	for k := range this.Selector {
+		keysForSelector = append(keysForSelector, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForSelector)
+	mapStringForSelector := "map[string]string{"
+	for _, k := range keysForSelector {
+		mapStringForSelector += fmt.Sprintf("%v: %v,", k, this.Selector[k])
+	}
+	mapStringForSelector += "}"
+	s := strings.Join([]string{`&ReplicationControllerSpec{`,
+		`Replicas:` + valueToStringGenerated(this.Replicas) + `,`,
+		`Selector:` + mapStringForSelector + `,`,
+		`Template:` + strings.Replace(fmt.Sprintf("%v", this.Template), "PodTemplateSpec", "PodTemplateSpec", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicationControllerStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicationControllerStatus{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`FullyLabeledReplicas:` + fmt.Sprintf("%v", this.FullyLabeledReplicas) + `,`,
+		`ObservedGeneration:` + fmt.Sprintf("%v", this.ObservedGeneration) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceFieldSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ResourceFieldSelector{`,
+		`ContainerName:` + fmt.Sprintf("%v", this.ContainerName) + `,`,
+		`Resource:` + fmt.Sprintf("%v", this.Resource) + `,`,
+		`Divisor:` + strings.Replace(strings.Replace(this.Divisor.String(), "Quantity", "k8s_io_kubernetes_pkg_api_resource.Quantity", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceQuota) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ResourceQuota{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ResourceQuotaSpec", "ResourceQuotaSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ResourceQuotaStatus", "ResourceQuotaStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceQuotaList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ResourceQuotaList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ResourceQuota", "ResourceQuota", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceQuotaSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForHard := make([]string, 0, len(this.Hard))
+	for k := range this.Hard {
+		keysForHard = append(keysForHard, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForHard)
+	mapStringForHard := "ResourceList{"
+	for _, k := range keysForHard {
+		mapStringForHard += fmt.Sprintf("%v: %v,", k, this.Hard[ResourceName(k)])
+	}
+	mapStringForHard += "}"
+	s := strings.Join([]string{`&ResourceQuotaSpec{`,
+		`Hard:` + mapStringForHard + `,`,
+		`Scopes:` + fmt.Sprintf("%v", this.Scopes) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceQuotaStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForHard := make([]string, 0, len(this.Hard))
+	for k := range this.Hard {
+		keysForHard = append(keysForHard, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForHard)
+	mapStringForHard := "ResourceList{"
+	for _, k := range keysForHard {
+		mapStringForHard += fmt.Sprintf("%v: %v,", k, this.Hard[ResourceName(k)])
+	}
+	mapStringForHard += "}"
+	keysForUsed := make([]string, 0, len(this.Used))
+	for k := range this.Used {
+		keysForUsed = append(keysForUsed, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForUsed)
+	mapStringForUsed := "ResourceList{"
+	for _, k := range keysForUsed {
+		mapStringForUsed += fmt.Sprintf("%v: %v,", k, this.Used[ResourceName(k)])
+	}
+	mapStringForUsed += "}"
+	s := strings.Join([]string{`&ResourceQuotaStatus{`,
+		`Hard:` + mapStringForHard + `,`,
+		`Used:` + mapStringForUsed + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ResourceRequirements) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForLimits := make([]string, 0, len(this.Limits))
+	for k := range this.Limits {
+		keysForLimits = append(keysForLimits, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForLimits)
+	mapStringForLimits := "ResourceList{"
+	for _, k := range keysForLimits {
+		mapStringForLimits += fmt.Sprintf("%v: %v,", k, this.Limits[ResourceName(k)])
+	}
+	mapStringForLimits += "}"
+	keysForRequests := make([]string, 0, len(this.Requests))
+	for k := range this.Requests {
+		keysForRequests = append(keysForRequests, string(k))
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForRequests)
+	mapStringForRequests := "ResourceList{"
+	for _, k := range keysForRequests {
+		mapStringForRequests += fmt.Sprintf("%v: %v,", k, this.Requests[ResourceName(k)])
+	}
+	mapStringForRequests += "}"
+	s := strings.Join([]string{`&ResourceRequirements{`,
+		`Limits:` + mapStringForLimits + `,`,
+		`Requests:` + mapStringForRequests + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SELinuxOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SELinuxOptions{`,
+		`User:` + fmt.Sprintf("%v", this.User) + `,`,
+		`Role:` + fmt.Sprintf("%v", this.Role) + `,`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Level:` + fmt.Sprintf("%v", this.Level) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Secret) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForData := make([]string, 0, len(this.Data))
+	for k := range this.Data {
+		keysForData = append(keysForData, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForData)
+	mapStringForData := "map[string][]byte{"
+	for _, k := range keysForData {
+		mapStringForData += fmt.Sprintf("%v: %v,", k, this.Data[k])
+	}
+	mapStringForData += "}"
+	keysForStringData := make([]string, 0, len(this.StringData))
+	for k := range this.StringData {
+		keysForStringData = append(keysForStringData, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForStringData)
+	mapStringForStringData := "map[string]string{"
+	for _, k := range keysForStringData {
+		mapStringForStringData += fmt.Sprintf("%v: %v,", k, this.StringData[k])
+	}
+	mapStringForStringData += "}"
+	s := strings.Join([]string{`&Secret{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Data:` + mapStringForData + `,`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`StringData:` + mapStringForStringData + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SecretKeySelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SecretKeySelector{`,
+		`LocalObjectReference:` + strings.Replace(strings.Replace(this.LocalObjectReference.String(), "LocalObjectReference", "LocalObjectReference", 1), `&`, ``, 1) + `,`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SecretList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SecretList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Secret", "Secret", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SecretVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SecretVolumeSource{`,
+		`SecretName:` + fmt.Sprintf("%v", this.SecretName) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "KeyToPath", "KeyToPath", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SecurityContext) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SecurityContext{`,
+		`Capabilities:` + strings.Replace(fmt.Sprintf("%v", this.Capabilities), "Capabilities", "Capabilities", 1) + `,`,
+		`Privileged:` + valueToStringGenerated(this.Privileged) + `,`,
+		`SELinuxOptions:` + strings.Replace(fmt.Sprintf("%v", this.SELinuxOptions), "SELinuxOptions", "SELinuxOptions", 1) + `,`,
+		`RunAsUser:` + valueToStringGenerated(this.RunAsUser) + `,`,
+		`RunAsNonRoot:` + valueToStringGenerated(this.RunAsNonRoot) + `,`,
+		`ReadOnlyRootFilesystem:` + valueToStringGenerated(this.ReadOnlyRootFilesystem) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SerializedReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SerializedReference{`,
+		`Reference:` + strings.Replace(strings.Replace(this.Reference.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Service) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Service{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ServiceSpec", "ServiceSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ServiceStatus", "ServiceStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceAccount) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServiceAccount{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Secrets:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Secrets), "ObjectReference", "ObjectReference", 1), `&`, ``, 1) + `,`,
+		`ImagePullSecrets:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ImagePullSecrets), "LocalObjectReference", "LocalObjectReference", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceAccountList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServiceAccountList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ServiceAccount", "ServiceAccount", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServiceList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Service", "Service", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServicePort) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServicePort{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Protocol:` + fmt.Sprintf("%v", this.Protocol) + `,`,
+		`Port:` + fmt.Sprintf("%v", this.Port) + `,`,
+		`TargetPort:` + strings.Replace(strings.Replace(this.TargetPort.String(), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1), `&`, ``, 1) + `,`,
+		`NodePort:` + fmt.Sprintf("%v", this.NodePort) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceProxyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServiceProxyOptions{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForSelector := make([]string, 0, len(this.Selector))
+	for k := range this.Selector {
+		keysForSelector = append(keysForSelector, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForSelector)
+	mapStringForSelector := "map[string]string{"
+	for _, k := range keysForSelector {
+		mapStringForSelector += fmt.Sprintf("%v: %v,", k, this.Selector[k])
+	}
+	mapStringForSelector += "}"
+	s := strings.Join([]string{`&ServiceSpec{`,
+		`Ports:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ports), "ServicePort", "ServicePort", 1), `&`, ``, 1) + `,`,
+		`Selector:` + mapStringForSelector + `,`,
+		`ClusterIP:` + fmt.Sprintf("%v", this.ClusterIP) + `,`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`ExternalIPs:` + fmt.Sprintf("%v", this.ExternalIPs) + `,`,
+		`DeprecatedPublicIPs:` + fmt.Sprintf("%v", this.DeprecatedPublicIPs) + `,`,
+		`SessionAffinity:` + fmt.Sprintf("%v", this.SessionAffinity) + `,`,
+		`LoadBalancerIP:` + fmt.Sprintf("%v", this.LoadBalancerIP) + `,`,
+		`LoadBalancerSourceRanges:` + fmt.Sprintf("%v", this.LoadBalancerSourceRanges) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ServiceStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ServiceStatus{`,
+		`LoadBalancer:` + strings.Replace(strings.Replace(this.LoadBalancer.String(), "LoadBalancerStatus", "LoadBalancerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TCPSocketAction) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TCPSocketAction{`,
+		`Port:` + strings.Replace(strings.Replace(this.Port.String(), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Taint) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Taint{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Value:` + fmt.Sprintf("%v", this.Value) + `,`,
+		`Effect:` + fmt.Sprintf("%v", this.Effect) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Toleration) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Toleration{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Value:` + fmt.Sprintf("%v", this.Value) + `,`,
+		`Effect:` + fmt.Sprintf("%v", this.Effect) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Volume) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Volume{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`VolumeSource:` + strings.Replace(strings.Replace(this.VolumeSource.String(), "VolumeSource", "VolumeSource", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *VolumeMount) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&VolumeMount{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`ReadOnly:` + fmt.Sprintf("%v", this.ReadOnly) + `,`,
+		`MountPath:` + fmt.Sprintf("%v", this.MountPath) + `,`,
+		`SubPath:` + fmt.Sprintf("%v", this.SubPath) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *VolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&VolumeSource{`,
+		`HostPath:` + strings.Replace(fmt.Sprintf("%v", this.HostPath), "HostPathVolumeSource", "HostPathVolumeSource", 1) + `,`,
+		`EmptyDir:` + strings.Replace(fmt.Sprintf("%v", this.EmptyDir), "EmptyDirVolumeSource", "EmptyDirVolumeSource", 1) + `,`,
+		`GCEPersistentDisk:` + strings.Replace(fmt.Sprintf("%v", this.GCEPersistentDisk), "GCEPersistentDiskVolumeSource", "GCEPersistentDiskVolumeSource", 1) + `,`,
+		`AWSElasticBlockStore:` + strings.Replace(fmt.Sprintf("%v", this.AWSElasticBlockStore), "AWSElasticBlockStoreVolumeSource", "AWSElasticBlockStoreVolumeSource", 1) + `,`,
+		`GitRepo:` + strings.Replace(fmt.Sprintf("%v", this.GitRepo), "GitRepoVolumeSource", "GitRepoVolumeSource", 1) + `,`,
+		`Secret:` + strings.Replace(fmt.Sprintf("%v", this.Secret), "SecretVolumeSource", "SecretVolumeSource", 1) + `,`,
+		`NFS:` + strings.Replace(fmt.Sprintf("%v", this.NFS), "NFSVolumeSource", "NFSVolumeSource", 1) + `,`,
+		`ISCSI:` + strings.Replace(fmt.Sprintf("%v", this.ISCSI), "ISCSIVolumeSource", "ISCSIVolumeSource", 1) + `,`,
+		`Glusterfs:` + strings.Replace(fmt.Sprintf("%v", this.Glusterfs), "GlusterfsVolumeSource", "GlusterfsVolumeSource", 1) + `,`,
+		`PersistentVolumeClaim:` + strings.Replace(fmt.Sprintf("%v", this.PersistentVolumeClaim), "PersistentVolumeClaimVolumeSource", "PersistentVolumeClaimVolumeSource", 1) + `,`,
+		`RBD:` + strings.Replace(fmt.Sprintf("%v", this.RBD), "RBDVolumeSource", "RBDVolumeSource", 1) + `,`,
+		`FlexVolume:` + strings.Replace(fmt.Sprintf("%v", this.FlexVolume), "FlexVolumeSource", "FlexVolumeSource", 1) + `,`,
+		`Cinder:` + strings.Replace(fmt.Sprintf("%v", this.Cinder), "CinderVolumeSource", "CinderVolumeSource", 1) + `,`,
+		`CephFS:` + strings.Replace(fmt.Sprintf("%v", this.CephFS), "CephFSVolumeSource", "CephFSVolumeSource", 1) + `,`,
+		`Flocker:` + strings.Replace(fmt.Sprintf("%v", this.Flocker), "FlockerVolumeSource", "FlockerVolumeSource", 1) + `,`,
+		`DownwardAPI:` + strings.Replace(fmt.Sprintf("%v", this.DownwardAPI), "DownwardAPIVolumeSource", "DownwardAPIVolumeSource", 1) + `,`,
+		`FC:` + strings.Replace(fmt.Sprintf("%v", this.FC), "FCVolumeSource", "FCVolumeSource", 1) + `,`,
+		`AzureFile:` + strings.Replace(fmt.Sprintf("%v", this.AzureFile), "AzureFileVolumeSource", "AzureFileVolumeSource", 1) + `,`,
+		`ConfigMap:` + strings.Replace(fmt.Sprintf("%v", this.ConfigMap), "ConfigMapVolumeSource", "ConfigMapVolumeSource", 1) + `,`,
+		`VsphereVolume:` + strings.Replace(fmt.Sprintf("%v", this.VsphereVolume), "VsphereVirtualDiskVolumeSource", "VsphereVirtualDiskVolumeSource", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *VsphereVirtualDiskVolumeSource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&VsphereVirtualDiskVolumeSource{`,
+		`VolumePath:` + fmt.Sprintf("%v", this.VolumePath) + `,`,
+		`FSType:` + fmt.Sprintf("%v", this.FSType) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *WeightedPodAffinityTerm) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&WeightedPodAffinityTerm{`,
+		`Weight:` + fmt.Sprintf("%v", this.Weight) + `,`,
+		`PodAffinityTerm:` + strings.Replace(strings.Replace(this.PodAffinityTerm.String(), "PodAffinityTerm", "PodAffinityTerm", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *AWSElasticBlockStoreVolumeSource) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/apps/v1alpha1/generated.pb.go
+++ b/pkg/apis/apps/v1alpha1/generated.pb.go
@@ -39,6 +39,9 @@ import math "math"
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -46,21 +49,17 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *PetSet) Reset()         { *m = PetSet{} }
-func (m *PetSet) String() string { return proto.CompactTextString(m) }
-func (*PetSet) ProtoMessage()    {}
+func (m *PetSet) Reset()      { *m = PetSet{} }
+func (*PetSet) ProtoMessage() {}
 
-func (m *PetSetList) Reset()         { *m = PetSetList{} }
-func (m *PetSetList) String() string { return proto.CompactTextString(m) }
-func (*PetSetList) ProtoMessage()    {}
+func (m *PetSetList) Reset()      { *m = PetSetList{} }
+func (*PetSetList) ProtoMessage() {}
 
-func (m *PetSetSpec) Reset()         { *m = PetSetSpec{} }
-func (m *PetSetSpec) String() string { return proto.CompactTextString(m) }
-func (*PetSetSpec) ProtoMessage()    {}
+func (m *PetSetSpec) Reset()      { *m = PetSetSpec{} }
+func (*PetSetSpec) ProtoMessage() {}
 
-func (m *PetSetStatus) Reset()         { *m = PetSetStatus{} }
-func (m *PetSetStatus) String() string { return proto.CompactTextString(m) }
-func (*PetSetStatus) ProtoMessage()    {}
+func (m *PetSetStatus) Reset()      { *m = PetSetStatus{} }
+func (*PetSetStatus) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*PetSet)(nil), "k8s.io.kubernetes.pkg.apis.apps.v1alpha1.PetSet")
@@ -329,6 +328,62 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *PetSet) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PetSet{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PetSetSpec", "PetSetSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PetSetStatus", "PetSetStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PetSetList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PetSetList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PetSet", "PetSet", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PetSetSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PetSetSpec{`,
+		`Replicas:` + valueToStringGenerated(this.Replicas) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "k8s_io_kubernetes_pkg_api_unversioned.LabelSelector", 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`VolumeClaimTemplates:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.VolumeClaimTemplates), "PersistentVolumeClaim", "k8s_io_kubernetes_pkg_api_v1.PersistentVolumeClaim", 1), `&`, ``, 1) + `,`,
+		`ServiceName:` + fmt.Sprintf("%v", this.ServiceName) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PetSetStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PetSetStatus{`,
+		`ObservedGeneration:` + valueToStringGenerated(this.ObservedGeneration) + `,`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *PetSet) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/autoscaling/v1/generated.pb.go
+++ b/pkg/apis/autoscaling/v1/generated.pb.go
@@ -42,6 +42,9 @@ import math "math"
 
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -49,37 +52,29 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *CrossVersionObjectReference) Reset()         { *m = CrossVersionObjectReference{} }
-func (m *CrossVersionObjectReference) String() string { return proto.CompactTextString(m) }
-func (*CrossVersionObjectReference) ProtoMessage()    {}
+func (m *CrossVersionObjectReference) Reset()      { *m = CrossVersionObjectReference{} }
+func (*CrossVersionObjectReference) ProtoMessage() {}
 
-func (m *HorizontalPodAutoscaler) Reset()         { *m = HorizontalPodAutoscaler{} }
-func (m *HorizontalPodAutoscaler) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscaler) ProtoMessage()    {}
+func (m *HorizontalPodAutoscaler) Reset()      { *m = HorizontalPodAutoscaler{} }
+func (*HorizontalPodAutoscaler) ProtoMessage() {}
 
-func (m *HorizontalPodAutoscalerList) Reset()         { *m = HorizontalPodAutoscalerList{} }
-func (m *HorizontalPodAutoscalerList) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerList) ProtoMessage()    {}
+func (m *HorizontalPodAutoscalerList) Reset()      { *m = HorizontalPodAutoscalerList{} }
+func (*HorizontalPodAutoscalerList) ProtoMessage() {}
 
-func (m *HorizontalPodAutoscalerSpec) Reset()         { *m = HorizontalPodAutoscalerSpec{} }
-func (m *HorizontalPodAutoscalerSpec) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerSpec) ProtoMessage()    {}
+func (m *HorizontalPodAutoscalerSpec) Reset()      { *m = HorizontalPodAutoscalerSpec{} }
+func (*HorizontalPodAutoscalerSpec) ProtoMessage() {}
 
-func (m *HorizontalPodAutoscalerStatus) Reset()         { *m = HorizontalPodAutoscalerStatus{} }
-func (m *HorizontalPodAutoscalerStatus) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerStatus) ProtoMessage()    {}
+func (m *HorizontalPodAutoscalerStatus) Reset()      { *m = HorizontalPodAutoscalerStatus{} }
+func (*HorizontalPodAutoscalerStatus) ProtoMessage() {}
 
-func (m *Scale) Reset()         { *m = Scale{} }
-func (m *Scale) String() string { return proto.CompactTextString(m) }
-func (*Scale) ProtoMessage()    {}
+func (m *Scale) Reset()      { *m = Scale{} }
+func (*Scale) ProtoMessage() {}
 
-func (m *ScaleSpec) Reset()         { *m = ScaleSpec{} }
-func (m *ScaleSpec) String() string { return proto.CompactTextString(m) }
-func (*ScaleSpec) ProtoMessage()    {}
+func (m *ScaleSpec) Reset()      { *m = ScaleSpec{} }
+func (*ScaleSpec) ProtoMessage() {}
 
-func (m *ScaleStatus) Reset()         { *m = ScaleStatus{} }
-func (m *ScaleStatus) String() string { return proto.CompactTextString(m) }
-func (*ScaleStatus) ProtoMessage()    {}
+func (m *ScaleStatus) Reset()      { *m = ScaleStatus{} }
+func (*ScaleStatus) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*CrossVersionObjectReference)(nil), "k8s.io.kubernetes.pkg.apis.autoscaling.v1.CrossVersionObjectReference")
@@ -510,6 +505,109 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *CrossVersionObjectReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CrossVersionObjectReference{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscaler) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscaler{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "HorizontalPodAutoscalerSpec", "HorizontalPodAutoscalerSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "HorizontalPodAutoscalerStatus", "HorizontalPodAutoscalerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "HorizontalPodAutoscaler", "HorizontalPodAutoscaler", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerSpec{`,
+		`ScaleTargetRef:` + strings.Replace(strings.Replace(this.ScaleTargetRef.String(), "CrossVersionObjectReference", "CrossVersionObjectReference", 1), `&`, ``, 1) + `,`,
+		`MinReplicas:` + valueToStringGenerated(this.MinReplicas) + `,`,
+		`MaxReplicas:` + fmt.Sprintf("%v", this.MaxReplicas) + `,`,
+		`TargetCPUUtilizationPercentage:` + valueToStringGenerated(this.TargetCPUUtilizationPercentage) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerStatus{`,
+		`ObservedGeneration:` + valueToStringGenerated(this.ObservedGeneration) + `,`,
+		`LastScaleTime:` + strings.Replace(fmt.Sprintf("%v", this.LastScaleTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`CurrentReplicas:` + fmt.Sprintf("%v", this.CurrentReplicas) + `,`,
+		`DesiredReplicas:` + fmt.Sprintf("%v", this.DesiredReplicas) + `,`,
+		`CurrentCPUUtilizationPercentage:` + valueToStringGenerated(this.CurrentCPUUtilizationPercentage) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Scale) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Scale{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ScaleSpec", "ScaleSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ScaleStatus", "ScaleStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScaleSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScaleSpec{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScaleStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScaleStatus{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`Selector:` + fmt.Sprintf("%v", this.Selector) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *CrossVersionObjectReference) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/batch/v1/generated.pb.go
+++ b/pkg/apis/batch/v1/generated.pb.go
@@ -42,6 +42,10 @@ import math "math"
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
 
+import strings "strings"
+import reflect "reflect"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -49,33 +53,26 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *Job) Reset()         { *m = Job{} }
-func (m *Job) String() string { return proto.CompactTextString(m) }
-func (*Job) ProtoMessage()    {}
+func (m *Job) Reset()      { *m = Job{} }
+func (*Job) ProtoMessage() {}
 
-func (m *JobCondition) Reset()         { *m = JobCondition{} }
-func (m *JobCondition) String() string { return proto.CompactTextString(m) }
-func (*JobCondition) ProtoMessage()    {}
+func (m *JobCondition) Reset()      { *m = JobCondition{} }
+func (*JobCondition) ProtoMessage() {}
 
-func (m *JobList) Reset()         { *m = JobList{} }
-func (m *JobList) String() string { return proto.CompactTextString(m) }
-func (*JobList) ProtoMessage()    {}
+func (m *JobList) Reset()      { *m = JobList{} }
+func (*JobList) ProtoMessage() {}
 
-func (m *JobSpec) Reset()         { *m = JobSpec{} }
-func (m *JobSpec) String() string { return proto.CompactTextString(m) }
-func (*JobSpec) ProtoMessage()    {}
+func (m *JobSpec) Reset()      { *m = JobSpec{} }
+func (*JobSpec) ProtoMessage() {}
 
-func (m *JobStatus) Reset()         { *m = JobStatus{} }
-func (m *JobStatus) String() string { return proto.CompactTextString(m) }
-func (*JobStatus) ProtoMessage()    {}
+func (m *JobStatus) Reset()      { *m = JobStatus{} }
+func (*JobStatus) ProtoMessage() {}
 
-func (m *LabelSelector) Reset()         { *m = LabelSelector{} }
-func (m *LabelSelector) String() string { return proto.CompactTextString(m) }
-func (*LabelSelector) ProtoMessage()    {}
+func (m *LabelSelector) Reset()      { *m = LabelSelector{} }
+func (*LabelSelector) ProtoMessage() {}
 
-func (m *LabelSelectorRequirement) Reset()         { *m = LabelSelectorRequirement{} }
-func (m *LabelSelectorRequirement) String() string { return proto.CompactTextString(m) }
-func (*LabelSelectorRequirement) ProtoMessage()    {}
+func (m *LabelSelectorRequirement) Reset()      { *m = LabelSelectorRequirement{} }
+func (*LabelSelectorRequirement) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*Job)(nil), "k8s.io.kubernetes.pkg.apis.batch.v1.Job")
@@ -590,6 +587,115 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *Job) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Job{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "JobSpec", "JobSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "JobStatus", "JobStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastProbeTime:` + strings.Replace(strings.Replace(this.LastProbeTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Job", "Job", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobSpec{`,
+		`Parallelism:` + valueToStringGenerated(this.Parallelism) + `,`,
+		`Completions:` + valueToStringGenerated(this.Completions) + `,`,
+		`ActiveDeadlineSeconds:` + valueToStringGenerated(this.ActiveDeadlineSeconds) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`ManualSelector:` + valueToStringGenerated(this.ManualSelector) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobStatus{`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "JobCondition", "JobCondition", 1), `&`, ``, 1) + `,`,
+		`StartTime:` + strings.Replace(fmt.Sprintf("%v", this.StartTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`CompletionTime:` + strings.Replace(fmt.Sprintf("%v", this.CompletionTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`Active:` + fmt.Sprintf("%v", this.Active) + `,`,
+		`Succeeded:` + fmt.Sprintf("%v", this.Succeeded) + `,`,
+		`Failed:` + fmt.Sprintf("%v", this.Failed) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForMatchLabels := make([]string, 0, len(this.MatchLabels))
+	for k := range this.MatchLabels {
+		keysForMatchLabels = append(keysForMatchLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMatchLabels)
+	mapStringForMatchLabels := "map[string]string{"
+	for _, k := range keysForMatchLabels {
+		mapStringForMatchLabels += fmt.Sprintf("%v: %v,", k, this.MatchLabels[k])
+	}
+	mapStringForMatchLabels += "}"
+	s := strings.Join([]string{`&LabelSelector{`,
+		`MatchLabels:` + mapStringForMatchLabels + `,`,
+		`MatchExpressions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.MatchExpressions), "LabelSelectorRequirement", "LabelSelectorRequirement", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelectorRequirement) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LabelSelectorRequirement{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", this.Values) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *Job) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/batch/v2alpha1/generated.pb.go
+++ b/pkg/apis/batch/v2alpha1/generated.pb.go
@@ -48,6 +48,10 @@ import math "math"
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
 
+import strings "strings"
+import reflect "reflect"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -55,57 +59,44 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *Job) Reset()         { *m = Job{} }
-func (m *Job) String() string { return proto.CompactTextString(m) }
-func (*Job) ProtoMessage()    {}
+func (m *Job) Reset()      { *m = Job{} }
+func (*Job) ProtoMessage() {}
 
-func (m *JobCondition) Reset()         { *m = JobCondition{} }
-func (m *JobCondition) String() string { return proto.CompactTextString(m) }
-func (*JobCondition) ProtoMessage()    {}
+func (m *JobCondition) Reset()      { *m = JobCondition{} }
+func (*JobCondition) ProtoMessage() {}
 
-func (m *JobList) Reset()         { *m = JobList{} }
-func (m *JobList) String() string { return proto.CompactTextString(m) }
-func (*JobList) ProtoMessage()    {}
+func (m *JobList) Reset()      { *m = JobList{} }
+func (*JobList) ProtoMessage() {}
 
-func (m *JobSpec) Reset()         { *m = JobSpec{} }
-func (m *JobSpec) String() string { return proto.CompactTextString(m) }
-func (*JobSpec) ProtoMessage()    {}
+func (m *JobSpec) Reset()      { *m = JobSpec{} }
+func (*JobSpec) ProtoMessage() {}
 
-func (m *JobStatus) Reset()         { *m = JobStatus{} }
-func (m *JobStatus) String() string { return proto.CompactTextString(m) }
-func (*JobStatus) ProtoMessage()    {}
+func (m *JobStatus) Reset()      { *m = JobStatus{} }
+func (*JobStatus) ProtoMessage() {}
 
-func (m *JobTemplate) Reset()         { *m = JobTemplate{} }
-func (m *JobTemplate) String() string { return proto.CompactTextString(m) }
-func (*JobTemplate) ProtoMessage()    {}
+func (m *JobTemplate) Reset()      { *m = JobTemplate{} }
+func (*JobTemplate) ProtoMessage() {}
 
-func (m *JobTemplateSpec) Reset()         { *m = JobTemplateSpec{} }
-func (m *JobTemplateSpec) String() string { return proto.CompactTextString(m) }
-func (*JobTemplateSpec) ProtoMessage()    {}
+func (m *JobTemplateSpec) Reset()      { *m = JobTemplateSpec{} }
+func (*JobTemplateSpec) ProtoMessage() {}
 
-func (m *LabelSelector) Reset()         { *m = LabelSelector{} }
-func (m *LabelSelector) String() string { return proto.CompactTextString(m) }
-func (*LabelSelector) ProtoMessage()    {}
+func (m *LabelSelector) Reset()      { *m = LabelSelector{} }
+func (*LabelSelector) ProtoMessage() {}
 
-func (m *LabelSelectorRequirement) Reset()         { *m = LabelSelectorRequirement{} }
-func (m *LabelSelectorRequirement) String() string { return proto.CompactTextString(m) }
-func (*LabelSelectorRequirement) ProtoMessage()    {}
+func (m *LabelSelectorRequirement) Reset()      { *m = LabelSelectorRequirement{} }
+func (*LabelSelectorRequirement) ProtoMessage() {}
 
-func (m *ScheduledJob) Reset()         { *m = ScheduledJob{} }
-func (m *ScheduledJob) String() string { return proto.CompactTextString(m) }
-func (*ScheduledJob) ProtoMessage()    {}
+func (m *ScheduledJob) Reset()      { *m = ScheduledJob{} }
+func (*ScheduledJob) ProtoMessage() {}
 
-func (m *ScheduledJobList) Reset()         { *m = ScheduledJobList{} }
-func (m *ScheduledJobList) String() string { return proto.CompactTextString(m) }
-func (*ScheduledJobList) ProtoMessage()    {}
+func (m *ScheduledJobList) Reset()      { *m = ScheduledJobList{} }
+func (*ScheduledJobList) ProtoMessage() {}
 
-func (m *ScheduledJobSpec) Reset()         { *m = ScheduledJobSpec{} }
-func (m *ScheduledJobSpec) String() string { return proto.CompactTextString(m) }
-func (*ScheduledJobSpec) ProtoMessage()    {}
+func (m *ScheduledJobSpec) Reset()      { *m = ScheduledJobSpec{} }
+func (*ScheduledJobSpec) ProtoMessage() {}
 
-func (m *ScheduledJobStatus) Reset()         { *m = ScheduledJobStatus{} }
-func (m *ScheduledJobStatus) String() string { return proto.CompactTextString(m) }
-func (*ScheduledJobStatus) ProtoMessage()    {}
+func (m *ScheduledJobStatus) Reset()      { *m = ScheduledJobStatus{} }
+func (*ScheduledJobStatus) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*Job)(nil), "k8s.io.kubernetes.pkg.apis.batch.v2alpha1.Job")
@@ -943,6 +934,185 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *Job) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Job{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "JobSpec", "JobSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "JobStatus", "JobStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastProbeTime:` + strings.Replace(strings.Replace(this.LastProbeTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Job", "Job", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobSpec{`,
+		`Parallelism:` + valueToStringGenerated(this.Parallelism) + `,`,
+		`Completions:` + valueToStringGenerated(this.Completions) + `,`,
+		`ActiveDeadlineSeconds:` + valueToStringGenerated(this.ActiveDeadlineSeconds) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`ManualSelector:` + valueToStringGenerated(this.ManualSelector) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobStatus{`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "JobCondition", "JobCondition", 1), `&`, ``, 1) + `,`,
+		`StartTime:` + strings.Replace(fmt.Sprintf("%v", this.StartTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`CompletionTime:` + strings.Replace(fmt.Sprintf("%v", this.CompletionTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`Active:` + fmt.Sprintf("%v", this.Active) + `,`,
+		`Succeeded:` + fmt.Sprintf("%v", this.Succeeded) + `,`,
+		`Failed:` + fmt.Sprintf("%v", this.Failed) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobTemplate) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobTemplate{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "JobTemplateSpec", "JobTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobTemplateSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobTemplateSpec{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "JobSpec", "JobSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForMatchLabels := make([]string, 0, len(this.MatchLabels))
+	for k := range this.MatchLabels {
+		keysForMatchLabels = append(keysForMatchLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMatchLabels)
+	mapStringForMatchLabels := "map[string]string{"
+	for _, k := range keysForMatchLabels {
+		mapStringForMatchLabels += fmt.Sprintf("%v: %v,", k, this.MatchLabels[k])
+	}
+	mapStringForMatchLabels += "}"
+	s := strings.Join([]string{`&LabelSelector{`,
+		`MatchLabels:` + mapStringForMatchLabels + `,`,
+		`MatchExpressions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.MatchExpressions), "LabelSelectorRequirement", "LabelSelectorRequirement", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelectorRequirement) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LabelSelectorRequirement{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", this.Values) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScheduledJob) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScheduledJob{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ScheduledJobSpec", "ScheduledJobSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ScheduledJobStatus", "ScheduledJobStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScheduledJobList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScheduledJobList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ScheduledJob", "ScheduledJob", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScheduledJobSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScheduledJobSpec{`,
+		`Schedule:` + fmt.Sprintf("%v", this.Schedule) + `,`,
+		`StartingDeadlineSeconds:` + valueToStringGenerated(this.StartingDeadlineSeconds) + `,`,
+		`ConcurrencyPolicy:` + fmt.Sprintf("%v", this.ConcurrencyPolicy) + `,`,
+		`Suspend:` + valueToStringGenerated(this.Suspend) + `,`,
+		`JobTemplate:` + strings.Replace(strings.Replace(this.JobTemplate.String(), "JobTemplateSpec", "JobTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScheduledJobStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScheduledJobStatus{`,
+		`Active:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Active), "ObjectReference", "k8s_io_kubernetes_pkg_api_v1.ObjectReference", 1), `&`, ``, 1) + `,`,
+		`LastScheduleTime:` + strings.Replace(fmt.Sprintf("%v", this.LastScheduleTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *Job) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/certificates/v1alpha1/generated.pb.go
+++ b/pkg/apis/certificates/v1alpha1/generated.pb.go
@@ -37,6 +37,9 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -44,25 +47,20 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *CertificateSigningRequest) Reset()         { *m = CertificateSigningRequest{} }
-func (m *CertificateSigningRequest) String() string { return proto.CompactTextString(m) }
-func (*CertificateSigningRequest) ProtoMessage()    {}
+func (m *CertificateSigningRequest) Reset()      { *m = CertificateSigningRequest{} }
+func (*CertificateSigningRequest) ProtoMessage() {}
 
-func (m *CertificateSigningRequestCondition) Reset()         { *m = CertificateSigningRequestCondition{} }
-func (m *CertificateSigningRequestCondition) String() string { return proto.CompactTextString(m) }
-func (*CertificateSigningRequestCondition) ProtoMessage()    {}
+func (m *CertificateSigningRequestCondition) Reset()      { *m = CertificateSigningRequestCondition{} }
+func (*CertificateSigningRequestCondition) ProtoMessage() {}
 
-func (m *CertificateSigningRequestList) Reset()         { *m = CertificateSigningRequestList{} }
-func (m *CertificateSigningRequestList) String() string { return proto.CompactTextString(m) }
-func (*CertificateSigningRequestList) ProtoMessage()    {}
+func (m *CertificateSigningRequestList) Reset()      { *m = CertificateSigningRequestList{} }
+func (*CertificateSigningRequestList) ProtoMessage() {}
 
-func (m *CertificateSigningRequestSpec) Reset()         { *m = CertificateSigningRequestSpec{} }
-func (m *CertificateSigningRequestSpec) String() string { return proto.CompactTextString(m) }
-func (*CertificateSigningRequestSpec) ProtoMessage()    {}
+func (m *CertificateSigningRequestSpec) Reset()      { *m = CertificateSigningRequestSpec{} }
+func (*CertificateSigningRequestSpec) ProtoMessage() {}
 
-func (m *CertificateSigningRequestStatus) Reset()         { *m = CertificateSigningRequestStatus{} }
-func (m *CertificateSigningRequestStatus) String() string { return proto.CompactTextString(m) }
-func (*CertificateSigningRequestStatus) ProtoMessage()    {}
+func (m *CertificateSigningRequestStatus) Reset()      { *m = CertificateSigningRequestStatus{} }
+func (*CertificateSigningRequestStatus) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*CertificateSigningRequest)(nil), "k8s.io.kubernetes.pkg.apis.certificates.v1alpha1.CertificateSigningRequest")
@@ -387,6 +385,74 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *CertificateSigningRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CertificateSigningRequest{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "CertificateSigningRequestSpec", "CertificateSigningRequestSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "CertificateSigningRequestStatus", "CertificateSigningRequestStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CertificateSigningRequestCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CertificateSigningRequestCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`LastUpdateTime:` + strings.Replace(strings.Replace(this.LastUpdateTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CertificateSigningRequestList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CertificateSigningRequestList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "CertificateSigningRequest", "CertificateSigningRequest", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CertificateSigningRequestSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CertificateSigningRequestSpec{`,
+		`Request:` + valueToStringGenerated(this.Request) + `,`,
+		`Username:` + fmt.Sprintf("%v", this.Username) + `,`,
+		`UID:` + fmt.Sprintf("%v", this.UID) + `,`,
+		`Groups:` + fmt.Sprintf("%v", this.Groups) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CertificateSigningRequestStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CertificateSigningRequestStatus{`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "CertificateSigningRequestCondition", "CertificateSigningRequestCondition", 1), `&`, ``, 1) + `,`,
+		`Certificate:` + valueToStringGenerated(this.Certificate) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *CertificateSigningRequest) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/extensions/v1beta1/generated.pb.go
+++ b/pkg/apis/extensions/v1beta1/generated.pb.go
@@ -106,6 +106,10 @@ import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
 
 import k8s_io_kubernetes_pkg_util_intstr "k8s.io/kubernetes/pkg/util/intstr"
 
+import strings "strings"
+import reflect "reflect"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -113,281 +117,212 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *APIVersion) Reset()         { *m = APIVersion{} }
-func (m *APIVersion) String() string { return proto.CompactTextString(m) }
-func (*APIVersion) ProtoMessage()    {}
-
-func (m *CPUTargetUtilization) Reset()         { *m = CPUTargetUtilization{} }
-func (m *CPUTargetUtilization) String() string { return proto.CompactTextString(m) }
-func (*CPUTargetUtilization) ProtoMessage()    {}
-
-func (m *CustomMetricCurrentStatus) Reset()         { *m = CustomMetricCurrentStatus{} }
-func (m *CustomMetricCurrentStatus) String() string { return proto.CompactTextString(m) }
-func (*CustomMetricCurrentStatus) ProtoMessage()    {}
-
-func (m *CustomMetricCurrentStatusList) Reset()         { *m = CustomMetricCurrentStatusList{} }
-func (m *CustomMetricCurrentStatusList) String() string { return proto.CompactTextString(m) }
-func (*CustomMetricCurrentStatusList) ProtoMessage()    {}
-
-func (m *CustomMetricTarget) Reset()         { *m = CustomMetricTarget{} }
-func (m *CustomMetricTarget) String() string { return proto.CompactTextString(m) }
-func (*CustomMetricTarget) ProtoMessage()    {}
-
-func (m *CustomMetricTargetList) Reset()         { *m = CustomMetricTargetList{} }
-func (m *CustomMetricTargetList) String() string { return proto.CompactTextString(m) }
-func (*CustomMetricTargetList) ProtoMessage()    {}
-
-func (m *DaemonSet) Reset()         { *m = DaemonSet{} }
-func (m *DaemonSet) String() string { return proto.CompactTextString(m) }
-func (*DaemonSet) ProtoMessage()    {}
-
-func (m *DaemonSetList) Reset()         { *m = DaemonSetList{} }
-func (m *DaemonSetList) String() string { return proto.CompactTextString(m) }
-func (*DaemonSetList) ProtoMessage()    {}
-
-func (m *DaemonSetSpec) Reset()         { *m = DaemonSetSpec{} }
-func (m *DaemonSetSpec) String() string { return proto.CompactTextString(m) }
-func (*DaemonSetSpec) ProtoMessage()    {}
-
-func (m *DaemonSetStatus) Reset()         { *m = DaemonSetStatus{} }
-func (m *DaemonSetStatus) String() string { return proto.CompactTextString(m) }
-func (*DaemonSetStatus) ProtoMessage()    {}
-
-func (m *Deployment) Reset()         { *m = Deployment{} }
-func (m *Deployment) String() string { return proto.CompactTextString(m) }
-func (*Deployment) ProtoMessage()    {}
-
-func (m *DeploymentList) Reset()         { *m = DeploymentList{} }
-func (m *DeploymentList) String() string { return proto.CompactTextString(m) }
-func (*DeploymentList) ProtoMessage()    {}
-
-func (m *DeploymentRollback) Reset()         { *m = DeploymentRollback{} }
-func (m *DeploymentRollback) String() string { return proto.CompactTextString(m) }
-func (*DeploymentRollback) ProtoMessage()    {}
-
-func (m *DeploymentSpec) Reset()         { *m = DeploymentSpec{} }
-func (m *DeploymentSpec) String() string { return proto.CompactTextString(m) }
-func (*DeploymentSpec) ProtoMessage()    {}
-
-func (m *DeploymentStatus) Reset()         { *m = DeploymentStatus{} }
-func (m *DeploymentStatus) String() string { return proto.CompactTextString(m) }
-func (*DeploymentStatus) ProtoMessage()    {}
-
-func (m *DeploymentStrategy) Reset()         { *m = DeploymentStrategy{} }
-func (m *DeploymentStrategy) String() string { return proto.CompactTextString(m) }
-func (*DeploymentStrategy) ProtoMessage()    {}
-
-func (m *ExportOptions) Reset()         { *m = ExportOptions{} }
-func (m *ExportOptions) String() string { return proto.CompactTextString(m) }
-func (*ExportOptions) ProtoMessage()    {}
-
-func (m *FSGroupStrategyOptions) Reset()         { *m = FSGroupStrategyOptions{} }
-func (m *FSGroupStrategyOptions) String() string { return proto.CompactTextString(m) }
-func (*FSGroupStrategyOptions) ProtoMessage()    {}
-
-func (m *HTTPIngressPath) Reset()         { *m = HTTPIngressPath{} }
-func (m *HTTPIngressPath) String() string { return proto.CompactTextString(m) }
-func (*HTTPIngressPath) ProtoMessage()    {}
-
-func (m *HTTPIngressRuleValue) Reset()         { *m = HTTPIngressRuleValue{} }
-func (m *HTTPIngressRuleValue) String() string { return proto.CompactTextString(m) }
-func (*HTTPIngressRuleValue) ProtoMessage()    {}
-
-func (m *HorizontalPodAutoscaler) Reset()         { *m = HorizontalPodAutoscaler{} }
-func (m *HorizontalPodAutoscaler) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscaler) ProtoMessage()    {}
-
-func (m *HorizontalPodAutoscalerList) Reset()         { *m = HorizontalPodAutoscalerList{} }
-func (m *HorizontalPodAutoscalerList) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerList) ProtoMessage()    {}
-
-func (m *HorizontalPodAutoscalerSpec) Reset()         { *m = HorizontalPodAutoscalerSpec{} }
-func (m *HorizontalPodAutoscalerSpec) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerSpec) ProtoMessage()    {}
-
-func (m *HorizontalPodAutoscalerStatus) Reset()         { *m = HorizontalPodAutoscalerStatus{} }
-func (m *HorizontalPodAutoscalerStatus) String() string { return proto.CompactTextString(m) }
-func (*HorizontalPodAutoscalerStatus) ProtoMessage()    {}
-
-func (m *HostPortRange) Reset()         { *m = HostPortRange{} }
-func (m *HostPortRange) String() string { return proto.CompactTextString(m) }
-func (*HostPortRange) ProtoMessage()    {}
-
-func (m *IDRange) Reset()         { *m = IDRange{} }
-func (m *IDRange) String() string { return proto.CompactTextString(m) }
-func (*IDRange) ProtoMessage()    {}
-
-func (m *Ingress) Reset()         { *m = Ingress{} }
-func (m *Ingress) String() string { return proto.CompactTextString(m) }
-func (*Ingress) ProtoMessage()    {}
-
-func (m *IngressBackend) Reset()         { *m = IngressBackend{} }
-func (m *IngressBackend) String() string { return proto.CompactTextString(m) }
-func (*IngressBackend) ProtoMessage()    {}
-
-func (m *IngressList) Reset()         { *m = IngressList{} }
-func (m *IngressList) String() string { return proto.CompactTextString(m) }
-func (*IngressList) ProtoMessage()    {}
-
-func (m *IngressRule) Reset()         { *m = IngressRule{} }
-func (m *IngressRule) String() string { return proto.CompactTextString(m) }
-func (*IngressRule) ProtoMessage()    {}
-
-func (m *IngressRuleValue) Reset()         { *m = IngressRuleValue{} }
-func (m *IngressRuleValue) String() string { return proto.CompactTextString(m) }
-func (*IngressRuleValue) ProtoMessage()    {}
-
-func (m *IngressSpec) Reset()         { *m = IngressSpec{} }
-func (m *IngressSpec) String() string { return proto.CompactTextString(m) }
-func (*IngressSpec) ProtoMessage()    {}
-
-func (m *IngressStatus) Reset()         { *m = IngressStatus{} }
-func (m *IngressStatus) String() string { return proto.CompactTextString(m) }
-func (*IngressStatus) ProtoMessage()    {}
-
-func (m *IngressTLS) Reset()         { *m = IngressTLS{} }
-func (m *IngressTLS) String() string { return proto.CompactTextString(m) }
-func (*IngressTLS) ProtoMessage()    {}
-
-func (m *Job) Reset()         { *m = Job{} }
-func (m *Job) String() string { return proto.CompactTextString(m) }
-func (*Job) ProtoMessage()    {}
-
-func (m *JobCondition) Reset()         { *m = JobCondition{} }
-func (m *JobCondition) String() string { return proto.CompactTextString(m) }
-func (*JobCondition) ProtoMessage()    {}
-
-func (m *JobList) Reset()         { *m = JobList{} }
-func (m *JobList) String() string { return proto.CompactTextString(m) }
-func (*JobList) ProtoMessage()    {}
-
-func (m *JobSpec) Reset()         { *m = JobSpec{} }
-func (m *JobSpec) String() string { return proto.CompactTextString(m) }
-func (*JobSpec) ProtoMessage()    {}
-
-func (m *JobStatus) Reset()         { *m = JobStatus{} }
-func (m *JobStatus) String() string { return proto.CompactTextString(m) }
-func (*JobStatus) ProtoMessage()    {}
-
-func (m *LabelSelector) Reset()         { *m = LabelSelector{} }
-func (m *LabelSelector) String() string { return proto.CompactTextString(m) }
-func (*LabelSelector) ProtoMessage()    {}
-
-func (m *LabelSelectorRequirement) Reset()         { *m = LabelSelectorRequirement{} }
-func (m *LabelSelectorRequirement) String() string { return proto.CompactTextString(m) }
-func (*LabelSelectorRequirement) ProtoMessage()    {}
-
-func (m *ListOptions) Reset()         { *m = ListOptions{} }
-func (m *ListOptions) String() string { return proto.CompactTextString(m) }
-func (*ListOptions) ProtoMessage()    {}
-
-func (m *NetworkPolicy) Reset()         { *m = NetworkPolicy{} }
-func (m *NetworkPolicy) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicy) ProtoMessage()    {}
-
-func (m *NetworkPolicyIngressRule) Reset()         { *m = NetworkPolicyIngressRule{} }
-func (m *NetworkPolicyIngressRule) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicyIngressRule) ProtoMessage()    {}
-
-func (m *NetworkPolicyList) Reset()         { *m = NetworkPolicyList{} }
-func (m *NetworkPolicyList) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicyList) ProtoMessage()    {}
-
-func (m *NetworkPolicyPeer) Reset()         { *m = NetworkPolicyPeer{} }
-func (m *NetworkPolicyPeer) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicyPeer) ProtoMessage()    {}
-
-func (m *NetworkPolicyPort) Reset()         { *m = NetworkPolicyPort{} }
-func (m *NetworkPolicyPort) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicyPort) ProtoMessage()    {}
-
-func (m *NetworkPolicySpec) Reset()         { *m = NetworkPolicySpec{} }
-func (m *NetworkPolicySpec) String() string { return proto.CompactTextString(m) }
-func (*NetworkPolicySpec) ProtoMessage()    {}
-
-func (m *PodSecurityPolicy) Reset()         { *m = PodSecurityPolicy{} }
-func (m *PodSecurityPolicy) String() string { return proto.CompactTextString(m) }
-func (*PodSecurityPolicy) ProtoMessage()    {}
-
-func (m *PodSecurityPolicyList) Reset()         { *m = PodSecurityPolicyList{} }
-func (m *PodSecurityPolicyList) String() string { return proto.CompactTextString(m) }
-func (*PodSecurityPolicyList) ProtoMessage()    {}
-
-func (m *PodSecurityPolicySpec) Reset()         { *m = PodSecurityPolicySpec{} }
-func (m *PodSecurityPolicySpec) String() string { return proto.CompactTextString(m) }
-func (*PodSecurityPolicySpec) ProtoMessage()    {}
-
-func (m *ReplicaSet) Reset()         { *m = ReplicaSet{} }
-func (m *ReplicaSet) String() string { return proto.CompactTextString(m) }
-func (*ReplicaSet) ProtoMessage()    {}
-
-func (m *ReplicaSetList) Reset()         { *m = ReplicaSetList{} }
-func (m *ReplicaSetList) String() string { return proto.CompactTextString(m) }
-func (*ReplicaSetList) ProtoMessage()    {}
-
-func (m *ReplicaSetSpec) Reset()         { *m = ReplicaSetSpec{} }
-func (m *ReplicaSetSpec) String() string { return proto.CompactTextString(m) }
-func (*ReplicaSetSpec) ProtoMessage()    {}
-
-func (m *ReplicaSetStatus) Reset()         { *m = ReplicaSetStatus{} }
-func (m *ReplicaSetStatus) String() string { return proto.CompactTextString(m) }
-func (*ReplicaSetStatus) ProtoMessage()    {}
-
-func (m *ReplicationControllerDummy) Reset()         { *m = ReplicationControllerDummy{} }
-func (m *ReplicationControllerDummy) String() string { return proto.CompactTextString(m) }
-func (*ReplicationControllerDummy) ProtoMessage()    {}
-
-func (m *RollbackConfig) Reset()         { *m = RollbackConfig{} }
-func (m *RollbackConfig) String() string { return proto.CompactTextString(m) }
-func (*RollbackConfig) ProtoMessage()    {}
-
-func (m *RollingUpdateDeployment) Reset()         { *m = RollingUpdateDeployment{} }
-func (m *RollingUpdateDeployment) String() string { return proto.CompactTextString(m) }
-func (*RollingUpdateDeployment) ProtoMessage()    {}
-
-func (m *RunAsUserStrategyOptions) Reset()         { *m = RunAsUserStrategyOptions{} }
-func (m *RunAsUserStrategyOptions) String() string { return proto.CompactTextString(m) }
-func (*RunAsUserStrategyOptions) ProtoMessage()    {}
-
-func (m *SELinuxStrategyOptions) Reset()         { *m = SELinuxStrategyOptions{} }
-func (m *SELinuxStrategyOptions) String() string { return proto.CompactTextString(m) }
-func (*SELinuxStrategyOptions) ProtoMessage()    {}
-
-func (m *Scale) Reset()         { *m = Scale{} }
-func (m *Scale) String() string { return proto.CompactTextString(m) }
-func (*Scale) ProtoMessage()    {}
-
-func (m *ScaleSpec) Reset()         { *m = ScaleSpec{} }
-func (m *ScaleSpec) String() string { return proto.CompactTextString(m) }
-func (*ScaleSpec) ProtoMessage()    {}
-
-func (m *ScaleStatus) Reset()         { *m = ScaleStatus{} }
-func (m *ScaleStatus) String() string { return proto.CompactTextString(m) }
-func (*ScaleStatus) ProtoMessage()    {}
-
-func (m *SubresourceReference) Reset()         { *m = SubresourceReference{} }
-func (m *SubresourceReference) String() string { return proto.CompactTextString(m) }
-func (*SubresourceReference) ProtoMessage()    {}
-
-func (m *SupplementalGroupsStrategyOptions) Reset()         { *m = SupplementalGroupsStrategyOptions{} }
-func (m *SupplementalGroupsStrategyOptions) String() string { return proto.CompactTextString(m) }
-func (*SupplementalGroupsStrategyOptions) ProtoMessage()    {}
-
-func (m *ThirdPartyResource) Reset()         { *m = ThirdPartyResource{} }
-func (m *ThirdPartyResource) String() string { return proto.CompactTextString(m) }
-func (*ThirdPartyResource) ProtoMessage()    {}
-
-func (m *ThirdPartyResourceData) Reset()         { *m = ThirdPartyResourceData{} }
-func (m *ThirdPartyResourceData) String() string { return proto.CompactTextString(m) }
-func (*ThirdPartyResourceData) ProtoMessage()    {}
-
-func (m *ThirdPartyResourceDataList) Reset()         { *m = ThirdPartyResourceDataList{} }
-func (m *ThirdPartyResourceDataList) String() string { return proto.CompactTextString(m) }
-func (*ThirdPartyResourceDataList) ProtoMessage()    {}
-
-func (m *ThirdPartyResourceList) Reset()         { *m = ThirdPartyResourceList{} }
-func (m *ThirdPartyResourceList) String() string { return proto.CompactTextString(m) }
-func (*ThirdPartyResourceList) ProtoMessage()    {}
+func (m *APIVersion) Reset()      { *m = APIVersion{} }
+func (*APIVersion) ProtoMessage() {}
+
+func (m *CPUTargetUtilization) Reset()      { *m = CPUTargetUtilization{} }
+func (*CPUTargetUtilization) ProtoMessage() {}
+
+func (m *CustomMetricCurrentStatus) Reset()      { *m = CustomMetricCurrentStatus{} }
+func (*CustomMetricCurrentStatus) ProtoMessage() {}
+
+func (m *CustomMetricCurrentStatusList) Reset()      { *m = CustomMetricCurrentStatusList{} }
+func (*CustomMetricCurrentStatusList) ProtoMessage() {}
+
+func (m *CustomMetricTarget) Reset()      { *m = CustomMetricTarget{} }
+func (*CustomMetricTarget) ProtoMessage() {}
+
+func (m *CustomMetricTargetList) Reset()      { *m = CustomMetricTargetList{} }
+func (*CustomMetricTargetList) ProtoMessage() {}
+
+func (m *DaemonSet) Reset()      { *m = DaemonSet{} }
+func (*DaemonSet) ProtoMessage() {}
+
+func (m *DaemonSetList) Reset()      { *m = DaemonSetList{} }
+func (*DaemonSetList) ProtoMessage() {}
+
+func (m *DaemonSetSpec) Reset()      { *m = DaemonSetSpec{} }
+func (*DaemonSetSpec) ProtoMessage() {}
+
+func (m *DaemonSetStatus) Reset()      { *m = DaemonSetStatus{} }
+func (*DaemonSetStatus) ProtoMessage() {}
+
+func (m *Deployment) Reset()      { *m = Deployment{} }
+func (*Deployment) ProtoMessage() {}
+
+func (m *DeploymentList) Reset()      { *m = DeploymentList{} }
+func (*DeploymentList) ProtoMessage() {}
+
+func (m *DeploymentRollback) Reset()      { *m = DeploymentRollback{} }
+func (*DeploymentRollback) ProtoMessage() {}
+
+func (m *DeploymentSpec) Reset()      { *m = DeploymentSpec{} }
+func (*DeploymentSpec) ProtoMessage() {}
+
+func (m *DeploymentStatus) Reset()      { *m = DeploymentStatus{} }
+func (*DeploymentStatus) ProtoMessage() {}
+
+func (m *DeploymentStrategy) Reset()      { *m = DeploymentStrategy{} }
+func (*DeploymentStrategy) ProtoMessage() {}
+
+func (m *ExportOptions) Reset()      { *m = ExportOptions{} }
+func (*ExportOptions) ProtoMessage() {}
+
+func (m *FSGroupStrategyOptions) Reset()      { *m = FSGroupStrategyOptions{} }
+func (*FSGroupStrategyOptions) ProtoMessage() {}
+
+func (m *HTTPIngressPath) Reset()      { *m = HTTPIngressPath{} }
+func (*HTTPIngressPath) ProtoMessage() {}
+
+func (m *HTTPIngressRuleValue) Reset()      { *m = HTTPIngressRuleValue{} }
+func (*HTTPIngressRuleValue) ProtoMessage() {}
+
+func (m *HorizontalPodAutoscaler) Reset()      { *m = HorizontalPodAutoscaler{} }
+func (*HorizontalPodAutoscaler) ProtoMessage() {}
+
+func (m *HorizontalPodAutoscalerList) Reset()      { *m = HorizontalPodAutoscalerList{} }
+func (*HorizontalPodAutoscalerList) ProtoMessage() {}
+
+func (m *HorizontalPodAutoscalerSpec) Reset()      { *m = HorizontalPodAutoscalerSpec{} }
+func (*HorizontalPodAutoscalerSpec) ProtoMessage() {}
+
+func (m *HorizontalPodAutoscalerStatus) Reset()      { *m = HorizontalPodAutoscalerStatus{} }
+func (*HorizontalPodAutoscalerStatus) ProtoMessage() {}
+
+func (m *HostPortRange) Reset()      { *m = HostPortRange{} }
+func (*HostPortRange) ProtoMessage() {}
+
+func (m *IDRange) Reset()      { *m = IDRange{} }
+func (*IDRange) ProtoMessage() {}
+
+func (m *Ingress) Reset()      { *m = Ingress{} }
+func (*Ingress) ProtoMessage() {}
+
+func (m *IngressBackend) Reset()      { *m = IngressBackend{} }
+func (*IngressBackend) ProtoMessage() {}
+
+func (m *IngressList) Reset()      { *m = IngressList{} }
+func (*IngressList) ProtoMessage() {}
+
+func (m *IngressRule) Reset()      { *m = IngressRule{} }
+func (*IngressRule) ProtoMessage() {}
+
+func (m *IngressRuleValue) Reset()      { *m = IngressRuleValue{} }
+func (*IngressRuleValue) ProtoMessage() {}
+
+func (m *IngressSpec) Reset()      { *m = IngressSpec{} }
+func (*IngressSpec) ProtoMessage() {}
+
+func (m *IngressStatus) Reset()      { *m = IngressStatus{} }
+func (*IngressStatus) ProtoMessage() {}
+
+func (m *IngressTLS) Reset()      { *m = IngressTLS{} }
+func (*IngressTLS) ProtoMessage() {}
+
+func (m *Job) Reset()      { *m = Job{} }
+func (*Job) ProtoMessage() {}
+
+func (m *JobCondition) Reset()      { *m = JobCondition{} }
+func (*JobCondition) ProtoMessage() {}
+
+func (m *JobList) Reset()      { *m = JobList{} }
+func (*JobList) ProtoMessage() {}
+
+func (m *JobSpec) Reset()      { *m = JobSpec{} }
+func (*JobSpec) ProtoMessage() {}
+
+func (m *JobStatus) Reset()      { *m = JobStatus{} }
+func (*JobStatus) ProtoMessage() {}
+
+func (m *LabelSelector) Reset()      { *m = LabelSelector{} }
+func (*LabelSelector) ProtoMessage() {}
+
+func (m *LabelSelectorRequirement) Reset()      { *m = LabelSelectorRequirement{} }
+func (*LabelSelectorRequirement) ProtoMessage() {}
+
+func (m *ListOptions) Reset()      { *m = ListOptions{} }
+func (*ListOptions) ProtoMessage() {}
+
+func (m *NetworkPolicy) Reset()      { *m = NetworkPolicy{} }
+func (*NetworkPolicy) ProtoMessage() {}
+
+func (m *NetworkPolicyIngressRule) Reset()      { *m = NetworkPolicyIngressRule{} }
+func (*NetworkPolicyIngressRule) ProtoMessage() {}
+
+func (m *NetworkPolicyList) Reset()      { *m = NetworkPolicyList{} }
+func (*NetworkPolicyList) ProtoMessage() {}
+
+func (m *NetworkPolicyPeer) Reset()      { *m = NetworkPolicyPeer{} }
+func (*NetworkPolicyPeer) ProtoMessage() {}
+
+func (m *NetworkPolicyPort) Reset()      { *m = NetworkPolicyPort{} }
+func (*NetworkPolicyPort) ProtoMessage() {}
+
+func (m *NetworkPolicySpec) Reset()      { *m = NetworkPolicySpec{} }
+func (*NetworkPolicySpec) ProtoMessage() {}
+
+func (m *PodSecurityPolicy) Reset()      { *m = PodSecurityPolicy{} }
+func (*PodSecurityPolicy) ProtoMessage() {}
+
+func (m *PodSecurityPolicyList) Reset()      { *m = PodSecurityPolicyList{} }
+func (*PodSecurityPolicyList) ProtoMessage() {}
+
+func (m *PodSecurityPolicySpec) Reset()      { *m = PodSecurityPolicySpec{} }
+func (*PodSecurityPolicySpec) ProtoMessage() {}
+
+func (m *ReplicaSet) Reset()      { *m = ReplicaSet{} }
+func (*ReplicaSet) ProtoMessage() {}
+
+func (m *ReplicaSetList) Reset()      { *m = ReplicaSetList{} }
+func (*ReplicaSetList) ProtoMessage() {}
+
+func (m *ReplicaSetSpec) Reset()      { *m = ReplicaSetSpec{} }
+func (*ReplicaSetSpec) ProtoMessage() {}
+
+func (m *ReplicaSetStatus) Reset()      { *m = ReplicaSetStatus{} }
+func (*ReplicaSetStatus) ProtoMessage() {}
+
+func (m *ReplicationControllerDummy) Reset()      { *m = ReplicationControllerDummy{} }
+func (*ReplicationControllerDummy) ProtoMessage() {}
+
+func (m *RollbackConfig) Reset()      { *m = RollbackConfig{} }
+func (*RollbackConfig) ProtoMessage() {}
+
+func (m *RollingUpdateDeployment) Reset()      { *m = RollingUpdateDeployment{} }
+func (*RollingUpdateDeployment) ProtoMessage() {}
+
+func (m *RunAsUserStrategyOptions) Reset()      { *m = RunAsUserStrategyOptions{} }
+func (*RunAsUserStrategyOptions) ProtoMessage() {}
+
+func (m *SELinuxStrategyOptions) Reset()      { *m = SELinuxStrategyOptions{} }
+func (*SELinuxStrategyOptions) ProtoMessage() {}
+
+func (m *Scale) Reset()      { *m = Scale{} }
+func (*Scale) ProtoMessage() {}
+
+func (m *ScaleSpec) Reset()      { *m = ScaleSpec{} }
+func (*ScaleSpec) ProtoMessage() {}
+
+func (m *ScaleStatus) Reset()      { *m = ScaleStatus{} }
+func (*ScaleStatus) ProtoMessage() {}
+
+func (m *SubresourceReference) Reset()      { *m = SubresourceReference{} }
+func (*SubresourceReference) ProtoMessage() {}
+
+func (m *SupplementalGroupsStrategyOptions) Reset()      { *m = SupplementalGroupsStrategyOptions{} }
+func (*SupplementalGroupsStrategyOptions) ProtoMessage() {}
+
+func (m *ThirdPartyResource) Reset()      { *m = ThirdPartyResource{} }
+func (*ThirdPartyResource) ProtoMessage() {}
+
+func (m *ThirdPartyResourceData) Reset()      { *m = ThirdPartyResourceData{} }
+func (*ThirdPartyResourceData) ProtoMessage() {}
+
+func (m *ThirdPartyResourceDataList) Reset()      { *m = ThirdPartyResourceDataList{} }
+func (*ThirdPartyResourceDataList) ProtoMessage() {}
+
+func (m *ThirdPartyResourceList) Reset()      { *m = ThirdPartyResourceList{} }
+func (*ThirdPartyResourceList) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*APIVersion)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.APIVersion")
@@ -4094,6 +4029,850 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *APIVersion) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&APIVersion{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CPUTargetUtilization) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CPUTargetUtilization{`,
+		`TargetPercentage:` + fmt.Sprintf("%v", this.TargetPercentage) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CustomMetricCurrentStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CustomMetricCurrentStatus{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`CurrentValue:` + strings.Replace(strings.Replace(this.CurrentValue.String(), "Quantity", "k8s_io_kubernetes_pkg_api_resource.Quantity", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CustomMetricCurrentStatusList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CustomMetricCurrentStatusList{`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "CustomMetricCurrentStatus", "CustomMetricCurrentStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CustomMetricTarget) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CustomMetricTarget{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`TargetValue:` + strings.Replace(strings.Replace(this.TargetValue.String(), "Quantity", "k8s_io_kubernetes_pkg_api_resource.Quantity", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CustomMetricTargetList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CustomMetricTargetList{`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "CustomMetricTarget", "CustomMetricTarget", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DaemonSet) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DaemonSet{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "DaemonSetSpec", "DaemonSetSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "DaemonSetStatus", "DaemonSetStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DaemonSetList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DaemonSetList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "DaemonSet", "DaemonSet", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DaemonSetSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DaemonSetSpec{`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DaemonSetStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DaemonSetStatus{`,
+		`CurrentNumberScheduled:` + fmt.Sprintf("%v", this.CurrentNumberScheduled) + `,`,
+		`NumberMisscheduled:` + fmt.Sprintf("%v", this.NumberMisscheduled) + `,`,
+		`DesiredNumberScheduled:` + fmt.Sprintf("%v", this.DesiredNumberScheduled) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Deployment) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Deployment{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "DeploymentSpec", "DeploymentSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "DeploymentStatus", "DeploymentStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeploymentList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeploymentList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Deployment", "Deployment", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeploymentRollback) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForUpdatedAnnotations := make([]string, 0, len(this.UpdatedAnnotations))
+	for k := range this.UpdatedAnnotations {
+		keysForUpdatedAnnotations = append(keysForUpdatedAnnotations, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForUpdatedAnnotations)
+	mapStringForUpdatedAnnotations := "map[string]string{"
+	for _, k := range keysForUpdatedAnnotations {
+		mapStringForUpdatedAnnotations += fmt.Sprintf("%v: %v,", k, this.UpdatedAnnotations[k])
+	}
+	mapStringForUpdatedAnnotations += "}"
+	s := strings.Join([]string{`&DeploymentRollback{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`UpdatedAnnotations:` + mapStringForUpdatedAnnotations + `,`,
+		`RollbackTo:` + strings.Replace(strings.Replace(this.RollbackTo.String(), "RollbackConfig", "RollbackConfig", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeploymentSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeploymentSpec{`,
+		`Replicas:` + valueToStringGenerated(this.Replicas) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`Strategy:` + strings.Replace(strings.Replace(this.Strategy.String(), "DeploymentStrategy", "DeploymentStrategy", 1), `&`, ``, 1) + `,`,
+		`MinReadySeconds:` + fmt.Sprintf("%v", this.MinReadySeconds) + `,`,
+		`RevisionHistoryLimit:` + valueToStringGenerated(this.RevisionHistoryLimit) + `,`,
+		`Paused:` + fmt.Sprintf("%v", this.Paused) + `,`,
+		`RollbackTo:` + strings.Replace(fmt.Sprintf("%v", this.RollbackTo), "RollbackConfig", "RollbackConfig", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeploymentStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeploymentStatus{`,
+		`ObservedGeneration:` + fmt.Sprintf("%v", this.ObservedGeneration) + `,`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`UpdatedReplicas:` + fmt.Sprintf("%v", this.UpdatedReplicas) + `,`,
+		`AvailableReplicas:` + fmt.Sprintf("%v", this.AvailableReplicas) + `,`,
+		`UnavailableReplicas:` + fmt.Sprintf("%v", this.UnavailableReplicas) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeploymentStrategy) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeploymentStrategy{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`RollingUpdate:` + strings.Replace(fmt.Sprintf("%v", this.RollingUpdate), "RollingUpdateDeployment", "RollingUpdateDeployment", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ExportOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ExportOptions{`,
+		`Export:` + fmt.Sprintf("%v", this.Export) + `,`,
+		`Exact:` + fmt.Sprintf("%v", this.Exact) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FSGroupStrategyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&FSGroupStrategyOptions{`,
+		`Rule:` + fmt.Sprintf("%v", this.Rule) + `,`,
+		`Ranges:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ranges), "IDRange", "IDRange", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HTTPIngressPath) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HTTPIngressPath{`,
+		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
+		`Backend:` + strings.Replace(strings.Replace(this.Backend.String(), "IngressBackend", "IngressBackend", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HTTPIngressRuleValue) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HTTPIngressRuleValue{`,
+		`Paths:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Paths), "HTTPIngressPath", "HTTPIngressPath", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscaler) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscaler{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "HorizontalPodAutoscalerSpec", "HorizontalPodAutoscalerSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "HorizontalPodAutoscalerStatus", "HorizontalPodAutoscalerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "HorizontalPodAutoscaler", "HorizontalPodAutoscaler", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerSpec{`,
+		`ScaleRef:` + strings.Replace(strings.Replace(this.ScaleRef.String(), "SubresourceReference", "SubresourceReference", 1), `&`, ``, 1) + `,`,
+		`MinReplicas:` + valueToStringGenerated(this.MinReplicas) + `,`,
+		`MaxReplicas:` + fmt.Sprintf("%v", this.MaxReplicas) + `,`,
+		`CPUUtilization:` + strings.Replace(fmt.Sprintf("%v", this.CPUUtilization), "CPUTargetUtilization", "CPUTargetUtilization", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HorizontalPodAutoscalerStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HorizontalPodAutoscalerStatus{`,
+		`ObservedGeneration:` + valueToStringGenerated(this.ObservedGeneration) + `,`,
+		`LastScaleTime:` + strings.Replace(fmt.Sprintf("%v", this.LastScaleTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`CurrentReplicas:` + fmt.Sprintf("%v", this.CurrentReplicas) + `,`,
+		`DesiredReplicas:` + fmt.Sprintf("%v", this.DesiredReplicas) + `,`,
+		`CurrentCPUUtilizationPercentage:` + valueToStringGenerated(this.CurrentCPUUtilizationPercentage) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HostPortRange) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HostPortRange{`,
+		`Min:` + fmt.Sprintf("%v", this.Min) + `,`,
+		`Max:` + fmt.Sprintf("%v", this.Max) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IDRange) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IDRange{`,
+		`Min:` + fmt.Sprintf("%v", this.Min) + `,`,
+		`Max:` + fmt.Sprintf("%v", this.Max) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Ingress) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Ingress{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "IngressSpec", "IngressSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "IngressStatus", "IngressStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressBackend) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressBackend{`,
+		`ServiceName:` + fmt.Sprintf("%v", this.ServiceName) + `,`,
+		`ServicePort:` + strings.Replace(strings.Replace(this.ServicePort.String(), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Ingress", "Ingress", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressRule) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressRule{`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`IngressRuleValue:` + strings.Replace(strings.Replace(this.IngressRuleValue.String(), "IngressRuleValue", "IngressRuleValue", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressRuleValue) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressRuleValue{`,
+		`HTTP:` + strings.Replace(fmt.Sprintf("%v", this.HTTP), "HTTPIngressRuleValue", "HTTPIngressRuleValue", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressSpec{`,
+		`Backend:` + strings.Replace(fmt.Sprintf("%v", this.Backend), "IngressBackend", "IngressBackend", 1) + `,`,
+		`TLS:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.TLS), "IngressTLS", "IngressTLS", 1), `&`, ``, 1) + `,`,
+		`Rules:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Rules), "IngressRule", "IngressRule", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressStatus{`,
+		`LoadBalancer:` + strings.Replace(strings.Replace(this.LoadBalancer.String(), "LoadBalancerStatus", "k8s_io_kubernetes_pkg_api_v1.LoadBalancerStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *IngressTLS) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&IngressTLS{`,
+		`Hosts:` + fmt.Sprintf("%v", this.Hosts) + `,`,
+		`SecretName:` + fmt.Sprintf("%v", this.SecretName) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Job) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Job{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "JobSpec", "JobSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "JobStatus", "JobStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobCondition) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobCondition{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
+		`LastProbeTime:` + strings.Replace(strings.Replace(this.LastProbeTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`LastTransitionTime:` + strings.Replace(strings.Replace(this.LastTransitionTime.String(), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1), `&`, ``, 1) + `,`,
+		`Reason:` + fmt.Sprintf("%v", this.Reason) + `,`,
+		`Message:` + fmt.Sprintf("%v", this.Message) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Job", "Job", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobSpec{`,
+		`Parallelism:` + valueToStringGenerated(this.Parallelism) + `,`,
+		`Completions:` + valueToStringGenerated(this.Completions) + `,`,
+		`ActiveDeadlineSeconds:` + valueToStringGenerated(this.ActiveDeadlineSeconds) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`AutoSelector:` + valueToStringGenerated(this.AutoSelector) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *JobStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&JobStatus{`,
+		`Conditions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Conditions), "JobCondition", "JobCondition", 1), `&`, ``, 1) + `,`,
+		`StartTime:` + strings.Replace(fmt.Sprintf("%v", this.StartTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`CompletionTime:` + strings.Replace(fmt.Sprintf("%v", this.CompletionTime), "Time", "k8s_io_kubernetes_pkg_api_unversioned.Time", 1) + `,`,
+		`Active:` + fmt.Sprintf("%v", this.Active) + `,`,
+		`Succeeded:` + fmt.Sprintf("%v", this.Succeeded) + `,`,
+		`Failed:` + fmt.Sprintf("%v", this.Failed) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelector) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForMatchLabels := make([]string, 0, len(this.MatchLabels))
+	for k := range this.MatchLabels {
+		keysForMatchLabels = append(keysForMatchLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForMatchLabels)
+	mapStringForMatchLabels := "map[string]string{"
+	for _, k := range keysForMatchLabels {
+		mapStringForMatchLabels += fmt.Sprintf("%v: %v,", k, this.MatchLabels[k])
+	}
+	mapStringForMatchLabels += "}"
+	s := strings.Join([]string{`&LabelSelector{`,
+		`MatchLabels:` + mapStringForMatchLabels + `,`,
+		`MatchExpressions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.MatchExpressions), "LabelSelectorRequirement", "LabelSelectorRequirement", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LabelSelectorRequirement) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LabelSelectorRequirement{`,
+		`Key:` + fmt.Sprintf("%v", this.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", this.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", this.Values) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListOptions{`,
+		`LabelSelector:` + fmt.Sprintf("%v", this.LabelSelector) + `,`,
+		`FieldSelector:` + fmt.Sprintf("%v", this.FieldSelector) + `,`,
+		`Watch:` + fmt.Sprintf("%v", this.Watch) + `,`,
+		`ResourceVersion:` + fmt.Sprintf("%v", this.ResourceVersion) + `,`,
+		`TimeoutSeconds:` + valueToStringGenerated(this.TimeoutSeconds) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicy) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicy{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "NetworkPolicySpec", "NetworkPolicySpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicyIngressRule) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicyIngressRule{`,
+		`Ports:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ports), "NetworkPolicyPort", "NetworkPolicyPort", 1), `&`, ``, 1) + `,`,
+		`From:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.From), "NetworkPolicyPeer", "NetworkPolicyPeer", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicyList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicyList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "NetworkPolicy", "NetworkPolicy", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicyPeer) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicyPeer{`,
+		`PodSelector:` + strings.Replace(fmt.Sprintf("%v", this.PodSelector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`NamespaceSelector:` + strings.Replace(fmt.Sprintf("%v", this.NamespaceSelector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicyPort) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicyPort{`,
+		`Protocol:` + valueToStringGenerated(this.Protocol) + `,`,
+		`Port:` + strings.Replace(fmt.Sprintf("%v", this.Port), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *NetworkPolicySpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&NetworkPolicySpec{`,
+		`PodSelector:` + strings.Replace(strings.Replace(this.PodSelector.String(), "LabelSelector", "LabelSelector", 1), `&`, ``, 1) + `,`,
+		`Ingress:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ingress), "NetworkPolicyIngressRule", "NetworkPolicyIngressRule", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSecurityPolicy) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodSecurityPolicy{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PodSecurityPolicySpec", "PodSecurityPolicySpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSecurityPolicyList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodSecurityPolicyList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PodSecurityPolicy", "PodSecurityPolicy", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodSecurityPolicySpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodSecurityPolicySpec{`,
+		`Privileged:` + fmt.Sprintf("%v", this.Privileged) + `,`,
+		`DefaultAddCapabilities:` + fmt.Sprintf("%v", this.DefaultAddCapabilities) + `,`,
+		`RequiredDropCapabilities:` + fmt.Sprintf("%v", this.RequiredDropCapabilities) + `,`,
+		`AllowedCapabilities:` + fmt.Sprintf("%v", this.AllowedCapabilities) + `,`,
+		`Volumes:` + fmt.Sprintf("%v", this.Volumes) + `,`,
+		`HostNetwork:` + fmt.Sprintf("%v", this.HostNetwork) + `,`,
+		`HostPorts:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.HostPorts), "HostPortRange", "HostPortRange", 1), `&`, ``, 1) + `,`,
+		`HostPID:` + fmt.Sprintf("%v", this.HostPID) + `,`,
+		`HostIPC:` + fmt.Sprintf("%v", this.HostIPC) + `,`,
+		`SELinux:` + strings.Replace(strings.Replace(this.SELinux.String(), "SELinuxStrategyOptions", "SELinuxStrategyOptions", 1), `&`, ``, 1) + `,`,
+		`RunAsUser:` + strings.Replace(strings.Replace(this.RunAsUser.String(), "RunAsUserStrategyOptions", "RunAsUserStrategyOptions", 1), `&`, ``, 1) + `,`,
+		`SupplementalGroups:` + strings.Replace(strings.Replace(this.SupplementalGroups.String(), "SupplementalGroupsStrategyOptions", "SupplementalGroupsStrategyOptions", 1), `&`, ``, 1) + `,`,
+		`FSGroup:` + strings.Replace(strings.Replace(this.FSGroup.String(), "FSGroupStrategyOptions", "FSGroupStrategyOptions", 1), `&`, ``, 1) + `,`,
+		`ReadOnlyRootFilesystem:` + fmt.Sprintf("%v", this.ReadOnlyRootFilesystem) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicaSet) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicaSet{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ReplicaSetSpec", "ReplicaSetSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ReplicaSetStatus", "ReplicaSetStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicaSetList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicaSetList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ReplicaSet", "ReplicaSet", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicaSetSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicaSetSpec{`,
+		`Replicas:` + valueToStringGenerated(this.Replicas) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "LabelSelector", 1) + `,`,
+		`Template:` + strings.Replace(strings.Replace(this.Template.String(), "PodTemplateSpec", "k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicaSetStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicaSetStatus{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`FullyLabeledReplicas:` + fmt.Sprintf("%v", this.FullyLabeledReplicas) + `,`,
+		`ObservedGeneration:` + fmt.Sprintf("%v", this.ObservedGeneration) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ReplicationControllerDummy) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ReplicationControllerDummy{`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RollbackConfig) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RollbackConfig{`,
+		`Revision:` + fmt.Sprintf("%v", this.Revision) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RollingUpdateDeployment) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RollingUpdateDeployment{`,
+		`MaxUnavailable:` + strings.Replace(fmt.Sprintf("%v", this.MaxUnavailable), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1) + `,`,
+		`MaxSurge:` + strings.Replace(fmt.Sprintf("%v", this.MaxSurge), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RunAsUserStrategyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RunAsUserStrategyOptions{`,
+		`Rule:` + fmt.Sprintf("%v", this.Rule) + `,`,
+		`Ranges:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ranges), "IDRange", "IDRange", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SELinuxStrategyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SELinuxStrategyOptions{`,
+		`Rule:` + fmt.Sprintf("%v", this.Rule) + `,`,
+		`SELinuxOptions:` + strings.Replace(fmt.Sprintf("%v", this.SELinuxOptions), "SELinuxOptions", "k8s_io_kubernetes_pkg_api_v1.SELinuxOptions", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Scale) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Scale{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "ScaleSpec", "ScaleSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "ScaleStatus", "ScaleStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScaleSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ScaleSpec{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ScaleStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForSelector := make([]string, 0, len(this.Selector))
+	for k := range this.Selector {
+		keysForSelector = append(keysForSelector, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForSelector)
+	mapStringForSelector := "map[string]string{"
+	for _, k := range keysForSelector {
+		mapStringForSelector += fmt.Sprintf("%v: %v,", k, this.Selector[k])
+	}
+	mapStringForSelector += "}"
+	s := strings.Join([]string{`&ScaleStatus{`,
+		`Replicas:` + fmt.Sprintf("%v", this.Replicas) + `,`,
+		`Selector:` + mapStringForSelector + `,`,
+		`TargetSelector:` + fmt.Sprintf("%v", this.TargetSelector) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SubresourceReference) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SubresourceReference{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`Subresource:` + fmt.Sprintf("%v", this.Subresource) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SupplementalGroupsStrategyOptions) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SupplementalGroupsStrategyOptions{`,
+		`Rule:` + fmt.Sprintf("%v", this.Rule) + `,`,
+		`Ranges:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Ranges), "IDRange", "IDRange", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ThirdPartyResource) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ThirdPartyResource{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Description:` + fmt.Sprintf("%v", this.Description) + `,`,
+		`Versions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Versions), "APIVersion", "APIVersion", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ThirdPartyResourceData) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ThirdPartyResourceData{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Data:` + valueToStringGenerated(this.Data) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ThirdPartyResourceDataList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ThirdPartyResourceDataList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ThirdPartyResourceData", "ThirdPartyResourceData", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ThirdPartyResourceList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ThirdPartyResourceList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ThirdPartyResource", "ThirdPartyResource", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *APIVersion) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/policy/v1alpha1/generated.pb.go
+++ b/pkg/apis/policy/v1alpha1/generated.pb.go
@@ -38,6 +38,9 @@ import math "math"
 
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -45,21 +48,17 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *PodDisruptionBudget) Reset()         { *m = PodDisruptionBudget{} }
-func (m *PodDisruptionBudget) String() string { return proto.CompactTextString(m) }
-func (*PodDisruptionBudget) ProtoMessage()    {}
+func (m *PodDisruptionBudget) Reset()      { *m = PodDisruptionBudget{} }
+func (*PodDisruptionBudget) ProtoMessage() {}
 
-func (m *PodDisruptionBudgetList) Reset()         { *m = PodDisruptionBudgetList{} }
-func (m *PodDisruptionBudgetList) String() string { return proto.CompactTextString(m) }
-func (*PodDisruptionBudgetList) ProtoMessage()    {}
+func (m *PodDisruptionBudgetList) Reset()      { *m = PodDisruptionBudgetList{} }
+func (*PodDisruptionBudgetList) ProtoMessage() {}
 
-func (m *PodDisruptionBudgetSpec) Reset()         { *m = PodDisruptionBudgetSpec{} }
-func (m *PodDisruptionBudgetSpec) String() string { return proto.CompactTextString(m) }
-func (*PodDisruptionBudgetSpec) ProtoMessage()    {}
+func (m *PodDisruptionBudgetSpec) Reset()      { *m = PodDisruptionBudgetSpec{} }
+func (*PodDisruptionBudgetSpec) ProtoMessage() {}
 
-func (m *PodDisruptionBudgetStatus) Reset()         { *m = PodDisruptionBudgetStatus{} }
-func (m *PodDisruptionBudgetStatus) String() string { return proto.CompactTextString(m) }
-func (*PodDisruptionBudgetStatus) ProtoMessage()    {}
+func (m *PodDisruptionBudgetStatus) Reset()      { *m = PodDisruptionBudgetStatus{} }
+func (*PodDisruptionBudgetStatus) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*PodDisruptionBudget)(nil), "k8s.io.kubernetes.pkg.apis.policy.v1alpha1.PodDisruptionBudget")
@@ -305,6 +304,61 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *PodDisruptionBudget) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodDisruptionBudget{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Spec:` + strings.Replace(strings.Replace(this.Spec.String(), "PodDisruptionBudgetSpec", "PodDisruptionBudgetSpec", 1), `&`, ``, 1) + `,`,
+		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "PodDisruptionBudgetStatus", "PodDisruptionBudgetStatus", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodDisruptionBudgetList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodDisruptionBudgetList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "PodDisruptionBudget", "PodDisruptionBudget", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodDisruptionBudgetSpec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodDisruptionBudgetSpec{`,
+		`MinAvailable:` + strings.Replace(strings.Replace(this.MinAvailable.String(), "IntOrString", "k8s_io_kubernetes_pkg_util_intstr.IntOrString", 1), `&`, ``, 1) + `,`,
+		`Selector:` + strings.Replace(fmt.Sprintf("%v", this.Selector), "LabelSelector", "k8s_io_kubernetes_pkg_api_unversioned.LabelSelector", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PodDisruptionBudgetStatus) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PodDisruptionBudgetStatus{`,
+		`PodDisruptionAllowed:` + fmt.Sprintf("%v", this.PodDisruptionAllowed) + `,`,
+		`CurrentHealthy:` + fmt.Sprintf("%v", this.CurrentHealthy) + `,`,
+		`DesiredHealthy:` + fmt.Sprintf("%v", this.DesiredHealthy) + `,`,
+		`ExpectedPods:` + fmt.Sprintf("%v", this.ExpectedPods) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *PodDisruptionBudget) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/apis/rbac/v1alpha1/generated.pb.go
+++ b/pkg/apis/rbac/v1alpha1/generated.pb.go
@@ -42,6 +42,9 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -49,45 +52,35 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *ClusterRole) Reset()         { *m = ClusterRole{} }
-func (m *ClusterRole) String() string { return proto.CompactTextString(m) }
-func (*ClusterRole) ProtoMessage()    {}
+func (m *ClusterRole) Reset()      { *m = ClusterRole{} }
+func (*ClusterRole) ProtoMessage() {}
 
-func (m *ClusterRoleBinding) Reset()         { *m = ClusterRoleBinding{} }
-func (m *ClusterRoleBinding) String() string { return proto.CompactTextString(m) }
-func (*ClusterRoleBinding) ProtoMessage()    {}
+func (m *ClusterRoleBinding) Reset()      { *m = ClusterRoleBinding{} }
+func (*ClusterRoleBinding) ProtoMessage() {}
 
-func (m *ClusterRoleBindingList) Reset()         { *m = ClusterRoleBindingList{} }
-func (m *ClusterRoleBindingList) String() string { return proto.CompactTextString(m) }
-func (*ClusterRoleBindingList) ProtoMessage()    {}
+func (m *ClusterRoleBindingList) Reset()      { *m = ClusterRoleBindingList{} }
+func (*ClusterRoleBindingList) ProtoMessage() {}
 
-func (m *ClusterRoleList) Reset()         { *m = ClusterRoleList{} }
-func (m *ClusterRoleList) String() string { return proto.CompactTextString(m) }
-func (*ClusterRoleList) ProtoMessage()    {}
+func (m *ClusterRoleList) Reset()      { *m = ClusterRoleList{} }
+func (*ClusterRoleList) ProtoMessage() {}
 
-func (m *PolicyRule) Reset()         { *m = PolicyRule{} }
-func (m *PolicyRule) String() string { return proto.CompactTextString(m) }
-func (*PolicyRule) ProtoMessage()    {}
+func (m *PolicyRule) Reset()      { *m = PolicyRule{} }
+func (*PolicyRule) ProtoMessage() {}
 
-func (m *Role) Reset()         { *m = Role{} }
-func (m *Role) String() string { return proto.CompactTextString(m) }
-func (*Role) ProtoMessage()    {}
+func (m *Role) Reset()      { *m = Role{} }
+func (*Role) ProtoMessage() {}
 
-func (m *RoleBinding) Reset()         { *m = RoleBinding{} }
-func (m *RoleBinding) String() string { return proto.CompactTextString(m) }
-func (*RoleBinding) ProtoMessage()    {}
+func (m *RoleBinding) Reset()      { *m = RoleBinding{} }
+func (*RoleBinding) ProtoMessage() {}
 
-func (m *RoleBindingList) Reset()         { *m = RoleBindingList{} }
-func (m *RoleBindingList) String() string { return proto.CompactTextString(m) }
-func (*RoleBindingList) ProtoMessage()    {}
+func (m *RoleBindingList) Reset()      { *m = RoleBindingList{} }
+func (*RoleBindingList) ProtoMessage() {}
 
-func (m *RoleList) Reset()         { *m = RoleList{} }
-func (m *RoleList) String() string { return proto.CompactTextString(m) }
-func (*RoleList) ProtoMessage()    {}
+func (m *RoleList) Reset()      { *m = RoleList{} }
+func (*RoleList) ProtoMessage() {}
 
-func (m *Subject) Reset()         { *m = Subject{} }
-func (m *Subject) String() string { return proto.CompactTextString(m) }
-func (*Subject) ProtoMessage()    {}
+func (m *Subject) Reset()      { *m = Subject{} }
+func (*Subject) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*ClusterRole)(nil), "k8s.io.kubernetes.pkg.apis.rbac.v1alpha1.ClusterRole")
@@ -763,6 +756,132 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *ClusterRole) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterRole{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Rules:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Rules), "PolicyRule", "PolicyRule", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterRoleBinding) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterRoleBinding{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Subjects:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Subjects), "Subject", "Subject", 1), `&`, ``, 1) + `,`,
+		`RoleRef:` + strings.Replace(strings.Replace(this.RoleRef.String(), "ObjectReference", "k8s_io_kubernetes_pkg_api_v1.ObjectReference", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterRoleBindingList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterRoleBindingList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ClusterRoleBinding", "ClusterRoleBinding", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ClusterRoleList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ClusterRoleList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "ClusterRole", "ClusterRole", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PolicyRule) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PolicyRule{`,
+		`Verbs:` + fmt.Sprintf("%v", this.Verbs) + `,`,
+		`AttributeRestrictions:` + strings.Replace(strings.Replace(this.AttributeRestrictions.String(), "RawExtension", "k8s_io_kubernetes_pkg_runtime.RawExtension", 1), `&`, ``, 1) + `,`,
+		`APIGroups:` + fmt.Sprintf("%v", this.APIGroups) + `,`,
+		`Resources:` + fmt.Sprintf("%v", this.Resources) + `,`,
+		`ResourceNames:` + fmt.Sprintf("%v", this.ResourceNames) + `,`,
+		`NonResourceURLs:` + fmt.Sprintf("%v", this.NonResourceURLs) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Role) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Role{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Rules:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Rules), "PolicyRule", "PolicyRule", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RoleBinding) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RoleBinding{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(this.ObjectMeta.String(), "ObjectMeta", "k8s_io_kubernetes_pkg_api_v1.ObjectMeta", 1), `&`, ``, 1) + `,`,
+		`Subjects:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Subjects), "Subject", "Subject", 1), `&`, ``, 1) + `,`,
+		`RoleRef:` + strings.Replace(strings.Replace(this.RoleRef.String(), "ObjectReference", "k8s_io_kubernetes_pkg_api_v1.ObjectReference", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RoleBindingList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RoleBindingList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "RoleBinding", "RoleBinding", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RoleList) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RoleList{`,
+		`ListMeta:` + strings.Replace(strings.Replace(this.ListMeta.String(), "ListMeta", "k8s_io_kubernetes_pkg_api_unversioned.ListMeta", 1), `&`, ``, 1) + `,`,
+		`Items:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Items), "Role", "Role", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Subject) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Subject{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Namespace:` + fmt.Sprintf("%v", this.Namespace) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *ClusterRole) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/runtime/generated.pb.go
+++ b/pkg/runtime/generated.pb.go
@@ -35,6 +35,9 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -42,17 +45,14 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *RawExtension) Reset()         { *m = RawExtension{} }
-func (m *RawExtension) String() string { return proto.CompactTextString(m) }
-func (*RawExtension) ProtoMessage()    {}
+func (m *RawExtension) Reset()      { *m = RawExtension{} }
+func (*RawExtension) ProtoMessage() {}
 
-func (m *TypeMeta) Reset()         { *m = TypeMeta{} }
-func (m *TypeMeta) String() string { return proto.CompactTextString(m) }
-func (*TypeMeta) ProtoMessage()    {}
+func (m *TypeMeta) Reset()      { *m = TypeMeta{} }
+func (*TypeMeta) ProtoMessage() {}
 
-func (m *Unknown) Reset()         { *m = Unknown{} }
-func (m *Unknown) String() string { return proto.CompactTextString(m) }
-func (*Unknown) ProtoMessage()    {}
+func (m *Unknown) Reset()      { *m = Unknown{} }
+func (*Unknown) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*RawExtension)(nil), "k8s.io.kubernetes.pkg.runtime.RawExtension")
@@ -224,6 +224,48 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *RawExtension) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RawExtension{`,
+		`Raw:` + valueToStringGenerated(this.Raw) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TypeMeta) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TypeMeta{`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Unknown) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Unknown{`,
+		`TypeMeta:` + strings.Replace(strings.Replace(this.TypeMeta.String(), "TypeMeta", "TypeMeta", 1), `&`, ``, 1) + `,`,
+		`Raw:` + valueToStringGenerated(this.Raw) + `,`,
+		`ContentEncoding:` + fmt.Sprintf("%v", this.ContentEncoding) + `,`,
+		`ContentType:` + fmt.Sprintf("%v", this.ContentType) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *RawExtension) Unmarshal(data []byte) error {
 	l := len(data)

--- a/pkg/watch/versioned/generated.pb.go
+++ b/pkg/watch/versioned/generated.pb.go
@@ -33,6 +33,9 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import strings "strings"
+import reflect "reflect"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -40,9 +43,8 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func (m *Event) Reset()         { *m = Event{} }
-func (m *Event) String() string { return proto.CompactTextString(m) }
-func (*Event) ProtoMessage()    {}
+func (m *Event) Reset()      { *m = Event{} }
+func (*Event) ProtoMessage() {}
 
 func init() {
 	proto.RegisterType((*Event)(nil), "k8s.io.kubernetes.pkg.watch.versioned.Event")
@@ -126,6 +128,25 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (this *Event) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Event{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`Object:` + strings.Replace(strings.Replace(this.Object.String(), "RawExtension", "k8s_io_kubernetes_pkg_runtime.RawExtension", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
 }
 func (m *Event) Unmarshal(data []byte) error {
 	l := len(data)


### PR DESCRIPTION
This replaces the bad string output generated by golang/proto with gogo/protobuf stringer generation. Makes the output similar to %#v and more debuggable. We have to have a String() method to implement proto.Message, so this is strictly better.

@wojtek-t, @thockin for after your PR merges

Fixes #28756
