### PR TITLE
t.Errorf output wrong variables in identity_mapper_test.go

### DIFF
--- a/pkg/controller/petset/identity_mappers_test.go
+++ b/pkg/controller/petset/identity_mappers_test.go
@@ -54,11 +54,11 @@ func TestPetIDDNS(t *testing.T) {
 			t.Fatalf("Failed to generate pet %v", err)
 		}
 		if hostname, ok := pod.Annotations[api_pod.PodHostnameAnnotation]; !ok || hostname != petName {
-			t.Errorf("Wrong hostname: %v", petName)
+			t.Errorf("Wrong hostname: %v", hostname)
 		}
 		// TODO: Check this against the governing service.
 		if subdomain, ok := pod.Annotations[api_pod.PodSubdomainAnnotation]; !ok || subdomain != petSubdomain {
-			t.Errorf("Wrong subdomain: %v", petName)
+			t.Errorf("Wrong subdomain: %v", subdomain)
 		}
 	}
 }


### PR DESCRIPTION
t.Errorf output wrong variables in identity_mapper_test.go

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29502)

<!-- Reviewable:end -->
