### PR TITLE
Modify GetLogs() in pod_expansion.go

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod_expansion.go
@@ -32,7 +32,7 @@ func (c *pods) Bind(binding *api.Binding) error {
 	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
 }
 
-// Get constructs a request for getting the logs for a pod
+// GetLogs constructs a request for getting the logs for a pod
 func (c *pods) GetLogs(name string, opts *api.PodLogOptions) *restclient.Request {
 	return c.client.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, api.ParameterCodec)
 }


### PR DESCRIPTION
File "pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod_expansion.go",
line 35:
"// Get constructs a request for getting the logs for a pod"
Here "Get" should be "GetLogs" because the fun name is GetLogs in line 36:
"func (c *pods) GetLogs(name string, opts *api.PodLogOptions) *restclient.Request"
