### PR TITLE
[client-gen] Allow passing subresources in Patch method

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_type.go
@@ -134,6 +134,8 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 		"NewRootUpdateSubresourceAction": c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootUpdateSubresourceAction"}),
 		"NewRootPatchAction":             c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootPatchAction"}),
 		"NewPatchAction":                 c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewPatchAction"}),
+		"NewRootPatchSubresourceAction":  c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootPatchSubresourceAction"}),
+		"NewPatchSubresourceAction":      c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewPatchSubresourceAction"}),
 	}
 
 	noMethods := extractBoolTagOrDie("noMethods", t.SecondClosestCommentLines) == true
@@ -301,10 +303,10 @@ func (c *Fake$.type|publicPlural$) Watch(opts $.apiListOptions|raw$) ($.watchInt
 
 var patchTemplate = `
 // Patch applies the patch and returns the patched $.type|private$.
-func (c *Fake$.type|publicPlural$) Patch(name string, pt $.PatchType|raw$, data []byte) (result *$.type|raw$, err error) {
+func (c *Fake$.type|publicPlural$) Patch(name string, pt $.PatchType|raw$, data []byte, subresources ...string) (result *$.type|raw$, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewPatchAction|raw$($.type|allLowercasePlural$Resource, c.ns, name, data), &$.type|raw${})
-		$else$Invokes($.NewRootPatchAction|raw$($.type|allLowercasePlural$Resource, name, data), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, name, data, subresources... ), &$.type|raw${})
+		$else$Invokes($.NewRootPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, name, data, subresources...), &$.type|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
@@ -161,7 +161,7 @@ var interfaceTemplate3 = `
 	Get(name string) (*$.type|raw$, error)
 	List(opts $.apiListOptions|raw$) (*$.type|raw$List, error)
 	Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error)
-	Patch(name string, pt $.PatchType|raw$, data []byte) (result *$.type|raw$, err error)`
+	Patch(name string, pt $.PatchType|raw$, data []byte, subresources ...string) (result *$.type|raw$, err error)`
 
 var interfaceTemplate4 = `
 	$.type|public$Expansion
@@ -315,11 +315,12 @@ func (c *$.type|privatePlural$) Watch(opts $.apiListOptions|raw$) ($.watchInterf
 
 var patchTemplate = `
 // Patch applies the patch and returns the patched $.type|private$.
