### PR TITLE
pkg/genericapiserver/options: don't import pkg/apiserver

### DIFF
--- a/pkg/genericapiserver/authorizer/authz_test.go
+++ b/pkg/genericapiserver/authorizer/authz_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apiserver
+package authorizer
 
 import (
 	"testing"
+
+	"k8s.io/kubernetes/pkg/genericapiserver/options"
 )
 
 // NewAlwaysAllowAuthorizer must return a struct which implements authorizer.Authorizer
@@ -42,7 +44,7 @@ func TestNewAlwaysDenyAuthorizer(t *testing.T) {
 // validates that errors are returned only when proper.
 func TestNewAuthorizerFromAuthorizationConfig(t *testing.T) {
 
-	examplePolicyFile := "../auth/authorizer/abac/example_policy_file.jsonl"
+	examplePolicyFile := "../../auth/authorizer/abac/example_policy_file.jsonl"
 
 	tests := []struct {
 		modes   []string
@@ -59,25 +61,25 @@ func TestNewAuthorizerFromAuthorizationConfig(t *testing.T) {
 		{
 			// ModeAlwaysAllow and ModeAlwaysDeny should return without authorizationPolicyFile
 			// but error if one is given
-			modes: []string{ModeAlwaysAllow, ModeAlwaysDeny},
+			modes: []string{options.ModeAlwaysAllow, options.ModeAlwaysDeny},
 			msg:   "returned an error for valid config",
 		},
 		{
 			// ModeABAC requires a policy file
-			modes:   []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABAC},
+			modes:   []string{options.ModeAlwaysAllow, options.ModeAlwaysDeny, options.ModeABAC},
 			wantErr: true,
 			msg:     "specifying ABAC with no policy file should return an error",
 		},
 		{
 			// ModeABAC should not error if a valid policy path is provided
-			modes:  []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABAC},
+			modes:  []string{options.ModeAlwaysAllow, options.ModeAlwaysDeny, options.ModeABAC},
 			config: AuthorizationConfig{PolicyFile: examplePolicyFile},
 			msg:    "errored while using a valid policy file",
 		},
 		{
 
 			// Authorization Policy file cannot be used without ModeABAC
-			modes:   []string{ModeAlwaysAllow, ModeAlwaysDeny},
+			modes:   []string{options.ModeAlwaysAllow, options.ModeAlwaysDeny},
 			config:  AuthorizationConfig{PolicyFile: examplePolicyFile},
 			wantErr: true,
 			msg:     "should have errored when Authorization Policy File is used without ModeABAC",
@@ -91,13 +93,13 @@ func TestNewAuthorizerFromAuthorizationConfig(t *testing.T) {
 		},
 		{
 			// ModeWebhook requires at minimum a target.
-			modes:   []string{ModeWebhook},
+			modes:   []string{options.ModeWebhook},
 			wantErr: true,
 			msg:     "should have errored when config was empty with ModeWebhook",
 		},
 		{
 			// Cannot provide webhook flags without ModeWebhook
-			modes:   []string{ModeAlwaysAllow},
+			modes:   []string{options.ModeAlwaysAllow},
 			config:  AuthorizationConfig{WebhookConfigFile: "authz_webhook_config.yml"},
 			wantErr: true,
 			msg:     "should have errored when Webhook config file is used without ModeWebhook",

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -41,13 +41,13 @@ import (
 	authenticationv1beta1 "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authenticator/bearertoken"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
 	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1"
+	apiserverauthorizer "k8s.io/kubernetes/pkg/genericapiserver/authorizer"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/tokentest"
@@ -500,7 +500,7 @@ func getPreviousResourceVersionKey(url, id string) string {
 func TestAuthModeAlwaysDeny(t *testing.T) {
 	// Set up a master
 	masterConfig := framework.NewIntegrationTestMasterConfig()
-	masterConfig.Authorizer = apiserver.NewAlwaysDenyAuthorizer()
+	masterConfig.Authorizer = apiserverauthorizer.NewAlwaysDenyAuthorizer()
 	_, s := framework.RunAMaster(masterConfig)
 	defer s.Close()
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/apiserver"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -46,6 +45,7 @@ import (
 	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/genericapiserver/authorizer"
 	"k8s.io/kubernetes/pkg/kubectl"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master"
@@ -203,7 +203,7 @@ func NewMasterConfig() *master.Config {
 			APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
 			APIPrefix:               "/api",
 			APIGroupPrefix:          "/apis",
-			Authorizer:              apiserver.NewAlwaysAllowAuthorizer(),
+			Authorizer:              authorizer.NewAlwaysAllowAuthorizer(),
 			AdmissionControl:        admit.NewAlwaysAdmit(),
 			Serializer:              api.Codecs,
 			EnableWatchCache:        true,


### PR DESCRIPTION
Refactor the authorization options for the API server so
pkg/apiserver isn't directly imported by the options package.

Closes #28544

cc @smarterclayton

@madhusudancs, @nikhiljindal I've updated `federation/cmd/federation-apiserver/app/server.go` to include the RBAC options with this change. I don't know if this was intentionally left out in the first place but would like your feedback.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28860)

<!-- Reviewable:end -->
