### PR TITLE
Improve fatal error description for init in genericapiserver.go

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -491,13 +491,13 @@ func (s *GenericAPIServer) init(c *Config) {
 
 	// After all wrapping is done, put a context filter around both handlers
 	if handler, err := api.NewRequestContextFilter(s.RequestContextMapper, s.Handler); err != nil {
-		glog.Fatalf("Could not initialize request context filter: %v", err)
+		glog.Fatalf("Could not initialize request context filter for s.Handler: %v", err)
 	} else {
 		s.Handler = handler
 	}
 
 	if handler, err := api.NewRequestContextFilter(s.RequestContextMapper, s.InsecureHandler); err != nil {
-		glog.Fatalf("Could not initialize request context filter: %v", err)
+		glog.Fatalf("Could not initialize request context filter for s.InsecureHandler: %v", err)
 	} else {
 		s.InsecureHandler = handler
 	}


### PR DESCRIPTION
When api.NewRequestContextFilter return error in the "init" function of genericapiserver.go, there are no handler info, add more information to indicate s.Handler or s.InsecureHandler, I suggest.
