### PR TITLE
Add static IP address for kubemark master.

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -80,8 +80,17 @@ run-gcloud-compute-with-retries disks create "${MASTER_NAME}-pd" \
   --type "${MASTER_DISK_TYPE}" \
   --size "${MASTER_DISK_SIZE}"
 
+REGION=${ZONE%-*}
+run-gcloud-compute-with-retries addresses create "${MASTER_NAME}-ip" \
+  --project "${PROJECT}" \
+  --region "${REGION}" -q
+
+MASTER_IP=$(gcloud compute addresses describe "${MASTER_NAME}-ip" \
+  --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
+
 run-gcloud-compute-with-retries instances create "${MASTER_NAME}" \
   ${GCLOUD_COMMON_ARGS} \
+  --address "${MASTER_IP}"
   --machine-type "${MASTER_SIZE}" \
   --image-project="${MASTER_IMAGE_PROJECT}" \
   --image "${MASTER_IMAGE}" \
@@ -96,9 +105,6 @@ run-gcloud-compute-with-retries firewall-rules create "${INSTANCE_PREFIX}-kubema
   --source-ranges "0.0.0.0/0" \
   --target-tags "${MASTER_TAG}" \
   --allow "tcp:443"
-
-MASTER_IP=$(gcloud compute instances describe ${MASTER_NAME} \
-  --zone="${ZONE}" --project="${PROJECT}" | grep natIP: | cut -f2 -d":" | sed "s/ //g")
 
 if [ "${SEPARATE_EVENT_MACHINE:-false}" == "true" ]; then
   EVENT_STORE_NAME="${INSTANCE_PREFIX}-event-store"

--- a/test/kubemark/stop-kubemark.sh
+++ b/test/kubemark/stop-kubemark.sh
@@ -32,6 +32,12 @@ gcloud compute instances delete "${MASTER_NAME}" \
 gcloud compute disks delete "${MASTER_NAME}-pd" \
     ${GCLOUD_COMMON_ARGS} || true
 
+REGION=${ZONE%-*}
+gcloud compute addresses delete "${MASTER_NAME}-ip" \
+    --project "${PROJECT}" \
+    --region "${REGION}" \
+    --quiet || true
+
 gcloud compute firewall-rules delete "${INSTANCE_PREFIX}-kubemark-master-https" \
 	--project "${PROJECT}" \
 	--quiet || true


### PR DESCRIPTION
This PR fixes kubemark, which was broken after https://github.com/kubernetes/kubernetes/pull/29295.

Because of https://github.com/kubernetes/kubernetes/issues/29392 merge queue is not blocked so it's not super urgent.

@k8s-oncall @wojtek-t  @roberthbailey @lavalamp 
