### PR TITLE
Func note not consistent with real fun name

### DIFF
--- a/plugin/pkg/webhook/webhook.go
+++ b/plugin/pkg/webhook/webhook.go
@@ -38,7 +38,7 @@ type GenericWebhook struct {
 	initialBackoff time.Duration
 }
 
-// New creates a new GenericWebhook from the provided kubeconfig file.
+// NewGenericWebhook creates a new GenericWebhook from the provided kubeconfig file.
 func NewGenericWebhook(kubeConfigFile string, groupVersions []unversioned.GroupVersion, initialBackoff time.Duration) (*GenericWebhook, error) {
 	for _, groupVersion := range groupVersions {
 		if !registered.IsEnabledVersion(groupVersion) {


### PR DESCRIPTION
File "plugin\pkg\webhook.go", line #41 :
"// New creates a new GenericWebhook from the provided kubeconfig file."
Here "New" not consistant with real fun name "NewGenericWebhook" in line #42 :
"func NewGenericWebhook(kubeConfigFile string, groupVersions []unversioned.GroupVersion, initialBackoff time.Duration) (*GenericWebhook, error) {"
