### PR TITLE
Revert "Follow on for 1.4 to default HTTP2 on by default"

### DIFF
--- a/pkg/util/net/http.go
+++ b/pkg/util/net/http.go
@@ -77,10 +77,8 @@ func SetOldTransportDefaults(t *http.Transport) *http.Transport {
 // for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
 func SetTransportDefaults(t *http.Transport) *http.Transport {
 	t = SetOldTransportDefaults(t)
-	// Allow clients to disable http2 if needed.
-	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
-		glog.Infof("HTTP2 has been explicitly disabled")
-	} else {
+	// Allow HTTP2 clients but default off for now
+	if s := os.Getenv("ENABLE_HTTP2"); len(s) > 0 {
 		if err := http2.ConfigureTransport(t); err != nil {
 			glog.Warningf("Transport failed http2 configuration: %v", err)
 		}


### PR DESCRIPTION
This reverts commit efe25553cdb28c8ce69e8e1c381bf011637ef718  
in order to address: #29001 #28537
