### PR TITLE
File "cluster/kube-env.sh" not exist

### DIFF
--- a/docs/devel/developer-guides/vagrant.md
+++ b/docs/devel/developer-guides/vagrant.md
@@ -278,7 +278,7 @@ Congratulations!
 ### Testing
 
 The following will run all of the end-to-end testing scenarios assuming you set
-your environment in `cluster/kube-env.sh`:
+your environment:
 
 ```shell
 NUM_NODES=3 go run hack/e2e.go -v --build --up --test --down


### PR DESCRIPTION
In file "docs/devel/developer-guides/vagrant.md", line 281:
"your environment in `cluster/kube-env.sh`:"
Here file "cluster/kube-env.sh" not exist.
