### PR TITLE
Modify the return about CloudProvider in plugins.go

### DIFF
--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -57,7 +57,7 @@ func GetCloudProvider(name string, config io.Reader) (Interface, error) {
 	defer providersMutex.Unlock()
 	f, found := providers[name]
 	if !found {
-		return nil, nil
+		return nil, fmt.Errorf("Cloud provider %s wasn't registered.", name)
 	}
 	return f(config)
 }
@@ -68,8 +68,7 @@ func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	var err error
 
 	if name == "" {
-		glog.Info("No cloud provider specified.")
-		return nil, nil
+		return nil, fmt.Errorf("No cloud provider specified.")
 	}
 
 	if configFilePath != "" {


### PR DESCRIPTION
The PR modify the return of InitCloudProvider and GetCloudProvider in plugins.go.  When return nil for the first parameter, it‘d better return error for the second parameter, not nil, because the upper caller perhaps doesn't judge if the cloud is nil when error is nil, and then it's wrong. For example, the caller "DefaultAndValidateRunOptions" function in genericapiserver.go, the caller "Run" in controllermanager.go......
