### PR TITLE
Change the name of the secret that delivers federation kubeconfig.

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -156,7 +156,7 @@ function create-federation-api-objects {
 	   create-kubeconfig
 
     # Create secret with federation-apiserver's kubeconfig
-    $host_kubectl create secret generic federation-apiserver-secret --from-file="${KUBECONFIG_DIR}/federation/federation-apiserver/kubeconfig" --namespace="${FEDERATION_NAMESPACE}"
+    $host_kubectl create secret generic federation-apiserver-kubeconfig --from-file="${KUBECONFIG_DIR}/federation/federation-apiserver/kubeconfig" --namespace="${FEDERATION_NAMESPACE}"
 
     # Create secrets with all the kubernetes-apiserver's kubeconfigs.
     # Note: This is used only by the test setup (where kubernetes clusters are

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -45,8 +46,18 @@ import (
 )
 
 const (
-	// "federation-apiserver-secret" is a reserved secret name which stores the kubeconfig for federation-apiserver.
-	FederationAPIServerSecretName = "federation-apiserver-secret"
+	// TODO(madhusudancs): Consider making this configurable via a flag.
+	// "federation-apiserver-kubeconfig" is a reserved secret name which
+	// stores the kubeconfig for federation-apiserver.
+	KubeconfigSecretName = "federation-apiserver-kubeconfig"
+	// "federation-apiserver-secret" was the old name we used to store
+	// Federation API server kubeconfig secret. Unfortunately, this name
+	// is very close to "federation-apiserver-secrets" and causes a lot
+	// of confusion, particularly while debugging. So deprecating it in
+	// favor of the new name but giving people time to migrate.
+	// TODO(madhusudancs): this name is deprecated in 1.4 and should be
+	// removed in 1.5. Remove it in 1.5.
+	DeprecatedKubeconfigSecretName = "federation-apiserver-secret"
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
@@ -78,10 +89,17 @@ func Run(s *options.CMServer) error {
 		glog.Errorf("unable to register configz: %s", err)
 	}
 	// Create the config to talk to federation-apiserver.
-	kubeconfigGetter := util.KubeconfigGetterForSecret(FederationAPIServerSecretName)
+	kubeconfigGetter := util.KubeconfigGetterForSecret(KubeconfigSecretName)
 	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
-	if err != nil {
-		return err
+	if err != nil || restClientCfg == nil {
+		// Retry with the deprecated name in 1.4.
+		// TODO(madhusudancs): Remove this in 1.5.
+		var depErr error
+		kubeconfigGetter := util.KubeconfigGetterForSecret(DeprecatedKubeconfigSecretName)
+		restClientCfg, depErr = clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
+		if depErr != nil {
+			return fmt.Errorf("failed to find the secret containing Federation API server kubeconfig, tried the secret name %s and the deprecated name %s: %v, %v", KubeconfigSecretName, DeprecatedKubeconfigSecretName, err, depErr)
+		}
 	}
 
 	// Override restClientCfg qps/burst settings from flags
@@ -115,7 +133,6 @@ func Run(s *options.CMServer) error {
 }
 
 func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) error {
-
 	ccClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, "cluster-controller"))
 	go clustercontroller.NewclusterController(ccClientset, s.ClusterMonitorPeriod.Duration).Run()
 	dns, err := dnsprovider.InitDnsProvider(s.DnsProvider, s.DnsConfigFile)


### PR DESCRIPTION
The current name, federation-apiserver-secret, is very similar to the
other secret we have, federation-apiserver-secrets, that delivers
somewhat similar data but in a different format. This is extremely
confusing, particularly while debugging.

This change should soothe the pain.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/28938)

<!-- Reviewable:end -->
