### PR TITLE
Use TLS 1.2 to access healthz API

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1211,7 +1211,13 @@ function wait-master() {
   echo "  up."
   echo
 
-  until $(curl --insecure --user ${KUBE_USER}:${KUBE_PASSWORD} --max-time 5 \
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
+
+  until $(curl $TLS_OPTS --user ${KUBE_USER}:${KUBE_PASSWORD} --max-time 5 \
     --fail --output $LOG --silent https://${KUBE_MASTER_IP}/healthz); do
     printf "."
     sleep 2

--- a/cluster/azure-legacy/util.sh
+++ b/cluster/azure-legacy/util.sh
@@ -386,7 +386,13 @@ function kube-up {
     echo "  up."
     echo
 
-    until curl --insecure --user "${KUBE_USER}:${KUBE_PASSWORD}" --max-time 5 \
+    if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+      TLS_OPTS="--insecure --tlsv1.2"
+    else
+      TLS_OPTS="--insecure"
+    fi
+
+    until curl $TLS_OPTS --user "${KUBE_USER}:${KUBE_PASSWORD}" --max-time 5 \
         --fail --output /dev/null --silent "https://${KUBE_MASTER_IP}/healthz"; do
         printf "."
         sleep 2

--- a/cluster/gce/gci/health-monitor.sh
+++ b/cluster/gce/gci/health-monitor.sh
@@ -42,10 +42,15 @@ function kubelet_monitoring {
   # TODO(andyzheng0831): replace it with a more reliable method if possible.
   sleep 120
   local -r max_seconds=10
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
   while [ 1 ]; do
-    if ! curl --insecure -m "${max_seconds}" -f -s https://127.0.0.1:${KUBELET_PORT:-10250}/healthz > /dev/null; then
+    if ! curl $TLS_OPTS -m "${max_seconds}" -f -s https://127.0.0.1:${KUBELET_PORT:-10250}/healthz > /dev/null; then
       echo "Kubelet is unhealthy!"
-      curl --insecure https://127.0.0.1:${KUBELET_PORT:-10250}/healthz
+      curl $TLS_OPTS https://127.0.0.1:${KUBELET_PORT:-10250}/healthz
       pkill kubelet
       # Wait for a while, as we don't want to kill it again before it is really up.
       sleep 60

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -101,7 +101,13 @@ function wait-for-master() {
     exit 1
   fi
 
-  until curl --insecure "${curl_auth_arg[@]}" --max-time 5 \
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
+
+  until curl $TLS_OPTS "${curl_auth_arg[@]}" --max-time 5 \
     --fail --output /dev/null --silent "https://${KUBE_MASTER_IP}/healthz"; do
     printf "."
     sleep 2

--- a/cluster/photon-controller/util.sh
+++ b/cluster/photon-controller/util.sh
@@ -692,7 +692,13 @@ function upload-server-tars {
 # Wait for the Kubernets healthz API to be responsive on the master
 #
 function wait-master-api {
-  local curl_creds="--insecure --user ${KUBE_USER}:${KUBE_PASSWORD}"
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
+
+  local curl_creds="${TLS_OPTS} --user ${KUBE_USER}:${KUBE_PASSWORD}"
   local curl_output="--fail --output /dev/null --silent"
   local curl_net="--max-time 1"
 

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -317,8 +317,14 @@ kube-up() {
   echo "  up."
   echo
 
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
+
   #This will fail until apiserver salt is updated
-  until $(curl --insecure --user ${KUBE_USER}:${KUBE_PASSWORD} --max-time 5 \
+  until $(curl $TLS_OPTS --user ${KUBE_USER}:${KUBE_PASSWORD} --max-time 5 \
           --fail --output /dev/null --silent https://${KUBE_MASTER_IP}/healthz); do
       printf "."
       sleep 2

--- a/cluster/saltbase/salt/supervisor/kubelet-checker.sh
+++ b/cluster/saltbase/salt/supervisor/kubelet-checker.sh
@@ -31,10 +31,16 @@ sleep 60
 
 max_seconds=10
 
+if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+  TLS_OPTS="--insecure --tlsv1.2"
+else
+  TLS_OPTS="--insecure"
+fi
+
 while true; do
-  if ! curl --insecure -m ${max_seconds} -f -s https://127.0.0.1:{{kubelet_port}}/healthz > /dev/null; then
+  if ! curl $TLS_OPTS -m ${max_seconds} -f -s https://127.0.0.1:{{kubelet_port}}/healthz > /dev/null; then
     echo "kubelet failed!"
-    curl --insecure https://127.0.0.1:{{kubelet_port}}/healthz
+    curl $TLS_OPTS https://127.0.0.1:{{kubelet_port}}/healthz
     exit 2
   fi
   sleep 10

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -461,7 +461,13 @@ function kube-up {
   echo "  This might loop forever if there was some uncaught error during start up."
   echo
 
-  until curl --insecure --user "${KUBE_USER}:${KUBE_PASSWORD}" --max-time 5 \
+  if [[ $(curl -V | awk '{print $2}' | head -1) > 7.34.0 ]]; then
+    TLS_OPTS="--insecure --tlsv1.2"
+  else
+    TLS_OPTS="--insecure"
+  fi
+
+  until curl $TLS_OPTS --user "${KUBE_USER}:${KUBE_PASSWORD}" --max-time 5 \
           --fail --output /dev/null --silent "https://${KUBE_MASTER_IP}/healthz"; do
       printf "."
       sleep 2


### PR DESCRIPTION
In the following PR, TLS was set to 1.2 as the minimum
because TLS1.0 and TLS1.1 are vulnerable:
https://github.com/kubernetes/kubernetes/pull/26169

However the scripts that used curl were not updated to match
the TLS version.

Fixes #28888
