### PR TITLE
Node E2E: Add document for node e2e --disable-kubenet flag.

### DIFF
--- a/docs/devel/e2e-node-tests.md
+++ b/docs/devel/e2e-node-tests.md
@@ -205,6 +205,26 @@ less useful for catching flakes related creating the instance from an image.**
 make test-e2e-node REMOTE=true RUN_UNTIL_FAILURE=true
 ```
 
+## Run tests with kubenet network plugin
+
+[kubenet](http://kubernetes.io/docs/admin/network-plugins/#kubenet) is
+the default network plugin used by kubelet since Kubernetes 1.3.  The
+plugin requires [CNI](https://github.com/containernetworking/cni) and
+[nsenter](http://man7.org/linux/man-pages/man1/nsenter.1.html).
+
+Currently, kubenet is enabled by default for Remote execution `REMOTE=true`,
+but disabled for Local execution.  **Note: kubenet is not supported for
+local execution currently. This may cause network related test result to be
+different for Local and Remote execution. So if you want to run network
+related test, Remote execution is recommended.**
+
+To enable/disable kubenet:
+
+```sh
+make test_e2e_node TEST_ARGS="--disable-kubenet=true" # enable kubenet
+make test_e2e_node TEST_ARGS="--disable-kubenet=false" # disable kubenet
+```
+
 ## Additional QoS Cgroups Hierarchy level testing
 
 For testing with the QoS Cgroup Hierarchy enabled, you can pass --cgroups-per-qos flag as an argument into Ginkgo using TEST_ARGS

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -127,10 +127,15 @@ else
     sudo -v || exit 1
   fi
 
+  # If the flag --disable-kubenet is not set, set true by default.
+  if ! [[ $test_args =~ "--disable-kubenet" ]]; then
+    test_args="$test_args --disable-kubenet=true"
+  fi
   # Test using the host the script was run on
   # Provided for backwards compatibility
+  set -x
   "${ginkgo}" --focus=$focus --skip=$skip "${KUBE_ROOT}/test/e2e_node/" --report-dir=${report} \
-    -- --alsologtostderr --v 2 --node-name $(hostname) --disable-kubenet=true --build-services=true \
-    --start-services=true --stop-services=true "$test_args"
+    -- --alsologtostderr --v 2 --node-name $(hostname) --build-services=false \
+    --start-services=true --stop-services=true $test_args
   exit $?
 fi


### PR DESCRIPTION
Address the comment https://github.com/kubernetes/kubernetes/pull/28213#discussion_r70137103.
Offline discussed with @vishh, we should document the `--disable-kubenet` flag in node e2e test.
