### PR TITLE
Remove dead code in scheduler_test.go

### DIFF
--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -233,8 +233,6 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 	// We use conflicted pod ports to incur fit predicate failure.
 	secondPod := podWithPort("bar", "", 8080)
 	queuedPodStore.Add(secondPod)
-	// queuedPodStore: [bar:8080]
-	// cache: [(assumed)foo:8080]
 
 	scheduler.scheduleOne()
 	select {
@@ -311,12 +309,8 @@ func setupTestSchedulerWithOnePod(t *testing.T, queuedPodStore *clientcache.FIFO
 	scheduler := New(cfg)
 
 	queuedPodStore.Add(pod)
-	// queuedPodStore: [foo:8080]
-	// cache: []
 
 	scheduler.scheduleOne()
-	// queuedPodStore: []
-	// cache: [(assumed)foo:8080]
 
 	select {
 	case b := <-bindingChan:


### PR DESCRIPTION
Dead code in "plugin\pkg\scheduler\scheduler_test.go" is confused and should be removed.
