### PR TITLE
Information is opposite to real meaning to express

### DIFF
--- a/pkg/cloudprovider/providers/mesos/mesos_test.go
+++ b/pkg/cloudprovider/providers/mesos/mesos_test.go
@@ -219,7 +219,7 @@ func Test_Master(t *testing.T) {
 	expectedMaster := unpackIPv4(TEST_MASTER_IP)
 
 	if master != expectedMaster {
-		t.Fatalf("Master returns the expected value: (expected: %#v, actual: %#v", expectedMaster, master)
+		t.Fatalf("Master returns the unexpected value: (expected: %#v, actual: %#v", expectedMaster, master)
 	}
 }
 


### PR DESCRIPTION
master is not equal to expectedMaster, the meaning should be the master is unexpected:
    master, err := mesosCloud.Master(clusterName)
    if master != expectedMaster {
        t.Fatalf("Master returns the expected value: (expected: %#v, actual: %#v", expectedMaster, master)
