### PR TITLE
Delete duplicated code

### DIFF
--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -127,13 +127,6 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 			t.Errorf("SetUp() failed: %v", err)
 		}
 	}
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("SetUp() failed, volume path not created: %s", path)
-		} else {
-			t.Errorf("SetUp() failed: %v", err)
-		}
-	}
 
 	unmounter, err := plug.(*rbdPlugin).newUnmounterInternal("vol1", types.UID("poduid"), fdm, &mount.FakeMounter{})
 	if err != nil {


### PR DESCRIPTION
The code block below is called twice sequentially in func `doTestPlugin`.
.

``` go
    if _, err := os.Stat(path); err != nil {
        if os.IsNotExist(err) {
            t.Errorf("SetUp() failed, volume path not created: %s", path)
        } else {
            t.Errorf("SetUp() failed: %v", err)
        }
    }
```
