### PR TITLE
Create event only if creation of PVC failed.

### DIFF
--- a/pkg/controller/petset/pet.go
+++ b/pkg/controller/petset/pet.go
@@ -231,7 +231,9 @@ func (p *apiServerPetClient) getPVC(pvcName, pvcNamespace string) (*api.Persiste
 	if errors.IsNotFound(err) {
 		found = false
 	}
-	if err != nil || !found {
+	if !found {
+		return nil, found, nil
+	} else if err != nil {
 		return nil, found, err
 	}
 	return pvc, true, nil
@@ -249,7 +251,8 @@ func (p *apiServerPetClient) SyncPVCs(pet *pcb) error {
 	for i, pvc := range pet.pvcs {
 		_, exists, err := p.getPVC(pvc.Name, pet.parent.Namespace)
 		if !exists {
-			if err := p.createPVC(&pet.pvcs[i]); err != nil {
+			var err error
+			if err = p.createPVC(&pet.pvcs[i]); err != nil {
 				errMsg += fmt.Sprintf("Failed to create %v: %v", pvc.Name, err)
 			}
 			p.event(pet.parent, "Create", fmt.Sprintf("pvc: %v", pvc.Name), err)


### PR DESCRIPTION
Fixes #28785.
We should report an event only if the petset can't find a PVC and can't create it either.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
