### PR TITLE
start k8s master by pod for ubuntu scripts

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -71,7 +71,7 @@ FLANNEL_OTHER_NET_CONFIG=''
 export ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,ResourceQuota
 
 # Path to the config file or directory of files of kubelet
-export KUBELET_CONFIG=${KUBELET_CONFIG:-""}
+export KUBELET_CONFIG=${KUBELET_CONFIG:-"/etc/default/kubeletconfig/master.json"}
 
 # A port range to reserve for services with NodePort visibility
 SERVICE_NODE_PORT_RANGE=${SERVICE_NODE_PORT_RANGE:-"30000-32767"}
@@ -119,3 +119,6 @@ DEBUG=${DEBUG:-"false"}
 
 # Add SSH_OPTS: Add this to config ssh port
 SSH_OPTS="-oPort=22 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"
+
+# Optional: When set to true, the kube-scheduler and kube-controller will started by kubelet in a pod
+STARTING_BY_CONTAINER=${STARTING_BY_CONTAINER:-"true"}

--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -85,6 +85,26 @@ grep -q "^${KUBE_VERSION}\$" binaries/.kubernetes 2>/dev/null || {
   echo ${KUBE_VERSION} > binaries/.kubernetes
 }
 
+# load the necessary images
+echo "load the kubernetes images ..."
+  sudo docker load -i kubernetes/server/kubernetes/server/bin/kube-controller-manager.tar
+  sudo docker load -i kubernetes/server/kubernetes/server/bin/kube-scheduler.tar
+
+
+# load the images and get the imagename
+  CONTROLLERTAG=$(sudo docker images |grep gcr.io/google_containers/kube-controller-manager |awk 'NR==1 {print $2}')
+  SCHEDULERTAG=$(sudo docker images |grep gcr.io/google_containers/kube-scheduler |awk 'NR==1 {print $2}')
+  
+  echo "load image: $CONTROLLERTAG"
+  echo "load image: $SCHEDULERTAG"
+  
+  cat <<EOF > ./imageinfo
+export IMAGECONTROLLER=gcr.io/google_containers/kube-controller-manager:${CONTROLLERTAG}
+export IMAGESCHEDULER=gcr.io/google_containers/kube-scheduler:${SCHEDULERTAG}
+EOF
+
+
+# if you want to reuse the tar files, you could delete following line
 rm -rf flannel* kubernetes* etcd*
 
 echo "Done! All your binaries locate in kubernetes/cluster/ubuntu/binaries directory"

--- a/cluster/ubuntu/master/kubeletconfig/master.json
+++ b/cluster/ubuntu/master/kubeletconfig/master.json
@@ -1,0 +1,44 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "name": "k8s-master"
+    },
+    "spec": {
+        "hostNetwork": true,
+        "containers": [
+            {
+                "name": "kube-controller-manager",
+                "image": "IMAGECONTROLLER",
+                "command": [
+                    "sh",
+                    "-c",
+                    "COMMANDCONTROLLER"
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/srv/kubernetes",
+                        "name": "certficate"
+                    }
+                ]
+            },
+            {
+                "name": "kube-scheduler",
+                "image": "IMAGESCHEDULER",
+                "command": [
+                    "sh",
+                    "-c",
+                    "COMMANDSCHEDULER"
+                ]
+            }
+        ],
+        "volumes": [
+            {
+                "name": "certficate",
+                "hostPath": {
+                    "path": "/srv/kubernetes"
+                }
+            }
+        ]
+    }
+}

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -251,6 +251,7 @@ KUBE_APISERVER_OPTS="\
  --tls-cert-file=/srv/kubernetes/server.cert\
  --tls-private-key-file=/srv/kubernetes/server.key"
 EOF
+
 }
 
 # Create ~/kube/default/kube-controller-manager with proper contents.
@@ -263,6 +264,16 @@ KUBE_CONTROLLER_MANAGER_OPTS="\
  --logtostderr=true"
 EOF
 
