### PR TITLE
Refactor: separate KubeletClient & ConnectionInfoGetter concepts

### DIFF
--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -51,7 +51,7 @@ type KubeletClientConfig struct {
 
 // KubeletClient is an interface for all kubelet functionality
 type KubeletClient interface {
-	ConnectionInfoGetter
+	GetRawConnectionInfo(ctx api.Context, nodeName string) (scheme string, port uint, transport http.RoundTripper, err error)
 }
 
 type ConnectionInfoGetter interface {
@@ -98,7 +98,7 @@ func NewStaticKubeletClient(config *KubeletClientConfig) (KubeletClient, error) 
 }
 
 // In default HTTPKubeletClient ctx is unused.
-func (c *HTTPKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (c *HTTPKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	if errs := validation.ValidateNodeName(nodeName, false); len(errs) != 0 {
 		return "", 0, nil, fmt.Errorf("invalid node name: %s", strings.Join(errs, ";"))
 	}
@@ -114,7 +114,7 @@ func (c *HTTPKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) 
 // no kubelets.
 type FakeKubeletClient struct{}
 
-func (c FakeKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (c FakeKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	return "", 0, nil, errors.New("Not Implemented")
 }
 

--- a/pkg/kubelet/client/kubelet_client_test.go
+++ b/pkg/kubelet/client/kubelet_client_test.go
@@ -102,7 +102,7 @@ func TestNewKubeletClientTLSValid(t *testing.T) {
 	}
 
 	{
-		scheme, port, transport, err := client.GetConnectionInfo(nil, "foo")
+		scheme, port, transport, err := client.GetRawConnectionInfo(nil, "foo")
 		if err != nil {
 			t.Errorf("Error getting info: %v", err)
 		}
@@ -118,7 +118,7 @@ func TestNewKubeletClientTLSValid(t *testing.T) {
 	}
 
 	{
-		_, _, _, err := client.GetConnectionInfo(nil, "foo bar")
+		_, _, _, err := client.GetRawConnectionInfo(nil, "foo bar")
 		if err == nil {
 			t.Errorf("Expected error getting connection info for invalid node name, got none")
 		}

--- a/pkg/registry/core/node/etcd/etcd.go
+++ b/pkg/registry/core/node/etcd/etcd.go
@@ -41,7 +41,7 @@ type NodeStorage struct {
 
 type REST struct {
 	*registry.Store
-	connection     client.ConnectionInfoGetter
+	connection     client.KubeletClient
 	proxyTransport http.RoundTripper
 }
 
@@ -65,7 +65,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 }
 
 // NewStorage returns a NodeStorage object that will work against nodes.
-func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper) NodeStorage {
+func NewStorage(opts generic.RESTOptions, connection client.KubeletClient, proxyTransport http.RoundTripper) NodeStorage {
 	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
@@ -140,7 +140,7 @@ func (r *REST) getKubeletPort(ctx api.Context, nodeName string) (int, error) {
 }
 
 func (c *REST) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
-	scheme, port, transport, err := c.connection.GetConnectionInfo(ctx, nodeName)
+	scheme, port, transport, err := c.connection.GetRawConnectionInfo(ctx, nodeName)
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/pkg/registry/core/node/etcd/etcd_test.go
+++ b/pkg/registry/core/node/etcd/etcd_test.go
@@ -33,7 +33,7 @@ import (
 type fakeConnectionInfoGetter struct {
 }
 
-func (fakeConnectionInfoGetter) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (fakeConnectionInfoGetter) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	return "http", 12345, nil, nil
 }
 


### PR DESCRIPTION
KubeletClient implements ConnectionInfoGetter, but it is not a complete
implementation: it does not set the kubelet port from the node record,
for example.

By renaming the method so that it does not implement the interface, we
are able to cleanly see where the "raw" GetConnectionInfo is used (it is
correct) and also have go type-checking enforce this for us.

This is related to #25532; I wanted to satisfy myself that what we were doing there was correct, and I wanted also to ensure that the compiler could enforce this going forwards.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29011)

<!-- Reviewable:end -->
