### PR TITLE
Revert "Scheduler predicates tests should consider unschedulable"

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -172,7 +172,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 		c = f.Client
 		ns = f.Namespace.Name
 		nodeList = &api.NodeList{}
-		nodes := framework.GetReadySchedulableNodesOrDie(c)
+		nodes, err := c.Nodes().List(api.ListOptions{})
 		masterNodes = sets.NewString()
 		for _, node := range nodes.Items {
 			if system.IsMasterNode(&node) {
@@ -182,7 +182,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 			}
 		}
 
-		err := framework.CheckTestingNSDeletedExcept(c, ns)
+		err = framework.CheckTestingNSDeletedExcept(c, ns)
 		framework.ExpectNoError(err)
 
 		// Every test case in this suite assumes that cluster add-on pods stay stable and


### PR DESCRIPTION
Reverts kubernetes/kubernetes#28970
See https://github.com/kubernetes/kubernetes/pull/28970#issuecomment-233817280

cc @pskrzyns @rmmh
