### PR TITLE
Modify wrong description about "InsecurePort" in genericapiserver.go

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -658,7 +658,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 	if s.enableSwaggerSupport {
 		s.InstallSwaggerAPI()
 	}
-	// We serve on 2 ports. See docs/accessing_the_api.md
+	// We serve on 2 ports. See docs/admin/accessing-the-api.md
 	secureLocation := ""
 	if options.SecurePort != 0 {
 		secureLocation = net.JoinHostPort(options.BindAddress.String(), strconv.Itoa(options.SecurePort))


### PR DESCRIPTION
Modify wrong description about "InsecurePort" in genericapiserver.go, avoid misleading.
