### PR TITLE
Fix incorrect if conditions

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1434,7 +1434,7 @@ var errNoPodOnContainer = fmt.Errorf("no pod information labels on Docker contai
 
 // containerAndPodFromLabels tries to load the appropriate container info off of a Docker container's labels
 func containerAndPodFromLabels(inspect *dockertypes.ContainerJSON) (pod *api.Pod, container *api.Container, err error) {
-	if inspect == nil && inspect.Config == nil && inspect.Config.Labels == nil {
+	if inspect == nil || inspect.Config == nil || inspect.Config.Labels == nil {
 		return nil, nil, errNoPodOnContainer
 	}
 	labels := inspect.Config.Labels

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2305,3 +2305,35 @@ func TestSyncPodGetsPodIPFromNetworkPlugin(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 }
+
+// only test conditions "if inspect == nil || inspect.Config == nil || inspect.Config.Labels == nil" now
+func TestContainerAndPodFromLabels(t *testing.T) {
+	tests := []struct {
+		inspect       *dockertypes.ContainerJSON
+		expectedError error
+	}{
+		{
+			inspect:       nil,
+			expectedError: errNoPodOnContainer,
+		},
+		{
+			inspect:       &dockertypes.ContainerJSON{},
+			expectedError: errNoPodOnContainer,
+		},
+		{
+			inspect: &dockertypes.ContainerJSON{
+				Config: &dockercontainer.Config{
+					Hostname: "foo",
+				},
+			},
+			expectedError: errNoPodOnContainer,
+		},
+	}
+
+	for k, v := range tests {
+		pod, container, err := containerAndPodFromLabels(v.inspect)
+		if pod != nil || container != nil || err != v.expectedError {
+			t.Errorf("case[%q]: expected: nil, nil, %v, got: %v, %v, %v", k, v.expectedError, pod, container, err)
+		}
+	}
+}


### PR DESCRIPTION
When the current conditions `if inspect == nil && inspect.Config == nil && inspect.Config.Labels == nil` is true, the func containerAndPodFromLabels will return. else will not. Suppose `inspect != nil` but `inspect.Config == nil`, the current conditions will be false and the func won't return, then the below `labels := inspect.Config.Labels` will lead to panic.
