### PR TITLE
Change SETUP_NODE to True for node e2e docker validation test.

### DIFF
--- a/test/e2e_node/jenkins/jenkins-docker-validation.properties
+++ b/test/e2e_node/jenkins/jenkins-docker-validation.properties
@@ -14,4 +14,4 @@ GCE_PROJECT=kubernetes-jenkins
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"
 CLEANUP=true
 GINKGO_FLAGS=--skip=FLAKY
-SETUP_NODE=false
+SETUP_NODE=true


### PR DESCRIPTION
The continuous node e2e docker validation test is failing because:

```
W0722 00:48:52.163940    1265 image_list.go:85] Could not pre-pull image gcr.io/google_containers/netexec:1.4 exit status 1 output:  Cannot connect to the Docker daemon. Is the docker daemon running on this host?
```

This is because jenkins is not added to docker user group.
For other images tested in node e2e, jenkins is added to docker user group when the images are initially created https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/environment/setup_host.sh#L102.

However, in node e2e docker validation test, we are using GCI image which doesn't do that.
So we should use the `SETUP_NODE` option to add user to docker group before test running https://github.com/kubernetes/kubernetes/blob/b6c87904f626395f63850c2f4e693859dffe558c/test/e2e_node/e2e_remote.go#L150-L159.

This is only one line change, could you help me review the PR? @wonderfly 
Thanks a lot! :)
