### PR TITLE
Unset https_proxy before roundtripper_test

### DIFF
--- a/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/httpstream"
 )
 
+// be sure to unset environment variable https_proxy (if exported) before testing, otherwise the testing will fail unexpectedly.
 func TestRoundTripAndNewConnection(t *testing.T) {
 	localhostPool := x509.NewCertPool()
 	if !localhostPool.AppendCertsFromPEM(localhostCert) {


### PR DESCRIPTION
When running `hack/test-go.sh`, if the testing env is behind a https proxy, roundtripper_test will fail randomly.

After `unset https_proxy`, the testing works well. So, add a comment to be a troubleshooting tip.

Fail info:

```
--- FAIL: TestRoundTripAndNewConnection (0.12s)
    roundtripper_test.go:319: proxied http->http: shouldError=false, got true: Get http://127.0.0.1:46711: unexpected EOF
FAIL
FAIL    k8s.io/kubernetes/pkg/util/httpstream/spdy  0.148s
```

```
--- FAIL: TestRoundTripAndNewConnection (0.12s)
    roundtripper_test.go:319: proxied https with auth (valid hostname + RootCAs) -> http: shouldError=false, got true: Get http://127.0.0.1:41028: unexpected EOF
FAIL
FAIL    k8s.io/kubernetes/pkg/util/httpstream/spdy  0.146s
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28816)

<!-- Reviewable:end -->
