### PR TITLE
Info about enabling the hostpath provisioner

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -51,7 +51,15 @@ There is no provisioner when running outside of any of those 3 cloud providers.
 
 A fourth provisioner is included for testing and development only.  It creates HostPath volumes,
 which will never work outside of a single node cluster. It is not supported in any way except for
-local for testing and development. This provisioner may be used by passing `--enable-hostpath-provisioner=true` to the controller manager while bringing it up. When using the hack/local_up_cluster.sh script, this flag is turned off by default. It may be turned on by setting the environment variable `ENABLE_HOSTPATH_PROVISIONER` to true prior to running the script.
+local for testing and development. This provisioner may be used by passing
+`--enable-hostpath-provisioner=true` to the controller manager while bringing it up.
+When using the `hack/local_up_cluster.sh` script, this flag is turned off by default.
+It may be turned on by setting the environment variable `ENABLE_HOSTPATH_PROVISIONER`
+to true prior to running the script.
+
+```
+env ENABLE_HOSTPATH_PROVISIONER=true hack/local-up-cluster.sh
+```
 
 ### User provisioning requests
 


### PR DESCRIPTION
The README for persistent volume provisioning had information about the
hostpath provisioner for testing purposes, but lacked instructions on
how to enable it.
