### PR TITLE
remove the omitempty tag from CertificateSigningRequestList.Items

### DIFF
--- a/api/swagger-spec/certificates_v1alpha1.json
+++ b/api/swagger-spec/certificates_v1alpha1.json
@@ -692,6 +692,9 @@
   "models": {
    "v1alpha1.CertificateSigningRequestList": {
     "id": "v1alpha1.CertificateSigningRequestList",
+    "required": [
+     "items"
+    ],
     "properties": {
      "kind": {
       "type": "string",

--- a/docs/api-reference/certificates/v1alpha1/definitions.html
+++ b/docs/api-reference/certificates/v1alpha1/definitions.html
@@ -432,7 +432,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1alpha1_certificatesigningrequest">v1alpha1.CertificateSigningRequest</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -1304,7 +1304,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-30 07:06:23 UTC
+Last updated 2016-07-22 19:31:19 UTC
 </div>
 </div>
 </body>

--- a/pkg/apis/certificates/v1alpha1/types.generated.go
+++ b/pkg/apis/certificates/v1alpha1/types.generated.go
@@ -1391,14 +1391,13 @@ func (x *CertificateSigningRequestList) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[0] = true
-			yyq2[1] = len(x.Items) != 0
 			yyq2[2] = x.Kind != ""
 			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn2 = 0
+				yynn2 = 1
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -1438,34 +1437,28 @@ func (x *CertificateSigningRequestList) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					if x.Items == nil {
-						r.EncodeNil()
-					} else {
-						yym9 := z.EncBinary()
-						_ = yym9
-						if false {
-						} else {
-							h.encSliceCertificateSigningRequest(([]CertificateSigningRequest)(x.Items), e)
-						}
-					}
-				} else {
+				if x.Items == nil {
 					r.EncodeNil()
+				} else {
+					yym9 := z.EncBinary()
+					_ = yym9
+					if false {
+					} else {
+						h.encSliceCertificateSigningRequest(([]CertificateSigningRequest)(x.Items), e)
+					}
 				}
 			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("items"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Items == nil {
-						r.EncodeNil()
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
 					} else {
-						yym10 := z.EncBinary()
-						_ = yym10
-						if false {
-						} else {
-							h.encSliceCertificateSigningRequest(([]CertificateSigningRequest)(x.Items), e)
-						}
+						h.encSliceCertificateSigningRequest(([]CertificateSigningRequest)(x.Items), e)
 					}
 				}
 			}

--- a/pkg/apis/certificates/v1alpha1/types.go
+++ b/pkg/apis/certificates/v1alpha1/types.go
@@ -81,5 +81,5 @@ type CertificateSigningRequestList struct {
 	unversioned.TypeMeta `json:",inline"`
 	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	Items []CertificateSigningRequest `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
+	Items []CertificateSigningRequest `json:"items" protobuf:"bytes,2,rep,name=items"`
 }


### PR DESCRIPTION
As a general rule, `Items` should be a required field in all lists. In a followup PR, I'll update the api-convention.md and add a check in the schema registration path to enforce the rule. I need to fix this bug to unblock other work.

@kubernetes/api-review-team cc @bgrant0607-cc 
