### PR TITLE
Remove id field from rbd examples

### DIFF
--- a/examples/volumes/rbd/rbd-with-secret.json
+++ b/examples/volumes/rbd/rbd-with-secret.json
@@ -1,6 +1,5 @@
 {
     "apiVersion": "v1",
-    "id": "rbdpd2",
     "kind": "Pod",
     "metadata": {
         "name": "rbd2"

--- a/examples/volumes/rbd/rbd.json
+++ b/examples/volumes/rbd/rbd.json
@@ -1,6 +1,5 @@
 {
     "apiVersion": "v1",
-    "id": "rbdpd",
     "kind": "Pod",
     "metadata": {
         "name": "rbd"


### PR DESCRIPTION
Currently the RBD examples fail with the following error:

```
kubectl create -f examples/volumes/rbd/rbd-with-secret.json 
error validating "examples/volumes/rbd/rbd-with-secret.json": error validating data: found invalid field id for v1.Pod; if you choose to ignore these errors, turn validation off with --validate=false
```

fixes #28831
