### PR TITLE
Add "federation" API group to the known versions list of federation API clients.

### DIFF
--- a/federation/client/clientset_generated/federation_release_1_4/import_known_versions.go
+++ b/federation/client/clientset_generated/federation_release_1_4/import_known_versions.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federation_release_1_4
+
+// These imports are the API groups the client will support.
+import (
+	_ "k8s.io/kubernetes/federation/apis/federation/install"
+)
+
+func init() {
+}


### PR DESCRIPTION
PR #29302 did not to add a list of known API groups to the release_1_4 client and that broke our tests. This PR should fix it (hopefully).

cc @quinton-hoole @nikhiljindal @kubernetes/sig-cluster-federation 

Ref: #28615.
