### PR TITLE
Register the federation core API conversion and default functions.

### DIFF
--- a/federation/apis/core/conversion.go
+++ b/federation/apis/core/conversion.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func addDefaultingFuncs(scheme *runtime.Scheme) {
+	scheme.AddDefaultingFuncs(
+		func(obj *api.ListOptions) {
+			if obj.LabelSelector == nil {
+				obj.LabelSelector = labels.Everything()
+			}
+			if obj.FieldSelector == nil {
+				obj.FieldSelector = fields.Everything()
+			}
+		},
+	)
+}
+
+func addConversionFuncs(scheme *runtime.Scheme) {
+	// Add non-generated conversion functions
+	err := scheme.AddConversionFuncs(
+		api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta,
+		api.Convert_unversioned_ListMeta_To_unversioned_ListMeta,
+		api.Convert_intstr_IntOrString_To_intstr_IntOrString,
+		api.Convert_unversioned_Time_To_unversioned_Time,
+		api.Convert_Slice_string_To_unversioned_Time,
+		api.Convert_string_To_labels_Selector,
+		api.Convert_string_To_fields_Selector,
+		api.Convert_Pointer_bool_To_bool,
+		api.Convert_bool_To_Pointer_bool,
+		api.Convert_Pointer_string_To_string,
+		api.Convert_string_To_Pointer_string,
+		api.Convert_labels_Selector_To_string,
+		api.Convert_fields_Selector_To_string,
+		api.Convert_resource_Quantity_To_resource_Quantity,
+	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+}

--- a/federation/apis/core/register.go
+++ b/federation/apis/core/register.go
@@ -72,4 +72,7 @@ func AddToScheme(scheme *runtime.Scheme) {
 		&unversioned.APIGroup{},
 		&unversioned.APIResourceList{},
 	)
+
+	addDefaultingFuncs(scheme)
+	addConversionFuncs(scheme)
 }

--- a/federation/apis/core/v1/conversion.go
+++ b/federation/apis/core/v1/conversion.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func addConversionFuncs(scheme *runtime.Scheme) {
+	// Add non-generated conversion functions
+	err := scheme.AddConversionFuncs(
+		v1.Convert_v1_DeleteOptions_To_api_DeleteOptions,
+		v1.Convert_api_DeleteOptions_To_v1_DeleteOptions,
+		v1.Convert_v1_ExportOptions_To_api_ExportOptions,
+		v1.Convert_api_ExportOptions_To_v1_ExportOptions,
+		v1.Convert_v1_List_To_api_List,
+		v1.Convert_api_List_To_v1_List,
+		v1.Convert_v1_ListOptions_To_api_ListOptions,
+		v1.Convert_api_ListOptions_To_v1_ListOptions,
+		v1.Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
+		v1.Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
+		v1.Convert_v1_ObjectMeta_To_api_ObjectMeta,
+		v1.Convert_api_ObjectMeta_To_v1_ObjectMeta,
+		v1.Convert_v1_ObjectReference_To_api_ObjectReference,
+		v1.Convert_api_ObjectReference_To_v1_ObjectReference,
+		v1.Convert_v1_OwnerReference_To_api_OwnerReference,
+		v1.Convert_api_OwnerReference_To_v1_OwnerReference,
+		v1.Convert_v1_Service_To_api_Service,
+		v1.Convert_api_Service_To_v1_Service,
+		v1.Convert_v1_ServiceList_To_api_ServiceList,
+		v1.Convert_api_ServiceList_To_v1_ServiceList,
+		v1.Convert_v1_ServicePort_To_api_ServicePort,
+		v1.Convert_api_ServicePort_To_v1_ServicePort,
+		v1.Convert_v1_ServiceProxyOptions_To_api_ServiceProxyOptions,
+		v1.Convert_api_ServiceProxyOptions_To_v1_ServiceProxyOptions,
+		v1.Convert_v1_ServiceSpec_To_api_ServiceSpec,
+		v1.Convert_api_ServiceSpec_To_v1_ServiceSpec,
+		v1.Convert_v1_ServiceStatus_To_api_ServiceStatus,
+		v1.Convert_api_ServiceStatus_To_v1_ServiceStatus,
+	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
+	for _, kind := range []string{
+		"Service",
+	} {
+		err = scheme.AddFieldLabelConversionFunc("v1", kind,
+			func(label, value string) (string, string, error) {
+				switch label {
+				case "metadata.namespace",
+					"metadata.name":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("field label %q not supported for %q", label, kind)
+				}
+			})
+		if err != nil {
+			// If one of the conversion functions is malformed, detect it immediately.
+			panic(err)
+		}
+	}
+}

--- a/federation/apis/core/v1/doc.go
+++ b/federation/apis/core/v1/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is probably not required for now because we are reusing the types
+// in k8s.io/kubernetes/pkg/api. But adding it now as a guard to ensure
+// that others don't stumble on this in the future when they add new
+// types here since adding it now doesn't hurt.
+// +k8s:conversion-gen=k8s.io/kubernetes/federation/apis/core
+
+package v1

--- a/federation/apis/core/v1/register.go
+++ b/federation/apis/core/v1/register.go
@@ -32,6 +32,8 @@ var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1
 func AddToScheme(scheme *runtime.Scheme) {
 	// Add the API to Scheme.
 	addKnownTypes(scheme)
+	addConversionFuncs(scheme)
+	addDefaultingFuncs(scheme)
 }
 
 // Adds the list of known types to api.Scheme.


### PR DESCRIPTION
This was removed by mistake in 9eb42f (PR #25978). Reverting some
of those changes and adding the new mechanism to autogenerate
conversions for the new types that we might define in this API
group in the future.

cc @kubernetes/sig-cluster-federation 

@thockin @lavalamp please take a look at this once even if the PR merges before you get a chance to take a look.

@thockin particularly see the `federation/apis/core/v1/doc.go` file.

Fixes issue #28615
