### PR TITLE
CRL: added CRL support for the apiserver [WIP]

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -184,6 +184,11 @@ func Run(s *options.APIServer) error {
 		}
 	}
 
+	// Enable CRL check when CRL path was set
+	if s.CRLFile != "" && s.CRLCheck == false {
+		s.CRLCheck = true
+	}
+
 	var serviceAccountGetter serviceaccount.ServiceAccountTokenGetter
 	if s.ServiceAccountLookup {
 		// If we need to look up service accounts and tokens,
@@ -210,6 +215,9 @@ func Run(s *options.APIServer) error {
 		KeystoneURL:                 s.KeystoneURL,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
+		CRLCheck:                    s.CRLCheck,
+		CRLHardFail:                 s.CRLHardFail,
+		CRLFile:                     s.CRLFile,
 	})
 
 	if err != nil {

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -20,6 +20,8 @@ import (
 	"crypto/rsa"
 	"time"
 
+	"github.com/cloudflare/cfssl/revoke"
+
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authenticator/bearertoken"
 	"k8s.io/kubernetes/pkg/serviceaccount"
@@ -49,6 +51,9 @@ type AuthenticatorConfig struct {
 	KeystoneURL                 string
 	WebhookTokenAuthnConfigFile string
 	WebhookTokenAuthnCacheTTL   time.Duration
+	CRLCheck                    bool
+	CRLHardFail                 bool
+	CRLFile                     string
 }
 
 // New returns an authenticator.Request or an error that supports the standard
@@ -65,7 +70,7 @@ func New(config AuthenticatorConfig) (authenticator.Request, error) {
 	}
 
 	if len(config.ClientCAFile) > 0 {
-		certAuth, err := newAuthenticatorFromClientCAFile(config.ClientCAFile)
+		certAuth, err := newAuthenticatorFromClientCAFile(&config)
 		if err != nil {
 			return nil, err
 		}
@@ -182,8 +187,10 @@ func newServiceAccountAuthenticator(keyfile string, lookup bool, serviceAccountG
 }
 
 // newAuthenticatorFromClientCAFile returns an authenticator.Request or an error
-func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Request, error) {
-	roots, err := crypto.CertPoolFromFile(clientCAFile)
+func newAuthenticatorFromClientCAFile(config *AuthenticatorConfig) (authenticator.Request, error) {
+	var rvc *revoke.Revoke
+
+	roots, err := crypto.CertPoolFromFile((*config).ClientCAFile)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +198,14 @@ func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Reques
 	opts := x509.DefaultVerifyOptions()
 	opts.Roots = roots
 
-	return x509.New(opts, x509.CommonNameUserConversion), nil
+	if (*config).CRLCheck {
+		rvc = revoke.New((*config).CRLHardFail)
+		if err = rvc.SetLocalCRL((*config).CRLFile); err != nil {
+			return nil, err
+		}
+	}
+
+	return x509.New(opts, x509.CommonNameUserConversion, rvc), nil
 }
 
 // newAuthenticatorFromTokenFile returns an authenticator.Request or an error

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -121,6 +121,9 @@ type ServerRunOptions struct {
 	TLSCertFile            string
 	TLSPrivateKeyFile      string
 	TokenAuthFile          string
+	CRLCheck               bool
+	CRLHardFail            bool
+	CRLFile                string
 	WatchCacheSizes        []string
 }
 
@@ -151,6 +154,8 @@ func NewServerRunOptions() *ServerRunOptions {
 		SecurePort:                               6443,
 		ServiceNodePortRange:                     DefaultServiceNodePortRange,
 		StorageVersions:                          registered.AllPreferredGroupVersions(),
+		CRLCheck:                                 false,
+		CRLHardFail:                              true,
 	}
 }
 
@@ -460,6 +465,17 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, ""+
 		"If set, the file that will be used to secure the secure port of the API server "+
 		"via token authentication.")
+
+	fs.BoolVar(&s.CRLCheck, "crl-check", s.CRLCheck,
+		"Enable CRL check for the client server.")
+
+	fs.BoolVar(&s.CRLHardFail, "crl-hard-fail", s.CRLHardFail,
+		"Enable hard fail revocation plan for the the client server."+
+			"Fail CRL check if CRL is unavailable.")
+
+	fs.StringVar(&s.CRLFile, "crl-file", s.CRLFile,
+		"Path to the client server certificate revocation list file."+
+			"If set, automatically enables --crl-check flag.")
 
 	fs.StringSliceVar(&s.WatchCacheSizes, "watch-cache-sizes", s.WatchCacheSizes, ""+
 		"List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. "+

--- a/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -19,8 +19,10 @@ package x509
 import (
 	"crypto/x509"
 	"encoding/asn1"
+	"errors"
 	"net/http"
 
+	"github.com/cloudflare/cfssl/revoke"
 	"k8s.io/kubernetes/pkg/auth/user"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
@@ -40,14 +42,15 @@ func (f UserConversionFunc) User(chain []*x509.Certificate) (user.Info, bool, er
 
 // Authenticator implements request.Authenticator by extracting user info from verified client certificates
 type Authenticator struct {
-	opts x509.VerifyOptions
-	user UserConversion
+	opts   x509.VerifyOptions
+	user   UserConversion
+	revoke *revoke.Revoke
 }
 
 // New returns a request.Authenticator that verifies client certificates using the provided
 // VerifyOptions, and converts valid certificate chains into user.Info using the provided UserConversion
-func New(opts x509.VerifyOptions, user UserConversion) *Authenticator {
-	return &Authenticator{opts, user}
+func New(opts x509.VerifyOptions, user UserConversion, revoke *revoke.Revoke) *Authenticator {
+	return &Authenticator{opts, user, revoke}
 }
 
 // AuthenticateRequest authenticates the request using presented client certificates
@@ -58,6 +61,17 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 
 	var errlist []error
 	for _, cert := range req.TLS.PeerCertificates {
+		if a.revoke != nil {
+			// Check whether certificate was revoked
+			revoked, ok := a.revoke.VerifyCertificate(cert)
+			if !ok && a.revoke.IsHardFail() {
+				return nil, false, errors.New("Failed to fetch CRL")
+			}
+			if revoked {
+				return nil, false, errors.New("Certificate has been revoked")
+			}
+		}
+
 		chains, err := cert.Verify(a.opts)
 		if err != nil {
 			errlist = append(errlist, err)


### PR DESCRIPTION
This PR depends on cfssl https://github.com/cloudflare/cfssl/pull/637
Resolves #18982

early comments are appreciated

vendor packages which should be added: 
- vendor/github.com/cloudflare/cfssl/revoke/
- vendor/github.com/cloudflare/cfssl/log/
- vendor/golang.org/x/crypto/ocsp/

How to run k8s-apiserver with the local CRL file:

``` sh
./kube-apiserver \
 --bind-address=0.0.0.0 \
 --etcd_servers=http://127.0.0.1:2379 \
 --service-cluster-ip-range=10.0.0.1/24 \
 --secure_port=4443 \
 --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --tls-cert-file ~/.ssl/server.pem \
 --tls-private-key-file ~/.ssl/server-key.pem \
 --client-ca-file ~/.ssl/ca.pem \
 --crl-file ~/.ssl/crl.pem
```

With fetching CRL using remote CRL server which is defined inside the client cert:

``` sh
./kube-apiserver \
 --bind-address=0.0.0.0 \
 --etcd_servers=http://127.0.0.1:2379 \
 --service-cluster-ip-range=10.0.0.1/24 \
 --secure_port=4443 \
 --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --tls-cert-file ~/.ssl/server.pem \
 --tls-private-key-file ~/.ssl/server-key.pem \
 --client-ca-file ~/.ssl/ca.pem \
 --crl-check
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29293)

<!-- Reviewable:end -->
