### PR TITLE
test/e2e: plug time.Ticker resource leak.

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -151,6 +151,7 @@ func logPodStartupStatus(c *client.Client, expectedPods int, ns string, observed
 	podStore := framework.NewPodStore(c, ns, label, fields.Everything())
 	defer podStore.Stop()
 	ticker := time.NewTicker(period)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
This commit ensures that `logPodStartupStatus` does not leak
running `time.Ticker` instances.  Upon termination of the consuming
routine, we stop the ticker.
