### PR TITLE
Allow VERBOSE var to not be defined

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -21,7 +21,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/lib/util.sh"
 
-if [ -n "${VERBOSE}" ]; then
+if [ -n "${VERBOSE:-}" ]; then
     SILENT=false
 else
     SILENT=true


### PR DESCRIPTION
Allows VERBOSE var to not be defined when calling "hack/verify-all.sh" or "make verify"

This prevents the following error from occuring:
`$ make verify OR hack/verify-all.sh`
`hack/make-rules/verify.sh: line 24: VERBOSE: unbound variable`
`make: *** [verify] Error 1`
