### PR TITLE
"server.go" directory error

### DIFF
--- a/docs/devel/profiling.md
+++ b/docs/devel/profiling.md
@@ -52,7 +52,7 @@ m.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 
 to the init(c *Config) method in 'pkg/master/master.go' and import 'net/http/pprof' package.
 
-In most use cases to use profiler service it's enough to do 'import _ net/http/pprof', which automatically registers a handler in the default http.Server. Slight inconvenience is that APIserver uses default server for intra-cluster communication, so plugging profiler to it is not really useful. In 'pkg/master/server/server.go' more servers are created and started as separate goroutines. The one that is usually serving external traffic is secureServer. The handler for this traffic is defined in 'pkg/master/master.go' and stored in Handler variable. It is created from HTTP multiplexer, so the only thing that needs to be done is adding profiler handler functions to this multiplexer. This is exactly what lines after TL;DR do.
+In most use cases to use profiler service it's enough to do 'import _ net/http/pprof', which automatically registers a handler in the default http.Server. Slight inconvenience is that APIserver uses default server for intra-cluster communication, so plugging profiler to it is not really useful. In 'pkg/kubelet/server/server.go' more servers are created and started as separate goroutines. The one that is usually serving external traffic is secureServer. The handler for this traffic is defined in 'pkg/master/master.go' and stored in Handler variable. It is created from HTTP multiplexer, so the only thing that needs to be done is adding profiler handler functions to this multiplexer. This is exactly what lines after TL;DR do.
 
 ## Connecting to the profiler
 


### PR DESCRIPTION
In file "docs\devel\profiling.md", line 55:
"In 'pkg/master/server/server.go' more servers are created“
Here server.go directory is wrong, should be :pkg/kubelet/server/server.go
