### PR TITLE
Don't panic if we hit a dangling symlink in mungedocs

### DIFF
--- a/cmd/mungedocs/mungedocs.go
+++ b/cmd/mungedocs/mungedocs.go
@@ -158,6 +158,12 @@ func (f fileProcessor) visit(path string) error {
 func newWalkFunc(fp *fileProcessor, changesNeeded *bool) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		stat, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
 		if path != *rootDir && stat.IsDir() && *norecurse {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
I hit this because I have a dangling symlink, which would cause a panic.
