### PR TITLE
AWS: Deprecate a few functions in favor of aws-sdk-go

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -415,26 +415,25 @@ func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
 	return client, nil
 }
 
+// stringPointerArray creates a slice of string pointers from a slice of strings
+// Deprecated: consider using aws.StringSlice - but note the slightly different behaviour with a nil input
 func stringPointerArray(orig []string) []*string {
 	if orig == nil {
 		return nil
 	}
-	n := make([]*string, len(orig))
-	for i := range orig {
-		n[i] = &orig[i]
-	}
-	return n
+	return aws.StringSlice(orig)
 }
 
+// isNilOrEmpty returns true if the value is nil or ""
+// Deprecated: prefer aws.StringValue(x) == "" (and elimination of this check altogether whrere possible)
 func isNilOrEmpty(s *string) bool {
 	return s == nil || *s == ""
 }
 
+// orEmpty returns the string value, or "" if the pointer is nil
+// Deprecated: prefer aws.StringValue
 func orEmpty(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
+	return aws.StringValue(s)
 }
 
 func newEc2Filter(name string, value string) *ec2.Filter {

--- a/pkg/cloudprovider/providers/aws/aws_utils.go
+++ b/pkg/cloudprovider/providers/aws/aws_utils.go
@@ -43,9 +43,8 @@ func stringSetFromPointers(in []*string) sets.String {
 	return out
 }
 
+// orZero returns the value, or 0 if the pointer is nil
+// Deprecated: prefer aws.Int64Value
 func orZero(v *int64) int64 {
-	if v == nil {
-		return 0
-	}
-	return *v
+	return aws.Int64Value(v)
 }


### PR DESCRIPTION
We have a few functions that predate aws-sdk-go, but they have natural
equivalents in aws-sdk-go.  Document them as deprecated, and replace
the implementation with the equivalent in aws-sdk-go to make it obvious
that they are the same.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29491)

<!-- Reviewable:end -->
