### PR TITLE
cleanup wrong naming: limitrange -> hpa

### DIFF
--- a/pkg/registry/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/horizontalpodautoscaler/strategy.go
@@ -84,7 +84,7 @@ func (autoscalerStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-func AutoscalerToSelectableFields(limitRange *autoscaling.HorizontalPodAutoscaler) fields.Set {
+func AutoscalerToSelectableFields(hpa *autoscaling.HorizontalPodAutoscaler) fields.Set {
 	return fields.Set{}
 }
 


### PR DESCRIPTION
The code is in `horizontalpodautoscaler/strategy.go`, but the parameter is "limitrange". This is legacy copy-paste issue...
