### PR TITLE
Fix the incorrect Errorf output object function.Name

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
@@ -941,10 +941,10 @@ func TestPrioritiesRegistered(t *testing.T) {
 		if err != nil {
 			switch err.Error() {
 			case "exit status 2":
-				t.Errorf("unexpected error when checking %s", function.Name)
+				t.Errorf("unexpected error when checking %s", function.Name.Name)
 			case "exit status 1":
 				t.Errorf("priority %s is implemented as public but seems not registered or used in any other place",
-					function.Name)
+					function.Name.Name)
 			}
 		}
 	}


### PR DESCRIPTION
The Errorf output object "function.Name" should be "function.Name.Name" because the err is caused by execing args "function.Name.Name":

```
    args := []string{"-rl", function.Name.Name}
    args = append(args, targetFiles...)
    err := exec.Command("grep", args...).Run()
    if err != nil {
        switch err.Error() {
        case "exit status 2":
            t.Errorf("unexpected error when checking %s", function.Name)
```
