### PR TITLE
fix kubectl rolling update empty file cause panic issue

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -220,6 +220,9 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 			if len(list.Items) > 1 {
 				return cmdutil.UsageError(cmd, "%s specifies multiple items", filename)
 			}
+			if len(list.Items) == 0 {
+				return cmdutil.UsageError(cmd, "please make sure %s exists and is not empty", filename)
+			}
 			obj = list.Items[0]
 		}
 		newRc, ok = obj.(*api.ReplicationController)


### PR DESCRIPTION
``` release-note
Fix issue with kubectl panicing when passed files that do not exist.
```

Fix #29398 
@pwittrock @justinsb ptal. This just fix on the cmd layer, I am thinking whether we should return err from marshal&unmarshal if the reader is empty.
