### PR TITLE
Both the file name and directory of fake docker manager are wrong

### DIFF
--- a/docs/devel/kubemark-guide.md
+++ b/docs/devel/kubemark-guide.md
@@ -229,7 +229,7 @@ other providers you’ll need to delete all this stuff by yourself.
 Kubemark master uses exactly the same binaries as ordinary Kubernetes does. This
 means that it will never be out of date. On the other hand HollowNodes use
 existing fake for Kubelet (called SimpleKubelet), which mocks its runtime
-manager with `pkg/kubelet/fake-docker-manager.go`, where most logic sits.
+manager with `pkg/kubelet/dockertools/fake_manager.go`, where most logic sits.
 Because there’s no easy way of mocking other managers (e.g. VolumeManager), they
 are not supported in Kubemark (e.g. we can’t schedule Pods with volumes in them
 yet).


### PR DESCRIPTION
In file "docs/devel/kubemark-guide.md b/docs/devel/kubemark-guide.md", line 232
"manager with `pkg/kubelet/fake-docker-manager.go`"
here both the name and directory of fake docker manger are wrong, it should be "pkg/kubelet/dockertools/fake_manager.go".
