### PR TITLE
Make clear where cherrypick PRs are being created

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -29,7 +29,7 @@ declare -r STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r REBASEMAGIC="${KUBE_ROOT}/.git/rebase-apply"
 
 if [[ -z ${GITHUB_USER:-} ]]; then
-  echo "Please export GITHUB_USER=<your-user>"
+  echo "Please export GITHUB_USER=<your-user> (or GH organization if that's where your fork lives)"
   exit 1
 fi
 
@@ -139,7 +139,7 @@ gitamcleanup=false
 
 function make-a-pr() {
   local rel="$(basename "${BRANCH}")"
-  echo "+++ Creating a pull request on github"
+  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
 
   # This looks like an unnecessary use of a tmpfile, but it avoids
   # https://github.com/github/hub/issues/976 Otherwise stdin is stolen

--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -29,7 +29,7 @@ declare -r STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r REBASEMAGIC="${KUBE_ROOT}/.git/rebase-apply"
 
 if [[ -z ${GITHUB_USER:-} ]]; then
-  echo "Please export GITHUB_USER=<your-user> (or GH organization if that's where your fork lives)"
+  echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
   exit 1
 fi
 


### PR DESCRIPTION
I spent a whole hour troubleshooting all sorts of auth issues today, until I noticed that it was trying to make a PR on my personal account, while the  fork is actually on my company's GH organization account.
