### PR TITLE
add IsDNS4592WildcardSubdomain method

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3198,7 +3198,7 @@ func ValidateLoadBalancerStatus(status *api.LoadBalancerStatus, fldPath *field.P
 			}
 		}
 		if len(ingress.Hostname) > 0 {
-			for _, msg := range validation.IsDNS4592WildcardSubdomain(ingress.Hostname) {
+			for _, msg := range validation.IsDNS1123Subdomain(ingress.Hostname) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("hostname"), ingress.Hostname, msg))
 			}
 			if isIP := (net.ParseIP(ingress.Hostname) != nil); isIP {

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3198,7 +3198,7 @@ func ValidateLoadBalancerStatus(status *api.LoadBalancerStatus, fldPath *field.P
 			}
 		}
 		if len(ingress.Hostname) > 0 {
-			for _, msg := range validation.IsDNS1123Subdomain(ingress.Hostname) {
+			for _, msg := range validation.IsDNS4592WildcardSubdomain(ingress.Hostname) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("hostname"), ingress.Hostname, msg))
 			}
 			if isIP := (net.ParseIP(ingress.Hostname) != nil); isIP {

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -367,7 +367,7 @@ func validateIngressRules(IngressRules []extensions.IngressRule, fldPath *field.
 		if len(ih.Host) > 0 {
 			// TODO: Ports and ips are allowed in the host part of a url
 			// according to RFC 3986, consider allowing them.
-			for _, msg := range validation.IsDNS1123Subdomain(ih.Host) {
+			for _, msg := range validation.IsDNS4592WildcardSubdomain(ih.Host) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("host"), ih.Host, msg))
 			}
 			if isIP := (net.ParseIP(ih.Host) != nil); isIP {

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -121,6 +121,23 @@ func IsDNS1123Subdomain(value string) []string {
 	return errs
 }
 
+const dns4592WildcardFmt string = "(\\*\\.)?"
+
+var dns4592WildcardSubdomainRegexp = regexp.MustCompile("^" + dns4592WildcardFmt + dns1123SubdomainFmt + "$")
+
+//IsDNS4592WildcardSubdomain tests for a string that conforms to the definition
+// of a subdomain in DNS (RFC 4592)
+func isDNS4592WildcardSubdomain(value string) []string {
+	var errs []string
+	if len(value) > DNS1123SubdomainMaxLength {
+		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	}
+	if !dns4592WildcardSubdomainRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns4592WildcardFmt+dns1123SubdomainFmt, "*.example.com"))
+	}
+	return errs
+}
+
 const dns952LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 const DNS952LabelMaxLength int = 24
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -86,6 +86,46 @@ func TestIsDNS1123Subdomain(t *testing.T) {
 	}
 }
 
+func TestIsDNS4592WildcardSubdomain(t *testing.T) {
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		"a.a", "ab.a", "abc.a", "a1.a", "a-1.a", "a--1--2--b.a",
+		"a.1", "ab.1", "abc.1", "a1.1", "a-1.1", "a--1--2--b.1",
+		"0.a", "01.a", "012.a", "1a.a", "1-a.a", "1--a--b--2",
+		"0.1", "01.1", "012.1", "1a.1", "1-a.1", "1--a--b--2.1",
+		"a.b.c.d.e", "aa.bb.cc.dd.ee", "1.2.3.4.5", "11.22.33.44.55",
+		"*.a", "*.aa.b",
+		strings.Repeat("a", 253),
+	}
+	for _, val := range goodValues {
+		if msgs := isDNS4592WildcardSubdomain(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
+	}
+
+	badValues := []string{
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a..b", "1.", ".1", "1..2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		"A.a", "aB.a", "ab.A", "A1.a", "a1.A",
+		"A.1", "aB.1", "A1.1", "1A.1",
+		"0.A", "01.A", "012.A", "1A.a", "1a.A",
+		"A.B.C.D.E", "AA.BB.CC.DD.EE", "a.B.c.d.e", "aa.bB.cc.dd.ee",
+		"a@b", "a,b", "a_b", "a;b",
+		"a:b", "a%b", "a?b", "a$b",
+		"*a", "**.a", "a.*.b",
+		strings.Repeat("a", 254),
+	}
+	for _, val := range badValues {
+		if msgs := isDNS4592WildcardSubdomain(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}
+
 func TestIsDNS952Label(t *testing.T) {
 	goodValues := []string{
 		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",


### PR DESCRIPTION
I would like to get the ball rolling with this pull request.  For some reason when I am running the tests pkg/api/validation/validation.go can not find the new method IsDNS4592WildcardSubdomain, but this is the essence of what I would like to change.  I created this pull request to help get the conversation going.

referencing issue https://github.com/kubernetes/kubernetes/issues/29151
