### PR TITLE
Apiserver ServeHTTP() modify

### DIFF
--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -120,7 +120,7 @@ type WatchServer struct {
 	t timeoutFactory
 }
 
-// Serve serves a series of encoded events via HTTP with Transfer-Encoding: chunked
+// ServeHTTP serves a series of encoded events via HTTP with Transfer-Encoding: chunked
 // or over a websocket connection.
 func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w = httplog.Unlogged(w)


### PR DESCRIPTION
In File "pkg\apiserver\watch.go", line 123:
"// Serve serves a series of encoded events via HTTP with Transfer-Encoding: chunked"
Here "Serve" should be "ServeHTTP" because the func name is ServeHTTP:
"func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request)"
