### PR TITLE
Automated cherry pick of #29071 upstream release 1.3

### DIFF
--- a/pkg/apis/rbac/validation/rulevalidation.go
+++ b/pkg/apis/rbac/validation/rulevalidation.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/serviceaccount"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
@@ -201,8 +202,7 @@ func appliesToUser(user user.Info, subject rbac.Subject) (bool, error) {
 		if subject.Namespace == "" {
 			return false, fmt.Errorf("subject of kind service account without specified namespace")
 		}
-		// TODO(ericchiang): Is there a better way of matching a service account name?
-		return "system:serviceaccount:"+subject.Name+":"+subject.Namespace == user.GetName(), nil
+		return serviceaccount.MakeUsername(subject.Namespace, subject.Name) == user.GetName(), nil
 	default:
 		return false, fmt.Errorf("unknown subject kind: %s", subject.Kind)
 	}

--- a/pkg/apis/rbac/validation/rulevalidation_test.go
+++ b/pkg/apis/rbac/validation/rulevalidation_test.go
@@ -234,7 +234,7 @@ func TestAppliesTo(t *testing.T) {
 			subjects: []rbac.Subject{
 				{Kind: rbac.UserKind, Name: "barfoo"},
 				{Kind: rbac.GroupKind, Name: "foobar"},
-				{Kind: rbac.ServiceAccountKind, Name: "kube-system", Namespace: "default"},
+				{Kind: rbac.ServiceAccountKind, Namespace: "kube-system", Name: "default"},
 			},
 			ctx: api.WithNamespace(
 				api.WithUser(api.NewContext(), &user.DefaultInfo{Name: "system:serviceaccount:kube-system:default"}),


### PR DESCRIPTION
RBAC authorizer assigns a role to a wrong service account.
