### PR TITLE
Warn when missing cloud-provider on kube controller

### DIFF
--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -160,7 +160,7 @@ func (s *ServiceController) Run(serviceSyncPeriod, nodeSyncPeriod time.Duration)
 
 func (s *ServiceController) init() error {
 	if s.cloud == nil {
-		return fmt.Errorf("ServiceController should not be run without a cloudprovider.")
+		return fmt.Errorf("WARNING: no cloud provider provided, services of type LoadBalancer will fail.")
 	}
 
 	balancer, ok := s.cloud.LoadBalancer()


### PR DESCRIPTION
This commit warns the user / gives better information that when using
--cloud-provider="" on kube-controller, that services such as
LoadBalancer will not work.

However, despite the error, kube-controller will still run as normal.

Fixes https://github.com/kubernetes/kubernetes/issues/12716
Fixes https://github.com/kubernetes/kubernetes/issues/11172
Fixes https://github.com/kubernetes/kubernetes/issues/27085
