### PR TITLE
Make a link in docs clickable

### DIFF
--- a/docs/design/resource-qos.md
+++ b/docs/design/resource-qos.md
@@ -54,7 +54,7 @@ Borg increased utilization by about 20% when it started allowing use of such non
 
 ## Requests and Limits
 
-For each resource, containers can specify a resource request and limit, `0 <= request <= [Node Allocatable](../proposals/node-allocatable.md)` & `request <= limit <= Infinity`.
+For each resource, containers can specify a resource request and limit, `0 <= request <= `[`Node Allocatable`](../proposals/node-allocatable.md) & `request <= limit <= Infinity`.
 If a pod is successfully scheduled, the container is guaranteed the amount of resources requested.
 Scheduling is based on `requests` and not `limits`.
 The pods and its containers will not be allowed to exceed the specified limit.


### PR DESCRIPTION
- Github flavored markdown doesn't support links inside codeblocks