+  if [[ "$STARTING_BY_CONTAINER" == "true" ]] ; then
+    echo "replace the command template in pod config file"
+	echo "controller manager image:" ${IMAGECONTROLLER}
+	sed -i "s@IMAGECONTROLLER@${IMAGECONTROLLER}@g" ~/kube/kubeletconfig/master.json
+	
+   COMMANDCONTROLLER="kube-controller-manager --master=127.0.0.1:8080 --root-ca-file=/srv/kubernetes/ca.crt --service-account-private-key-file=/srv/kubernetes/server.key --logtostderr=true"	
+   
+   sed -i "s@COMMANDCONTROLLER@${COMMANDCONTROLLER}@g" ~/kube/kubeletconfig/master.json
+  fi 
+
 }
 
 # Create ~/kube/default/kube-scheduler with proper contents.
@@ -272,6 +283,16 @@ KUBE_SCHEDULER_OPTS="\
  --logtostderr=true\
  --master=127.0.0.1:8080"
 EOF
+
+  if [[ "$STARTING_BY_CONTAINER" == "true" ]] ; then
+    echo "replace the command template in pod config file"
+	echo "kube-scheduler image:" ${IMAGESCHEDULER}
+	sed -i "s@IMAGESCHEDULER@${IMAGESCHEDULER}@g" ~/kube/kubeletconfig/master.json
+	
+   COMMANDSCHEDULER="kube-scheduler --logtostderr=true --master=127.0.0.1:8080"
+		
+	sed -i "s@COMMANDSCHEDULER@${COMMANDSCHEDULER}@g" ~/kube/kubeletconfig/master.json
+  fi
 
 }
 
@@ -497,8 +518,9 @@ function provision-master() {
       '" || {
       echo "Deploying master on machine ${MASTER_IP} failed"
       exit 1
-    }
+   }
 }
+
 
 function provision-node() {
 
@@ -581,6 +603,78 @@ function provision-node() {
   }
 }
 
