### PR TITLE
rkt: Fix /etc/hosts /etc/resolv.conf permissions

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -659,7 +659,7 @@ func copyfile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0640)
+	return ioutil.WriteFile(dst, data, 0644)
 }
 
 // TODO(yifan): Can make rkt handle this when '--net=host'. See https://github.com/coreos/rkt/issues/2430.


### PR DESCRIPTION
#29024 introduced copying /etc/hosts and /etc/resolv.conf before mounting them into rkt containers. However, the new files' permissions are set to 0640, which make these files unusable by any other users than root in the container as shown below. This small patch changes the permissions to 0644, as typically set.

```
# host rabbitmq
rabbitmq.default.svc.cluster.local has address 10.3.0.211
# ls -la /etc/resolv.conf
-rw-r-----. 1 root root 102 Jul 23 13:20 /etc/resolv.conf
# sudo -E -u foo bash
$ cat /etc/resolv.conf
cat: /etc/resolv.conf: Permission denied
$ host rabbitmq
;; connection timed out; no servers could be reached
# exit
# chmod 0644 /etc/resolv.conf /etc/hosts
# sudo -E -u foo host rabbitmq
rabbitmq.default.svc.cluster.local has address 10.3.0.211
```

cc @kubernetes/sig-rktnetes @yifan-gu @euank 
