### PR TITLE
correct describe_example

### DIFF
--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -68,7 +68,7 @@ var (
 		kubectl describe pods
 
 		# Describe pods by label name=myLabel
-		kubectl describe po -l name=myLabel
+		kubectl describe pods -l name=myLabel
 
 		# Describe all pods managed by the 'frontend' replication controller (rc-created pods
 		# get the name of the rc as a prefix in the pod the name).


### PR DESCRIPTION
correct describe_example from '`kubectl describe po -l name=myLabel`' to '`kubectl describe pods -l name=myLabel`'