+
+function start-masterbypod() {
+  # remote login to the master/node and configue k8s
+  ssh $SSH_OPTS -t "$MASTER" "
+    set +e
+    ${BASH_DEBUG_FLAGS}
+    source ~/kube/util.sh
+	source ~/kube/config-default.sh 
+	export STARTING_BY_CONTAINER="true"
+   
+    setClusterInfo
+    create-etcd-opts '${MASTER_IP}'
+	
+	source ~/kube/imageinfo
+    create-kube-apiserver-opts \
+      '${SERVICE_CLUSTER_IP_RANGE}' \
+      '${ADMISSION_CONTROL}' \
+      '${SERVICE_NODE_PORT_RANGE}' \
+      '${MASTER_IP}' \
+      '${ALLOW_PRIVILEGED}'
+    create-kube-controller-manager-opts '${NODE_IPS}'
+    create-kube-scheduler-opts
+
+    create-kubelet-opts \
+      '${MASTER_IP}' \
+      '${MASTER_IP}' \
+      '${DNS_SERVER_IP}' \
+      '${DNS_DOMAIN}' \
+      '${KUBELET_CONFIG}' \
+      '${ALLOW_PRIVILEGED}' \
+      '${CNI_PLUGIN_CONF}'
+    create-kube-proxy-opts \
+      '${MASTER_IP}' \
+      '${MASTER_IP}' \
+      '${KUBE_PROXY_EXTRA_OPTS}'
+    create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
+
+    FLANNEL_OTHER_NET_CONFIG='${FLANNEL_OTHER_NET_CONFIG}' sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
+      ${BASH_DEBUG_FLAGS}
+      cp ~/kube/default/flanneld /etc/default/
+	  cp ~/kube/default/etcd /etc/default/
+	  cp ~/kube/default/kube-proxy /etc/default/
+	  cp ~/kube/default/kube-apiserver /etc/default/
+	  cp ~/kube/default/kubelet /etc/default/
+	
+	  cp -r ~/kube/kubeletconfig /etc/default/
+      cp ~/kube/init_conf/etcd* /etc/init/
+      cp ~/kube/init_scripts/etcd* /etc/init.d/
+	  cp ~/kube/init_conf/flanneld* /etc/init/
+      cp ~/kube/init_scripts/flanneld* /etc/init.d/
+	  cp ~/kube/init_conf/kube-apiserver* /etc/init/
+      cp ~/kube/init_scripts/kube-apiserver* /etc/init.d/
+	  cp ~/kube/init_conf/kubelet* /etc/init/
+      cp ~/kube/init_scripts/kubelet* /etc/init.d/
+	  cp ~/kube/init_conf/kube-proxy* /etc/init/
+      cp ~/kube/init_scripts/kube-proxy* /etc/init.d/
+
+
+      groupadd -f -r kube-cert
+      ${PROXY_SETTING} DEBUG='${DEBUG}' ~/kube/make-ca-cert.sh \"${MASTER_IP}\" \"${EXTRA_SANS}\"
+      mkdir -p /opt/bin/
+      cp ~/kube/master/* /opt/bin/
+      cp ~/kube/minion/* /opt/bin/
+
+      service etcd start
+      if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" ~/kube/reconfDocker.sh ai; fi
+      '" || {
+      echo "Deploying master and node on machine ${MASTER_IP} failed"
+	  exit 1
+	}
+}
+
 function provision-masterandnode() {
 
   echo -e "\nDeploying master and node on machine ${MASTER_IP}"
@@ -594,6 +688,7 @@ function provision-masterandnode() {
     easy-rsa.tar.gz \
     "${KUBE_CONFIG_FILE}" \
     ubuntu/util.sh \
+    ubuntu/imageinfo \
     ubuntu/minion/* \
     ubuntu/master/* \
     ubuntu/reconfDocker.sh \
@@ -638,6 +733,10 @@ function provision-masterandnode() {
     BASH_DEBUG_FLAGS="set -x"
   fi
 
+  if [[ "$STARTING_BY_CONTAINER" == "true" ]] ; then
+    echo "start the master component by pod"
+	start-masterbypod
+  else
   # remote login to the master/node and configue k8s
   ssh $SSH_OPTS -t "$MASTER" "
     set +e
@@ -684,8 +783,11 @@ function provision-masterandnode() {
       if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" ~/kube/reconfDocker.sh ai; fi
       '" || {
       echo "Deploying master and node on machine ${MASTER_IP} failed"
-      exit 1
-  }
+	  exit 1      
+    }
+  	
+	fi
+
 }
 
 # check whether kubelet has torn down all of the pods


### PR DESCRIPTION
Just as @resouer mentioned in  [#23241](https://github.com/kubernetes/kubernetes/issues/23241#issuecomment-232616567), this pr add the capability to start the kube-controller-manager and kube-scheduler in a pod for ubuntu scripts. 
if set the env STARTING_BY_CONTAINER=true the kube-controller-manager and kube-scheduler will started by a pod when the node identity is ai , if set the env STARTING_BY_CONTAINER=false, the component will be started in original upstart way.

```
$ export KUBE_VERSION=1.3.0
$ export FLANNEL_VERSION=0.5.0
$ export ETCD_VERSION=2.2.0
$ export nodes="parallels@10.211.55.5"
$ export role="ai"
$ export NUM_NODES=${NUM_NODES:-1}
$ export SERVICE_CLUSTER_IP_RANGE=192.168.3.0/24
$ export FLANNEL_NET=172.16.0.0/16
$ export STARTING_BY_CONTAINER=true
$ KUBERNETES_PROVIDER=ubuntu ./kube-up.sh

...

Validating parallels@10.211.55.5parallels@10.211.55.5's password: 
parallels@10.211.55.5's password: 
parallels@10.211.55.5's password: 

Using master 10.211.55.5
cluster "ubuntu" set.
user "ubuntu" set.
context "ubuntu" set.
switched to context "ubuntu".
Wrote config for ubuntu to /home/parallels/.kube/config
... calling validate-cluster
Found 1 node(s).
NAME          STATUS    AGE
10.211.55.5   Ready     38s
Validate output:
NAME                 STATUS    MESSAGE              ERROR
controller-manager   Healthy   ok                   
scheduler            Healthy   ok                   
etcd-0               Healthy   {"health": "true"}   
Cluster validation succeeded
Done, listing cluster services:

Kubernetes master is running at http://10.211.55.5:8080

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.


# ./kubectl get pod
NAME                     READY     STATUS    RESTARTS   AGE
k8s-master-10.211.55.5   2/2       Running   2          3m
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29180)

<!-- Reviewable:end -->
