### PR TITLE
Mention that comments keep pull-requests open

### DIFF
--- a/docs/devel/automation.md
+++ b/docs/devel/automation.md
@@ -118,7 +118,8 @@ happening is to add the "keep-open" label on the pull-request.
 Feel free to re-open and maybe add the "keep-open" label if this happens to a
 valid pull-request. It may also be a good opportunity to get more attention by
 verifying that it is properly assigned and/or mention people that might be
-interested.
+interested. Commenting on the pull-request will also keep it open for another 90
+days.
 
 ## PR builder
 


### PR DESCRIPTION
A comment in a pull-request will keep it open for another 90 days. Let's
mention that in the documentation for people who can't add labels.
