### PR TITLE
 Move displaying global-flags to separate help sub-command

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -195,9 +195,6 @@ Available Sub-commands:{{range .Commands}}{{if .IsAvailableCommand}}
 Flags:
 {{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasInheritedFlags}}
 
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
-
 Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}
 

--- a/pkg/kubectl/cmd/help.go
+++ b/pkg/kubectl/cmd/help.go
@@ -25,8 +25,26 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-const help_long = `Help provides help for any command in the application.
-Simply type kubectl help [path to command] for full details.`
+const (
+	help_long = `Help provides help for any command in the application.
+Simply type kubectl help [path to command] for full details.
+
+# Show usage of kubectl
+kubectl help
+
+# Show a list of global flags
+kubectl help global-flags
+# or
+kubectl help gf
+
+# Show help for help command. Yes, you can do it.
+kubectl help help
+`
+
+	help_long_for_global_flags = `Global flags are top-level flags that affect all commands.
+
+List of global flags:`
+)
 
 func NewCmdHelp(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,12 +61,16 @@ func NewCmdHelp(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 func RunHelp(cmd *cobra.Command, args []string) {
 	foundCmd, _, err := cmd.Root().Find(args)
 
-	// NOTE(andreykurilin): actually, I did not find any cases when foundCmd can be nil,
+	// NOTE(andreykurilin): actually, I did not find any cases when foundCmd can be nil
+	//   (in case of unexisting command search, Find method returns `kubectl` command handler),
 	//   but let's make this check since it is included in original code of initHelpCmd
 	//   from github.com/spf13/cobra
 	if foundCmd == nil {
 		cmd.Printf("Unknown help topic %#q.\n", args)
 		cmd.Root().Usage()
+	} else if len(args) >= 1 && (args[0] == "gf" || args[0] == "global-flags") {
+		cmd.Println(help_long_for_global_flags)
+		cmd.Println(foundCmd.Flags().FlagUsages())
 	} else if err != nil {
 		// print error message at first, since it can contain suggestions
 		cmd.Println(err)


### PR DESCRIPTION
Move displaying global-flags to separate help sub-commands and make help command of regular `kubectl` commands more clear.

Output of new sub-command

```
$ kubectl help global-flags
Global flags are top-level flags that affect all commands.

List of global flags:
      --alsologtostderr[=false]: log to standard error as well as files
      --as="": Username to impersonate for the operation
      --certificate-authority="": Path to a cert. file for the certificate authority
      --client-certificate="": Path to a client certificate file for TLS
      --client-key="": Path to a client key file for TLS
      --cluster="": The name of the kubeconfig cluster to use
      --context="": The name of the kubeconfig context to use
      --insecure-skip-tls-verify[=false]: If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig="": Path to the kubeconfig file to use for CLI requests.
      --log-backtrace-at=:0: when logging hits line file:N, emit a stack trace
      --log-dir="": If non-empty, write log files in this directory
      --log-flush-frequency=5s: Maximum number of seconds between log flushes
      --logtostderr[=true]: log to standard error instead of files
      --match-server-version[=false]: Require server version to match client version
      --namespace="": If present, the namespace scope for this CLI request
      --password="": Password for basic authentication to the API server
  -s, --server="": The address and port of the Kubernetes API server
      --stderrthreshold=2: logs at or above this threshold go to stderr
      --token="": Bearer token for authentication to the API server
      --user="": The name of the kubeconfig user to use
      --username="": Username for basic authentication to the API server
      --v=0: log level for V logs
      --vmodule=: comma-separated list of pattern=N settings for file-filtered logging

```

Output of help for help command:

```
Help provides help for any command in the application.
Simply type kubectl help [path to command] for full details.

# Show usage of kubectl
kubectl help

# Show a list of global flags
kubectl help global-flags
# or
kubectl help gf

# Show help for help command. Yes, you can do it.
kubectl help help

Additional help topics:

Usage:
  kubectl help [command] | STRING_TO_SEARCH [flags]

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29150)

<!-- Reviewable:end -->
