### PR TITLE
Correctly document cloudprovider Instances contract

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -106,12 +106,11 @@ type Instances interface {
 	// make this clearer.
 	NodeAddresses(name string) ([]api.NodeAddress, error)
 	// ExternalID returns the cloud provider ID of the specified instance (deprecated).
+	// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 	ExternalID(name string) (string, error)
 	// InstanceID returns the cloud provider ID of the specified instance.
-	// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 	InstanceID(name string) (string, error)
 	// InstanceType returns the type of the specified instance.
-	// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 	InstanceType(name string) (string, error)
 	// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
 	List(filter string) ([]string, error)


### PR DESCRIPTION
The requirement that ExternalID returns InstanceNotFound when the
instance not found was incorrectly documented on InstanceID and
InstanceType.  This requirement arises from the node controller, which
is the only place that checks for the InstanceNotFound error.
