### PR TITLE
check zero before using after getting podList.Items

### DIFF
--- a/pkg/controller/podautoscaler/metrics/metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client.go
@@ -119,6 +119,11 @@ func (h *HeapsterMetricsClient) GetCpuConsumptionAndRequestInMillis(namespace st
 	if err != nil {
 		return 0, 0, time.Time{}, fmt.Errorf("failed to get pod list: %v", err)
 	}
+
+	if len(podList.Items) == 0 {
+		return 0, 0, time.Time{}, fmt.Errorf("empty pod list for selector: %v", selector)
+	}
+
 	podNames := map[string]struct{}{}
 	requestSum := int64(0)
 	missing := false


### PR DESCRIPTION
It is better to check zero before using after getting podList.Items: line 116

```
podList, err := h.client.Core().Pods(namespace).
    List(api.ListOptions{LabelSelector: selector})
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29530)

<!-- Reviewable:end -->
