### PR TITLE
For e2e_node tests tell etcd to listen on ports 2379 and 4001

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -190,7 +190,9 @@ func (es *e2eService) startEtcd() (*killCmd, error) {
 		}
 		etcdPath = defaultEtcdPath
 	}
-	cmd := exec.Command(etcdPath)
+	cmd := exec.Command(etcdPath,
+		"--listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001",
+		"--advertise-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001")
 	// Execute etcd in the data directory instead of using --data-dir because the flag sometimes requires additional
 	// configuration (e.g. --name in version 0.4.9)
 	cmd.Dir = es.etcdDataDir

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -181,7 +181,12 @@ func (es *e2eService) startEtcd() (*killCmd, error) {
 		return nil, err
 	}
 	es.etcdDataDir = dataDir
-	etcdPath, err := exec.LookPath("etcd")
+	var etcdPath string
+	// CoreOS ships a binary named 'etcd' which is really old, so prefer 'etcd2' if it exists
+	etcdPath, err = exec.LookPath("etcd2")
+	if err != nil {
+		etcdPath, err = exec.LookPath("etcd")
+	}
 	if err != nil {
 		glog.Infof("etcd not found in PATH. Defaulting to %s...", defaultEtcdPath)
 		_, err = os.Stat(defaultEtcdPath)


### PR DESCRIPTION
This is the default for etcd2, but etcd3 only listens on 2379.
Specifying the ports keeps things consistent no matter which version the user has installed.

Fixes #29117
