### PR TITLE
Fix devices information struct in container

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -381,6 +381,15 @@ type PortMapping struct {
 	HostIP string
 }
 
+type DeviceInfo struct {
+	// Path on host for mapping
+	PathOnHost string
+	// Path in Container to map
+	PathInContainer string
+	// Cgroup permissions
+	Permissions string
+}
+
 // RunContainerOptions specify the options which are necessary for running containers
 type RunContainerOptions struct {
 	// The environment variables list.
@@ -388,7 +397,7 @@ type RunContainerOptions struct {
 	// The mounts for the containers.
 	Mounts []Mount
 	// The host devices mapped into the containers.
-	Devices []string
+	Devices []DeviceInfo
 	// The port mappings for the containers.
 	PortMappings []PortMapping
 	// If the container has specified the TerminationMessagePath, then


### PR DESCRIPTION
So far nowhere use the `Devices` which in `RunContainerOptions`. But when I want to use it, found that it could be better if change it, because Devices in container is like:

``` json
"Devices": [
                {
                    "PathOnHost": "/dev/nvidiactl",
                    "PathInContainer": "/dev/nvidiactl",
                    "CgroupPermissions": "mrw"
                },
                {
                    "PathOnHost": "/dev/nvidia-uvm",
                    "PathInContainer": "/dev/nvidia-uvm",
                    "CgroupPermissions": "mrw"
                },
                {
                    "PathOnHost": "/dev/nvidia0",
                    "PathInContainer": "/dev/nvidia0",
                    "CgroupPermissions": "mrw"
                }
            ],
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29509)

<!-- Reviewable:end -->
