### PR TITLE
e2e-runner: Update the image family used for GCI canary test images

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -216,8 +216,8 @@ if [[ -n "${JENKINS_GCI_IMAGE_FAMILY:-}" ]]; then
   export KUBE_GCE_MASTER_PROJECT="${GCI_STAGING_PROJECT}"
   export KUBE_GCE_MASTER_IMAGE="$(get_latest_gci_image "${GCI_STAGING_PROJECT}" "${JENKINS_GCI_IMAGE_FAMILY}")"
   export KUBE_OS_DISTRIBUTION="gci"
-  if [[ "${JENKINS_GCI_IMAGE_FAMILY}" == "gci-preview-test" ]]; then
-    # The family "gci-preview-test" is reserved for a special type of GCI images
+  if [[ "${JENKINS_GCI_IMAGE_FAMILY}" == "gci-canary-test" ]]; then
+    # The family "gci-canary-test" is reserved for a special type of GCI images
     # that are used to continuously validate Docker releases.
     export KUBE_GCI_DOCKER_VERSION="$(get_latest_docker_release)"
   fi


### PR DESCRIPTION
@Amey-D @spxtr Can you review?
@Random-Liu Heads up
cc/ @kubernetes/goog-image 
