### PR TITLE
Modify the provider name in e2e-tests.md

### DIFF
--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -296,7 +296,7 @@ Next, specify the docker repository where your ci images will be pushed.
 	* `${FEDERATION_PUSH_REPO_BASE}/federation-controller-manager`
 
 	These repositories must allow public read access, as the e2e node docker daemons will not have any credentials. If you're using
-	gce/gke as your provider, the repositories will have read-access by default.
+	GCE/GKE as your provider, the repositories will have read-access by default.
 
 #### Build
 


### PR DESCRIPTION
gce/gke not easy to identify, can be modify to GCE/GKE.
