### PR TITLE
Refactor Cloudprovider routes so providerID is useable

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -123,6 +123,14 @@ type Instances interface {
 	CurrentNodeName(hostname string) (string, error)
 }
 
+type Instance struct {
+	// Name is the name of the instance as Kubernetes understands it. Usually the hostname
+	Name string
+
+	// ID is the instance ID. To be used for clouds that don't have a mapping of hostname to instance
+	ID string
+}
+
 // Route is a representation of an advanced routing rule.
 type Route struct {
 	// Name is the name of the routing rule in the cloud-provider.
@@ -130,7 +138,7 @@ type Route struct {
 	Name string
 	// TargetInstance is the name of the instance as specified in routing rules
 	// for the cloud-provider (in gce: the Instance Name).
-	TargetInstance string
+	TargetInstance Instance
 	// DestinationCIDR is the CIDR format IP range that this routing rule
 	// applies to.
 	DestinationCIDR string

--- a/pkg/cloudprovider/providers/aws/aws_routes.go
+++ b/pkg/cloudprovider/providers/aws/aws_routes.go
@@ -88,7 +88,7 @@ func (c *Cloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
 		}
 		instanceName := orEmpty(instance.PrivateDnsName)
 		routeName := clusterName + "-" + destinationCIDR
-		routes = append(routes, &cloudprovider.Route{Name: routeName, TargetInstance: instanceName, DestinationCIDR: destinationCIDR})
+		routes = append(routes, &cloudprovider.Route{Name: routeName, TargetInstance: cloudprovider.Instance{Name: instanceName}, DestinationCIDR: destinationCIDR})
 	}
 
 	return routes, nil
@@ -110,7 +110,7 @@ func (c *Cloud) configureInstanceSourceDestCheck(instanceID string, sourceDestCh
 // CreateRoute implements Routes.CreateRoute
 // Create the described route
 func (c *Cloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
-	instance, err := c.getInstanceByNodeName(route.TargetInstance)
+	instance, err := c.getInstanceByNodeName(route.TargetInstance.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -2193,7 +2193,7 @@ func (gce *GCECloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, err
 			}
 
 			target := path.Base(r.NextHopInstance)
-			routes = append(routes, &cloudprovider.Route{Name: r.Name, TargetInstance: target, DestinationCIDR: r.DestRange})
+			routes = append(routes, &cloudprovider.Route{Name: r.Name, TargetInstance: cloudprovider.Instance{Name: target}, DestinationCIDR: r.DestRange})
 		}
 	}
 	if page >= maxPages {
@@ -2209,7 +2209,7 @@ func gceNetworkURL(project, network string) string {
 func (gce *GCECloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
 	routeName := truncateClusterName(clusterName) + "-" + nameHint
 
-	targetInstance, err := gce.getInstanceByName(route.TargetInstance)
+	targetInstance, err := gce.getInstanceByName(route.TargetInstance.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -95,7 +95,7 @@ func (rc *RouteController) reconcile(nodes []api.Node, routes []*cloudprovider.R
 	// routeMap maps routeTargetInstance->route
 	routeMap := make(map[string]*cloudprovider.Route)
 	for _, route := range routes {
-		routeMap[route.TargetInstance] = route
+		routeMap[route.TargetInstance.Name] = route
 	}
 
 	wg := sync.WaitGroup{}
@@ -111,7 +111,10 @@ func (rc *RouteController) reconcile(nodes []api.Node, routes []*cloudprovider.R
 		if r == nil || r.DestinationCIDR != node.Spec.PodCIDR {
 			// If not, create the route.
 			route := &cloudprovider.Route{
-				TargetInstance:  node.Name,
+				TargetInstance: cloudprovider.Instance{
+					Name:     node.Name,
+					ID:       node.Spec.ProviderID,
+				},
 				DestinationCIDR: node.Spec.PodCIDR,
 			}
 			nameHint := string(node.UID)
@@ -144,7 +147,7 @@ func (rc *RouteController) reconcile(nodes []api.Node, routes []*cloudprovider.R
 	for _, route := range routes {
 		if rc.isResponsibleForRoute(route) {
 			// Check if this route applies to a node we know about & has correct CIDR.
-			if nodeCIDRs[route.TargetInstance] != route.DestinationCIDR {
+			if nodeCIDRs[route.TargetInstance.Name] != route.DestinationCIDR {
 				wg.Add(1)
 				// Delete the route.
 				go func(route *cloudprovider.Route, startTime time.Time) {


### PR DESCRIPTION
Expose provider ID in Routes interface.

Allows cloud providers to directly use provider IDs rather than Kubernetes names for clouds where there is not direct lookups available for hostname to cloud instance.

Used in proposed implementation at https://github.com/ammeon/kubernetes/pull/4/commits/b35528d926e41e1344440d110db0a0b7242dfb40

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29281)

<!-- Reviewable:end -->
