### PR TITLE
Create client from API version passed in config or use default

### DIFF
--- a/pkg/client/unversioned/apps.go
+++ b/pkg/client/unversioned/apps.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -38,7 +36,7 @@ func (c *AppsClient) PetSets(namespace string) PetSetInterface {
 
 func NewApps(c *restclient.Config) (*AppsClient, error) {
 	config := *c
-	if err := setAppsDefaults(&config); err != nil {
+	if err := setGroupDefaults(apps.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -54,23 +52,4 @@ func NewAppsOrDie(c *restclient.Config) *AppsClient {
 		panic(err)
 	}
 	return client
-}
-
-func setAppsDefaults(config *restclient.Config) error {
-	g, err := registered.Group(apps.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/client/unversioned/autoscaling.go
+++ b/pkg/client/unversioned/autoscaling.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -38,7 +36,7 @@ func (c *AutoscalingClient) HorizontalPodAutoscalers(namespace string) Horizonta
 
 func NewAutoscaling(c *restclient.Config) (*AutoscalingClient, error) {
 	config := *c
-	if err := setAutoscalingDefaults(&config); err != nil {
+	if err := setGroupDefaults(autoscaling.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -54,24 +52,4 @@ func NewAutoscalingOrDie(c *restclient.Config) *AutoscalingClient {
 		panic(err)
 	}
 	return client
-}
-
-func setAutoscalingDefaults(config *restclient.Config) error {
-	// if autoscaling group is not registered, return an error
-	g, err := registered.Group(autoscaling.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/client/unversioned/batch.go
+++ b/pkg/client/unversioned/batch.go
@@ -17,11 +17,7 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/batch"
-	"k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
@@ -45,19 +41,7 @@ func (c *BatchClient) ScheduledJobs(namespace string) ScheduledJobInterface {
 
 func NewBatch(c *restclient.Config) (*BatchClient, error) {
 	config := *c
-	if err := setBatchDefaults(&config, nil); err != nil {
-		return nil, err
-	}
-	client, err := restclient.RESTClientFor(&config)
-	if err != nil {
-		return nil, err
-	}
-	return &BatchClient{client}, nil
-}
-
-func NewBatchV2Alpha1(c *restclient.Config) (*BatchClient, error) {
-	config := *c
-	if err := setBatchDefaults(&config, &v2alpha1.SchemeGroupVersion); err != nil {
+	if err := setGroupDefaults(batch.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -68,40 +52,9 @@ func NewBatchV2Alpha1(c *restclient.Config) (*BatchClient, error) {
 }
 
 func NewBatchOrDie(c *restclient.Config) *BatchClient {
-	var (
-		client *BatchClient
-		err    error
-	)
-	if c.ContentConfig.GroupVersion != nil && *c.ContentConfig.GroupVersion == v2alpha1.SchemeGroupVersion {
-		client, err = NewBatchV2Alpha1(c)
-	} else {
-		client, err = NewBatch(c)
-	}
+	client, err := NewBatch(c)
 	if err != nil {
 		panic(err)
 	}
 	return client
-}
-
-func setBatchDefaults(config *restclient.Config, gv *unversioned.GroupVersion) error {
-	// if batch group is not registered, return an error
-	g, err := registered.Group(batch.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	if gv != nil {
-		copyGroupVersion = *gv
-	}
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/client/unversioned/certificates.go
+++ b/pkg/client/unversioned/certificates.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -60,22 +58,7 @@ func NewCertificatesOrDie(c *restclient.Config) *CertificatesClient {
 }
 
 func setCertificatesDefaults(config *restclient.Config) error {
-	// if certificates group is not registered, return an error
-	g, err := registered.Group(certificates.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
+	setGroupDefaults(certificates.GroupName, config)
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -88,7 +86,7 @@ func (c *ExtensionsClient) ReplicaSets(namespace string) ReplicaSetInterface {
 // incompatible ways at any time.
 func NewExtensions(c *restclient.Config) (*ExtensionsClient, error) {
 	config := *c
-	if err := setExtensionsDefaults(&config); err != nil {
+	if err := setGroupDefaults(extensions.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -108,24 +106,4 @@ func NewExtensionsOrDie(c *restclient.Config) *ExtensionsClient {
 		panic(err)
 	}
 	return client
-}
-
-func setExtensionsDefaults(config *restclient.Config) error {
-	// if experimental group is not registered, return an error
-	g, err := registered.Group(extensions.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -258,16 +258,35 @@ func SetKubernetesDefaults(config *restclient.Config) error {
 	if config.APIPath == "" {
 		config.APIPath = legacyAPIPath
 	}
-	g, err := registered.Group(api.GroupName)
-	if err != nil {
-		return err
+	if config.GroupVersion == nil || config.GroupVersion.Group != api.GroupName {
+		g, err := registered.Group(api.GroupName)
+		if err != nil {
+			return err
+		}
+		copyGroupVersion := g.GroupVersion
+		config.GroupVersion = &copyGroupVersion
 	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
 	if config.NegotiatedSerializer == nil {
 		config.NegotiatedSerializer = api.Codecs
 	}
-
 	return restclient.SetKubernetesDefaults(config)
+}
+
+func setGroupDefaults(groupName string, config *restclient.Config) error {
+	config.APIPath = defaultAPIPath
+	if config.UserAgent == "" {
+		config.UserAgent = restclient.DefaultKubernetesUserAgent()
+	}
+	if config.GroupVersion == nil || config.GroupVersion.Group != groupName {
+		g, err := registered.Group(groupName)
+		if err != nil {
+			return err
+		}
+		copyGroupVersion := g.GroupVersion
+		config.GroupVersion = &copyGroupVersion
+	}
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = api.Codecs
+	}
+	return nil
 }

--- a/pkg/client/unversioned/policy.go
+++ b/pkg/client/unversioned/policy.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -38,7 +36,7 @@ func (c *PolicyClient) PodDisruptionBudgets(namespace string) PodDisruptionBudge
 
 func NewPolicy(c *restclient.Config) (*PolicyClient, error) {
 	config := *c
-	if err := setPolicyDefaults(&config); err != nil {
+	if err := setGroupDefaults(policy.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -54,23 +52,4 @@ func NewPolicyOrDie(c *restclient.Config) *PolicyClient {
 		panic(err)
 	}
 	return client
-}
-
-func setPolicyDefaults(config *restclient.Config) error {
-	g, err := registered.Group(policy.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/client/unversioned/rbac.go
+++ b/pkg/client/unversioned/rbac.go
@@ -17,8 +17,6 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
@@ -54,7 +52,7 @@ func (c *RbacClient) ClusterRoles() ClusterRoleInterface {
 // NewRbac creates a new RbacClient for the given config.
 func NewRbac(c *restclient.Config) (*RbacClient, error) {
 	config := *c
-	if err := setRbacDefaults(&config); err != nil {
+	if err := setGroupDefaults(rbac.GroupName, &config); err != nil {
 		return nil, err
 	}
 	client, err := restclient.RESTClientFor(&config)
@@ -72,25 +70,4 @@ func NewRbacOrDie(c *restclient.Config) *RbacClient {
 		panic(err)
 	}
 	return client
-}
-
-func setRbacDefaults(config *restclient.Config) error {
-	// if rbac group is not registered, return an error
-	g, err := registered.Group(rbac.GroupName)
-	if err != nil {
-		return err
-	}
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-
-	// TODO: Unconditionally set the config.Version, until we fix the config.
-	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
-	config.GroupVersion = &copyGroupVersion
-	//}
-
-	config.NegotiatedSerializer = api.Codecs
-	return nil
 }

--- a/pkg/kubectl/cmd/util/clientcache.go
+++ b/pkg/kubectl/cmd/util/clientcache.go
@@ -76,12 +76,12 @@ func (c *ClientCache) ClientConfigForVersion(version *unversioned.GroupVersion) 
 		preferredGV = &versionCopy
 	}
 
+	client.SetKubernetesDefaults(&config)
 	negotiatedVersion, err := client.NegotiateVersion(c.defaultClient, &config, preferredGV, registered.EnabledVersions())
 	if err != nil {
 		return nil, err
 	}
 	config.GroupVersion = negotiatedVersion
-	client.SetKubernetesDefaults(&config)
 
 	if version != nil {
 		c.configs[*version] = &config

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -343,49 +343,29 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			return clients.ClientConfigForVersion(nil)
 		},
 		ClientForMapping: func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
-			gvk := mapping.GroupVersionKind
-			mappingVersion := mapping.GroupVersionKind.GroupVersion()
-			c, err := clients.ClientForVersion(&mappingVersion)
+			cfg, err := clientConfig.ClientConfig()
 			if err != nil {
 				return nil, err
 			}
-			switch gvk.Group {
-			case api.GroupName:
-				return c.RESTClient, nil
-			case autoscaling.GroupName:
-				return c.AutoscalingClient.RESTClient, nil
-			case batch.GroupName:
-				return c.BatchClient.RESTClient, nil
-			case policy.GroupName:
-				return c.PolicyClient.RESTClient, nil
-			case apps.GroupName:
-				return c.AppsClient.RESTClient, nil
-			case extensions.GroupName:
-				return c.ExtensionsClient.RESTClient, nil
-			case api.SchemeGroupVersion.Group:
-				return c.RESTClient, nil
-			case extensions.SchemeGroupVersion.Group:
-				return c.ExtensionsClient.RESTClient, nil
-			case federation.GroupName:
-				return clients.FederationClientForVersion(&mappingVersion)
-			case rbac.GroupName:
-				return c.RbacClient.RESTClient, nil
-			case certificates.GroupName:
-				return c.CertificatesClient.RESTClient, nil
-			default:
-				if !registered.IsThirdPartyAPIGroupVersion(gvk.GroupVersion()) {
-					return nil, fmt.Errorf("unknown api group/version: %s", gvk.String())
-				}
-				cfg, err := clientConfig.ClientConfig()
-				if err != nil {
-					return nil, err
-				}
-				gv := gvk.GroupVersion()
-				cfg.GroupVersion = &gv
-				cfg.APIPath = "/apis"
-				cfg.NegotiatedSerializer = thirdpartyresourcedata.NewNegotiatedSerializer(api.Codecs, gvk.Kind, gv, gv)
-				return restclient.RESTClientFor(cfg)
+			if err := client.SetKubernetesDefaults(cfg); err != nil {
+				return nil, err
 			}
+			gvk := mapping.GroupVersionKind
+			switch gvk.Group {
+			case federation.GroupName:
+				mappingVersion := mapping.GroupVersionKind.GroupVersion()
+				return clients.FederationClientForVersion(&mappingVersion)
+			case api.GroupName:
+				cfg.APIPath = "/api"
+			default:
+				cfg.APIPath = "/apis"
+			}
+			gv := gvk.GroupVersion()
+			cfg.GroupVersion = &gv
+			if registered.IsThirdPartyAPIGroupVersion(gvk.GroupVersion()) {
+				cfg.NegotiatedSerializer = thirdpartyresourcedata.NewNegotiatedSerializer(api.Codecs, gvk.Kind, gv, gv)
+			}
+			return restclient.RESTClientFor(cfg)
 		},
 		Describer: func(mapping *meta.RESTMapping) (kubectl.Describer, error) {
 			mappingVersion := mapping.GroupVersionKind.GroupVersion()


### PR DESCRIPTION
When creating a client read the `GroupVersion` value passed in the `restclient.Config`. If the passed `GroupVersion` does not match current group or is not enabled fallback to default `GroupVersion` for that group.

This PR should allow accessing `ScheduledJob` properly in `batch/v2alpha1`.

@smarterclayton @deads2k @caesarxuchao @lavalamp ptal
