### PR TITLE
AWS kube-up: export kube_user to salt

### DIFF
--- a/cluster/aws/templates/configure-vm-aws.sh
+++ b/cluster/aws/templates/configure-vm-aws.sh
@@ -102,6 +102,7 @@ EOF
   fi
 
   env-to-grains "runtime_config"
+  env-to-grains "kube_user"
 }
 
 salt-node-role() {


### PR DESCRIPTION
This was done for GCE in #29164, but not for AWS.

Fixes #29424
