### PR TITLE
Add jsonnet support for kubectl

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -33,6 +33,8 @@ import (
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/yaml"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/pkg/util/jsonnet"
+	"github.com/golang/glog"
 )
 
 const (
@@ -474,6 +476,19 @@ type FileVisitor struct {
 
 // Visit in a FileVisitor is just taking care of opening/closing files
 func (v *FileVisitor) Visit(fn VisitorFunc) error {
+	if jsonnet.IsJsonnet(v.Path) {
+		glog.V(4).Infof("Visit is jsonnet")
+		var f *bytes.Reader
+		var err error
+		if f, err = jsonnet.Open(v.Path); err != nil {
+			glog.V(4).Infof("Visit jsonnet failed %v", err)
+			return err
+		}
+		v.StreamVisitor.Reader = f
+
+		return v.StreamVisitor.Visit(fn)
+	}
+	glog.V(4).Infof("Visit is not jsonnet")
 	var f *os.File
 	if v.Path == constSTDINstr {
 		f = os.Stdin

--- a/pkg/util/jsonnet/jsonnet.go
+++ b/pkg/util/jsonnet/jsonnet.go
@@ -1,0 +1,40 @@
+// JSONNET Decoder
+package jsonnet
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+	utilexec "k8s.io/kubernetes/pkg/util/exec"
+)
+
+const cmdJsonnet string = "jsonnet"
+
+// Run converts a single JSONNET document into a JSON document
+func Run(args ...string) ([]byte, error) {
+	glog.V(4).Infof("running jsonnet %v", args)
+	return utilexec.New().Command(cmdJsonnet, args...).CombinedOutput()
+}
+
+// Open convert a single JSONNET file into a io.reader
+func Open(args ...string) (*bytes.Reader, error) {
+	output, err := Run(args...)
+	return bytes.NewReader(output), err
+}
+
+// IsJsonnet reports whether the filename is a standard JSONNET file
+func IsJsonnet(filename string) bool {
+	if _, err := os.Stat(filename); err != nil {
+		glog.V(4).Infof("file %v is not existing %v", filename, err)
+		return false
+	}
+	if strings.ToLower(strings.TrimSpace(path.Ext(filename))) == ".jsonnet" {
+		glog.V(4).Infof("file %v is jsonnet", filename)
+		return true
+	}
+	glog.V(4).Infof("file %v is not jsonnet", filename)
+	return false
+}


### PR DESCRIPTION
This PR is aiming to add JSONNET support for kubectl.
Since [go-jsonnet](https://github.com/google/go-jsonnet) is still in progress, this PR uses jsonnet binary to decode. So it requires pre-build jsonnet binary in your path.
Fixes #28943 .
