### PR TITLE
Fix a bug in mirror pod node e2e test.

### DIFF
--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e_node
 
 import (
+	goerrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -160,7 +161,7 @@ func checkMirrorPodDisappear(cl *client.Client, name, namespace string) error {
 	if errors.IsNotFound(err) {
 		return nil
 	}
-	return err
+	return goerrors.New("pod not disappear")
 }
 
 func checkMirrorPodRunning(cl *client.Client, name, namespace string) error {


### PR DESCRIPTION
Fixed a bug in test/e2e_node/mirror_pod_test.go. The function 'checkMirrorPodDisappear' returns nil even when the pod does not disappear. It should return a non-nil error. 

@Random-Liu 
