### PR TITLE
dnsprovider: Use route53 page functions to avoid truncated results

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
@@ -27,9 +27,9 @@ var _ Route53API = &Route53APIStub{}
 
 /* Route53API is the subset of the AWS Route53 API that we actually use.  Add methods as required. Signatures must match exactly. */
 type Route53API interface {
-	ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
+	ListResourceRecordSetsPages(input *route53.ListResourceRecordSetsInput, fn func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool)) error
 	ChangeResourceRecordSets(*route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
-	ListHostedZones(*route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error)
+	ListHostedZonesPages(input *route53.ListHostedZonesInput, fn func(p *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool)) error
 	CreateHostedZone(*route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error)
 	DeleteHostedZone(*route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error)
 }
@@ -50,7 +50,7 @@ func NewRoute53APIStub() *Route53APIStub {
 	}
 }
 
-func (r *Route53APIStub) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+func (r *Route53APIStub) ListResourceRecordSetsPages(input *route53.ListResourceRecordSetsInput, fn func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool)) error {
 	output := route53.ListResourceRecordSetsOutput{} // TODO: Support optional input args.
 	if len(r.recordSets) <= 0 {
 		output.ResourceRecordSets = []*route53.ResourceRecordSet{}
@@ -63,7 +63,9 @@ func (r *Route53APIStub) ListResourceRecordSets(input *route53.ListResourceRecor
 			}
 		}
 	}
-	return &output, nil
+	lastPage := true
+	fn(&output, lastPage)
+	return nil
 }
 
 func (r *Route53APIStub) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
@@ -93,12 +95,14 @@ func (r *Route53APIStub) ChangeResourceRecordSets(input *route53.ChangeResourceR
 	return output, nil // TODO: We should ideally return status etc, but we dont' use that yet.
 }
 
-func (r *Route53APIStub) ListHostedZones(*route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
+func (r *Route53APIStub) ListHostedZonesPages(input *route53.ListHostedZonesInput, fn func(p *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool)) error {
 	output := &route53.ListHostedZonesOutput{}
 	for _, zone := range r.zones {
 		output.HostedZones = append(output.HostedZones, zone)
 	}
-	return output, nil
+	lastPage := true
+	fn(output, lastPage)
+	return nil
 }
 
 func (r *Route53APIStub) CreateHostedZone(input *route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error) {

--- a/federation/pkg/dnsprovider/providers/aws/route53/zones.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/zones.go
@@ -31,17 +31,17 @@ type Zones struct {
 }
 
 func (zones Zones) List() ([]dnsprovider.Zone, error) {
+	var zoneList []dnsprovider.Zone
+
 	input := route53.ListHostedZonesInput{}
-	response, err := zones.interface_.service.ListHostedZones(&input)
+	err := zones.interface_.service.ListHostedZonesPages(&input, func(page *route53.ListHostedZonesOutput, lastPage bool) bool {
+		for _, zone := range page.HostedZones {
+			zoneList = append(zoneList, &Zone{zone, &zones})
+		}
+		return true
+	})
 	if err != nil {
 		return []dnsprovider.Zone{}, err
-	}
-	hostedZones := response.HostedZones
-	// TODO: Handle result truncation
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/route53/Route53.html#ListHostedZones-instance_method
-	zoneList := make([]dnsprovider.Zone, len(hostedZones))
-	for i, zone := range hostedZones {
-		zoneList[i] = &Zone{zone, &zones}
 	}
 	return zoneList, nil
 }


### PR DESCRIPTION
The List<Type>Pages functions make it pretty easy to avoid result truncation;
switch to using them
