### PR TITLE
kubectl: notfound errors should not error out

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -397,9 +397,10 @@ func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Durati
 	for _, rc := range rsList.Items {
 		if err := rsReaper.Stop(rc.Namespace, rc.Name, timeout, gracePeriod); err != nil {
 			scaleGetErr, ok := err.(*ScaleError)
-			if !errors.IsNotFound(err) || ok && !errors.IsNotFound(scaleGetErr.ActualError) {
-				errList = append(errList, err)
+			if errors.IsNotFound(err) || (ok && errors.IsNotFound(scaleGetErr.ActualError)) {
+				continue
 			}
+			errList = append(errList, err)
 		}
 	}
 	if len(errList) > 0 {


### PR DESCRIPTION
Fixes the flake in https://github.com/kubernetes/kubernetes/issues/28378#issuecomment-234677846

@pwittrock ptal
