### PR TITLE
Use metadata to match hostnames and get instance IDs

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -165,6 +165,8 @@ func TestInstances(t *testing.T) {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 
+	os.openStackInstance = &OpenStackInstance{InstanceID: "id", Hostname: "name"}
+
 	i, ok := os.Instances()
 	if !ok {
 		t.Fatalf("Instances() returned false")
@@ -296,7 +298,7 @@ func TestVolumes(t *testing.T) {
 
 	WaitForVolumeStatus(t, os, vol, volumeAvailableStatus, volumeCreateTimeoutSeconds)
 
-	diskId, err := os.AttachDisk(os.localInstanceID, vol)
+	diskId, err := os.AttachDisk(os.openStackInstance.InstanceID, vol)
 	if err != nil {
 		t.Fatalf("Cannot AttachDisk Cinder volume %s: %v", vol, err)
 	}
@@ -304,7 +306,7 @@ func TestVolumes(t *testing.T) {
 
 	WaitForVolumeStatus(t, os, vol, volumeInUseStatus, volumeCreateTimeoutSeconds)
 
-	err = os.DetachDisk(os.localInstanceID, vol)
+	err = os.DetachDisk(os.openStackInstance.InstanceID, vol)
 	if err != nil {
 		t.Fatalf("Cannot DetachDisk Cinder volume %s: %v", vol, err)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_utils.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_utils.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+func getInstanceIDFromProviderID(providerID string) string {
+	if ind := strings.LastIndex(providerID, "/"); ind >= 0 {
+		return providerID[(ind + 1):]
+	}
+	return providerID
+}
+
+func (os *OpenStack) createKubernetesMetaData(serverID string, name string) error {
+	updateOpts := servers.MetadataOpts{"KubernetesName": name}
+	_, err := servers.UpdateMetadata(os.compute, serverID, updateOpts).Extract()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (os *OpenStack) getKubernetesMetaData(serverID string) (string, error) {
+	metadata, err := servers.Metadata(os.compute, serverID).Extract()
+	if err != nil {
+		return "", err
+	}
+	if val, ok := metadata["KubernetesName"]; ok {
+		return val, nil
+	}
+	return "", fmt.Errorf("KubernetesName metadata does not exist on server: %s", serverID)
+}
+
+func (os *OpenStack) getServerFromMetadata(metadata string) (*servers.Server, error) {
+	opts := servers.ListOpts{
+		Status: "ACTIVE",
+	}
+	pager := servers.List(os.compute, opts)
+
+	serverList := make([]servers.Server, 0, 1)
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		s, err := servers.ExtractServers(page)
+		if err != nil {
+			return false, err
+		}
+		for _, server := range s {
+			name, err := os.getKubernetesMetaData(server.ID)
+			if err == nil && name == metadata {
+				serverList = append(serverList, server)
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(serverList) == 0 {
+		return nil, ErrNotFound
+	} else if len(serverList) > 1 {
+		return nil, ErrMultipleResults
+	}
+
+	return &serverList[0], nil
+}


### PR DESCRIPTION
Improve fetching of InstanceID and ExternalID for use in cloud provider.

The metadata is stored and then used to avoid unnessecary lookups for ExternalId and InstanceID methods.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29282)

<!-- Reviewable:end -->
