### PR TITLE
Optimize the code logic for PodGCController.gc()

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -96,11 +96,7 @@ func (gcc *PodGCController) gc() {
 	terminatedPodCount := len(terminatedPods)
 	sort.Sort(byCreationTimestamp(terminatedPods))
 
-	deleteCount := terminatedPodCount - gcc.threshold
-
-	if deleteCount > terminatedPodCount {
-		deleteCount = terminatedPodCount
-	}
+	deleteCount := terminatedPodCount
 	if deleteCount > 0 {
 		glog.Infof("garbage collecting %v pods", deleteCount)
 	}


### PR DESCRIPTION
The optimized cod is:

```
deleteCount := terminatedPodCount - gcc.threshold

if deleteCount > terminatedPodCount {
    deleteCount = terminatedPodCount
}
```

It is just equal to:

```
deleteCount := terminatedPodCount
```
