### PR TITLE
Change the docker validation node e2e test to use gci-canary-test

### DIFF
--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -37,6 +37,7 @@ ARTIFACTS=${WORKSPACE}/_artifacts
 mkdir -p ${ARTIFACTS}
 go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
   --zone="$GCE_ZONE" --project="$GCE_PROJECT" --hosts="$GCE_HOSTS" \
+  --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
   --image-config-file="$GCE_IMAGE_CONFIG_PATH" --cleanup="$CLEANUP" \
   --results-dir="$ARTIFACTS" --ginkgo-flags="$GINKGO_FLAGS" \
   --setup-node="$SETUP_NODE" --instance-metadata="$GCE_INSTANCE_METADATA"

--- a/test/e2e_node/jenkins/jenkins-docker-validation.properties
+++ b/test/e2e_node/jenkins/jenkins-docker-validation.properties
@@ -1,5 +1,5 @@
 GCI_IMAGE_PROJECT=container-vm-image-staging
-GCI_IMAGE_FAMILY=gci-preview-test
+GCI_IMAGE_FAMILY=gci-canary-test
 GCI_IMAGE=$(gcloud compute images describe-from-family ${GCI_IMAGE_FAMILY} --project=${GCI_IMAGE_PROJECT} --format="value(name)")
 DOCKER_VERSION=$(curl -fsSL --retry 3 https://api.github.com/repos/docker/docker/releases | tac | tac | grep -m 1 "\"tag_name\"\:" | grep -Eo "[0-9\.rc-]+")
 GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
@@ -9,7 +9,6 @@ GCE_IMAGES=${GCI_IMAGE}
 GCE_IMAGE_PROJECT=${GCI_IMAGE_PROJECT}
 GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins
-# kubernetes-jenkins
 # user-data is the GCI cloud init config file.
 # gci-docker-version specifies docker version in GCI image.
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"


### PR DESCRIPTION
This PR changed the continuous docker validation node e2e test to use the image config file introduced in https://github.com/kubernetes/kubernetes/pull/28708. @euank 

This PR also changed the gci image family from `gci-preview-test` to `gci-canary-test`. @wonderfly 
