### PR TITLE
move api.ObjectReference.ObjectKind to pkg/api/ref.go

### DIFF
--- a/pkg/api/meta.go
+++ b/pkg/api/meta.go
@@ -67,8 +67,6 @@ func ListMetaFor(obj runtime.Object) (*unversioned.ListMeta, error) {
 
 func (obj *ObjectMeta) GetObjectMeta() meta.Object { return obj }
 
-func (obj *ObjectReference) GetObjectKind() unversioned.ObjectKind { return obj }
-
 // Namespace implements meta.Object for any object with an ObjectMeta typed field. Allows
 // fast, direct access to metadata fields for API objects.
 func (meta *ObjectMeta) GetNamespace() string                   { return meta.Namespace }

--- a/pkg/api/ref.go
+++ b/pkg/api/ref.go
@@ -128,3 +128,5 @@ func (obj *ObjectReference) SetGroupVersionKind(gvk unversioned.GroupVersionKind
 func (obj *ObjectReference) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
+
+func (obj *ObjectReference) GetObjectKind() unversioned.ObjectKind { return obj }


### PR DESCRIPTION
This is needed to convert k8s components to use versioned clientset.

To let components use versioned client, we need to convert `pkg/client/record` to v1, which depends on `pkg/api/ref.go`, so we need to make a `pkg/api/v1/ref.go`. And this [line](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/ref.go#L44) requires v1.ObjectReference to be a runtime.Object. Moving `api.ObjectReference.ObjectKind` to `pkg/api/ref.go` will make the writing a conversion script easier because all the necessary changes will be restricted in `ref.go`.
