### PR TITLE
Fix 'make test-e2e-node' example to run some tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ test-e2e: ginkgo generated_files
 #    have the name "${INSTANCE_PREFIX}-${IMAGE_NAME}".  Defaults to "test".
 #
 # Example:
-#   make test-e2e-node FOCUS=kubelet SKIP=container
+#   make test-e2e-node FOCUS=Kubelet SKIP=container
 #   make test-e2e-node REMOTE=true DELETE_INSTANCES=true
 #   make test-e2e-node TEST_ARGS="--cgroups-per-qos=true"
 # Build and run tests.


### PR DESCRIPTION
This PR fixes the minor problem that if you take the first example given in the Makefile and paste it verbatim,

```
make test-e2e-node FOCUS=kubelet SKIP=container
```

it says something like "Will run 0 of 34 specs".  Several of the test suite descriptions contain "Kubernetes" with a capital K, but none match with a lower-case k.

The second part of the line is not great either, since some tests use "container" and some use "Container",   but fixing that seems to require some standardisation on how you name the tests.