-func (c *$.type|privatePlural$) Patch(name string, pt $.PatchType|raw$, data []byte) (result *$.type|raw$, err error) {
+func (c *$.type|privatePlural$) Patch(name string, pt $.PatchType|raw$, data []byte, subresources ...string) (result *$.type|raw$, err error) {
 	result = &$.type|raw${}
 	err = c.client.Patch(pt).
 		$if .namespaced$Namespace(c.ns).$end$
 		Resource("$.type|allLowercasePlural$").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
@@ -23,7 +23,6 @@ import (
 	core "k8s.io/kubernetes/pkg/client/testing/core"
 	labels "k8s.io/kubernetes/pkg/labels"
 	watch "k8s.io/kubernetes/pkg/watch"
-	"path"
 )
 
 // FakeTestTypes implements TestTypeInterface
@@ -119,7 +118,7 @@ func (c *FakeTestTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 // Patch applies the patch and returns the patched testType.
 func (c *FakeTestTypes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *testgroup_k8s_io.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchSubresourceAction(testtypesResource, c.ns, name, data, path.Join(subresources...)), &testgroup_k8s_io.TestType{})
+		Invokes(core.NewPatchSubresourceAction(testtypesResource, c.ns, name, data, subresources...), &testgroup_k8s_io.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
@@ -23,6 +23,7 @@ import (
 	core "k8s.io/kubernetes/pkg/client/testing/core"
 	labels "k8s.io/kubernetes/pkg/labels"
 	watch "k8s.io/kubernetes/pkg/watch"
+	"path"
 )
 
 // FakeTestTypes implements TestTypeInterface
@@ -116,9 +117,9 @@ func (c *FakeTestTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched testType.
-func (c *FakeTestTypes) Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error) {
+func (c *FakeTestTypes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *testgroup_k8s_io.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(testtypesResource, c.ns, name, data), &testgroup_k8s_io.TestType{})
+		Invokes(core.NewPatchSubresourceAction(testtypesResource, c.ns, name, data, path.Join(subresources...)), &testgroup_k8s_io.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
@@ -267,3 +267,25 @@ func TestPatchTestType(t *testing.T) {
 	receivedTestType, err := c.Setup(t).TestTypes(ns).Patch(requestTestType.Name, api.StrategicMergePatchType, []byte{})
 	c.simpleClient.Validate(t, receivedTestType, err)
 }
+
+func TestPatchSubresourcesTestType(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestTestType := &testgroup.TestType{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+	}
+	c := DecoratedSimpleClient{
+		simpleClient: simple.Client{
+			Request:  simple.Request{Method: "PATCH", Path: testHelper.ResourcePath("testtypes", ns, "foo/status"), Query: simple.BuildQueryValues(nil)},
+			Response: simple.Response{StatusCode: http.StatusOK, Body: requestTestType},
+		},
+	}
+	receivedTestType, err := c.Setup(t).TestTypes(ns).Patch(requestTestType.Name, api.StrategicMergePatchType, []byte{}, "status")
+	c.simpleClient.Validate(t, receivedTestType, err)
+}

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
@@ -38,7 +38,7 @@ type TestTypeInterface interface {
 	Get(name string) (*testgroup_k8s_io.TestType, error)
 	List(opts api.ListOptions) (*testgroup_k8s_io.TestTypeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *testgroup_k8s_io.TestType, err error)
 	TestTypeExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *testTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched testType.
-func (c *testTypes) Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error) {
+func (c *testTypes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *testgroup_k8s_io.TestType, err error) {
 	result = &testgroup_k8s_io.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("testtypes").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_service.go
@@ -115,9 +115,9 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &api.Service{})
+		Invokes(core.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &api.Service{})
 
 	if obj == nil {
 		return nil, err

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
@@ -37,7 +37,7 @@ type ServiceInterface interface {
 	Get(name string) (*api.Service, error)
 	List(opts api.ListOptions) (*api.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error)
 	ServiceExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+func (c *services) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("services").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
@@ -38,7 +38,7 @@ type ClusterInterface interface {
 	Get(name string) (*federation.Cluster, error)
 	List(opts api.ListOptions) (*federation.ClusterList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *federation.Cluster, err error)
 	ClusterExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *clusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched cluster.
-func (c *clusters) Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error) {
+func (c *clusters) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *federation.Cluster, err error) {
 	result = &federation.Cluster{}
 	err = c.client.Patch(pt).
 		Resource("clusters").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_cluster.go
@@ -108,9 +108,9 @@ func (c *FakeClusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched cluster.
-func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error) {
+func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *federation.Cluster, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(clustersResource, name, data), &federation.Cluster{})
+		Invokes(core.NewRootPatchSubresourceAction(clustersResource, name, data, subresources...), &federation.Cluster{})
 	if obj == nil {
 		return nil, err
 	}

--- a/federation/client/clientset_generated/federation_release_1_4/typed/core/v1/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_release_1_4/typed/core/v1/fake/fake_service.go
@@ -116,9 +116,9 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &v1.Service{})
+		Invokes(core.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &v1.Service{})
 
 	if obj == nil {
 		return nil, err

--- a/federation/client/clientset_generated/federation_release_1_4/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_release_1_4/typed/core/v1/service.go
@@ -38,7 +38,7 @@ type ServiceInterface interface {
 	Get(name string) (*v1.Service, error)
 	List(opts api.ListOptions) (*v1.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error)
 	ServiceExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+func (c *services) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
 	result = &v1.Service{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("services").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/federation/client/clientset_generated/federation_release_1_4/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_4/typed/federation/v1beta1/cluster.go
@@ -38,7 +38,7 @@ type ClusterInterface interface {
 	Get(name string) (*v1beta1.Cluster, error)
 	List(opts api.ListOptions) (*v1beta1.ClusterList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Cluster, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Cluster, err error)
 	ClusterExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *clusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched cluster.
-func (c *clusters) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Cluster, err error) {
+func (c *clusters) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Cluster, err error) {
 	result = &v1beta1.Cluster{}
 	err = c.client.Patch(pt).
 		Resource("clusters").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/federation/client/clientset_generated/federation_release_1_4/typed/federation/v1beta1/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_4/typed/federation/v1beta1/fake/fake_cluster.go
@@ -108,9 +108,9 @@ func (c *FakeClusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched cluster.
-func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Cluster, err error) {
+func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Cluster, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(clustersResource, name, data), &v1beta1.Cluster{})
+		Invokes(core.NewRootPatchSubresourceAction(clustersResource, name, data, subresources...), &v1beta1.Cluster{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_horizontalpodautoscaler.go
@@ -116,9 +116,9 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &autoscaling.HorizontalPodAutoscaler{})
+		Invokes(core.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &autoscaling.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
@@ -38,7 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*autoscaling.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*autoscaling.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *autoscaling.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_job.go
@@ -116,9 +116,9 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error) {
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &batch.Job{})
+		Invokes(core.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &batch.Job{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
@@ -116,9 +116,9 @@ func (c *FakeScheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error)
 }
 
 // Patch applies the patch and returns the patched scheduledJob.
-func (c *FakeScheduledJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error) {
+func (c *FakeScheduledJobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.ScheduledJob, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(scheduledjobsResource, c.ns, name, data), &batch.ScheduledJob{})
+		Invokes(core.NewPatchSubresourceAction(scheduledjobsResource, c.ns, name, data, subresources...), &batch.ScheduledJob{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
@@ -38,7 +38,7 @@ type JobInterface interface {
 	Get(name string) (*batch.Job, error)
 	List(opts api.ListOptions) (*batch.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.Job, err error)
 	JobExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error) {
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.Job, err error) {
 	result = &batch.Job{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("jobs").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
@@ -38,7 +38,7 @@ type ScheduledJobInterface interface {
 	Get(name string) (*batch.ScheduledJob, error)
 	List(opts api.ListOptions) (*batch.ScheduledJobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.ScheduledJob, err error)
 	ScheduledJobExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *scheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched scheduledJob.
-func (c *scheduledJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error) {
+func (c *scheduledJobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *batch.ScheduledJob, err error) {
 	result = &batch.ScheduledJob{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("scheduledjobs").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificatesigningrequest.go
@@ -38,7 +38,7 @@ type CertificateSigningRequestInterface interface {
 	Get(name string) (*certificates.CertificateSigningRequest, error)
 	List(opts api.ListOptions) (*certificates.CertificateSigningRequestList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *certificates.CertificateSigningRequest, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *certificates.CertificateSigningRequest, err error)
 	CertificateSigningRequestExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *certificateSigningRequests) Watch(opts api.ListOptions) (watch.Interfac
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.
-func (c *certificateSigningRequests) Patch(name string, pt api.PatchType, data []byte) (result *certificates.CertificateSigningRequest, err error) {
+func (c *certificateSigningRequests) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}
 	err = c.client.Patch(pt).
 		Resource("certificatesigningrequests").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificatesigningrequest.go
@@ -108,9 +108,9 @@ func (c *FakeCertificateSigningRequests) Watch(opts api.ListOptions) (watch.Inte
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.
-func (c *FakeCertificateSigningRequests) Patch(name string, pt api.PatchType, data []byte) (result *certificates.CertificateSigningRequest, err error) {
+func (c *FakeCertificateSigningRequests) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *certificates.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(certificatesigningrequestsResource, name, data), &certificates.CertificateSigningRequest{})
+		Invokes(core.NewRootPatchSubresourceAction(certificatesigningrequestsResource, name, data, subresources...), &certificates.CertificateSigningRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
@@ -36,7 +36,7 @@ type ComponentStatusInterface interface {
 	Get(name string) (*api.ComponentStatus, error)
 	List(opts api.ListOptions) (*api.ComponentStatusList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ComponentStatus, err error)
 	ComponentStatusExpansion
 }
 
@@ -127,10 +127,11 @@ func (c *componentStatuses) Watch(opts api.ListOptions) (watch.Interface, error)
 }
 
 // Patch applies the patch and returns the patched componentStatus.
-func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error) {
+func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Patch(pt).
 		Resource("componentstatuses").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
@@ -36,7 +36,7 @@ type ConfigMapInterface interface {
 	Get(name string) (*api.ConfigMap, error)
 	List(opts api.ListOptions) (*api.ConfigMapList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ConfigMap, err error)
 	ConfigMapExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *configMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched configMap.
-func (c *configMaps) Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error) {
+func (c *configMaps) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ConfigMap, err error) {
 	result = &api.ConfigMap{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("configmaps").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
@@ -36,7 +36,7 @@ type EndpointsInterface interface {
 	Get(name string) (*api.Endpoints, error)
 	List(opts api.ListOptions) (*api.EndpointsList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Endpoints, err error)
 	EndpointsExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *endpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched endpoints.
-func (c *endpoints) Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error) {
+func (c *endpoints) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Endpoints, err error) {
 	result = &api.Endpoints{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("endpoints").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
@@ -36,7 +36,7 @@ type EventInterface interface {
 	Get(name string) (*api.Event, error)
 	List(opts api.ListOptions) (*api.EventList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Event, err error)
 	EventExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched event.
-func (c *events) Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error) {
+func (c *events) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Event, err error) {
 	result = &api.Event{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("events").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_componentstatus.go
@@ -98,9 +98,9 @@ func (c *FakeComponentStatuses) Watch(opts api.ListOptions) (watch.Interface, er
 }
 
 // Patch applies the patch and returns the patched componentStatus.
-func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(componentstatusesResource, name, data), &api.ComponentStatus{})
+		Invokes(core.NewRootPatchSubresourceAction(componentstatusesResource, name, data, subresources...), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_configmap.go
@@ -105,9 +105,9 @@ func (c *FakeConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched configMap.
-func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error) {
+func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(configmapsResource, c.ns, name, data), &api.ConfigMap{})
+		Invokes(core.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &api.ConfigMap{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_endpoints.go
@@ -105,9 +105,9 @@ func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched endpoints.
-func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error) {
+func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Endpoints, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(endpointsResource, c.ns, name, data), &api.Endpoints{})
+		Invokes(core.NewPatchSubresourceAction(endpointsResource, c.ns, name, data, subresources...), &api.Endpoints{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event.go
@@ -105,9 +105,9 @@ func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched event.
-func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error) {
+func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(eventsResource, c.ns, name, data), &api.Event{})
+		Invokes(core.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &api.Event{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_limitrange.go
@@ -105,9 +105,9 @@ func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched limitRange.
-func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error) {
+func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(limitrangesResource, c.ns, name, data), &api.LimitRange{})
+		Invokes(core.NewPatchSubresourceAction(limitrangesResource, c.ns, name, data, subresources...), &api.LimitRange{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_namespace.go
@@ -107,9 +107,9 @@ func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched namespace.
-func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error) {
+func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(namespacesResource, name, data), &api.Namespace{})
+		Invokes(core.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &api.Namespace{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node.go
@@ -107,9 +107,9 @@ func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched node.
-func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error) {
+func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Node, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(nodesResource, name, data), &api.Node{})
+		Invokes(core.NewRootPatchSubresourceAction(nodesResource, name, data, subresources...), &api.Node{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node_expansion.go
@@ -23,7 +23,7 @@ import (
 
 func (c *FakeNodes) PatchStatus(nodeName string, data []byte) (*api.Node, error) {
 	obj, err := c.Fake.Invokes(
-		core.NewPatchSubresourceAction(nodesResource, "status"), &api.Node{})
+		core.NewRootPatchSubresourceAction(nodesResource, nodeName, data, "status"), &api.Node{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolume.go
@@ -107,9 +107,9 @@ func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, er
 }
 
 // Patch applies the patch and returns the patched persistentVolume.
-func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error) {
+func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(persistentvolumesResource, name, data), &api.PersistentVolume{})
+		Invokes(core.NewRootPatchSubresourceAction(persistentvolumesResource, name, data, subresources...), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolumeclaim.go
@@ -115,9 +115,9 @@ func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interfac
 }
 
 // Patch applies the patch and returns the patched persistentVolumeClaim.
-func (c *FakePersistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error) {
+func (c *FakePersistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(persistentvolumeclaimsResource, c.ns, name, data), &api.PersistentVolumeClaim{})
+		Invokes(core.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, name, data, subresources...), &api.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_pod.go
@@ -115,9 +115,9 @@ func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched pod.
-func (c *FakePods) Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error) {
+func (c *FakePods) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Pod, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(podsResource, c.ns, name, data), &api.Pod{})
+		Invokes(core.NewPatchSubresourceAction(podsResource, c.ns, name, data, subresources...), &api.Pod{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_podtemplate.go
@@ -105,9 +105,9 @@ func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) 
 }
 
 // Patch applies the patch and returns the patched podTemplate.
-func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error) {
+func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(podtemplatesResource, c.ns, name, data), &api.PodTemplate{})
+		Invokes(core.NewPatchSubresourceAction(podtemplatesResource, c.ns, name, data, subresources...), &api.PodTemplate{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_replicationcontroller.go
@@ -115,9 +115,9 @@ func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interfac
 }
 
 // Patch applies the patch and returns the patched replicationController.
-func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error) {
+func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(replicationcontrollersResource, c.ns, name, data), &api.ReplicationController{})
+		Invokes(core.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, name, data, subresources...), &api.ReplicationController{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_resourcequota.go
@@ -115,9 +115,9 @@ func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error
 }
 
 // Patch applies the patch and returns the patched resourceQuota.
-func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error) {
+func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(resourcequotasResource, c.ns, name, data), &api.ResourceQuota{})
+		Invokes(core.NewPatchSubresourceAction(resourcequotasResource, c.ns, name, data, subresources...), &api.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_secret.go
@@ -105,9 +105,9 @@ func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched secret.
-func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error) {
+func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(secretsResource, c.ns, name, data), &api.Secret{})
+		Invokes(core.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &api.Secret{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_service.go
@@ -115,9 +115,9 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &api.Service{})
+		Invokes(core.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &api.Service{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_serviceaccount.go
@@ -105,9 +105,9 @@ func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched serviceAccount.
-func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error) {
+func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(serviceaccountsResource, c.ns, name, data), &api.ServiceAccount{})
+		Invokes(core.NewPatchSubresourceAction(serviceaccountsResource, c.ns, name, data, subresources...), &api.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
@@ -36,7 +36,7 @@ type LimitRangeInterface interface {
 	Get(name string) (*api.LimitRange, error)
 	List(opts api.ListOptions) (*api.LimitRangeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.LimitRange, err error)
 	LimitRangeExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched limitRange.
-func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error) {
+func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.LimitRange, err error) {
 	result = &api.LimitRange{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("limitranges").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
@@ -37,7 +37,7 @@ type NamespaceInterface interface {
 	Get(name string) (*api.Namespace, error)
 	List(opts api.ListOptions) (*api.NamespaceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Namespace, err error)
 	NamespaceExpansion
 }
 
@@ -140,10 +140,11 @@ func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched namespace.
-func (c *namespaces) Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error) {
+func (c *namespaces) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Patch(pt).
 		Resource("namespaces").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
@@ -37,7 +37,7 @@ type NodeInterface interface {
 	Get(name string) (*api.Node, error)
 	List(opts api.ListOptions) (*api.NodeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Node, err error)
 	NodeExpansion
 }
 
@@ -140,10 +140,11 @@ func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched node.
-func (c *nodes) Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error) {
+func (c *nodes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Node, err error) {
 	result = &api.Node{}
 	err = c.client.Patch(pt).
 		Resource("nodes").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
@@ -37,7 +37,7 @@ type PersistentVolumeInterface interface {
 	Get(name string) (*api.PersistentVolume, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolume, err error)
 	PersistentVolumeExpansion
 }
 
@@ -140,10 +140,11 @@ func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error)
 }
 
 // Patch applies the patch and returns the patched persistentVolume.
-func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error) {
+func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Patch(pt).
 		Resource("persistentvolumes").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
@@ -37,7 +37,7 @@ type PersistentVolumeClaimInterface interface {
 	Get(name string) (*api.PersistentVolumeClaim, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeClaimList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolumeClaim, err error)
 	PersistentVolumeClaimExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *persistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, e
 }
 
 // Patch applies the patch and returns the patched persistentVolumeClaim.
-func (c *persistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error) {
+func (c *persistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
@@ -37,7 +37,7 @@ type PodInterface interface {
 	Get(name string) (*api.Pod, error)
 	List(opts api.ListOptions) (*api.PodList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Pod, err error)
 	PodExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *pods) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched pod.
-func (c *pods) Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error) {
+func (c *pods) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Pod, err error) {
 	result = &api.Pod{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("pods").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
@@ -36,7 +36,7 @@ type PodTemplateInterface interface {
 	Get(name string) (*api.PodTemplate, error)
 	List(opts api.ListOptions) (*api.PodTemplateList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PodTemplate, err error)
 	PodTemplateExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched podTemplate.
-func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error) {
+func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("podtemplates").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
@@ -37,7 +37,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*api.ReplicationController, error)
 	List(opts api.ListOptions) (*api.ReplicationControllerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ReplicationController, err error)
 	ReplicationControllerExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 }
 
 // Patch applies the patch and returns the patched replicationController.
-func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error) {
+func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
@@ -37,7 +37,7 @@ type ResourceQuotaInterface interface {
 	Get(name string) (*api.ResourceQuota, error)
 	List(opts api.ListOptions) (*api.ResourceQuotaList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ResourceQuota, err error)
 	ResourceQuotaExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched resourceQuota.
-func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error) {
+func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("resourcequotas").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
@@ -36,7 +36,7 @@ type SecretInterface interface {
 	Get(name string) (*api.Secret, error)
 	List(opts api.ListOptions) (*api.SecretList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Secret, err error)
 	SecretExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched secret.
-func (c *secrets) Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error) {
+func (c *secrets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Secret, err error) {
 	result = &api.Secret{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("secrets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
@@ -37,7 +37,7 @@ type ServiceInterface interface {
 	Get(name string) (*api.Service, error)
 	List(opts api.ListOptions) (*api.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error)
 	ServiceExpansion
 }
 
@@ -150,11 +150,12 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+func (c *services) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("services").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
@@ -36,7 +36,7 @@ type ServiceAccountInterface interface {
 	Get(name string) (*api.ServiceAccount, error)
 	List(opts api.ListOptions) (*api.ServiceAccountList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ServiceAccount, err error)
 	ServiceAccountExpansion
 }
 
@@ -136,11 +136,12 @@ func (c *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched serviceAccount.
-func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error) {
+func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *api.ServiceAccount, err error) {
 	result = &api.ServiceAccount{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("serviceaccounts").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
@@ -38,7 +38,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*extensions.DaemonSet, error)
 	List(opts api.ListOptions) (*extensions.DaemonSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched daemonSet.
-func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error) {
+func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("daemonsets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
@@ -38,7 +38,7 @@ type DeploymentInterface interface {
 	Get(name string) (*extensions.Deployment, error)
 	List(opts api.ListOptions) (*extensions.DeploymentList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error)
 	DeploymentExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched deployment.
-func (c *deployments) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error) {
+func (c *deployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("deployments").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_daemonset.go
@@ -116,9 +116,9 @@ func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched daemonSet.
-func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error) {
+func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(daemonsetsResource, c.ns, name, data), &extensions.DaemonSet{})
+		Invokes(core.NewPatchSubresourceAction(daemonsetsResource, c.ns, name, data, subresources...), &extensions.DaemonSet{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_deployment.go
@@ -116,9 +116,9 @@ func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched deployment.
-func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error) {
+func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(deploymentsResource, c.ns, name, data), &extensions.Deployment{})
+		Invokes(core.NewPatchSubresourceAction(deploymentsResource, c.ns, name, data, subresources...), &extensions.Deployment{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_ingress.go
@@ -116,9 +116,9 @@ func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched ingress.
-func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error) {
+func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(ingressesResource, c.ns, name, data), &extensions.Ingress{})
+		Invokes(core.NewPatchSubresourceAction(ingressesResource, c.ns, name, data, subresources...), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_podsecuritypolicy.go
@@ -99,9 +99,9 @@ func (c *FakePodSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, 
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.
-func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error) {
+func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(podsecuritypoliciesResource, name, data), &extensions.PodSecurityPolicy{})
+		Invokes(core.NewRootPatchSubresourceAction(podsecuritypoliciesResource, name, data, subresources...), &extensions.PodSecurityPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_replicaset.go
@@ -116,9 +116,9 @@ func (c *FakeReplicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched replicaSet.
-func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error) {
+func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ReplicaSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(replicasetsResource, c.ns, name, data), &extensions.ReplicaSet{})
+		Invokes(core.NewPatchSubresourceAction(replicasetsResource, c.ns, name, data, subresources...), &extensions.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_thirdpartyresource.go
@@ -99,9 +99,9 @@ func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, 
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.
-func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error) {
+func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(thirdpartyresourcesResource, name, data), &extensions.ThirdPartyResource{})
+		Invokes(core.NewRootPatchSubresourceAction(thirdpartyresourcesResource, name, data, subresources...), &extensions.ThirdPartyResource{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
@@ -38,7 +38,7 @@ type IngressInterface interface {
 	Get(name string) (*extensions.Ingress, error)
 	List(opts api.ListOptions) (*extensions.IngressList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Ingress, err error)
 	IngressExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched ingress.
-func (c *ingresses) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error) {
+func (c *ingresses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("ingresses").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
@@ -37,7 +37,7 @@ type PodSecurityPolicyInterface interface {
 	Get(name string) (*extensions.PodSecurityPolicy, error)
 	List(opts api.ListOptions) (*extensions.PodSecurityPolicyList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.PodSecurityPolicy, err error)
 	PodSecurityPolicyExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *podSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.
-func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error) {
+func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.PodSecurityPolicy, err error) {
 	result = &extensions.PodSecurityPolicy{}
 	err = c.client.Patch(pt).
 		Resource("podsecuritypolicies").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
@@ -38,7 +38,7 @@ type ReplicaSetInterface interface {
 	Get(name string) (*extensions.ReplicaSet, error)
 	List(opts api.ListOptions) (*extensions.ReplicaSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ReplicaSet, err error)
 	ReplicaSetExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *replicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched replicaSet.
-func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error) {
+func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("replicasets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
@@ -37,7 +37,7 @@ type ThirdPartyResourceInterface interface {
 	Get(name string) (*extensions.ThirdPartyResource, error)
 	List(opts api.ListOptions) (*extensions.ThirdPartyResourceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ThirdPartyResource, err error)
 	ThirdPartyResourceExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *thirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.
-func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error) {
+func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.ThirdPartyResource, err error) {
 	result = &extensions.ThirdPartyResource{}
 	err = c.client.Patch(pt).
 		Resource("thirdpartyresources").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
@@ -37,7 +37,7 @@ type ClusterRoleInterface interface {
 	Get(name string) (*rbac.ClusterRole, error)
 	List(opts api.ListOptions) (*rbac.ClusterRoleList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRole, err error)
 	ClusterRoleExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *clusterRoles) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched clusterRole.
-func (c *clusterRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error) {
+func (c *clusterRoles) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRole, err error) {
 	result = &rbac.ClusterRole{}
 	err = c.client.Patch(pt).
 		Resource("clusterroles").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
@@ -37,7 +37,7 @@ type ClusterRoleBindingInterface interface {
 	Get(name string) (*rbac.ClusterRoleBinding, error)
 	List(opts api.ListOptions) (*rbac.ClusterRoleBindingList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRoleBinding, err error)
 	ClusterRoleBindingExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *clusterRoleBindings) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.
-func (c *clusterRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error) {
+func (c *clusterRoleBindings) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRoleBinding, err error) {
 	result = &rbac.ClusterRoleBinding{}
 	err = c.client.Patch(pt).
 		Resource("clusterrolebindings").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrole.go
@@ -99,9 +99,9 @@ func (c *FakeClusterRoles) Watch(opts api.ListOptions) (watch.Interface, error) 
 }
 
 // Patch applies the patch and returns the patched clusterRole.
-func (c *FakeClusterRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error) {
+func (c *FakeClusterRoles) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRole, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(clusterrolesResource, name, data), &rbac.ClusterRole{})
+		Invokes(core.NewRootPatchSubresourceAction(clusterrolesResource, name, data, subresources...), &rbac.ClusterRole{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrolebinding.go
@@ -99,9 +99,9 @@ func (c *FakeClusterRoleBindings) Watch(opts api.ListOptions) (watch.Interface, 
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.
-func (c *FakeClusterRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error) {
+func (c *FakeClusterRoleBindings) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(clusterrolebindingsResource, name, data), &rbac.ClusterRoleBinding{})
+		Invokes(core.NewRootPatchSubresourceAction(clusterrolebindingsResource, name, data, subresources...), &rbac.ClusterRoleBinding{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_role.go
@@ -106,9 +106,9 @@ func (c *FakeRoles) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched role.
-func (c *FakeRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error) {
+func (c *FakeRoles) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.Role, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(rolesResource, c.ns, name, data), &rbac.Role{})
+		Invokes(core.NewPatchSubresourceAction(rolesResource, c.ns, name, data, subresources...), &rbac.Role{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rolebinding.go
@@ -106,9 +106,9 @@ func (c *FakeRoleBindings) Watch(opts api.ListOptions) (watch.Interface, error) 
 }
 
 // Patch applies the patch and returns the patched roleBinding.
-func (c *FakeRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error) {
+func (c *FakeRoleBindings) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.RoleBinding, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(rolebindingsResource, c.ns, name, data), &rbac.RoleBinding{})
+		Invokes(core.NewPatchSubresourceAction(rolebindingsResource, c.ns, name, data, subresources...), &rbac.RoleBinding{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
@@ -37,7 +37,7 @@ type RoleInterface interface {
 	Get(name string) (*rbac.Role, error)
 	List(opts api.ListOptions) (*rbac.RoleList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.Role, err error)
 	RoleExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *roles) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched role.
-func (c *roles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error) {
+func (c *roles) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.Role, err error) {
 	result = &rbac.Role{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("roles").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
@@ -37,7 +37,7 @@ type RoleBindingInterface interface {
 	Get(name string) (*rbac.RoleBinding, error)
 	List(opts api.ListOptions) (*rbac.RoleBindingList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.RoleBinding, err error)
 	RoleBindingExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *roleBindings) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched roleBinding.
-func (c *roleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error) {
+func (c *roleBindings) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *rbac.RoleBinding, err error) {
 	result = &rbac.RoleBinding{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("rolebindings").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -116,9 +116,9 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &v1.HorizontalPodAutoscaler{})
+		Invokes(core.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -38,7 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*v1.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*v1.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error) {
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/batch/v1/fake/fake_job.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/batch/v1/fake/fake_job.go
@@ -116,9 +116,9 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error) {
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &v1.Job{})
+		Invokes(core.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &v1.Job{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/batch/v1/job.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/batch/v1/job.go
@@ -38,7 +38,7 @@ type JobInterface interface {
 	Get(name string) (*v1.Job, error)
 	List(opts api.ListOptions) (*v1.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Job, err error)
 	JobExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error) {
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Job, err error) {
 	result = &v1.Job{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("jobs").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/componentstatus.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/componentstatus.go
@@ -37,7 +37,7 @@ type ComponentStatusInterface interface {
 	Get(name string) (*v1.ComponentStatus, error)
 	List(opts api.ListOptions) (*v1.ComponentStatusList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ComponentStatus, err error)
 	ComponentStatusExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *componentStatuses) Watch(opts api.ListOptions) (watch.Interface, error)
 }
 
 // Patch applies the patch and returns the patched componentStatus.
-func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error) {
+func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
 	err = c.client.Patch(pt).
 		Resource("componentstatuses").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/configmap.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/configmap.go
@@ -37,7 +37,7 @@ type ConfigMapInterface interface {
 	Get(name string) (*v1.ConfigMap, error)
 	List(opts api.ListOptions) (*v1.ConfigMapList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error)
 	ConfigMapExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *configMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched configMap.
-func (c *configMaps) Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error) {
+func (c *configMaps) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
 	result = &v1.ConfigMap{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("configmaps").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/endpoints.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/endpoints.go
@@ -37,7 +37,7 @@ type EndpointsInterface interface {
 	Get(name string) (*v1.Endpoints, error)
 	List(opts api.ListOptions) (*v1.EndpointsList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Endpoints, err error)
 	EndpointsExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *endpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched endpoints.
-func (c *endpoints) Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error) {
+func (c *endpoints) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Endpoints, err error) {
 	result = &v1.Endpoints{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("endpoints").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/event.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/event.go
@@ -37,7 +37,7 @@ type EventInterface interface {
 	Get(name string) (*v1.Event, error)
 	List(opts api.ListOptions) (*v1.EventList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Event, err error)
 	EventExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched event.
-func (c *events) Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error) {
+func (c *events) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Event, err error) {
 	result = &v1.Event{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("events").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_componentstatus.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_componentstatus.go
@@ -99,9 +99,9 @@ func (c *FakeComponentStatuses) Watch(opts api.ListOptions) (watch.Interface, er
 }
 
 // Patch applies the patch and returns the patched componentStatus.
-func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(componentstatusesResource, name, data), &v1.ComponentStatus{})
+		Invokes(core.NewRootPatchSubresourceAction(componentstatusesResource, name, data, subresources...), &v1.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_configmap.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_configmap.go
@@ -106,9 +106,9 @@ func (c *FakeConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched configMap.
-func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error) {
+func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(configmapsResource, c.ns, name, data), &v1.ConfigMap{})
+		Invokes(core.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_endpoints.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_endpoints.go
@@ -106,9 +106,9 @@ func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched endpoints.
-func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error) {
+func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Endpoints, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(endpointsResource, c.ns, name, data), &v1.Endpoints{})
+		Invokes(core.NewPatchSubresourceAction(endpointsResource, c.ns, name, data, subresources...), &v1.Endpoints{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_event.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_event.go
@@ -106,9 +106,9 @@ func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched event.
-func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error) {
+func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(eventsResource, c.ns, name, data), &v1.Event{})
+		Invokes(core.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &v1.Event{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_limitrange.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_limitrange.go
@@ -106,9 +106,9 @@ func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched limitRange.
-func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error) {
+func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(limitrangesResource, c.ns, name, data), &v1.LimitRange{})
+		Invokes(core.NewPatchSubresourceAction(limitrangesResource, c.ns, name, data, subresources...), &v1.LimitRange{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_namespace.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_namespace.go
@@ -108,9 +108,9 @@ func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched namespace.
-func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error) {
+func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(namespacesResource, name, data), &v1.Namespace{})
+		Invokes(core.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_node.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_node.go
@@ -108,9 +108,9 @@ func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched node.
-func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error) {
+func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(nodesResource, name, data), &v1.Node{})
+		Invokes(core.NewRootPatchSubresourceAction(nodesResource, name, data, subresources...), &v1.Node{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_persistentvolume.go
@@ -108,9 +108,9 @@ func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, er
 }
 
 // Patch applies the patch and returns the patched persistentVolume.
-func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error) {
+func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(persistentvolumesResource, name, data), &v1.PersistentVolume{})
+		Invokes(core.NewRootPatchSubresourceAction(persistentvolumesResource, name, data, subresources...), &v1.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_pod.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_pod.go
@@ -116,9 +116,9 @@ func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched pod.
-func (c *FakePods) Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error) {
+func (c *FakePods) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Pod, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(podsResource, c.ns, name, data), &v1.Pod{})
+		Invokes(core.NewPatchSubresourceAction(podsResource, c.ns, name, data, subresources...), &v1.Pod{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_podtemplate.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_podtemplate.go
@@ -106,9 +106,9 @@ func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) 
 }
 
 // Patch applies the patch and returns the patched podTemplate.
-func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error) {
+func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(podtemplatesResource, c.ns, name, data), &v1.PodTemplate{})
+		Invokes(core.NewPatchSubresourceAction(podtemplatesResource, c.ns, name, data, subresources...), &v1.PodTemplate{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_replicationcontroller.go
@@ -116,9 +116,9 @@ func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interfac
 }
 
 // Patch applies the patch and returns the patched replicationController.
-func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error) {
+func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(replicationcontrollersResource, c.ns, name, data), &v1.ReplicationController{})
+		Invokes(core.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, name, data, subresources...), &v1.ReplicationController{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_resourcequota.go
@@ -116,9 +116,9 @@ func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error
 }
 
 // Patch applies the patch and returns the patched resourceQuota.
-func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error) {
+func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(resourcequotasResource, c.ns, name, data), &v1.ResourceQuota{})
+		Invokes(core.NewPatchSubresourceAction(resourcequotasResource, c.ns, name, data, subresources...), &v1.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_secret.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_secret.go
@@ -106,9 +106,9 @@ func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched secret.
-func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error) {
+func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(secretsResource, c.ns, name, data), &v1.Secret{})
+		Invokes(core.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &v1.Secret{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_service.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_service.go
@@ -116,9 +116,9 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &v1.Service{})
+		Invokes(core.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &v1.Service{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_serviceaccount.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_serviceaccount.go
@@ -106,9 +106,9 @@ func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched serviceAccount.
-func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error) {
+func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(serviceaccountsResource, c.ns, name, data), &v1.ServiceAccount{})
+		Invokes(core.NewPatchSubresourceAction(serviceaccountsResource, c.ns, name, data, subresources...), &v1.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/limitrange.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/limitrange.go
@@ -37,7 +37,7 @@ type LimitRangeInterface interface {
 	Get(name string) (*v1.LimitRange, error)
 	List(opts api.ListOptions) (*v1.LimitRangeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.LimitRange, err error)
 	LimitRangeExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched limitRange.
-func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error) {
+func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.LimitRange, err error) {
 	result = &v1.LimitRange{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("limitranges").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/namespace.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/namespace.go
@@ -38,7 +38,7 @@ type NamespaceInterface interface {
 	Get(name string) (*v1.Namespace, error)
 	List(opts api.ListOptions) (*v1.NamespaceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error)
 	NamespaceExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched namespace.
-func (c *namespaces) Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error) {
+func (c *namespaces) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Patch(pt).
 		Resource("namespaces").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/node.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/node.go
@@ -38,7 +38,7 @@ type NodeInterface interface {
 	Get(name string) (*v1.Node, error)
 	List(opts api.ListOptions) (*v1.NodeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Node, err error)
 	NodeExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched node.
-func (c *nodes) Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error) {
+func (c *nodes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Patch(pt).
 		Resource("nodes").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/persistentvolume.go
@@ -38,7 +38,7 @@ type PersistentVolumeInterface interface {
 	Get(name string) (*v1.PersistentVolume, error)
 	List(opts api.ListOptions) (*v1.PersistentVolumeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolume, err error)
 	PersistentVolumeExpansion
 }
 
@@ -141,10 +141,11 @@ func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error)
 }
 
 // Patch applies the patch and returns the patched persistentVolume.
-func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error) {
+func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Patch(pt).
 		Resource("persistentvolumes").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/pod.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/pod.go
@@ -38,7 +38,7 @@ type PodInterface interface {
 	Get(name string) (*v1.Pod, error)
 	List(opts api.ListOptions) (*v1.PodList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Pod, err error)
 	PodExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *pods) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched pod.
-func (c *pods) Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error) {
+func (c *pods) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("pods").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/podtemplate.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/podtemplate.go
@@ -37,7 +37,7 @@ type PodTemplateInterface interface {
 	Get(name string) (*v1.PodTemplate, error)
 	List(opts api.ListOptions) (*v1.PodTemplateList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PodTemplate, err error)
 	PodTemplateExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched podTemplate.
-func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error) {
+func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PodTemplate, err error) {
 	result = &v1.PodTemplate{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("podtemplates").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/replicationcontroller.go
@@ -38,7 +38,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*v1.ReplicationController, error)
 	List(opts api.ListOptions) (*v1.ReplicationControllerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ReplicationController, err error)
 	ReplicationControllerExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 }
 
 // Patch applies the patch and returns the patched replicationController.
-func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error) {
+func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/resourcequota.go
@@ -38,7 +38,7 @@ type ResourceQuotaInterface interface {
 	Get(name string) (*v1.ResourceQuota, error)
 	List(opts api.ListOptions) (*v1.ResourceQuotaList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ResourceQuota, err error)
 	ResourceQuotaExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched resourceQuota.
-func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error) {
+func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("resourcequotas").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/secret.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/secret.go
@@ -37,7 +37,7 @@ type SecretInterface interface {
 	Get(name string) (*v1.Secret, error)
 	List(opts api.ListOptions) (*v1.SecretList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Secret, err error)
 	SecretExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched secret.
-func (c *secrets) Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error) {
+func (c *secrets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Secret, err error) {
 	result = &v1.Secret{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("secrets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/service.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/service.go
@@ -38,7 +38,7 @@ type ServiceInterface interface {
 	Get(name string) (*v1.Service, error)
 	List(opts api.ListOptions) (*v1.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error)
 	ServiceExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched service.
-func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+func (c *services) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
 	result = &v1.Service{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("services").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/serviceaccount.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/serviceaccount.go
@@ -37,7 +37,7 @@ type ServiceAccountInterface interface {
 	Get(name string) (*v1.ServiceAccount, error)
 	List(opts api.ListOptions) (*v1.ServiceAccountList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ServiceAccount, err error)
 	ServiceAccountExpansion
 }
 
@@ -137,11 +137,12 @@ func (c *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched serviceAccount.
-func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error) {
+func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.ServiceAccount, err error) {
 	result = &v1.ServiceAccount{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("serviceaccounts").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/daemonset.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/daemonset.go
@@ -38,7 +38,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*v1beta1.DaemonSet, error)
 	List(opts api.ListOptions) (*v1beta1.DaemonSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched daemonSet.
-func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error) {
+func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("daemonsets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/deployment.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/deployment.go
@@ -38,7 +38,7 @@ type DeploymentInterface interface {
 	Get(name string) (*v1beta1.Deployment, error)
 	List(opts api.ListOptions) (*v1beta1.DeploymentList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error)
 	DeploymentExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched deployment.
-func (c *deployments) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error) {
+func (c *deployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("deployments").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -116,9 +116,9 @@ func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched daemonSet.
-func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error) {
+func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(daemonsetsResource, c.ns, name, data), &v1beta1.DaemonSet{})
+		Invokes(core.NewPatchSubresourceAction(daemonsetsResource, c.ns, name, data, subresources...), &v1beta1.DaemonSet{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -116,9 +116,9 @@ func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched deployment.
-func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error) {
+func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(deploymentsResource, c.ns, name, data), &v1beta1.Deployment{})
+		Invokes(core.NewPatchSubresourceAction(deploymentsResource, c.ns, name, data, subresources...), &v1beta1.Deployment{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_horizontalpodautoscaler.go
@@ -116,9 +116,9 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &v1beta1.HorizontalPodAutoscaler{})
+		Invokes(core.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &v1beta1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -116,9 +116,9 @@ func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched ingress.
-func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error) {
+func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(ingressesResource, c.ns, name, data), &v1beta1.Ingress{})
+		Invokes(core.NewPatchSubresourceAction(ingressesResource, c.ns, name, data, subresources...), &v1beta1.Ingress{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_job.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_job.go
@@ -116,9 +116,9 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error) {
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &v1beta1.Job{})
+		Invokes(core.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &v1beta1.Job{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -99,9 +99,9 @@ func (c *FakePodSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, 
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.
-func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error) {
+func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(podsecuritypoliciesResource, name, data), &v1beta1.PodSecurityPolicy{})
+		Invokes(core.NewRootPatchSubresourceAction(podsecuritypoliciesResource, name, data, subresources...), &v1beta1.PodSecurityPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -116,9 +116,9 @@ func (c *FakeReplicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched replicaSet.
-func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error) {
+func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchAction(replicasetsResource, c.ns, name, data), &v1beta1.ReplicaSet{})
+		Invokes(core.NewPatchSubresourceAction(replicasetsResource, c.ns, name, data, subresources...), &v1beta1.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
@@ -99,9 +99,9 @@ func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, 
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.
-func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error) {
+func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootPatchAction(thirdpartyresourcesResource, name, data), &v1beta1.ThirdPartyResource{})
+		Invokes(core.NewRootPatchSubresourceAction(thirdpartyresourcesResource, name, data, subresources...), &v1beta1.ThirdPartyResource{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/horizontalpodautoscaler.go
@@ -38,7 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*v1beta1.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*v1beta1.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error) {
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.HorizontalPodAutoscaler, err error) {
 	result = &v1beta1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/ingress.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/ingress.go
@@ -38,7 +38,7 @@ type IngressInterface interface {
 	Get(name string) (*v1beta1.Ingress, error)
 	List(opts api.ListOptions) (*v1beta1.IngressList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Ingress, err error)
 	IngressExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched ingress.
-func (c *ingresses) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error) {
+func (c *ingresses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("ingresses").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/job.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/job.go
@@ -38,7 +38,7 @@ type JobInterface interface {
 	Get(name string) (*v1beta1.Job, error)
 	List(opts api.ListOptions) (*v1beta1.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Job, err error)
 	JobExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched job.
-func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error) {
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.Job, err error) {
 	result = &v1beta1.Job{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("jobs").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -37,7 +37,7 @@ type PodSecurityPolicyInterface interface {
 	Get(name string) (*v1beta1.PodSecurityPolicy, error)
 	List(opts api.ListOptions) (*v1beta1.PodSecurityPolicyList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error)
 	PodSecurityPolicyExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *podSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.
-func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error) {
+func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Patch(pt).
 		Resource("podsecuritypolicies").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/replicaset.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/replicaset.go
@@ -38,7 +38,7 @@ type ReplicaSetInterface interface {
 	Get(name string) (*v1beta1.ReplicaSet, error)
 	List(opts api.ListOptions) (*v1beta1.ReplicaSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ReplicaSet, err error)
 	ReplicaSetExpansion
 }
 
@@ -151,11 +151,12 @@ func (c *replicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 // Patch applies the patch and returns the patched replicaSet.
-func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error) {
+func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("replicasets").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/thirdpartyresource.go
@@ -37,7 +37,7 @@ type ThirdPartyResourceInterface interface {
 	Get(name string) (*v1beta1.ThirdPartyResource, error)
 	List(opts api.ListOptions) (*v1beta1.ThirdPartyResourceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
-	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ThirdPartyResource, err error)
 	ThirdPartyResourceExpansion
 }
 
@@ -128,10 +128,11 @@ func (c *thirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, erro
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.
-func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error) {
+func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1beta1.ThirdPartyResource, err error) {
 	result = &v1beta1.ThirdPartyResource{}
 	err = c.client.Patch(pt).
 		Resource("thirdpartyresources").
+		SubResource(subresources...).
 		Name(name).
 		Body(data).
 		Do().

--- a/pkg/client/testing/core/actions.go
+++ b/pkg/client/testing/core/actions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"path"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -139,11 +140,25 @@ func NewPatchAction(resource unversioned.GroupVersionResource, namespace string,
 	return action
 }
 
-func NewPatchSubresourceAction(resource unversioned.GroupVersionResource, subresource string) PatchActionImpl {
+func NewRootPatchSubresourceAction(resource unversioned.GroupVersionResource, name string, patch []byte, subresources ...string) PatchActionImpl {
 	action := PatchActionImpl{}
 	action.Verb = "patch"
 	action.Resource = resource
-	action.Subresource = subresource
+	action.Subresource = path.Join(subresources...)
+	action.Name = name
+	action.Patch = patch
+
+	return action
+}
+
+func NewPatchSubresourceAction(resource unversioned.GroupVersionResource, namespace, name string, patch []byte, subresources ...string) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Subresource = path.Join(subresources...)
+	action.Namespace = namespace
+	action.Name = name
+	action.Patch = patch
 
 	return action
 }

--- a/pkg/controller/node/test_utils.go
+++ b/pkg/controller/node/test_utils.go
@@ -186,7 +186,7 @@ func (m *FakeNodeHandler) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return nil, nil
 }
 
-func (m *FakeNodeHandler) Patch(name string, pt api.PatchType, data []byte) (*api.Node, error) {
+func (m *FakeNodeHandler) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (*api.Node, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Expand the Patch() method from:

```
Patch(name string, pt api.PatchType, data []byte)
```

to

```
Patch(name string, pt api.PatchType, data []byte, subresources ...string)
```

Continue on #27293. Fixes #26580.

cc @Random-Liu @lavalamp 
