### PR TITLE
Change some node e2e test to use the prepull image framework.

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -100,7 +100,7 @@ test/e2e/host_path.go:			fmt.Sprintf("--file_content_in_loop=%v", filePath),
 test/e2e/host_path.go:			fmt.Sprintf("--file_content_in_loop=%v", filePathInReader),
 test/e2e/host_path.go:			fmt.Sprintf("--retry_time=%d", retryDuration),
 test/e2e/host_path.go:			fmt.Sprintf("--retry_time=%d", retryDuration),
-test/e2e_node/configmap.go:						Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=/etc/configmap-volume/data-1"},
+test/e2e_node/configmap_test.go:						Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=/etc/configmap-volume/data-1"},
 test/images/mount-tester/mt.go:	flag.BoolVar(&breakOnExpectedContent, "break_on_expected_content", true, "Break out of loop on expected content, (use with --file_content_in_loop flag only)")
 test/images/mount-tester/mt.go:	flag.IntVar(&retryDuration, "retry_time", 180, "Retry time during the loop")
 test/images/mount-tester/mt.go:	flag.StringVar(&readFileContentInLoopPath, "file_content_in_loop", "", "Path to read the file content in loop from")

--- a/test/e2e_node/cgroup_manager_test.go
+++ b/test/e2e_node/cgroup_manager_test.go
@@ -42,7 +42,7 @@ var _ = framework.KubeDescribe("Kubelet Cgroup Manager", func() {
 							RestartPolicy: api.RestartPolicyNever,
 							Containers: []api.Container{
 								{
-									Image:   "gcr.io/google_containers/busybox:1.24",
+									Image:   ImageRegistry[busyBoxImage],
 									Name:    contName,
 									Command: []string{"sh", "-c", "if [ -d /tmp/memory/Burstable ] && [ -d /tmp/memory/BestEffort ]; then exit 0; else exit 1; fi"},
 									VolumeMounts: []api.VolumeMount{

--- a/test/e2e_node/configmap_test.go
+++ b/test/e2e_node/configmap_test.go
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 				Containers: []api.Container{
 					{
 						Name:    containerName,
-						Image:   "gcr.io/google_containers/mounttest:0.6",
+						Image:   ImageRegistry[mountTestImage],
 						Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=/etc/configmap-volume/data-1"},
 						VolumeMounts: []api.VolumeMount{
 							{
@@ -158,7 +158,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 				Containers: []api.Container{
 					{
 						Name:    "env-test",
-						Image:   "gcr.io/google_containers/busybox:1.24",
+						Image:   ImageRegistry[busyBoxImage],
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{
@@ -238,7 +238,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64) {
 			Containers: []api.Container{
 				{
 					Name:  "configmap-volume-test",
-					Image: "gcr.io/google_containers/mounttest:0.6",
+					Image: ImageRegistry[mountTestImage],
 					Args:  []string{"--file_content=/etc/configmap-volume/data-1"},
 					VolumeMounts: []api.VolumeMount{
 						{
@@ -311,7 +311,7 @@ func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64) {
 			Containers: []api.Container{
 				{
 					Name:  "configmap-volume-test",
-					Image: "gcr.io/google_containers/mounttest:0.6",
+					Image: ImageRegistry[mountTestImage],
 					Args:  []string{"--file_content=/etc/configmap-volume/path/to/data-2"},
 					VolumeMounts: []api.VolumeMount{
 						{

--- a/test/e2e_node/downward_api_test.go
+++ b/test/e2e_node/downward_api_test.go
@@ -140,7 +140,7 @@ func testDownwardAPI(f *framework.Framework, podName string, env []api.EnvVar, e
 			Containers: []api.Container{
 				{
 					Name:    "dapi-container",
-					Image:   "gcr.io/google_containers/busybox:1.24",
+					Image:   ImageRegistry[busyBoxImage],
 					Command: []string{"sh", "-c", "env"},
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -35,6 +35,8 @@ const (
 	hostExecImage
 	netExecImage
 	nginxImage
+	mountTestImage
+	testWebServer
 	pauseImage
 
 	// Images just used for explicitly testing pulling of images
@@ -45,11 +47,13 @@ const (
 )
 
 var ImageRegistry = map[int]string{
-	busyBoxImage:  "gcr.io/google_containers/busybox:1.24",
-	hostExecImage: "gcr.io/google_containers/hostexec:1.2",
-	netExecImage:  "gcr.io/google_containers/netexec:1.4",
-	nginxImage:    "gcr.io/google_containers/nginx-slim:0.7",
-	pauseImage:    framework.GetPauseImageNameForHostArch(),
+	busyBoxImage:   "gcr.io/google_containers/busybox:1.24",
+	hostExecImage:  "gcr.io/google_containers/hostexec:1.2",
+	netExecImage:   "gcr.io/google_containers/netexec:1.4",
+	nginxImage:     "gcr.io/google_containers/nginx-slim:0.7",
+	mountTestImage: "gcr.io/google_containers/mounttest:0.6",
+	testWebServer:  "gcr.io/google_containers/test-webserver:e2e",
+	pauseImage:     framework.GetPauseImageNameForHostArch(),
 }
 
 // These are used by tests that explicitly test the ability to pull images


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/28868.

Node e2e test framework pre-pulls all images in [image_list.go](https://github.com/kubernetes/kubernetes/blob/bc2f223f5a3dcbd38cbdf36b5a18e0f596d8fea5/test/e2e_node/image_list.go)

All node e2e test should use image from the "image_list". If a test needs new image, we should update the image_list to include the new image.

/cc @kubernetes/sig-node to notice people to use `image_list` when adding test. :)
