### PR TITLE
Remove -e from 'go list' so missing files will halt the build

### DIFF
--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -237,14 +237,14 @@ $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
 $(META_DIR)/$(DEEPCOPY_GEN).mk:
 	mkdir -p $(@D);                                        \
 	(echo -n "$(DEEPCOPY_GEN): ";                          \
-	 DIRECT=$$(go list -e -f '{{.Dir}} {{.Dir}}/*.go'      \
+	 DIRECT=$$(go list -f '{{.Dir}} {{.Dir}}/*.go'         \
 	     ./cmd/libs/go2idl/deepcopy-gen);                  \
-	 INDIRECT=$$(go list -e                                \
+	 INDIRECT=$$(go list                                   \
 	     -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}'          \
 	     ./cmd/libs/go2idl/deepcopy-gen                    \
 	     | grep --color=never "^$(PRJ_SRC_PATH)"           \
 	     | sed 's|^$(PRJ_SRC_PATH)|./|'                    \
-	     | xargs go list -e -f '{{.Dir}} {{.Dir}}/*.go');  \
+	     | xargs go list -f '{{.Dir}} {{.Dir}}/*.go');     \
 	 echo $$DIRECT $$INDIRECT                              \
 	     | sed 's/ / \\=,/g'                               \
 	     | tr '=,' '\n\t';                                 \
@@ -416,14 +416,14 @@ $(CONVERSION_FILES): $(CONVERSION_GEN)
 $(META_DIR)/$(CONVERSION_GEN).mk:
 	mkdir -p $(@D);                                        \
 	(echo -n "$(CONVERSION_GEN): ";                        \
-	 DIRECT=$$(go list -e -f '{{.Dir}} {{.Dir}}/*.go'      \
+	 DIRECT=$$(go list -f '{{.Dir}} {{.Dir}}/*.go'         \
 	     ./cmd/libs/go2idl/conversion-gen);                \
-	 INDIRECT=$$(go list -e                                \
+	 INDIRECT=$$(go list                                   \
 	     -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}'          \
 	     ./cmd/libs/go2idl/conversion-gen                  \
 	     | grep --color=never "^$(PRJ_SRC_PATH)"           \
 	     | sed 's|^$(PRJ_SRC_PATH)|./|'                    \
-	     | xargs go list -e -f '{{.Dir}} {{.Dir}}/*.go');  \
+	     | xargs go list -f '{{.Dir}} {{.Dir}}/*.go');     \
 	 echo $$DIRECT $$INDIRECT                              \
 	     | sed 's/ / \\=,/g'                               \
 	     | tr '=,' '\n\t';                                 \


### PR DESCRIPTION
In the case that any of the files being processed by this pipeline are missing, `go list -e` sends the error to the template, which results in cryptic build errors like `No rule to make target '/*.go'`

This came up in #28987, and although that issue has already been fixed by munging the specific path - https://github.com/kubernetes/kubernetes/commit/2a4495cf8926b093e3f19ff5289c470002b940ec#diff-78183b4162626e1797dae5558b01caa0R423 - I suggest it would be best to take out the possibility of the same thing happening again for different reasons.
