### PR TITLE
Quota was not counting services with multiple nodeports properly

### DIFF
--- a/pkg/quota/evaluator/core/services.go
+++ b/pkg/quota/evaluator/core/services.go
@@ -57,7 +57,8 @@ func ServiceUsageFunc(object runtime.Object) api.ResourceList {
 		result[api.ResourceServices] = resource.MustParse("1")
 		switch service.Spec.Type {
 		case api.ServiceTypeNodePort:
-			result[api.ResourceServicesNodePorts] = resource.MustParse("1")
+			value := resource.NewQuantity(int64(len(service.Spec.Ports)), resource.DecimalSI)
+			result[api.ResourceServicesNodePorts] = *value
 		case api.ServiceTypeLoadBalancer:
 			result[api.ResourceServicesLoadBalancers] = resource.MustParse("1")
 		}

--- a/pkg/quota/evaluator/core/services_test.go
+++ b/pkg/quota/evaluator/core/services_test.go
@@ -71,11 +71,35 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 			service: &api.Service{
 				Spec: api.ServiceSpec{
 					Type: api.ServiceTypeNodePort,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+					},
 				},
 			},
 			usage: api.ResourceList{
 				api.ResourceServices:          resource.MustParse("1"),
 				api.ResourceServicesNodePorts: resource.MustParse("1"),
+			},
+		},
+		"multi-nodeports": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeNodePort,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+						{
+							Port: 27444,
+						},
+					},
+				},
+			},
+			usage: api.ResourceList{
+				api.ResourceServices:          resource.MustParse("1"),
+				api.ResourceServicesNodePorts: resource.MustParse("2"),
 			},
 		},
 	}

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -292,7 +292,10 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 	}
 	newService := &api.Service{
 		ObjectMeta: api.ObjectMeta{Name: "service", Namespace: "test"},
-		Spec:       api.ServiceSpec{Type: api.ServiceTypeNodePort},
+		Spec: api.ServiceSpec{
+			Type:  api.ServiceTypeNodePort,
+			Ports: []api.ServicePort{{Port: 1234}},
+		},
 	}
 	err := handler.Admit(admission.NewAttributesRecord(newService, oldService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {


### PR DESCRIPTION
``` release-note
If a service of type node port declares multiple ports, quota on "services.nodeports" will charge for each port in the service.
```

Fixes https://github.com/kubernetes/kubernetes/issues/29456

/cc @kubernetes/rh-cluster-infra @sdminonne 
