### PR TITLE
Modify setConfigDefaults() in batch_client.go

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
@@ -80,10 +80,8 @@ func setConfigDefaults(config *restclient.Config) error {
 		config.UserAgent = restclient.DefaultKubernetesUserAgent()
 	}
 	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
 	copyGroupVersion := g.GroupVersion
 	config.GroupVersion = &copyGroupVersion
-	//}
 
 	config.NegotiatedSerializer = api.Codecs
 


### PR DESCRIPTION
File "pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go", line 83 :
        //if config.Version == "" {
        copyGroupVersion := g.GroupVersion
        config.GroupVersion = &copyGroupVersion
        //}
Here line 83 and 86 are dead code, can be deleted.
