### PR TITLE
Automated cherry pick of #26439

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -32,7 +32,7 @@ kube::util::wait_for_url() {
   local i
   for i in $(seq 1 $times); do
     local out
-    if out=$(curl -fs $url 2>/dev/null); then
+    if out=$(curl -gfs $url 2>/dev/null); then
       kube::log::status "On try ${i}, ${prefix}: ${out}"
       return 0
     fi


### PR DESCRIPTION
Cherry picked from: https://github.com/kubernetes/kubernetes/pull/26439

Add `-g` curl option

```
This  option  switches  off  the "URL globbing parser". When you set this option,
you can specify URLs that contain the letters {}[] without having them being
interpreted by curl itself. Note that these letters are not normal legal URL
contents but they should be encoded according to the URI standard.
```

> Why?

So that IPv6 addresses with `[` and `]`, like `[::1]:8080`, work with that script.

Signed-off-by: André Martins aanm90@gmail.com

Ping @ixdy 
