### PR TITLE
Fix "PVC Volume not detached if pod deleted via namespace deletion" issue

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -54,7 +54,7 @@ const (
 
 	// desiredStateOfWorldPopulatorLoopSleepPeriod is the amount of time the
 	// DesiredStateOfWorldPopulator loop waits between successive executions
-	desiredStateOfWorldPopulatorLoopSleepPeriod time.Duration = 5 * time.Minute
+	desiredStateOfWorldPopulatorLoopSleepPeriod time.Duration = 1 * time.Minute
 )
 
 // AttachDetachController defines the operations supported by this controller.

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -82,12 +82,26 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 			glog.Errorf("MetaNamespaceKeyFunc failed for pod %q (UID %q) with: %v", dswPodKey, dswPodUID, err)
 			continue
 		}
-		// retrieve the pod object from pod informer with the namespace key
-		informerPodObj, exists, err := dswp.podInformer.GetStore().GetByKey(dswPodKey)
-		if err != nil || informerPodObj == nil {
-			glog.Errorf("podInformer GetByKey failed for pod %q (UID %q) with %v", dswPodKey, dswPodUID, err)
+
+		// Retrieve the pod object from pod informer with the namespace key
+		informerPodObj, exists, err :=
+			dswp.podInformer.GetStore().GetByKey(dswPodKey)
+		if err != nil {
+			glog.Errorf(
+				"podInformer GetByKey failed for pod %q (UID %q) with %v",
+				dswPodKey,
+				dswPodUID,
+				err)
 			continue
 		}
+		if exists && informerPodObj == nil {
+			glog.Info(
+				"podInformer GetByKey found pod, but informerPodObj is nil for pod %q (UID %q)",
+				dswPodKey,
+				dswPodUID)
+			continue
+		}
+
 		if exists {
 			informerPod, ok := informerPodObj.(*api.Pod)
 			if !ok {
@@ -95,7 +109,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 				continue
 			}
 			informerPodUID := volumehelper.GetUniquePodName(informerPod)
-			// Check whether the unique idenfier of the pod from dsw matches the one retrived from pod informer
+			// Check whether the unique identifier of the pod from dsw matches the one retrieved from pod informer
 			if informerPodUID == dswPodUID {
 				glog.V(10).Infof(
 					"Verified pod %q (UID %q) from dsw exists in pod informer.", dswPodKey, dswPodUID)
@@ -103,7 +117,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 
 			}
 		}
-		// the pod from dsw does not exist in pod informer, or it does not match the unique idenfier retrieved
+		// the pod from dsw does not exist in pod informer, or it does not match the unique identifer retrieved
 		// from the informer, delete it from dsw
 		glog.V(1).Infof(
 			"Removing pod %q (UID %q) from dsw because it does not exist in pod informer.", dswPodKey, dswPodUID)


### PR DESCRIPTION
Fixes #29051: "PVC Volume not detached if pod deleted via namespace deletion"

This PR:
- Fixes a bug in `desired_state_of_the_world_populator.go` to check the value of `exists` returned by the `podInformer` so that it can delete pods even if the delete event is missed (or fails).
- Reduces the desired state of the world populators sleep period from 5 min to 1 min (reducing the amount of time a volume would remain attached if a volume delete event is missed or fails).
