### PR TITLE
Lack of closing stop chan in controller_test.go

### DIFF
--- a/pkg/controller/framework/controller_test.go
+++ b/pkg/controller/framework/controller_test.go
@@ -234,6 +234,7 @@ func TestHammerController(t *testing.T) {
 
 	// Run the controller and run it until we close stop.
 	stop := make(chan struct{})
+	defer close(stop)
 	go controller.Run(stop)
 
 	// Let's wait for the controller to do its initial sync
@@ -392,6 +393,7 @@ func TestUpdate(t *testing.T) {
 	// Once Run() is called, calls to testDoneWG.Done() might start, so
 	// all testDoneWG.Add() calls must happen before this point
 	stop := make(chan struct{})
+	defer close(stop)
 	go controller.Run(stop)
 	<-watchCh
 


### PR DESCRIPTION
Complete handling has been present at line 165:
    stop := make(chan struct{})
    defer close(stop)
    go controller.Run(stop)
there are two places need to add handling
