### PR TITLE
modify Failure to failed

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -129,7 +129,7 @@ func Run(s *options.APIServer) error {
 
 	kubeletClient, err := kubeletclient.NewStaticKubeletClient(&s.KubeletConfig)
 	if err != nil {
-		glog.Fatalf("Failure to start kubelet client: %v", err)
+		glog.Fatalf("Failed to start kubelet client: %v", err)
 	}
 
 	storageGroupsToEncodingVersion, err := s.StorageGroupsToEncodingVersion()


### PR DESCRIPTION
use 'failed' is more suitable than 'Failure'
