### PR TITLE
AWS kube-up: Fix unbound KUBE_MANIFESTS_TAR_URL variable in Salt config

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -517,7 +517,7 @@ function build-kube-env {
 
   local server_binary_tar_url=$SERVER_BINARY_TAR_URL
   local salt_tar_url=$SALT_TAR_URL
-  local kube_manifests_tar_url=$KUBE_MANIFESTS_TAR_URL
+  local kube_manifests_tar_url="${KUBE_MANIFESTS_TAR_URL:-}"
   if [[ "${master}" == "true" && "${MASTER_OS_DISTRIBUTION}" == "coreos" ]] || \
      [[ "${master}" == "false" && "${NODE_OS_DISTRIBUTION}" == "coreos" ]] ; then
     # TODO: Support fallback .tar.gz settings on CoreOS


### PR DESCRIPTION
It shouldn't be necessary for all distros to define this env variable (broken in 97f3f80833f61fcb369d3da7f1b2422b875ec54f).

This should get our e2es back creating AWS clusters, at least.
