### PR TITLE
Support --files-from in kubectl create/delete

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -173,6 +173,7 @@ federation-name
 file-check-frequency
 file-suffix
 file_content_in_loop
+files-from
 flex-volume-plugin-dir
 forward-services
 framework-name

--- a/pkg/kubectl/bash_comp_utils.go
+++ b/pkg/kubectl/bash_comp_utils.go
@@ -34,3 +34,13 @@ func AddJsonFilenameFlag(cmd *cobra.Command, value *[]string, usage string) {
 	}
 	cmd.Flags().SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
 }
+
+func AddJsonFilelistFlag(cmd *cobra.Command, value *[]string, usage string) {
+	var FileExtensions = []string{".txt"}
+	cmd.Flags().StringSliceVar(value, "files-from", *value, usage)
+	annotations := make([]string, 0, len(FileExtensions))
+	for _, ext := range FileExtensions {
+		annotations = append(annotations, strings.TrimLeft(ext, "."))
+	}
+	cmd.Flags().SetAnnotation("filelist", cobra.BashCompFilenameExt, annotations)
+}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -33,6 +33,7 @@ import (
 // referencing the cmd.Flags()
 type CreateOptions struct {
 	Filenames []string
+	Filesfrom []string
 	Recursive bool
 }
 
@@ -53,12 +54,13 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &CreateOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "create -f FILENAME",
+		Use:     "create (-f FILENAME | --files-from=FILENAME)",
 		Short:   "Create a resource by filename or stdin",
 		Long:    create_long,
 		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(options.Filenames) == 0 {
+			if len(options.Filenames) == 0 &&
+				len(options.Filesfrom) == 0 {
 				cmd.Help()
 				return
 			}
@@ -71,6 +73,10 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	usage := "Filename, directory, or URL to file to use to create the resource"
 	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	cmd.MarkFlagRequired("filename")
+
+	usage = "URL or file with a list of resource file paths"
+	kubectl.AddJsonFilelistFlag(cmd, &options.Filesfrom, usage)
+
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
 	cmdutil.AddOutputFlagsForMutation(cmd)
@@ -109,6 +115,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilesFromParam(enforceNamespace, options.Filesfrom...).
 		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -36,6 +36,7 @@ import (
 // referencing the cmd.Flags()
 type DeleteOptions struct {
 	Filenames []string
+	Filesfrom []string
 	Recursive bool
 }
 
@@ -88,7 +89,7 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "delete ([-f FILENAME] | TYPE [(NAME | -l label | --all)])",
+		Use:     "delete ((-f FILENAME | --files-from=FILENAME) | TYPE [(NAME | -l label | --all)])",
 		Short:   "Delete resources by filenames, stdin, resources and names, or by resources and label selector",
 		Long:    delete_long,
 		Example: delete_example,
@@ -103,6 +104,10 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 	usage := "Filename, directory, or URL to a file containing the resource to delete."
 	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
+
+	usage = "URL or file with a list of resource file paths"
+	kubectl.AddJsonFilelistFlag(cmd, &options.Filesfrom, usage)
+
 	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
 	cmd.Flags().Bool("all", false, "[-all] to select all the specified resources.")
@@ -126,6 +131,7 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilesFromParam(enforceNamespace, options.Filesfrom...).
 		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(deleteAll).

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -17,11 +17,14 @@ limitations under the License.
 package resource
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
@@ -96,13 +99,106 @@ func (b *Builder) Schema(schema validation.Schema) *Builder {
 	return b
 }
 
+func (b *Builder) FilesFromParam(enforceNamespace bool, paths ...string) *Builder {
+	for _, s := range paths {
+		switch {
+		case s == "-":
+			location, err := os.Getwd()
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("failure getting working directory: %v", err))
+				continue
+			}
+			b.processFile(enforceNamespace, location, os.Stdin)
+		case strings.Index(s, "http://") == 0 || strings.Index(s, "https://") == 0:
+			location, err := url.Parse(s)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("the URL passed to filename %q is not valid: %v", s, err))
+				continue
+			}
+
+			body, err := readHttpWithRetries(httpgetImpl, time.Second, location.String(), defaultHttpGetAttempts)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("failing reading url %q: %v", s, err))
+				continue
+			}
+			defer body.Close()
+			base, _ := location.Parse(".")
+			b.processFile(enforceNamespace, base.String(), body)
+		default:
+			location, err := filepath.Abs(s)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("failure opening %s: %v", location, err))
+				continue
+			}
+			file, err := os.Open(location)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("failure opening %s: %v", location, err))
+				continue
+			}
+			defer file.Close()
+			b.processFile(enforceNamespace, filepath.Dir(location), file)
+		}
+	}
+	return b
+}
+
+func (b *Builder) processFile(enforceNamespace bool, base string, file io.Reader) {
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		path := strings.TrimSpace(scanner.Text())
+		// skip empty lines
+		if len(path) == 0 {
+			continue
+		}
+
+		if strings.Index(path, "http://") == 0 || strings.Index(path, "https://") == 0 {
+			b.FilenameParam(enforceNamespace, false, path)
+		} else {
+			location := path
+			if !filepath.IsAbs(location) {
+				if strings.Index(base, "http://") == 0 || strings.Index(base, "https://") == 0 {
+					cwd, err := os.Getwd()
+					if err != nil {
+						b.errs = append(b.errs, fmt.Errorf("failure getting working directory: %v", err))
+						continue
+					}
+					location = filepath.Join(cwd, path)
+				} else {
+					location = filepath.Join(base, path)
+				}
+			}
+			var err error
+			if _, err = os.Stat(location); err == nil {
+				b.FilenameParam(enforceNamespace, false, location)
+				continue
+			}
+
+			if strings.Index(base, "http://") == 0 || strings.Index(base, "https://") == 0 {
+				if base[len(base)-1] == '/' {
+					location = base + path
+				} else {
+					location = base + "/" + path
+				}
+				url, err := url.Parse(location)
+				if err != nil {
+					b.errs = append(b.errs, fmt.Errorf("problem parsing %q: %v", location, err))
+					continue
+				}
+				b.FilenameParam(enforceNamespace, false, url.String())
+			} else {
+				b.errs = append(b.errs, fmt.Errorf("unable to access file %q: %v", location, err))
+			}
+		}
+	}
+}
+
 // FilenameParam groups input in two categories: URLs and files (files, directories, STDIN)
 // If enforceNamespace is false, namespaces in the specs will be allowed to
 // override the default namespace. If it is true, namespaces that don't match
 // will cause an error.
 // If ContinueOnError() is set prior to this method, objects on the path that are not
 // recognized will be ignored (but logged at V(2)).
-func (b *Builder) FilenameParam(enforceNamespace, recursive bool, paths ...string) *Builder {
+func (b *Builder) FilenameParam(enforceNamespace bool, recursive bool, paths ...string) *Builder {
 	for _, s := range paths {
 		switch {
 		case s == "-":


### PR DESCRIPTION
Ability to specify a file in the command line which in turn has the
list of resource files. Example:

kubectl create --files-from examples/guestbook/deploy-guestbook.txt
kubectl delete --files-from examples/guestbook/deploy-guestbook.txt
ls -1 examples/guestbook/_.yaml | kubectl create -F -
ls -1 examples/guestbook/_.yaml | kubectl delete -F -

Ref #24649

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29466)

<!-- Reviewable:end -->
