### PR TITLE
Eviction manager needs to start as runtime dependent module

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -101,8 +101,9 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 }
 
 // Start starts the control loop to observe and response to low compute resources.
-func (m *managerImpl) Start(podFunc ActivePodsFunc, monitoringInterval time.Duration) {
+func (m *managerImpl) Start(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc, monitoringInterval time.Duration) error {
 	go wait.Until(func() { m.synchronize(podFunc) }, monitoringInterval, wait.NeverStop)
+	return nil
 }
 
 // IsUnderMemoryPressure returns true if the node is under memory pressure.

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -65,10 +65,16 @@ type Threshold struct {
 // Manager evaluates when an eviction threshold for node stability has been met on the node.
 type Manager interface {
 	// Start starts the control loop to monitor eviction thresholds at specified interval.
-	Start(podFunc ActivePodsFunc, monitoringInterval time.Duration)
+	Start(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc, monitoringInterval time.Duration) error
 
 	// IsUnderMemoryPressure returns true if the node is under memory pressure.
 	IsUnderMemoryPressure() bool
+}
+
+// DiskInfoProvider is responsible for informing the manager how disk is configured.
+type DiskInfoProvider interface {
+	// HasDedicatedImageFs returns true if the imagefs is on a separate device from the rootfs.
+	HasDedicatedImageFs() (bool, error)
 }
 
 // KillPodFunc kills a pod.

--- a/pkg/kubelet/kubelet_cadvisor.go
+++ b/pkg/kubelet/kubelet_cadvisor.go
@@ -45,6 +45,19 @@ func (kl *Kubelet) GetContainerInfo(podFullName string, podUID types.UID, contai
 	return &ci, nil
 }
 
+// HasDedicatedImageFs returns true if the imagefs has a dedicated device.
+func (kl *Kubelet) HasDedicatedImageFs() (bool, error) {
+	imageFsInfo, err := kl.ImagesFsInfo()
+	if err != nil {
+		return false, err
+	}
+	rootFsInfo, err := kl.RootFsInfo()
+	if err != nil {
+		return false, err
+	}
+	return imageFsInfo.Device != rootFsInfo.Device, nil
+}
+
 // GetContainerInfoV2 returns stats (from Cadvisor) for containers.
 func (kl *Kubelet) GetContainerInfoV2(name string, options cadvisorapiv2.RequestOptions) (map[string]cadvisorapiv2.ContainerInfo, error) {
 	return kl.cadvisor.ContainerInfoV2(name, options)

--- a/pkg/kubelet/kubelet_cadvisor_test.go
+++ b/pkg/kubelet/kubelet_cadvisor_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 )
@@ -231,4 +232,38 @@ func TestGetContainerInfoWithNoMatchingContainers(t *testing.T) {
 		t.Errorf("non-nil stats when dockertools returned no containers")
 	}
 	mockCadvisor.AssertExpectations(t)
+}
+
+func TestHasDedicatedImageFs(t *testing.T) {
+	testCases := map[string]struct {
+		imageFsInfo cadvisorapiv2.FsInfo
+		rootFsInfo  cadvisorapiv2.FsInfo
+		expected    bool
+	}{
+		"has-dedicated-image-fs": {
+			imageFsInfo: cadvisorapiv2.FsInfo{Device: "123"},
+			rootFsInfo:  cadvisorapiv2.FsInfo{Device: "456"},
+			expected:    true,
+		},
+		"has-unified-image-fs": {
+			imageFsInfo: cadvisorapiv2.FsInfo{Device: "123"},
+			rootFsInfo:  cadvisorapiv2.FsInfo{Device: "123"},
+			expected:    false,
+		},
+	}
+	for testName, testCase := range testCases {
+		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+		kubelet := testKubelet.kubelet
+		mockCadvisor := testKubelet.fakeCadvisor
+		mockCadvisor.On("Start").Return(nil)
+		mockCadvisor.On("ImagesFsInfo").Return(testCase.imageFsInfo, nil)
+		mockCadvisor.On("RootFsInfo").Return(testCase.rootFsInfo, nil)
+		actual, err := kubelet.HasDedicatedImageFs()
+		if err != nil {
+			t.Errorf("case: %s, unexpected error: %v", testName, err)
+		}
+		if actual != testCase.expected {
+			t.Errorf("case: %s, expected: %v, actual: %v", testName, testCase.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
To support disk eviction, the eviction manager needs to know if there is a dedicated device for the imagefs.  In order to know that information, we need to start the eviction manager after cadvisor.  This refactors the location eviction manager is started.

/cc @kubernetes/sig-node @kubernetes/rh-cluster-infra @vishh @ronnielai 
