### PR TITLE
Add SSH_OPTS to config ssh and scp port

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -117,3 +117,5 @@ ALLOW_PRIVILEGED=${ALLOW_PRIVILEGED:-"false"}
 
 DEBUG=${DEBUG:-"false"}
 
+# Add SSH_OPTS: Add this to config ssh port
+SSH_OPTS="-oPort=22 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"


### PR DESCRIPTION
Add SSH_OPTS support.This can change ssh and scp default port.

fixes #17934
