### PR TITLE
kubelet/cni: lock pod network setup operations

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -19,6 +19,7 @@ package cni
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/appc/cni/libcni"
 	cnitypes "github.com/appc/cni/pkg/types"
@@ -43,6 +44,8 @@ type cniNetworkPlugin struct {
 	host           network.Host
 	execer         utilexec.Interface
 	nsenterPath    string
+	mu             sync.Mutex
+	podMutexes     map[string]*sync.Mutex
 }
 
 type cniNetwork struct {
@@ -60,6 +63,7 @@ func probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, vendorCNIDirPrefix str
 	return append(configList, &cniNetworkPlugin{
 		defaultNetwork: network,
 		execer:         utilexec.New(),
+		podMutexes:     make(map[string]*sync.Mutex),
 	})
 }
 
@@ -112,7 +116,23 @@ func (plugin *cniNetworkPlugin) Name() string {
 	return CNIPluginName
 }
 
+func (plugin *cniNetworkPlugin) lockPodMutex(id kubecontainer.ContainerID) *sync.Mutex {
+	plugin.mu.Lock()
+	defer plugin.mu.Unlock()
+
+	podMutex, ok := plugin.podMutexes[id.ID]
+	if !ok {
+		podMutex = &sync.Mutex{}
+		plugin.podMutexes[id.ID] = podMutex
+	}
+	podMutex.Lock()
+	return podMutex
+}
+
 func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+	podMutex := plugin.lockPodMutex(id)
+	defer podMutex.Unlock()
+
 	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
 	if err != nil {
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
@@ -128,6 +148,10 @@ func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubec
 }
 
 func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.ContainerID) error {
+	podMutex := plugin.lockPodMutex(id)
+	defer podMutex.Unlock()
+	defer delete(plugin.podMutexes, id.ID)
+
 	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
 	if err != nil {
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
@@ -139,6 +163,9 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 // TODO: Use the addToNetwork function to obtain the IP of the Pod. That will assume idempotent ADD call to the plugin.
 // Also fix the runtime's call to Status function to be done only in the case that the IP is lost, no need to do periodic calls
 func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
+	podMutex := plugin.lockPodMutex(id)
+	defer podMutex.Unlock()
+
 	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
 	if err != nil {
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)


### PR DESCRIPTION
Depending on goroutine scheduling it could happen that kubelet requests
status for a pod before network setup is complete, and for CNI that can
return an error which will cause the pod to fail.  Prevent that from
happening by locking network operations on a pod level.

```
Jul 18 20:50:11 openshift-node-2 openshift[296]: I0718 20:50:11.948186     296 docker_manager.go:360] Container inspect result: {ContainerJSONBase:0xc820e7ba20 Mounts:[] Config:0
xc82117fc20 NetworkSettings:0xc820c20d00}
Jul 18 20:50:11 openshift-node-2 openshift[296]: E0718 20:50:11.958239     296 docker_manager.go:345] NetworkPlugin cni failed on the status hook for pod 'hi-openshift' - Unexpected command output Device "eth0" does not exist.
Jul 18 20:50:11 openshift-node-2 openshift[296]:  with error: exit status 1
Jul 18 20:50:11 openshift-node-2 openshift[296]: I0718 20:50:11.958263     296 generic.go:329] PLEG: Write status for hi-openshift/default: &{ID:375d0b17-4d29-11e6-b25d-0242a73d1e4e Name:hi-openshift Namespace:default IP: ContainerStatuses:[0xc820aa50a0]} (err: <nil>)
Jul 18 20:50:11 openshift-node-2 openshift[296]: I0718 20:50:11.958350     296 kubelet.go:2577] SyncLoop (PLEG): "hi-openshift_default(375d0b17-4d29-11e6-b25d-0242a73d1e4e)", event: &pleg.PodLifecycleEvent{ID:"375d0b17-4d29-11e6-b25d-0242a73d1e4e", Type:"ContainerStarted", Data:"cf3c2a446986e37a1211c8c691ff1559a389d1f5cfcbf978ca80b92d7c67f379"}
Jul 18 20:50:11 openshift-node-2 ovs-vsctl[567]: ovs|00001|vsctl|INFO|Called as ovs-vsctl add-port br0 veth515343ed
Jul 18 20:50:12 openshift-node-2 ovs-vsctl[574]: ovs|00001|vsctl|INFO|Called as ovs-vsctl create qos type=linux-htb other-config:max-rate=10000000
Jul 18 20:50:12 openshift-node-2 ovs-vsctl[575]: ovs|00001|vsctl|INFO|Called as ovs-vsctl set port veth515343ed qos=d4ec8812-6818-424d-b5c6-0c227fbd914b
Jul 18 20:50:12 openshift-node-2 ovs-vsctl[576]: ovs|00001|vsctl|INFO|Called as ovs-vsctl set interface veth515343ed ingress_policing_rate=5000
Jul 18 20:50:12 openshift-node-2 openshift[296]: I0718 20:50:12.032996     296 docker_manager.go:2082] Creating container &{Name:hi-openshift Image:dcbw/fedora-net Command:[sleep 450] Args:[] WorkingDir: Ports:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:default-token-ouk9m ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath:}] LivenessProbe:<nil> ReadinessProbe:<nil> Lifecycle:<nil> TerminationMessagePath:/dev/termination-log ImagePullPolicy:Always SecurityContext:0xc821307d70 Stdin:false StdinOnce:false TTY:false} in pod hi-openshift_default(375d0b17-4d29-11e6-b25d-0242a73d1e4e)
```
