### PR TITLE
TestLoadBalancer() test v1 not v2

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -204,7 +204,7 @@ func TestLoadBalancer(t *testing.T) {
 		t.Skipf("No config found in environment")
 	}
 
-	cfg.LoadBalancer.LBVersion = "v2"
+	cfg.LoadBalancer.LBVersion = "v1"
 
 	os, err := newOpenStack(cfg)
 	if err != nil {


### PR DESCRIPTION
TestLoadBalancer() should test v1 and TestLoadBalancerV2() test v2, but In TestLoadBalancerV() there are codes:
cfg.LoadBalancer.LBVersion = "v2"
