### PR TITLE
[kubelet] Add pod cgroups support

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -25,6 +25,17 @@ import (
 	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
 )
 
+// cgroupSubsystems holds information about the mounted cgroup subsytems
+type cgroupSubsystems struct {
+	// Cgroup subsystem mounts.
+	// e.g.: "/sys/fs/cgroup/cpu" -> ["cpu", "cpuacct"]
+	mounts []libcontainercgroups.Mount
+
+	// Cgroup subsystem to their mount location.
+	// e.g.: "cpu" -> "/sys/fs/cgroup/cpu"
+	mountPoints map[string]string
+}
+
 // cgroupManagerImpl implements the CgroupManager interface.
 // Its a stateless object which can be used to
 // update,create or delete any number of cgroups
@@ -98,7 +109,7 @@ type subsystem interface {
 }
 
 // Cgroup subsystems we currently support
-var supportedSubsystems []subsystem = []subsystem{
+var supportedSubsystems = []subsystem{
 	&cgroupfs.MemoryGroup{},
 	&cgroupfs.CpuGroup{},
 }
@@ -142,11 +153,18 @@ func (m *cgroupManagerImpl) Update(cgroupConfig *CgroupConfig) error {
 		resources.CpuQuota = *resourceConfig.CpuQuota
 	}
 
+	// Get map of all cgroup paths on the system for the particular cgroup
+	cgroupPaths := make(map[string]string, len(m.subsystems.mountPoints))
+	for key, val := range m.subsystems.mountPoints {
+		cgroupPaths[key] = path.Join(val, name)
+	}
+
 	// Initialize libcontainer's cgroup config
 	libcontainerCgroupConfig := &libcontainerconfigs.Cgroup{
 		Name:      path.Base(name),
 		Parent:    path.Dir(name),
 		Resources: resources,
+		Paths:     cgroupPaths,
 	}
 
 	if err := setSupportedSubsytems(libcontainerCgroupConfig); err != nil {
@@ -177,7 +195,7 @@ func (m *cgroupManagerImpl) Create(cgroupConfig *CgroupConfig) error {
 	// It creates cgroup files for each subsytems and writes the pid
 	// in the tasks file. We use the function to create all the required
 	// cgroup files but not attach any "real" pid to the cgroup.
-	if err := fsCgroupManager.Apply(0); err != nil {
+	if err := fsCgroupManager.Apply(-1); err != nil {
 		return fmt.Errorf("Failed to apply cgroup config for %v: %v", name, err)
 	}
 	return nil

--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -25,6 +25,11 @@ type unsupportedCgroupManager struct{}
 // Make sure that unsupportedCgroupManager implements the CgroupManager interface
 var _ CgroupManager = &unsupportedCgroupManager{}
 
+type CgroupSubsystems struct {
+	Mounts      []interface{}
+	MountPoints map[string]string
+}
+
 func NewCgroupManager(_ interface{}) CgroupManager {
 	return &unsupportedCgroupManager{}
 }

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -25,7 +25,7 @@ type ContainerManager interface {
 	// Runs the container manager's housekeeping.
 	// - Ensures that the Docker daemon is in a container.
 	// - Creates the system container where all non-containerized processes run.
-	Start() error
+	Start(*api.Node) error
 
 	// Returns resources allocated to system cgroups in the machine.
 	// These cgroups include the system and Kubernetes services.
@@ -36,6 +36,13 @@ type ContainerManager interface {
 
 	// Returns internal Status.
 	Status() Status
+
+	// NewPodContainerManager is a factory method which returns a podContainerManager object
+	// Returns a noop implementation if qos cgroup hierarchy is not enabled
+	NewPodContainerManager() PodContainerManager
+
+	// GetQOSContainersInfo returns the names of top level QoS containers
+	GetQOSContainersInfo() QOSContainersInfo
 }
 
 type NodeConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -196,6 +196,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 			qosContainersInfo: cm.qosContainers,
 			nodeInfo:          cm.nodeInfo,
 			subsystems:        cm.subsystems,
+			qosPolicy:         CreatePodQOSPolicyMap(),
 			cgroupManager:     NewCgroupManager(cm.subsystems),
 		}
 	}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -25,7 +25,7 @@ type containerManagerStub struct{}
 
 var _ ContainerManager = &containerManagerStub{}
 
-func (cm *containerManagerStub) Start() error {
+func (cm *containerManagerStub) Start(_ *api.Node) error {
 	glog.V(2).Infof("Starting stub container manager")
 	return nil
 }
@@ -38,8 +38,16 @@ func (cm *containerManagerStub) GetNodeConfig() NodeConfig {
 	return NodeConfig{}
 }
 
+func (cm *containerManagerStub) GetQOSContainersInfo() QOSContainersInfo {
+	return QOSContainersInfo{}
+}
+
 func (cm *containerManagerStub) Status() Status {
 	return Status{}
+}
+
+func (cm *containerManagerStub) NewPodContainerManager() PodContainerManager {
+	return &podContainerManagerStub{}
 }
 
 func NewStubContainerManager() ContainerManager {

--- a/pkg/kubelet/cm/container_manager_unsupported.go
+++ b/pkg/kubelet/cm/container_manager_unsupported.go
@@ -31,7 +31,7 @@ type unsupportedContainerManager struct {
 
 var _ ContainerManager = &unsupportedContainerManager{}
 
-func (unsupportedContainerManager) Start() error {
+func (unsupportedContainerManager) Start(_ *api.Node) error {
 	return fmt.Errorf("Container Manager is unsupported in this build")
 }
 
@@ -43,8 +43,16 @@ func (unsupportedContainerManager) GetNodeConfig() NodeConfig {
 	return NodeConfig{}
 }
 
+func (unsupportedContainerManager) GetQOSContainersInfo() QOSContainersInfo {
+	return QOSContainersInfo{}
+}
+
 func (cm *unsupportedContainerManager) Status() Status {
 	return Status{}
+}
+
+func (cm *unsupportedContainerManager) NewPodContainerManager() PodContainerManager {
+	return &unsupportedPodContainerManager{}
 }
 
 func NewContainerManager(_ mount.Interface, _ cadvisor.Interface, _ NodeConfig) (ContainerManager, error) {

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -22,20 +22,9 @@ import (
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
-// cgroupSubsystems holds information about the mounted cgroup subsytems
-type cgroupSubsystems struct {
-	// Cgroup subsystem mounts.
-	// e.g.: "/sys/fs/cgroup/cpu" -> ["cpu", "cpuacct"]
-	mounts []libcontainercgroups.Mount
-
-	// Cgroup subsystem to their mount location.
-	// e.g.: "cpu" -> "/sys/fs/cgroup/cpu"
-	mountPoints map[string]string
-}
-
 // GetCgroupSubsystems returns information about the mounted cgroup subsystems
-func getCgroupSubsystems() (*cgroupSubsystems, error) {
-	// Get all cgroup mounts.
+func GetCgroupSubsystems() (*cgroupSubsystems, error) {
+	// get all cgroup mounts.
 	allCgroups, err := libcontainercgroups.GetCgroupMounts()
 	if err != nil {
 		return &cgroupSubsystems{}, err
@@ -44,7 +33,6 @@ func getCgroupSubsystems() (*cgroupSubsystems, error) {
 		return &cgroupSubsystems{}, fmt.Errorf("failed to find cgroup mounts")
 	}
 
-	//TODO(@dubstack) should we trim to only the supported ones
 	mountPoints := make(map[string]string, len(allCgroups))
 	for _, mount := range allCgroups {
 		for _, subsystem := range mount.Subsystems {

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+// getResourceRequirements returns a ResourceRequirements object
+func getResourceRequirements(requests, limits api.ResourceList) api.ResourceRequirements {
+	res := api.ResourceRequirements{}
+	res.Requests = requests
+	res.Limits = limits
+	return res
+}
+
+// newContainer creates and returns a new container
+// with the specified configuration
+func newContainer(name string, requests api.ResourceList, limits api.ResourceList) api.Container {
+	return api.Container{
+		Name:      name,
+		Resources: getResourceRequirements(requests, limits),
+	}
+}
+
+// newPod creates and returns a new pod with
+// the specified pod name and containers
+func newPod(name string, containers []api.Container) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: api.PodSpec{
+			Containers: containers,
+		},
+	}
+}
+
+// getResourceList returns a ResourceList with the
+// specified cpu and memory resource values
+func getResourceList(cpu, memory string) api.ResourceList {
+	res := api.ResourceList{}
+	if cpu != "" {
+		res[api.ResourceCPU] = resource.MustParse(cpu)
+	}
+	if memory != "" {
+		res[api.ResourceMemory] = resource.MustParse(memory)
+	}
+	return res
+}
+
+// getNode returns a Node object with the cpu and memory allocatable
+// set to the specified values
+func getNode(cpu, memory string) *api.Node {
+	cpuCores := resource.MustParse(cpu)
+	memoryAllocatable := resource.MustParse(memory)
+	allocatable := api.ResourceList{}
+	allocatable[api.ResourceCPU] = cpuCores
+	allocatable[api.ResourceMemory] = memoryAllocatable
+	return &api.Node{
+		Status: api.NodeStatus{
+			Allocatable: allocatable,
+		},
+	}
+}
+
+func TestGetPodResourceRequests(t *testing.T) {
+	testCases := []struct {
+		pod      *api.Pod
+		expected api.ResourceList
+	}{
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "")),
+			}),
+			expected: getResourceList("", ""),
+		},
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("100m", ""), getResourceList("", "")),
+			}),
+			expected: getResourceList("100m", ""),
+		},
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: getResourceList("100m", "100Mi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("", "")),
+				newContainer("bar", getResourceList("200m", "100Mi"), getResourceList("", "")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: getResourceList("350m", "300Mi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "")),
+				newContainer("bar", getResourceList("", "100Mi"), getResourceList("", "")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: getResourceList("50m", "200Mi"),
+		},
+	}
+	as := assert.New(t)
+	for idx, tc := range testCases {
+		actual := GetPodResourceRequests(tc.pod)
+		as.Equal(tc.expected.Cpu().Value(), actual.Cpu().Value(), "expected test case [%d] to return %v; got %v instead", idx, tc.expected, actual)
+		as.Equal(tc.expected.Memory().Value(), actual.Memory().Value(), "expected test case [%d] to return %v; got %v instead", idx, tc.expected, actual)
+	}
+}
+
+func TestGetPodResourceLimits(t *testing.T) {
+	nodeInfo := getNode("10", "10Gi")
+	testCases := []struct {
+		pod      *api.Pod
+		expected api.ResourceList
+	}{
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "")),
+			}),
+			expected: getResourceList("10", "10Gi"),
+		},
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("100m", "")),
+			}),
+			expected: getResourceList("100m", "10Gi"),
+		},
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "2Gi")),
+			}),
+			expected: getResourceList("10", "2Gi"),
+		},
+		{
+			pod: newPod("foo", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("100m", "100Mi")),
+			}),
+			expected: getResourceList("100m", "100Mi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("100m", "100Mi")),
+				newContainer("bar", getResourceList("", ""), getResourceList("200m", "100Mi")),
+				newContainer("foobar", getResourceList("", ""), getResourceList("50m", "100Mi")),
+			}),
+			expected: getResourceList("350m", "300Mi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "100Mi")),
+				newContainer("bar", getResourceList("", ""), getResourceList("", "100Mi")),
+				newContainer("foobar", getResourceList("", ""), getResourceList("50m", "100Mi")),
+			}),
+			expected: getResourceList("10", "300Mi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("100m", "")),
+				newContainer("bar", getResourceList("", ""), getResourceList("200m", "100Mi")),
+				newContainer("foobar", getResourceList("", ""), getResourceList("50m", "100Mi")),
+			}),
+			expected: getResourceList("350m", "10Gi"),
+		},
+		{
+			pod: newPod("bar", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "100Mi")),
+				newContainer("bar", getResourceList("", ""), getResourceList("200m", "100Mi")),
+				newContainer("foobar", getResourceList("", ""), getResourceList("50m", "")),
+			}),
+			expected: getResourceList("10", "10Gi"),
+		},
+	}
+	as := assert.New(t)
+	for idx, tc := range testCases {
+		actual := GetPodResourceLimits(tc.pod, nodeInfo)
+		as.Equal(tc.expected.Cpu().Value(), actual.Cpu().Value(), "expected test case [%d] to return %v; got %v instead", idx, tc.expected.Memory().Value(), actual.Memory().Value())
+		as.Equal(tc.expected.Memory().Value(), actual.Memory().Value(), "expected test case [%d] to return %v; got %v instead", idx, tc.expected.Memory().Value(), actual.Memory().Value())
+	}
+}

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"fmt"
+	"path"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/kubelet/qos"
+)
+
+const (
+	podCgroupNamePrefix = "pod#"
+)
+
+// podContainerManagerImpl implements podContainerManager interface.
+// It is the general implementation which allows pod level container
+// management if qos Cgroup is enabled.
+type podContainerManagerImpl struct {
+	// nodeInfo stores information about the node resource allocatable
+	nodeInfo *api.Node
+	// qosContainersInfo hold absolute paths of the top level qos containers
+	qosContainersInfo QOSContainersInfo
+	// Stores the mounted cgroup subsystems
+	subsystems *cgroupSubsystems
+	// cgroupManager is the cgroup Manager Object responsible for managing all
+	// pod cgroups.
+	cgroupManager CgroupManager
+}
+
+// Make sure that podContainerManagerImpl implements the PodContainerManager interface
+var _ PodContainerManager = &podContainerManagerImpl{}
+
+// applyLimits sets pod cgroup resource limits
+// It also updates the resource limits on top level qos containers.
+func (m *podContainerManagerImpl) applyLimits(pod *api.Pod) error {
+	// This function will house the logic for setting the resource parameters
+	// on the pod container config and updating top level qos container configs
+	return nil
+}
+
+// Exists checks if the pod's cgroup already exists
+func (m *podContainerManagerImpl) Exists(pod *api.Pod) bool {
+	podContainerName := m.GetPodContainerName(pod)
+	return m.cgroupManager.Exists(podContainerName)
+}
+
+// EnsureExists takes a pod as argument and makes sure that
+// pod cgroup exists if qos cgroup hierarchy flag is enabled.
+// If the pod level container doesen't already exist it is created.
+func (m *podContainerManagerImpl) EnsureExists(pod *api.Pod) error {
+	podContainerName := m.GetPodContainerName(pod)
+	// check if container already exist
+	alreadyExists := m.Exists(pod)
+	if !alreadyExists {
+		// Create the pod container
+		containerConfig := &CgroupConfig{
+			Name:               podContainerName,
+			ResourceParameters: &ResourceConfig{},
+		}
+		if err := m.cgroupManager.Create(containerConfig); err != nil {
+			return fmt.Errorf("failed to create container for %v : %v", podContainerName, err)
+		}
+	}
+	// Apply appropriate resource limits on the pod container
+	// Top level qos containers limits are not updated
+	// until we figure how to maintain the desired state in the kubelet.
+	// Because maintaining the desired state is difficult without checkpointing.
+	if err := m.applyLimits(pod); err != nil {
+		return fmt.Errorf("failed to apply resource limits on container for %v : %v", podContainerName, err)
+	}
+	return nil
+}
+
+// GetPodContainerName is a util func takes in a pod as an argument
+// and returns the pod's cgroup name. We follow a pod cgroup naming format
+// which is opaque and deterministic. Given a pod it's cgroup would be named
+// "pod-UID" where the UID is the Pod UID
+func (m *podContainerManagerImpl) GetPodContainerName(pod *api.Pod) string {
+	podQOS := qos.GetPodQOS(pod)
+	// Get the parent QOS container name
+	var parentContainer string
+	switch podQOS {
+	case qos.Guaranteed:
+		parentContainer = m.qosContainersInfo.Guaranteed
+	case qos.Burstable:
+		parentContainer = m.qosContainersInfo.Burstable
+	case qos.BestEffort:
+		parentContainer = m.qosContainersInfo.BestEffort
+	}
+	podContainer := podCgroupNamePrefix + string(pod.UID)
+	// Get the absolute path of the cgroup
+	return path.Join(parentContainer, podContainer)
+}
+
+// Destroy destroys the pod container cgroup paths
+func (m *podContainerManagerImpl) Destroy(podCgroup string) error {
+	// This will house the logic for destroying the pod cgroups.
+	// Will be handled in the next PR.
+	return nil
+}
+
+// podContainerManagerNoop implements podContainerManager interface.
+// It is a no-op implementation and basically does nothing
+// podContainerManagerNoop is used in case the QoS cgroup Hierarchy is not
+// enabled, so Exists() returns true always as the cgroupRoot
+// is expected to always exist.
+type podContainerManagerNoop struct {
+	cgroupRoot string
+}
+
+// Make sure that podContainerManagerStub implements the PodContainerManager interface
+var _ PodContainerManager = &podContainerManagerNoop{}
+
+func (m *podContainerManagerNoop) Exists(_ *api.Pod) bool {
+	return true
+}
+
+func (m *podContainerManagerNoop) EnsureExists(_ *api.Pod) error {
+	return nil
+}
+
+func (m *podContainerManagerNoop) GetPodContainerName(_ *api.Pod) string {
+	return m.cgroupRoot
+}
+
+// Destroy destroys the pod container cgroup paths
+func (m *podContainerManagerNoop) Destroy(_ string) error {
+	return nil
+}

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kubetypes "k8s.io/kubernetes/pkg/types"
+)
+
+// mockCgroupManager is a mock object which implements the cm.CgroupManager interface
+type mockCgroupManager struct {
+	mock.Mock
+}
+
+// Make sure that mockLibcontainerManager implements CgroupManager interface
+var _ CgroupManager = &mockCgroupManager{}
+
+func (m *mockCgroupManager) Exists(name string) bool {
+	args := m.Called(name)
+	return args.Bool(0)
+}
+
+func (m *mockCgroupManager) Update(cgroupConfig *CgroupConfig) error {
+	args := m.Called(cgroupConfig)
+	return args.Error(0)
+}
+func (m *mockCgroupManager) Destroy(cgroupConfig *CgroupConfig) error {
+	args := m.Called(cgroupConfig)
+	return args.Error(0)
+}
+
+func (m *mockCgroupManager) Create(cgroupConfig *CgroupConfig) error {
+	args := m.Called(cgroupConfig)
+	return args.Error(0)
+}
+
+// getQOSContainersInfo returns the default top level QOS containers name.
+func getQOSContainersInfo(cgroupRoot string) QOSContainersInfo {
+	return QOSContainersInfo{
+		Guaranteed: cgroupRoot,
+		Burstable:  path.Join(cgroupRoot, "Burstable"),
+		BestEffort: path.Join(cgroupRoot, "BestEffort"),
+	}
+}
+
+// newPodWithUID creates and returns a new pod
+// with the specified UID and containers
+func newPodWithUID(uid string, containers []api.Container) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID: kubetypes.UID(uid),
+		},
+		Spec: api.PodSpec{
+			Containers: containers,
+		},
+	}
+}
+
+// getResourceConfig returns a ResourceConfig
+// with the specified cpu and memory resource limits and shares
+func getResourceConfig(cpuShares, cpuQuota, memoryLimit string) *ResourceConfig {
+	res := &ResourceConfig{}
+	if cpuShares != "" {
+		cs := getMilliValue(resource.MustParse(cpuShares))
+		res.CpuShares = cs
+	}
+	if cpuQuota != "" {
+		cq := getMilliValue(resource.MustParse(cpuQuota))
+		res.CpuQuota = cq
+	}
+	if memoryLimit != "" {
+		m := getValue(resource.MustParse(memoryLimit))
+		res.Memory = m
+	}
+	return res
+}
+
+// getConfig returns a CgroupConfig object with the
+// specified cgroup configuration
+func getConfig(name, cpuShares, cpuQuota, memoryLimit string) *CgroupConfig {
+	return &CgroupConfig{
+		Name:               name,
+		ResourceParameters: getResourceConfig(cpuShares, cpuQuota, memoryLimit),
+	}
+}
+
+// NewFakePodContainerManager is a factory method that
+// returns a fake Pod container manager
+func NewFakePodContainerManager(nodeInfo *api.Node, mockObject *mockCgroupManager, qosContainersInfo QOSContainersInfo) *podContainerManagerImpl {
+	return &podContainerManagerImpl{
+		cgroupManager:     mockObject,
+		qosContainersInfo: qosContainersInfo,
+		qosPolicy:         CreatePodQOSPolicyMap(),
+		nodeInfo:          nodeInfo,
+	}
+}
+
+func TestPodContainerApplyLimits(t *testing.T) {
+	nodeInfo := getNode("10", "10Gi")
+	testCases := []struct {
+		pod      *api.Pod
+		expected *CgroupConfig
+	}{
+		{
+			pod: newPodWithUID("guaranteed", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+				newContainer("bar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+			}),
+			expected: getConfig("/pod#guaranteed", "200m", "200m", "300Mi"),
+		},
+		{
+			pod: newPodWithUID("burstable", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("100m", "200Mi")),
+				newContainer("bar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			expected: getConfig("/Burstable/pod#burstable", "200m", "250m", "400Mi"),
+		},
+		{
+			pod: newPodWithUID("burstable", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("", "")),
+				newContainer("bar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("", "100Mi")),
+			}),
+			expected: getConfig("/Burstable/pod#burstable", "200m", "10", "10Gi"),
+		},
+		{
+			pod: newPodWithUID("besteffort", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "")),
+				newContainer("bar", getResourceList("", ""), getResourceList("", "")),
+			}),
+			expected: getConfig("/BestEffort/pod#besteffort", "2m", "", ""),
+		},
+	}
+	for _, tc := range testCases {
+		mockObject := &mockCgroupManager{}
+		// Set expectation. Check if Cgroup Manager Update() method is being called with
+		// the expected CgroupConfig Object
+		mockObject.On("Update", tc.expected).Return(nil)
+		pm := NewFakePodContainerManager(nodeInfo, mockObject, getQOSContainersInfo("/"))
+		pm.applyLimits(tc.pod)
+		mockObject.AssertExpectations(t)
+	}
+}
+
+func TestGetPodContainerName(t *testing.T) {
+	nodeInfo := getNode("10", "10Gi")
+	testCases := []struct {
+		pod               *api.Pod
+		qosContainersInfo QOSContainersInfo
+		expected          string
+	}{
+		{
+			pod: newPodWithUID("guaranteed", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+				newContainer("bar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+			}),
+			qosContainersInfo: getQOSContainersInfo("/"),
+			expected:          "/pod#guaranteed",
+		},
+		{
+			pod: newPodWithUID("burstable", []api.Container{
+				newContainer("foo", getResourceList("100m", "100Mi"), getResourceList("100m", "200Mi")),
+				newContainer("bar", getResourceList("50m", "100Mi"), getResourceList("50m", "100Mi")),
+				newContainer("foobar", getResourceList("50m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			qosContainersInfo: getQOSContainersInfo("/foo/bar/"),
+			expected:          "/foo/bar/Burstable/pod#burstable",
+		},
+		{
+			pod: newPodWithUID("besteffort", []api.Container{
+				newContainer("foo", getResourceList("", ""), getResourceList("", "")),
+				newContainer("bar", getResourceList("", ""), getResourceList("", "")),
+			}),
+			qosContainersInfo: getQOSContainersInfo("/foo"),
+			expected:          "/foo/BestEffort/pod#besteffort",
+		},
+	}
+	mockObject := &mockCgroupManager{}
+	for _, tc := range testCases {
+		// Set expectation. Check if Cgroup Manager Update() method is being called with
+		// the expected CgroupConfig Object
+		pm := NewFakePodContainerManager(nodeInfo, mockObject, tc.qosContainersInfo)
+		actual := pm.GetPodContainerName(tc.pod)
+		assert.Equal(t, tc.expected, actual)
+	}
+}

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import "k8s.io/kubernetes/pkg/api"
+
+type podContainerManagerStub struct {
+}
+
+var _ PodContainerManager = &podContainerManagerStub{}
+
+func (m *podContainerManagerStub) Exists(_ *api.Pod) bool {
+	return true
+}
+
+func (m *podContainerManagerStub) EnsureExists(_ *api.Pod) error {
+	return nil
+}
+
+func (m *podContainerManagerStub) GetPodContainerName(_ *api.Pod) string {
+	return ""
+}
+
+func (m *podContainerManagerStub) Destroy(_ string) error {
+	return nil
+}

--- a/pkg/kubelet/cm/pod_container_manager_unsupported.go
+++ b/pkg/kubelet/cm/pod_container_manager_unsupported.go
@@ -1,0 +1,42 @@
+// +build !linux
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import "k8s.io/kubernetes/pkg/api"
+
+type unsupportedPodContainerManager struct {
+}
+
+var _ PodContainerManager = &unsupportedPodContainerManager{}
+
+func (m *unsupportedPodContainerManager) Exists(_ *api.Pod) bool {
+	return true
+}
+
+func (m *unsupportedPodContainerManager) EnsureExists(_ *api.Pod) error {
+	return nil
+}
+
+func (m *unsupportedPodContainerManager) GetPodContainerName(_ *api.Pod) string {
+	return ""
+}
+
+func (m *unsupportedPodContainerManager) Destroy(_ string) error {
+	return nil
+}

--- a/pkg/kubelet/cm/policy.go
+++ b/pkg/kubelet/cm/policy.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/qos"
+)
+
+func getValue(q resource.Quantity) *int64 {
+	val := q.Value()
+	return &val
+}
+
+func getMilliValue(q resource.Quantity) *int64 {
+	val := q.MilliValue()
+	return &val
+}
+
+func getValueFromQuantityPointer(q *resource.Quantity) *int64 {
+	val := q.Value()
+	return &val
+}
+
+func getMilliValueFromQuantityPointer(q *resource.Quantity) *int64 {
+	val := q.MilliValue()
+	return &val
+}
+
+// 2 is the lowest value of CpuShares, and our standard is milliCPUs
+// So we set the Best Effort pods cgroup
+const (
+	minimalCpuShares = "2m"
+)
+
+func CreatePodQOSPolicyMap() map[qos.QOSClass]func(api.ResourceList, api.ResourceList) *ResourceConfig {
+	return map[qos.QOSClass]func(api.ResourceList, api.ResourceList) *ResourceConfig{
+		qos.Guaranteed: GuaranteedPodQOSPolicy,
+		qos.Burstable:  BurstablePodQOSPolicy,
+		qos.BestEffort: BestEffortPodQOSPolicy,
+	}
+}
+
+func GuaranteedPodQOSPolicy(requests api.ResourceList, limits api.ResourceList) *ResourceConfig {
+	return &ResourceConfig{
+		CpuShares: getMilliValueFromQuantityPointer(requests.Cpu()),
+		CpuQuota:  getMilliValueFromQuantityPointer(limits.Cpu()),
+		Memory:    getValueFromQuantityPointer(limits.Memory()),
+	}
+}
+
+func BurstablePodQOSPolicy(requests api.ResourceList, limits api.ResourceList) *ResourceConfig {
+	return &ResourceConfig{
+		CpuShares: getMilliValueFromQuantityPointer(requests.Cpu()),
+		CpuQuota:  getMilliValueFromQuantityPointer(limits.Cpu()),
+		Memory:    getValueFromQuantityPointer(limits.Memory()),
+	}
+}
+
+func BestEffortPodQOSPolicy(requests api.ResourceList, limits api.ResourceList) *ResourceConfig {
+	return &ResourceConfig{
+		CpuShares: getMilliValue(resource.MustParse(minimalCpuShares)),
+	}
+}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package cm
 
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
 // ResourceConfig holds information about all the supported cgroup resource parameters.
 type ResourceConfig struct {
 	// Memory limit (in bytes).
@@ -57,9 +61,27 @@ type CgroupManager interface {
 	Exists(string) bool
 }
 
-// QOSContainersInfo hold the names of containers per qos
+// QOSContainersInfo stores the names of containers per qos
 type QOSContainersInfo struct {
 	Guaranteed string
 	BestEffort string
 	Burstable  string
+}
+
+// PodContainerManager stores and manages pod level containers
+// The Pod workers interact with the PodContainerManager to create and destroy
+// containers for the pod.
+type PodContainerManager interface {
+	// getPodContainerName returns the pod container's absolute name
+	GetPodContainerName(*api.Pod) string
+
+	// EnsureExists takes a pod as argument and makes sure that
+	// pod cgroup exists if qos cgroup hierarchy flag is enabled.
+	// If the pod cgroup doesen't already exist this method creates it.
+	EnsureExists(*api.Pod) error
+
+	Exists(*api.Pod) bool
+
+	//Destroy takes a pod as argument and destroys the pod's container.
+	Destroy(string) error
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -914,7 +914,13 @@ func (kl *Kubelet) initializeModules() error {
 	}
 
 	// Step 5: Start container manager.
-	if err := kl.containerManager.Start(); err != nil {
+	node, err := kl.getNodeAnyWay()
+	if err != nil {
+		glog.Errorf("Cannot get Node info: %v", err)
+		return fmt.Errorf("Kubelet failed to get node info.")
+	}
+
+	if err := kl.containerManager.Start(node); err != nil {
 		return fmt.Errorf("Failed to start ContainerManager %v", err)
 	}
 


### PR DESCRIPTION
This PR is linked to the upstream issue #27204 for introducing pod level cgroups into Kubernetes.

@derekwaynecarr  @vishh @Random-Liu PTAL.

I would like some suggestion/discussion on some comments that I would add in the PR.
I would also be adding e2e tests to this PR.
Please note that only the second commit is unique to this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29087)

<!-- Reviewable:end -->
