### PR TITLE
Type define note "errNotAcceptable" should be "errUnsupportedMediaType"

### DIFF
--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -126,7 +126,7 @@ func (e errNotAcceptable) Status() unversioned.Status {
 	}
 }
 
-// errNotAcceptable indicates Content-Type is not recognized
+// errUnsupportedMediaType indicates Content-Type is not recognized
 // TODO: move to api/errors if other code needs to return this
 type errUnsupportedMediaType struct {
 	accepted []string


### PR DESCRIPTION
In file "pkg\apiserver\errors.go", line 129:
"// errNotAcceptable indicates Content-Type is not recognized"
Here "errNotAcceptable" shuould be "errUnsupportedMediaType", thus consistent with line 131:
"type errUnsupportedMediaType struct"
