### PR TITLE
Improve quota controller performance by eliminating unneeded list calls

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -270,6 +270,10 @@ func (rq *ResourceQuotaController) syncResourceQuota(resourceQuota api.ResourceQ
 	newUsage := api.ResourceList{}
 	usageStatsOptions := quota.UsageStatsOptions{Namespace: resourceQuota.Namespace, Scopes: resourceQuota.Spec.Scopes}
 	for _, evaluator := range evaluators {
+		// only trigger the evaluator if it matches a resource in the quota, otherwise, skip calculating anything
+		if intersection := quota.Intersection(evaluator.MatchesResources(), matchedResources); len(intersection) == 0 {
+			continue
+		}
 		stats, err := evaluator.UsageStats(usageStatsOptions)
 		if err != nil {
 			return err

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -122,12 +122,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	expectedActionSet := sets.NewString(
-		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
-		strings.Join([]string{"list", "services", ""}, "-"),
 		strings.Join([]string{"list", "pods", ""}, "-"),
-		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
-		strings.Join([]string{"list", "secrets", ""}, "-"),
-		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
 		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
 	)
 	actionSet := sets.NewString()
@@ -213,12 +208,7 @@ func TestSyncResourceQuotaSpecChange(t *testing.T) {
 	}
 
 	expectedActionSet := sets.NewString(
-		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
-		strings.Join([]string{"list", "services", ""}, "-"),
 		strings.Join([]string{"list", "pods", ""}, "-"),
-		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
-		strings.Join([]string{"list", "secrets", ""}, "-"),
-		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
 		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
 	)
 	actionSet := sets.NewString()
@@ -293,12 +283,7 @@ func TestSyncResourceQuotaNoChange(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	expectedActionSet := sets.NewString(
-		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
-		strings.Join([]string{"list", "services", ""}, "-"),
 		strings.Join([]string{"list", "pods", ""}, "-"),
-		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
-		strings.Join([]string{"list", "secrets", ""}, "-"),
-		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
 	)
 	actionSet := sets.NewString()
 	for _, action := range kubeClient.Actions() {


### PR DESCRIPTION
Previously, when syncing quota usage, we asked each registered `Evaluator` to determine the usage it knows to track associated with a `GroupKind` even if that particular `GroupKind` had no associated resources under quota.

This fix makes it that when we sync a quota that just had only `Pod` related compute resources, we do not also calculate the usage stats for things like `ConfigMap`, `Secret`, etc. per quota.

This should be a significant performance gain when running large numbers of `Namespace`'s each with `ResourceQuota` that tracks a subset of resources.

/cc @deads2k @kubernetes/rh-cluster-infra 
