### PR TITLE
Fix make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ KUBE_GOFLAGS := $(GOFLAGS)
 KUBE_GOLDFLAGS := $(GOLDFLAGS)
 
 GOGCFLAGS ?=
+BRANCH ?=
 KUBE_GOGCFLAGS = $(GOGCFLAGS)
 export KUBE_GOGCFLAGS GOGCFLAGS
 
@@ -94,6 +95,7 @@ ginkgo:
 .PHONY: verify
 verify:
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh -v
+	hack/make-rules/vet.sh
 
 # Build and run tests.
 #

--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -38,4 +38,4 @@ export LOG_LEVEL=4
 cd /go/src/k8s.io/kubernetes
 
 ./hack/install-etcd.sh
-make verify VERBOSE=1
+make verify

--- a/hack/jenkins/verify.sh
+++ b/hack/jenkins/verify.sh
@@ -34,4 +34,4 @@ export PATH=${GOPATH}/bin:${HOME}/third_party/etcd:/usr/local/go/bin:$PATH
 command -v etcd &>/dev/null || ./hack/install-etcd.sh
 go get -u github.com/tools/godep
 
-make verify VERBOSE=1
+make verify

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -21,15 +21,10 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/lib/util.sh"
 
-if [ -n "${VERBOSE}" ]; then
-    SILENT=false
-else
-    SILENT=true
-fi
-
 # Excluded checks are always skipped.
 EXCLUDED_CHECKS=(
   "verify-linkcheck.sh"  # runs in separate Jenkins job once per day due to high network usage
+  "verify-govet.sh"      # it has a separate make vet target
   )
 
 function is-excluded {


### PR DESCRIPTION
@thockin this fixes `make verify` which was previously failing due to undefined `BRANCH` and `VERBOSE` variables, ptal
