### PR TITLE
Fix working_set calculation in kubelet

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -927,203 +927,203 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1/test",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.23.6",
-			"Rev": "4dbefc9b671b81257973a33211fb12370c1a526e"
+			"Comment": "v0.23.7",
+			"Rev": "c2ea32971ae033041f0fb0f309b1dee94fd1d55f"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",

--- a/vendor/github.com/google/cadvisor/container/libcontainer/helpers.go
+++ b/vendor/github.com/google/cadvisor/container/libcontainer/helpers.go
@@ -387,23 +387,16 @@ func toContainerStats2(s *cgroups.Stats, ret *info.ContainerStats) {
 		ret.Memory.ContainerData.Pgmajfault = v
 		ret.Memory.HierarchicalData.Pgmajfault = v
 	}
-	if v, ok := s.MemoryStats.Stats["total_inactive_anon"]; ok {
-		workingSet := ret.Memory.Usage
+
+	workingSet := ret.Memory.Usage
+	if v, ok := s.MemoryStats.Stats["total_inactive_file"]; ok {
 		if workingSet < v {
 			workingSet = 0
 		} else {
 			workingSet -= v
 		}
-
-		if v, ok := s.MemoryStats.Stats["total_inactive_file"]; ok {
-			if workingSet < v {
-				workingSet = 0
-			} else {
-				workingSet -= v
-			}
-		}
-		ret.Memory.WorkingSet = workingSet
 	}
+	ret.Memory.WorkingSet = workingSet
 }
 
 func toContainerStats3(libcontainerStats *libcontainer.Stats, ret *info.ContainerStats) {


### PR DESCRIPTION
Update cadvisor to v0.23.7

Fixes #28619

Note that this PR is not a typical cherry-pick because `master` branch has diverged from `release-1.3` branch and can no longer compile against cadvisor's `release-0.23` branch which was created specifically for k8s `release-1.3` branch. 
