### PR TITLE
Fix node e2e (kubelet metrics) panic

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/wait"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
@@ -67,8 +68,9 @@ func (c *PodClient) CreateBatch(pods []*api.Pod) []*api.Pod {
 	for i, pod := range pods {
 		wg.Add(1)
 		go func(i int, pod *api.Pod) {
+			defer wg.Done()
+			defer GinkgoRecover()
 			ps[i] = c.CreateSync(pod)
-			wg.Done()
 		}(i, pod)
 	}
 	wg.Wait()


### PR DESCRIPTION
On systems (rhel7, and fedora 24), the kubelet metrics node e2e panics:

```
[k8s.io] Kubelet metrics api when querying /stats/summary
  it should report resource usage through the stats api
  /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:146
[BeforeEach] [k8s.io] Kubelet
  /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e/framework/framework.go:132
STEP: Creating a kubernetes client
STEP: Building a namespace api object
Jul 18 10:45:45.004: INFO: Skipping waiting for service account
[It] it should report resource usage through the stats api
  /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e_node/kubelet_test.go:146
W0718 10:45:45.036201   17112 request.go:347] Field selector: v1 - pods - metadata.name - stats-busybox-4edb73ec-4cf6-11e6-9ecc-52540041b7801: need to check if this is versioned correctly.
W0718 10:45:45.036213   17112 request.go:347] Field selector: v1 - pods - metadata.name - stats-busybox-4edb73ec-4cf6-11e6-9ecc-52540041b7800: need to check if this is versioned correctly.
E0718 10:50:45.036630   17112 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
Jul 18 10:50:45.036: INFO: Unexpected error occurred: timed out waiting for the condition
panic:
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

        defer GinkgoRecover()

at the top of the goroutine that caused this panic.


goroutine 68 [running]:
panic(0x1958fc0, 0xc8204ba6b0)
        /usr/lib/golang/src/runtime/panic.go:481 +0x3e6
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo.Fail(0xc820302160, 0xb0, 0xc8204ba2c8, 0x1, 0x1)
        /root/upstream-code/gocode/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:244 +0x116
k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).match(0xc820820080, 0x2b2337d20268, 0x30a2da8, 0x0, 0x0, 0x0, 0x0, 0x30a2da8)
        /root/upstream-code/gocode/src/k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x32d
k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).NotTo(0xc820820080, 0x2b2337d20268, 0x30a2da8, 0x0, 0x0, 0x0, 0x2b2337d20220)
        /root/upstream-code/gocode/src/k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:43 +0x92
k8s.io/kubernetes/test/e2e/framework.ExpectNoError(0x2b2336968028, 0xc8200b30c0, 0x0, 0x0, 0x0)
        /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e/framework/util.go:1811 +0x203
k8s.io/kubernetes/test/e2e/framework.(*Framework).CreatePods.func1(0xc8200a6540, 0xc820204f40, 0x33, 0xc8201576c0)
        /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e/framework/pods.go:68 +0x68
created by k8s.io/kubernetes/test/e2e/framework.(*Framework).CreatePods
        /root/upstream-code/gocode/src/k8s.io/kubernetes/test/e2e/framework/pods.go:70 +0x213

Ginkgo ran 1 suite in 5m20.524270699s
Test Suite Failed
!!! Error in hack/make-rules/test-e2e-node.sh:132
  '"${ginkgo}" --focus=$focus --skip=$skip "${KUBE_ROOT}/test/e2e_node/" --report-dir=${report} -- --alsologtostderr --v 2 --node-name $(hostname) --disable-kubenet=true --build-services=true --start-services=true --stop-services=true "$test_args"' exited with status 1
Call stack:
  1: hack/make-rules/test-e2e-node.sh:132 main(...)
Exiting with status 1
make: *** [test-e2e-node] Error 1
```
