### PR TITLE
Fix Windows terminal handling

### DIFF
--- a/cmd/hyperkube/kubectl.go
+++ b/cmd/hyperkube/kubectl.go
@@ -17,15 +17,14 @@ limitations under the License.
 package main
 
 import (
-	"github.com/docker/docker/pkg/term"
+	"os"
+
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 func NewKubectlServer() *Server {
-	// need to use term.StdStreams to get the right IO refs on Windows
-	stdin, stdout, stderr := term.StdStreams()
-	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), stdin, stdout, stderr)
+	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
 	localFlags := cmd.LocalFlags()
 	localFlags.SetInterspersed(false)
 

--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -17,7 +17,7 @@ limitations under the License.
 package app
 
 import (
-	"github.com/docker/docker/pkg/term"
+	"os"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -28,8 +28,6 @@ WARNING: this logic is duplicated, with minor changes, in cmd/hyperkube/kubectl.
 Any salient changes here will need to be manually reflected in that file.
 */
 func Run() error {
-	// need to use term.StdStreams to get the right IO refs on Windows
-	stdin, stdout, stderr := term.StdStreams()
-	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), stdin, stdout, stderr)
+	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()
 }

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -74,21 +74,21 @@ func TestPodAndContainerAttach(t *testing.T) {
 			name:        "no container, no flags",
 		},
 		{
-			p:                 &AttachOptions{ContainerName: "bar"},
+			p:                 &AttachOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
 			args:              []string{"foo"},
 			expectedPod:       "foo",
 			expectedContainer: "bar",
 			name:              "container in flag",
 		},
 		{
-			p:                 &AttachOptions{ContainerName: "initfoo"},
+			p:                 &AttachOptions{StreamOptions: StreamOptions{ContainerName: "initfoo"}},
 			args:              []string{"foo"},
 			expectedPod:       "foo",
 			expectedContainer: "initfoo",
 			name:              "init container in flag",
 		},
 		{
-			p:           &AttachOptions{ContainerName: "bar"},
+			p:           &AttachOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
 			args:        []string{"foo", "-c", "wrong"},
 			expectError: true,
 			name:        "non-existing container in flag",
@@ -187,11 +187,13 @@ func TestAttach(t *testing.T) {
 			remoteAttach.err = fmt.Errorf("attach error")
 		}
 		params := &AttachOptions{
-			ContainerName: test.container,
-			In:            bufIn,
-			Out:           bufOut,
-			Err:           bufErr,
-			Attach:        remoteAttach,
+			StreamOptions: StreamOptions{
+				ContainerName: test.container,
+				In:            bufIn,
+				Out:           bufOut,
+				Err:           bufErr,
+			},
+			Attach: remoteAttach,
 		}
 		cmd := &cobra.Command{}
 		if err := params.Complete(f, cmd, []string{"foo"}); err != nil {
@@ -261,13 +263,15 @@ func TestAttachWarnings(t *testing.T) {
 		bufIn := bytes.NewBuffer([]byte{})
 		ex := &fakeRemoteAttach{}
 		params := &AttachOptions{
-			ContainerName: test.container,
-			In:            bufIn,
-			Out:           bufOut,
-			Err:           bufErr,
-			Stdin:         test.stdin,
-			TTY:           test.tty,
-			Attach:        ex,
+			StreamOptions: StreamOptions{
+				ContainerName: test.container,
+				In:            bufIn,
+				Out:           bufOut,
+				Err:           bufErr,
+				Stdin:         test.stdin,
+				TTY:           test.tty,
+			},
+			Attach: ex,
 		}
 		cmd := &cobra.Command{}
 		if err := params.Complete(f, cmd, []string{"foo"}); err != nil {

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -20,9 +20,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -65,19 +67,19 @@ func TestPodAndContainer(t *testing.T) {
 			name:          "empty",
 		},
 		{
-			p:             &ExecOptions{PodName: "foo"},
+			p:             &ExecOptions{StreamOptions: StreamOptions{PodName: "foo"}},
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "no cmd",
 		},
 		{
-			p:             &ExecOptions{PodName: "foo", ContainerName: "bar"},
+			p:             &ExecOptions{StreamOptions: StreamOptions{PodName: "foo", ContainerName: "bar"}},
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "no cmd, w/ container",
 		},
 		{
-			p:             &ExecOptions{PodName: "foo"},
+			p:             &ExecOptions{StreamOptions: StreamOptions{PodName: "foo"}},
 			args:          []string{"cmd"},
 			argsLenAtDash: -1,
 			expectedPod:   "foo",
@@ -115,7 +117,7 @@ func TestPodAndContainer(t *testing.T) {
 			name:          "cmd, cmd is behind dash",
 		},
 		{
-			p:                 &ExecOptions{ContainerName: "bar"},
+			p:                 &ExecOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
 			args:              []string{"foo", "cmd"},
 			argsLenAtDash:     -1,
 			expectedPod:       "foo",
@@ -206,12 +208,14 @@ func TestExec(t *testing.T) {
 			ex.execErr = fmt.Errorf("exec error")
 		}
 		params := &ExecOptions{
-			PodName:       "foo",
-			ContainerName: "bar",
-			In:            bufIn,
-			Out:           bufOut,
-			Err:           bufErr,
-			Executor:      ex,
+			StreamOptions: StreamOptions{
+				PodName:       "foo",
+				ContainerName: "bar",
+				In:            bufIn,
+				Out:           bufOut,
+				Err:           bufErr,
+			},
+			Executor: ex,
 		}
 		cmd := &cobra.Command{}
 		args := []string{"test", "command"}
@@ -255,5 +259,126 @@ func execPod() *api.Pod {
 		Status: api.PodStatus{
 			Phase: api.PodRunning,
 		},
+	}
+}
+
+func TestSetupTTY(t *testing.T) {
+	stderr := &bytes.Buffer{}
+
+	// test 1 - don't attach stdin
+	o := &StreamOptions{
+		// InterruptParent: ,
+		Stdin: false,
+		In:    &bytes.Buffer{},
+		Out:   &bytes.Buffer{},
+		Err:   stderr,
+		TTY:   true,
+	}
+
+	tty := o.setupTTY()
+
+	if o.In != nil {
+		t.Errorf("don't attach stdin: o.In should be nil")
+	}
+	if tty.In != nil {
+		t.Errorf("don't attach stdin: tty.In should be nil")
+	}
+	if o.TTY {
+		t.Errorf("don't attach stdin: o.TTY should be false")
+	}
+	if tty.Raw {
+		t.Errorf("don't attach stdin: tty.Raw should be false")
+	}
+	if len(stderr.String()) > 0 {
+		t.Errorf("don't attach stdin: stderr wasn't empty: %s", stderr.String())
+	}
+
+	// tests from here on attach stdin
+	// test 2 - don't request a TTY
+	o.Stdin = true
+	o.In = &bytes.Buffer{}
+	o.TTY = false
+
+	tty = o.setupTTY()
+
+	if o.In == nil {
+		t.Errorf("attach stdin, no TTY: o.In should not be nil")
+	}
+	if tty.In != o.In {
+		t.Errorf("attach stdin, no TTY: tty.In should equal o.In")
+	}
+	if o.TTY {
+		t.Errorf("attach stdin, no TTY: o.TTY should be false")
+	}
+	if tty.Raw {
+		t.Errorf("attach stdin, no TTY: tty.Raw should be false")
+	}
+	if len(stderr.String()) > 0 {
+		t.Errorf("attach stdin, no TTY: stderr wasn't empty: %s", stderr.String())
+	}
+
+	// test 3 - request a TTY, but stdin is not a terminal
+	o.Stdin = true
+	o.In = &bytes.Buffer{}
+	o.Err = stderr
+	o.TTY = true
+
+	tty = o.setupTTY()
+
+	if o.In == nil {
+		t.Errorf("attach stdin, TTY, not a terminal: o.In should not be nil")
+	}
+	if tty.In != o.In {
+		t.Errorf("attach stdin, TTY, not a terminal: tty.In should equal o.In")
+	}
+	if o.TTY {
+		t.Errorf("attach stdin, TTY, not a terminal: o.TTY should be false")
+	}
+	if tty.Raw {
+		t.Errorf("attach stdin, TTY, not a terminal: tty.Raw should be false")
+	}
+	if !strings.Contains(stderr.String(), "input is not a terminal") {
+		t.Errorf("attach stdin, TTY, not a terminal: expected 'input is not a terminal' to stderr")
+	}
+
+	// test 4 - request a TTY, stdin is a terminal
+	o.Stdin = true
+	o.In = &bytes.Buffer{}
+	stderr.Reset()
+	o.TTY = true
+
+	overrideStdin := ioutil.NopCloser(&bytes.Buffer{})
+	overrideStdout := &bytes.Buffer{}
+	overrideStderr := &bytes.Buffer{}
+	o.overrideStreams = func() (io.ReadCloser, io.Writer, io.Writer) {
+		return overrideStdin, overrideStdout, overrideStderr
+	}
+
+	o.isTerminalIn = func(tty term.TTY) bool {
+		return true
+	}
+
+	tty = o.setupTTY()
+
+	if o.In != overrideStdin {
+		t.Errorf("attach stdin, TTY, is a terminal: o.In should equal overrideStdin")
+	}
+	if tty.In != o.In {
+		t.Errorf("attach stdin, TTY, is a terminal: tty.In should equal o.In")
+	}
+	if !o.TTY {
+		t.Errorf("attach stdin, TTY, is a terminal: o.TTY should be true")
+	}
+	if !tty.Raw {
+		t.Errorf("attach stdin, TTY, is a terminal: tty.Raw should be true")
+	}
+	if len(stderr.String()) > 0 {
+		t.Errorf("attach stdin, TTY, is a terminal: stderr wasn't empty: %s", stderr.String())
+	}
+	if o.Out != overrideStdout {
+		t.Errorf("attach stdin, TTY, is a terminal: o.Out should equal overrideStdout")
+	}
+	if tty.Out != o.Out {
+		t.Errorf("attach stdin, TTY, is a terminal: tty.Out should equal o.Out")
 	}
 }

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -226,11 +226,13 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 
 	if attach {
 		opts := &AttachOptions{
-			In:    cmdIn,
-			Out:   cmdOut,
-			Err:   cmdErr,
-			Stdin: interactive,
-			TTY:   tty,
+			StreamOptions: StreamOptions{
+				In:    cmdIn,
+				Out:   cmdOut,
+				Err:   cmdErr,
+				Stdin: interactive,
+				TTY:   tty,
+			},
 
 			CommandName: cmd.Parent().CommandPath() + " attach",
 

--- a/pkg/util/term/resizeevents_windows.go
+++ b/pkg/util/term/resizeevents_windows.go
@@ -29,7 +29,11 @@ func monitorResizeEvents(fd uintptr, resizeEvents chan<- Size, stop chan struct{
 	go func() {
 		defer runtime.HandleCrash()
 
-		var lastSize Size
+		size := GetSize(fd)
+		if size == nil {
+			return
+		}
+		lastSize := *size
 
 		for {
 			// see if we need to stop running


### PR DESCRIPTION
Fix some issues with Windows terminal handling with respect to TTYs that came up as part of the
code that adds support for terminal resizing.

cc @smarterclayton @sttts @csrwng 
