### PR TITLE
Run goimport for the whole repo

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
@@ -19,6 +19,7 @@ package stubs
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 

--- a/federation/pkg/federation-controller/service/cluster_helper.go
+++ b/federation/pkg/federation-controller/service/cluster_helper.go
@@ -31,9 +31,10 @@ import (
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 
+	"reflect"
+
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
-	"reflect"
 )
 
 type clusterCache struct {

--- a/federation/registry/cluster/strategy_test.go
+++ b/federation/registry/cluster/strategy_test.go
@@ -19,13 +19,14 @@ package cluster
 import (
 	"testing"
 
+	"reflect"
+
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
-	"reflect"
 )
 
 func validNewCluster() *federation.Cluster {

--- a/pkg/api/service/util_test.go
+++ b/pkg/api/service/util_test.go
@@ -19,9 +19,10 @@ package service
 import (
 	"testing"
 
+	"strings"
+
 	"k8s.io/kubernetes/pkg/api"
 	netsets "k8s.io/kubernetes/pkg/util/net/sets"
-	"strings"
 )
 
 func TestGetLoadBalancerSourceRanges(t *testing.T) {

--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -19,10 +19,11 @@ package apiserver
 import (
 	"net/http"
 
+	"time"
+
 	"k8s.io/kubernetes/pkg/probe"
 	httpprober "k8s.io/kubernetes/pkg/probe/http"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
-	"time"
 )
 
 const (

--- a/pkg/apiserver/validator_test.go
+++ b/pkg/apiserver/validator_test.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/probe"
 	"net/http"
 	"net/url"
 	"time"
+
+	"k8s.io/kubernetes/pkg/probe"
 )
 
 type fakeHttpProber struct {

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -30,8 +30,9 @@ import (
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 
-	"github.com/golang/glog"
 	"net/http"
+
+	"github.com/golang/glog"
 )
 
 const maxTriesPerEvent = 12

--- a/pkg/client/restclient/client_test.go
+++ b/pkg/client/restclient/client_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/gcfg.v1"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -39,7 +41,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/golang/glog"
-	"gopkg.in/gcfg.v1"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/service"

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -23,9 +23,11 @@ import (
 	"net"
 	"regexp"
 
+	"golang.org/x/net/context"
+
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/detector"
-	"golang.org/x/net/context"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"gopkg.in/gcfg.v1"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/gcfg.v1"
+
+	"github.com/golang/glog"
 	"github.com/rackspace/gophercloud"
 	osvolumeattach "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	osservers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
@@ -36,9 +39,7 @@ import (
 	"github.com/rackspace/gophercloud/rackspace/blockstorage/v1/volumes"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/volumeattach"
-	"gopkg.in/gcfg.v1"
 
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -25,6 +25,9 @@ import (
 	"path"
 	"strings"
 
+	"gopkg.in/gcfg.v1"
+
+	"github.com/golang/glog"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -32,9 +35,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
-	"gopkg.in/gcfg.v1"
 
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/util/runtime"

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/endpoints"

--- a/pkg/controller/node/cidr_set_test.go
+++ b/pkg/controller/node/cidr_set_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package node
 
 import (
-	"github.com/golang/glog"
 	"math/big"
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/golang/glog"
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {

--- a/pkg/controller/petset/identity_mappers_test.go
+++ b/pkg/controller/petset/identity_mappers_test.go
@@ -21,9 +21,10 @@ import (
 	"reflect"
 	"strings"
 
+	"testing"
+
 	"k8s.io/kubernetes/pkg/api"
 	api_pod "k8s.io/kubernetes/pkg/api/pod"
-	"testing"
 )
 
 func TestPetIDName(t *testing.T) {

--- a/pkg/controller/petset/iterator_test.go
+++ b/pkg/controller/petset/iterator_test.go
@@ -19,9 +19,10 @@ package petset
 import (
 	"fmt"
 
+	"testing"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/sets"
-	"testing"
 )
 
 func TestPetQueueCreates(t *testing.T) {

--- a/pkg/dns/treecache.go
+++ b/pkg/dns/treecache.go
@@ -19,8 +19,9 @@ package dns
 import (
 	"bytes"
 	"encoding/json"
-	skymsg "github.com/skynetservices/skydns/msg"
 	"strings"
+
+	skymsg "github.com/skynetservices/skydns/msg"
 )
 
 type TreeCache struct {

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	"fmt"
+	"net"
+	"strings"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	"net"
-	"strings"
 )
 
 func checkAllLines(t *testing.T, table utiliptables.Table, save []byte, expectedLines map[utiliptables.Chain]string) {

--- a/pkg/registry/componentstatus/rest.go
+++ b/pkg/registry/componentstatus/rest.go
@@ -19,12 +19,13 @@ package componentstatus
 import (
 	"fmt"
 
+	"sync"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/probe"
 	httpprober "k8s.io/kubernetes/pkg/probe/http"
 	"k8s.io/kubernetes/pkg/runtime"
-	"sync"
 )
 
 type REST struct {

--- a/pkg/registry/componentstatus/rest_test.go
+++ b/pkg/registry/componentstatus/rest_test.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 	"testing"
 
+	"net/http"
+	"net/url"
+	"time"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/probe"
 	"k8s.io/kubernetes/pkg/util/diff"
-	"net/http"
-	"net/url"
-	"time"
 )
 
 type fakeHttpProber struct {

--- a/pkg/registry/podsecuritypolicy/strategy.go
+++ b/pkg/registry/podsecuritypolicy/strategy.go
@@ -18,6 +18,7 @@ package podsecuritypolicy
 
 import (
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/extensions"

--- a/pkg/security/podsecuritypolicy/capabilities/mustrunas_test.go
+++ b/pkg/security/podsecuritypolicy/capabilities/mustrunas_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package capabilities
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"reflect"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
 )
 
 func TestGenerateAdds(t *testing.T) {

--- a/pkg/util/flowcontrol/backoff_test.go
+++ b/pkg/util/flowcontrol/backoff_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package flowcontrol
 
 import (
-	"k8s.io/kubernetes/pkg/util/clock"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/pkg/util/clock"
 )
 
 func TestSlowBackoff(t *testing.T) {

--- a/pkg/util/keymutex/keymutex.go
+++ b/pkg/util/keymutex/keymutex.go
@@ -18,8 +18,9 @@ package keymutex
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"sync"
+
+	"github.com/golang/glog"
 )
 
 // KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -27,14 +27,15 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 
-	"github.com/golang/glog"
 	"hash/fnv"
-	"k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/util/sets"
 	"math/rand"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // RecycleVolumeByWatchingPodUntilCompletion is intended for use with volume

--- a/plugin/pkg/admission/initialresources/hawkular_test.go
+++ b/plugin/pkg/admission/initialresources/hawkular_test.go
@@ -18,13 +18,14 @@ package initialresources
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/pkg/api"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/pkg/api"
 
 	assert "github.com/stretchr/testify/require"
 )

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -22,6 +22,7 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -22,6 +22,7 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"


### PR DESCRIPTION
While removing GOMAXPROC and running goimports, I noticed quite a lot of other files also needed a goimport format. Didn't commit `*.generated.go`, `*.deepcopy.go` or files in `vendor`

This is more for testing if it builds.
The only strange thing here is the gopkg.in/gcfg.v1 => github.com/scalingdata/gcfg replace.
cc @jfrazelle @thockin
