### PR TITLE
Fix killing child sudo process in e2e_node tests

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -283,18 +282,6 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 		// Set the command to write the output file
 		cmd.Cmd.Stdout = outfile
 		cmd.Cmd.Stderr = outfile
-
-		// Killing the sudo command should kill the server as well.
-		attrs := &syscall.SysProcAttr{}
-		// Hack to set linux-only field without build tags.
-		deathSigField := reflect.ValueOf(attrs).Elem().FieldByName("Pdeathsig")
-		if deathSigField.IsValid() {
-			deathSigField.Set(reflect.ValueOf(syscall.SIGKILL))
-		} else {
-			cmdErrorChan <- fmt.Errorf("Failed to set Pdeathsig field (non-linux build)")
-			return
-		}
-		cmd.Cmd.SysProcAttr = attrs
 
 		// Run the command
 		err = cmd.Run()

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -361,7 +361,10 @@ func (k *killCmd) Kill() error {
 	const timeout = 10 * time.Second
 	for _, signal := range []string{"-TERM", "-KILL"} {
 		glog.V(2).Infof("Killing process %d (%s) with %s", pid, name, signal)
-		_, err := exec.Command("sudo", "kill", signal, strconv.Itoa(pid)).Output()
+		cmd := exec.Command("sudo", "kill", signal, strconv.Itoa(pid))
+		// Run the 'kill' command in a separate process group so sudo doesn't ignore it
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		_, err := cmd.Output()
 		if err != nil {
 			glog.Errorf("Error signaling process %d (%s) with %s: %v", pid, name, signal, err)
 			continue


### PR DESCRIPTION
Fixes #29211.

The context is we are trying to kill a process started as `sudo kube-apiserver`, but `sudo` ignores signals from the same process group. Applying `Setpgid` means the `sudo kill` process won't be in the same process group, so will not fall foul of this nifty feature.

I also took the liberty of removing some code setting `Pdeathsig` because it claims to be doing something  in the same area, but actually it doesn't do that at all.  The setting is applied to the forked process, i.e. `sudo`, and it means the `sudo` will get killed if we (`e2e_node.test`) die.  This (a) isn't what the comment says and (b) doesn't help because sending SIGKILL to the sudo process leaves sudo's child alive.

I didn't use the "hack for linux-only" approach because I think `Setpgid` is available on all platforms that `e2e_node` builds on.
