### PR TITLE
export KUBE_USER to salt (support custom usernames) for vagrant, vsph…

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
@@ -24,6 +24,7 @@ write_files:
         docker_opts: ""
         master_extra_sans: "DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local,DNS:kubernetes-master"
         keep_host_etcd: true
+        kube_user: $KUBE_USER
   - path: /srv/kubernetes/openstack.conf
     content: |
       [Global]

--- a/cluster/photon-controller/templates/salt-master.sh
+++ b/cluster/photon-controller/templates/salt-master.sh
@@ -29,6 +29,7 @@ grains:
   cloud: photon-controller
   master_extra_sans: $MASTER_EXTRA_SANS
   api_servers: $MASTER_NAME
+  kube_user: $KUBE_USER
 EOF
 
 # Auto accept all keys from minions that try to join

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -90,6 +90,7 @@ grains:
   docker_opts: '$(echo "$DOCKER_OPTS" | sed -e "s/'/''/g")'
   master_extra_sans: '$(echo "$MASTER_EXTRA_SANS" | sed -e "s/'/''/g")'
   keep_host_etcd: true
+  kube_user: '$(echo "$KUBE_USER" | sed -e "s/'/''/g")'
 EOF
 }
 

--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -28,6 +28,7 @@ grains:
   cbr-cidr: $MASTER_IP_RANGE
   cloud: vsphere
   master_extra_sans: $MASTER_EXTRA_SANS
+  kube_user: $KUBE_USER
 EOF
 
 # Auto accept all keys from minions that try to join


### PR DESCRIPTION
GCE/GKE were handled in #29164, AWS was handled in #29428. This should cover the rest of the configurations that use ABAC.
