### PR TITLE
make exception handling complete in endpoints_controller.go

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -374,6 +374,8 @@ func (e *EndpointController) syncService(key string) {
 			tolerateUnreadyEndpoints = b
 		} else {
 			glog.Errorf("Failed to parse annotation %v: %v", TolerateUnreadyEndpointsAnnotation, err)
+			e.queue.Add(key) // Retry
+			return
 		}
 	}
 


### PR DESCRIPTION
It should return when important error occurs.
