### PR TITLE
Remove GOMAXPROCS() calls because they are unnecessary

### DIFF
--- a/cmd/genswaggertypedocs/swagger_type_docs.go
+++ b/cmd/genswaggertypedocs/swagger_type_docs.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	kruntime "k8s.io/kubernetes/pkg/runtime"
 
@@ -35,7 +34,6 @@ var (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
 
 	if *typeSrc == "" {

--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 
 	"k8s.io/kubernetes/pkg/util"
 	utilflag "k8s.io/kubernetes/pkg/util/flag"
@@ -188,7 +187,6 @@ func (hk *HyperKube) Run(args []string) error {
 
 // RunToExit will run the hyperkube and then call os.Exit with an appropriate exit code.
 func (hk *HyperKube) RunToExit(args []string) {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	err := hk.Run(args)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err.Error())

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"time"
 
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
@@ -35,7 +34,6 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	s := options.NewAPIServer()

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -23,7 +23,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
@@ -40,7 +39,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	s := options.NewCMServer()
 	s.AddFlags(pflag.CommandLine)
 

--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -22,10 +22,11 @@ import (
 	"os"
 
 	"fmt"
-	"github.com/spf13/pflag"
-	"k8s.io/kubernetes/pkg/util/validation"
 	_ "net/http/pprof"
 	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/util/validation"
 )
 
 type KubeDNSConfig struct {

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
@@ -36,7 +35,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	config := options.NewProxyConfig()
 	config.AddFlags(pflag.CommandLine)
 

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -18,13 +18,11 @@ package main
 
 import (
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/cmd/kubectl/app"
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	if err := app.Run(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -23,7 +23,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
@@ -35,7 +34,6 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	s := options.NewKubeletServer()
 	s.AddFlags(pflag.CommandLine)
 

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"runtime"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
@@ -83,7 +82,6 @@ func (c *HollowNodeConfig) createClientFromFile() (*client.Client, error) {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	config := HollowNodeConfig{}
 	config.addFlags(pflag.CommandLine)

--- a/contrib/mesos/cmd/k8sm-controller-manager/main.go
+++ b/contrib/mesos/cmd/k8sm-controller-manager/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util"
@@ -36,7 +35,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	s := controllermanager.NewCMServer()
 	s.AddFlags(pflag.CommandLine)

--- a/contrib/mesos/cmd/k8sm-executor/main.go
+++ b/contrib/mesos/cmd/k8sm-executor/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/contrib/mesos/pkg/executor/service"
@@ -30,7 +29,6 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	s := service.NewKubeletExecutorServer()
 	s.AddFlags(pflag.CommandLine)

--- a/contrib/mesos/cmd/k8sm-scheduler/main.go
+++ b/contrib/mesos/cmd/k8sm-scheduler/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/contrib/mesos/pkg/hyperkube"
@@ -30,7 +29,6 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	s := service.NewSchedulerServer()
 	s.AddStandaloneFlags(pflag.CommandLine)
 

--- a/contrib/mesos/cmd/km/hyperkube.go
+++ b/contrib/mesos/cmd/km/hyperkube.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/version/verflag"
@@ -177,7 +176,6 @@ func (hk *HyperKube) Run(args []string) error {
 
 // RunToExit will run the hyperkube and then call os.Exit with an appropriate exit code.
 func (hk *HyperKube) RunToExit(args []string) {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	err := hk.Run(args)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err.Error())

--- a/federation/cmd/federation-apiserver/apiserver.go
+++ b/federation/cmd/federation-apiserver/apiserver.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"time"
 
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
@@ -35,7 +34,6 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	s := genericoptions.NewServerRunOptions()

--- a/federation/cmd/federation-controller-manager/controller-manager.go
+++ b/federation/cmd/federation-controller-manager/controller-manager.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app"
@@ -35,7 +34,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	s := options.NewCMServer()
 	s.AddFlags(pflag.CommandLine)
 

--- a/plugin/cmd/kube-scheduler/scheduler.go
+++ b/plugin/cmd/kube-scheduler/scheduler.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"runtime"
-
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/flag"
@@ -34,7 +32,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	s := options.NewSchedulerServer()
 	s.AddFlags(pflag.CommandLine)
 


### PR DESCRIPTION
Now we're setting GOMAXPROCS when every binary starts up, but we don't have to do that anymore, since we've upgraded to Go 1.6

Documentation for it:

> func GOMAXPROCS(n int) int
> 
> GOMAXPROCS sets the maximum number of CPUs that can be executing simultaneously and returns the previous setting. If n < 1, it does not change the current setting. The number of logical CPUs on the local machine can be queried with NumCPU. This call will go away when the scheduler improves. 

A simple program to prove it's unnecessary:

``` go
package main
import (
    "fmt"
    "runtime"
)
func main(){
    numCPUBefore := runtime.GOMAXPROCS(runtime.NumCPU())
    numCPUAfter := runtime.GOMAXPROCS(runtime.NumCPU())
    fmt.Println(numCPUBefore, numCPUAfter)
}
```

Output with Go 1.4.2: `1 4`
Output with Go 1.6.2: `4 4`

So I think we should remove calls to GOMAXPROCS now, and it should be pretty straightforward

@thockin @wojtek-t @gmarek @lavalamp @vishh 
