### PR TITLE
Use response content-type on restclient errors

### DIFF
--- a/pkg/client/restclient/config.go
+++ b/pkg/client/restclient/config.go
@@ -131,6 +131,9 @@ type TLSClientConfig struct {
 }
 
 type ContentConfig struct {
+	// AcceptContentTypes specifies the types the client will accept and is optional.
+	// If not set, ContentType will be used to define the Accept header
+	AcceptContentTypes string
 	// ContentType specifies the wire format used to communicate with the server.
 	// This value will be set as the Accept header on requests made to the server, and
 	// as the default content type on any object sent to the server. If not set,

--- a/pkg/client/typed/dynamic/client.go
+++ b/pkg/client/typed/dynamic/client.go
@@ -58,6 +58,7 @@ func NewClient(conf *restclient.Config) (*Client, error) {
 
 	// TODO: it's questionable that this should be using anything other than unstructured schema and JSON
 	conf.ContentType = runtime.ContentTypeJSON
+	conf.AcceptContentTypes = runtime.ContentTypeJSON
 	streamingInfo, _ := api.Codecs.StreamingSerializerForMediaType("application/json;stream=watch", nil)
 	conf.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec}, streamingInfo)
 


### PR DESCRIPTION
Also allow a new AcceptContentTypes field to allow the client to ask for
a fallback serialization when getting responses from the server. This
allows a new client to ask for protobuf and JSON, falling back to JSON
when necessary.

The changes to request.go allow error responses from non-JSON servers to
be properly decoded.

@wojtek-t - also alters #28910 slightly (this is better output)
