### PR TITLE
Move versioner to its own package

### DIFF
--- a/pkg/registry/generic/registry/storage_factory.go
+++ b/pkg/registry/generic/registry/storage_factory.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
 )
 
 // Creates a cacher on top of the given 'storageInterface'.
@@ -36,7 +35,6 @@ func StorageWithCacher(
 	config := storage.CacherConfig{
 		CacheCapacity:        capacity,
 		Storage:              storageInterface,
-		Versioner:            etcdstorage.APIObjectVersioner{},
 		Type:                 objectType,
 		ResourcePrefix:       resourcePrefix,
 		NewListFunc:          newListFunc,

--- a/pkg/registry/generic/registry/store.go
+++ b/pkg/registry/generic/registry/store.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/storage/versioner"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/watch"
@@ -317,13 +318,13 @@ func (e *Store) Update(ctx api.Context, name string, objInfo rest.UpdatedObjectI
 		// If AllowUnconditionalUpdate() is true and the object specified by the user does not have a resource version,
 		// then we populate it with the latest version.
 		// Else, we check that the version specified by the user matches the version of latest storage object.
-		resourceVersion, err := e.Storage.Versioner().ObjectResourceVersion(obj)
+		resourceVersion, err := versioner.ObjectResourceVersion(obj)
 		if err != nil {
 			return nil, nil, err
 		}
 		doUnconditionalUpdate := resourceVersion == 0 && e.UpdateStrategy.AllowUnconditionalUpdate()
 
-		version, err := e.Storage.Versioner().ObjectResourceVersion(existing)
+		version, err := versioner.ObjectResourceVersion(existing)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -347,13 +348,13 @@ func (e *Store) Update(ctx api.Context, name string, objInfo rest.UpdatedObjectI
 		creatingObj = nil
 		if doUnconditionalUpdate {
 			// Update the object's resource version to match the latest storage object's resource version.
-			err = e.Storage.Versioner().UpdateObject(obj, res.ResourceVersion)
+			err = versioner.UpdateObject(obj, res.ResourceVersion)
 			if err != nil {
 				return nil, nil, err
 			}
 		} else {
 			// Check if the object's resource version matches the latest resource version.
-			newVersion, err := e.Storage.Versioner().ObjectResourceVersion(obj)
+			newVersion, err := versioner.ObjectResourceVersion(obj)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/registry/generic/registry/store_test.go
+++ b/pkg/registry/generic/registry/store_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	storagetesting "k8s.io/kubernetes/pkg/storage/testing"
+	"k8s.io/kubernetes/pkg/storage/versioner"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -219,7 +220,6 @@ func TestStoreListResourceVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	versioner := etcdstorage.APIObjectVersioner{}
 	rev, err := versioner.ObjectResourceVersion(obj)
 	if err != nil {
 		t.Fatal(err)
@@ -1020,7 +1020,6 @@ func newTestGenericStoreRegistry(t *testing.T, hasCacheEnabled bool) (*etcdtesti
 		config := storage.CacherConfig{
 			CacheCapacity:  10,
 			Storage:        s,
-			Versioner:      etcdstorage.APIObjectVersioner{},
 			Type:           &api.Pod{},
 			ResourcePrefix: podPrefix,
 			KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NoNamespaceKeyFunc(podPrefix, obj) },

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -54,7 +54,6 @@ func newTestCacher(s storage.Interface) *storage.Cacher {
 	config := storage.CacherConfig{
 		CacheCapacity:  10,
 		Storage:        s,
-		Versioner:      etcdstorage.APIObjectVersioner{},
 		Type:           &api.Pod{},
 		ResourcePrefix: prefix,
 		KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) },

--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
 	etcdutil "k8s.io/kubernetes/pkg/storage/etcd/util"
+	"k8s.io/kubernetes/pkg/storage/versioner"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -78,11 +79,7 @@ func exceptKey(except string) includeFunc {
 
 // etcdWatcher converts a native etcd watch to a watch.Interface.
 type etcdWatcher struct {
-	encoding runtime.Codec
-	// Note that versioner is required for etcdWatcher to work correctly.
-	// There is no public constructor of it, so be careful when manipulating
-	// with it manually.
-	versioner storage.Versioner
+	encoding  runtime.Codec
 	transform TransformFunc
 
 	list    bool // If we're doing a recursive watch, should be true.
@@ -117,11 +114,10 @@ const watchWaitDuration = 100 * time.Millisecond
 // The versioner must be able to handle the objects that transform creates.
 func newEtcdWatcher(
 	list bool, quorum bool, include includeFunc, filter storage.Filter,
-	encoding runtime.Codec, versioner storage.Versioner, transform TransformFunc,
+	encoding runtime.Codec, transform TransformFunc,
 	cache etcdCache) *etcdWatcher {
 	w := &etcdWatcher{
 		encoding:  encoding,
-		versioner: versioner,
 		transform: transform,
 		list:      list,
 		quorum:    quorum,
@@ -329,7 +325,7 @@ func (w *etcdWatcher) decodeObject(node *etcd.Node) (runtime.Object, error) {
 	}
 
 	// ensure resource version is set on the object we load from etcd
-	if err := w.versioner.UpdateObject(obj, node.ModifiedIndex); err != nil {
+	if err := versioner.UpdateObject(obj, node.ModifiedIndex); err != nil {
 		utilruntime.HandleError(fmt.Errorf("failure to version api object (%d) %#v: %v", node.ModifiedIndex, obj, err))
 	}
 
@@ -399,7 +395,7 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 	if res.PrevNode != nil && res.PrevNode.Value != "" {
 		// Ignore problems reading the old object.
 		if oldObj, err = w.decodeObject(res.PrevNode); err == nil {
-			if err := w.versioner.UpdateObject(oldObj, res.Node.ModifiedIndex); err != nil {
+			if err := versioner.UpdateObject(oldObj, res.Node.ModifiedIndex); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failure to version api object (%d) %#v: %v", res.Node.ModifiedIndex, oldObj, err))
 			}
 			oldObjPasses = w.filter.Filter(oldObj)

--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -111,7 +111,6 @@ type etcdWatcher struct {
 const watchWaitDuration = 100 * time.Millisecond
 
 // newEtcdWatcher returns a new etcdWatcher; if list is true, watch sub-nodes.
-// The versioner must be able to handle the objects that transform creates.
 func newEtcdWatcher(
 	list bool, quorum bool, include includeFunc, filter storage.Filter,
 	encoding runtime.Codec, transform TransformFunc,

--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -34,8 +34,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-var versioner = APIObjectVersioner{}
-
 // Implements etcdCache interface as empty methods (i.e. does not cache any objects)
 type fakeEtcdCache struct{}
 
@@ -140,7 +138,7 @@ func TestWatchInterpretations(t *testing.T) {
 
 	for name, item := range table {
 		for _, action := range item.actions {
-			w := newEtcdWatcher(true, false, nil, &firstLetterIsB{}, codec, versioner, nil, &fakeEtcdCache{})
+			w := newEtcdWatcher(true, false, nil, &firstLetterIsB{}, codec, nil, &fakeEtcdCache{})
 			emitCalled := false
 			w.emit = func(event watch.Event) {
 				emitCalled = true
@@ -179,7 +177,7 @@ func TestWatchInterpretations(t *testing.T) {
 
 func TestWatchInterpretation_ResponseNotSet(t *testing.T) {
 	_, codec := testScheme(t)
-	w := newEtcdWatcher(false, false, nil, storage.Everything, codec, versioner, nil, &fakeEtcdCache{})
+	w := newEtcdWatcher(false, false, nil, storage.Everything, codec, nil, &fakeEtcdCache{})
 	w.emit = func(e watch.Event) {
 		t.Errorf("Unexpected emit: %v", e)
 	}
@@ -194,7 +192,7 @@ func TestWatchInterpretation_ResponseNoNode(t *testing.T) {
 	_, codec := testScheme(t)
 	actions := []string{"create", "set", "compareAndSwap", "delete"}
 	for _, action := range actions {
-		w := newEtcdWatcher(false, false, nil, storage.Everything, codec, versioner, nil, &fakeEtcdCache{})
+		w := newEtcdWatcher(false, false, nil, storage.Everything, codec, nil, &fakeEtcdCache{})
 		w.emit = func(e watch.Event) {
 			t.Errorf("Unexpected emit: %v", e)
 		}
@@ -209,7 +207,7 @@ func TestWatchInterpretation_ResponseBadData(t *testing.T) {
 	_, codec := testScheme(t)
 	actions := []string{"create", "set", "compareAndSwap", "delete"}
 	for _, action := range actions {
-		w := newEtcdWatcher(false, false, nil, storage.Everything, codec, versioner, nil, &fakeEtcdCache{})
+		w := newEtcdWatcher(false, false, nil, storage.Everything, codec, nil, &fakeEtcdCache{})
 		w.emit = func(e watch.Event) {
 			t.Errorf("Unexpected emit: %v", e)
 		}

--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -233,7 +233,7 @@ func TestSendResultDeleteEventHaveLatestIndex(t *testing.T) {
 		return obj.(*api.Pod).Name != "bar"
 	}
 	filter := storage.NewSimpleFilter(filterFunc, storage.NoTriggerFunc)
-	w := newEtcdWatcher(false, false, nil, filter, codec, versioner, nil, &fakeEtcdCache{})
+	w := newEtcdWatcher(false, false, nil, filter, codec, nil, &fakeEtcdCache{})
 
 	eventChan := make(chan watch.Event, 1)
 	w.emit = func(e watch.Event) {

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -101,9 +101,6 @@ type Interface interface {
 	// of this method from the interface.
 	Backends(ctx context.Context) []string
 
-	// Returns Versioner associated with this interface.
-	Versioner() Versioner
-
 	// Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
 	// in seconds (0 means forever). If no error is returned and out is not nil, out will be
 	// set to the read value from database.

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -23,22 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
-// Versioner abstracts setting and retrieving metadata fields from database response
-// onto the object ot list.
-type Versioner interface {
-	// UpdateObject sets storage metadata into an API object. Returns an error if the object
-	// cannot be updated correctly. May return nil if the requested object does not need metadata
-	// from database.
-	UpdateObject(obj runtime.Object, resourceVersion uint64) error
-	// UpdateList sets the resource version into an API list object. Returns an error if the object
-	// cannot be updated correctly. May return nil if the requested object does not need metadata
-	// from database.
-	UpdateList(obj runtime.Object, resourceVersion uint64) error
-	// ObjectResourceVersion returns the resource version (for persistence) of the specified object.
-	// Should return an error if the specified object does not have a persistable version.
-	ObjectResourceVersion(obj runtime.Object) (uint64, error)
-}
-
 // ResponseMeta contains information about the database metadata that is associated with
 // an object. It abstracts the actual underlying objects to prevent coupling with concrete
 // database and to improve testability.

--- a/pkg/storage/versioner/versioner.go
+++ b/pkg/storage/versioner/versioner.go
@@ -73,12 +73,12 @@ func ObjectResourceVersion(obj runtime.Object) (uint64, error) {
 // CompareResourceVersion compares etcd resource versions.  Outside this API they are all strings,
 // but etcd resource versions are special, they're actually ints, so we can easily compare them.
 func CompareResourceVersion(lhs, rhs runtime.Object) int {
-	lhsVersion, err := Versioner.ObjectResourceVersion(lhs)
+	lhsVersion, err := ObjectResourceVersion(lhs)
 	if err != nil {
 		// coder error
 		panic(err)
 	}
-	rhsVersion, err := Versioner.ObjectResourceVersion(rhs)
+	rhsVersion, err := ObjectResourceVersion(rhs)
 	if err != nil {
 		// coder error
 		panic(err)

--- a/pkg/storage/versioner/versioner_test.go
+++ b/pkg/storage/versioner/versioner_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package etcd
+package versioner
 
 import (
 	"testing"
@@ -24,15 +24,14 @@ import (
 )
 
 func TestObjectVersioner(t *testing.T) {
-	v := APIObjectVersioner{}
-	if ver, err := v.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
+	if ver, err := ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
-	if ver, err := v.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
+	if ver, err := ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
 	obj := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
-	if err := v.UpdateObject(obj, 5); err != nil {
+	if err := UpdateObject(obj, 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if obj.ResourceVersion != "5" || obj.DeletionTimestamp != nil {
@@ -44,15 +43,13 @@ func TestCompareResourceVersion(t *testing.T) {
 	five := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}
 	six := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "6"}}
 
-	versioner := APIObjectVersioner{}
-
-	if e, a := -1, versioner.CompareResourceVersion(five, six); e != a {
+	if e, a := -1, CompareResourceVersion(five, six); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
-	if e, a := 1, versioner.CompareResourceVersion(six, five); e != a {
+	if e, a := 1, CompareResourceVersion(six, five); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
-	if e, a := 0, versioner.CompareResourceVersion(six, six); e != a {
+	if e, a := 0, CompareResourceVersion(six, six); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
 }

--- a/pkg/storage/versioner/versioner_test.go
+++ b/pkg/storage/versioner/versioner_test.go
@@ -14,24 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versioner
+package versioner_test
 
 import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	storagetesting "k8s.io/kubernetes/pkg/storage/testing"
+	"k8s.io/kubernetes/pkg/storage/versioner"
 )
 
 func TestObjectVersioner(t *testing.T) {
-	if ver, err := ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
+	if ver, err := versioner.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
-	if ver, err := ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
+	if ver, err := versioner.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
 	obj := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
-	if err := UpdateObject(obj, 5); err != nil {
+	if err := versioner.UpdateObject(obj, 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if obj.ResourceVersion != "5" || obj.DeletionTimestamp != nil {
@@ -43,13 +44,13 @@ func TestCompareResourceVersion(t *testing.T) {
 	five := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}
 	six := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "6"}}
 
-	if e, a := -1, CompareResourceVersion(five, six); e != a {
+	if e, a := -1, versioner.CompareResourceVersion(five, six); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
-	if e, a := 1, CompareResourceVersion(six, five); e != a {
+	if e, a := 1, versioner.CompareResourceVersion(six, five); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
-	if e, a := 0, CompareResourceVersion(six, six); e != a {
+	if e, a := 0, versioner.CompareResourceVersion(six, six); e != a {
 		t.Errorf("expected %v got %v", e, a)
 	}
 }

--- a/plugin/pkg/admission/resourcequota/resource_access.go
+++ b/plugin/pkg/admission/resourcequota/resource_access.go
@@ -24,11 +24,11 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/storage/versioner"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage/etcd"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -113,8 +113,6 @@ func (e *quotaAccessor) UpdateQuotaStatus(newQuota *api.ResourceQuota) error {
 	return nil
 }
 
-var etcdVersioner = etcd.APIObjectVersioner{}
-
 // checkCache compares the passed quota against the value in the look-aside cache and returns the newer
 // if the cache is out of date, it deletes the stale entry.  This only works because of etcd resourceVersions
 // being monotonically increasing integers
@@ -126,7 +124,7 @@ func (e *quotaAccessor) checkCache(quota *api.ResourceQuota) *api.ResourceQuota 
 	}
 	cachedQuota := uncastCachedQuota.(*api.ResourceQuota)
 
-	if etcdVersioner.CompareResourceVersion(quota, cachedQuota) >= 0 {
+	if versioner.CompareResourceVersion(quota, cachedQuota) >= 0 {
 		e.updatedQuotas.Remove(key)
 		return quota
 	}


### PR DESCRIPTION
This PR:
- ~~removes the versioner interface, objects~~ (outdated)
- move versioner to its own package.

Why?
- Those methods aren't generic. The generic part is pretty much done by object meta accessor.
- Some use cases that want to make use of versioner just creates their own versioner object. This is very fragmented. ref: #25091, [etcd_watcher_test.go](https://github.com/kubernetes/kubernetes/blob/1d9bc58328cb45164bc20167db613fd0eb60fb9f/pkg/storage/etcd/etcd_watcher_test.go#L37)
- Versioner() method is redundant in storage.Interface.

TODO:
- UpdateObject -> SetResourceVersion
- UpdateList -> SetListResourceVersion
