### PR TITLE
Log information wrong while wait.ForeverTestTimeout

### DIFF
--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -481,7 +481,7 @@ func TestWatchControllers(t *testing.T) {
 	select {
 	case <-received:
 	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("Expected 1 call but got 0")
+		t.Errorf("unexpected timeout from result channel")
 	}
 }
 
@@ -528,7 +528,7 @@ func TestWatchPods(t *testing.T) {
 	select {
 	case <-received:
 	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("Expected 1 call but got 0")
+		t.Errorf("unexpected timeout from result channel")
 	}
 }
 

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -95,45 +95,34 @@ func newReplicationController(replicas int) *api.ReplicationController {
 	return rc
 }
 
-// create a pod with the given phase for the given rc (same selectors and namespace).
-func newPod(name string, rc *api.ReplicationController, status api.PodPhase) *api.Pod {
-	return &api.Pod{
-		ObjectMeta: api.ObjectMeta{
-			Name:      name,
-			Labels:    rc.Spec.Selector,
-			Namespace: rc.Namespace,
-		},
-		Status: api.PodStatus{Phase: status},
-	}
-}
-
 // create count pods with the given phase for the given rc (same selectors and namespace), and add them to the store.
 func newPodList(store cache.Store, count int, status api.PodPhase, rc *api.ReplicationController, name string) *api.PodList {
 	pods := []api.Pod{}
-	var trueVar = true
-	controllerReference := api.OwnerReference{UID: rc.UID, APIVersion: "v1", Kind: "ReplicationController", Name: rc.Name, Controller: &trueVar}
 	for i := 0; i < count; i++ {
-		pod := newPod(fmt.Sprintf("%s%d", name, i), rc, status)
-		pod.OwnerReferences = []api.OwnerReference{controllerReference}
-		if store != nil {
-			store.Add(pod)
+		newPod := api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:      fmt.Sprintf("%s%d", name, i),
+				Labels:    rc.Spec.Selector,
+				Namespace: rc.Namespace,
+			},
+			Status: api.PodStatus{Phase: status},
 		}
-		pods = append(pods, *pod)
+		if store != nil {
+			store.Add(&newPod)
+		}
+		pods = append(pods, newPod)
 	}
 	return &api.PodList{
 		Items: pods,
 	}
 }
 
-func validateSyncReplication(t *testing.T, fakePodControl *controller.FakePodControl, expectedCreates, expectedDeletes, expectedPatches int) {
-	if e, a := expectedCreates, len(fakePodControl.Templates); e != a {
-		t.Errorf("Unexpected number of creates.  Expected %d, saw %d\n", e, a)
+func validateSyncReplication(t *testing.T, fakePodControl *controller.FakePodControl, expectedCreates, expectedDeletes int) {
+	if len(fakePodControl.Templates) != expectedCreates {
+		t.Errorf("Unexpected number of creates.  Expected %d, saw %d\n", expectedCreates, len(fakePodControl.Templates))
 	}
-	if e, a := expectedDeletes, len(fakePodControl.DeletePodName); e != a {
-		t.Errorf("Unexpected number of deletes.  Expected %d, saw %d\n", e, a)
-	}
-	if e, a := expectedPatches, len(fakePodControl.Patches); e != a {
-		t.Errorf("Unexpected number of patches.  Expected %d, saw %d\n", e, a)
+	if len(fakePodControl.DeletePodName) != expectedDeletes {
+		t.Errorf("Unexpected number of deletes.  Expected %d, saw %d\n", expectedDeletes, len(fakePodControl.DeletePodName))
 	}
 }
 
@@ -159,7 +148,7 @@ func TestSyncReplicationControllerDoesNothing(t *testing.T) {
 
 	manager.podControl = &fakePodControl
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 }
 
 func TestSyncReplicationControllerDeletes(t *testing.T) {
@@ -175,7 +164,7 @@ func TestSyncReplicationControllerDeletes(t *testing.T) {
 	newPodList(manager.podStore.Indexer, 2, api.PodRunning, controllerSpec, "pod")
 
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 0, 1, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 1)
 }
 
 func TestDeleteFinalStateUnknown(t *testing.T) {
@@ -223,7 +212,7 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.syncReplicationController(getKey(rc, t))
-	validateSyncReplication(t, &fakePodControl, 2, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 2, 0)
 }
 
 func TestStatusUpdatesWithoutReplicasChange(t *testing.T) {
@@ -249,7 +238,7 @@ func TestStatusUpdatesWithoutReplicasChange(t *testing.T) {
 	manager.podControl = &fakePodControl
 	manager.syncReplicationController(getKey(rc, t))
 
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 	if fakeHandler.RequestReceived != nil {
 		t.Errorf("Unexpected update when pods and rcs are in a steady state")
 	}
@@ -308,7 +297,7 @@ func TestControllerUpdateReplicas(t *testing.T) {
 
 	decRc := runtime.EncodeOrDie(testapi.Default.Codec(), rc)
 	fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name)+"/status", "PUT", &decRc)
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 1, 0)
 }
 
 func TestSyncReplicationControllerDormancy(t *testing.T) {
@@ -332,13 +321,13 @@ func TestSyncReplicationControllerDormancy(t *testing.T) {
 	// Creates a replica and sets expectations
 	controllerSpec.Status.Replicas = 1
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 1, 0)
 
 	// Expectations prevents replicas but not an update on status
 	controllerSpec.Status.Replicas = 0
 	fakePodControl.Clear()
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 
 	// Get the key for the controller
 	rcKey, err := controller.KeyFunc(controllerSpec)
@@ -347,20 +336,19 @@ func TestSyncReplicationControllerDormancy(t *testing.T) {
 	}
 
 	// Lowering expectations should lead to a sync that creates a replica, however the
-	// fakePodControl error will prevent this, leaving expectations at 0, 0.
+	// fakePodControl error will prevent this, leaving expectations at 0, 0
 	manager.expectations.CreationObserved(rcKey)
 	controllerSpec.Status.Replicas = 1
 	fakePodControl.Clear()
 	fakePodControl.Err = fmt.Errorf("Fake Error")
 
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 
 	// This replica should not need a Lowering of expectations, since the previous create failed
-	fakePodControl.Clear()
 	fakePodControl.Err = nil
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 1, 0)
 
 	// 1 PUT for the rc status during dormancy window.
 	// Note that the pod creates go through pod control so they're not recorded.
@@ -466,7 +454,7 @@ func TestWatchControllers(t *testing.T) {
 	select {
 	case <-received:
 	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("Expected 1 call but got 0")
+		t.Errorf("unexpected timeout from result channel")
 	}
 }
 
@@ -512,7 +500,7 @@ func TestWatchPods(t *testing.T) {
 	select {
 	case <-received:
 	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("Expected 1 call but got 0")
+		t.Errorf("unexpected timeout from result channel")
 	}
 }
 
@@ -709,7 +697,7 @@ func doTestControllerBurstReplicas(t *testing.T, burstReplicas, numReplicas int)
 					expectedPods = burstReplicas
 				}
 				// This validates the rc manager sync actually created pods
-				validateSyncReplication(t, &fakePodControl, expectedPods, 0, 0)
+				validateSyncReplication(t, &fakePodControl, expectedPods, 0)
 
 				// This simulates the watch events for all but 1 of the expected pods.
 				// None of these should wake the controller because it has expectations==BurstReplicas.
@@ -730,7 +718,7 @@ func doTestControllerBurstReplicas(t *testing.T, burstReplicas, numReplicas int)
 				if expectedPods > burstReplicas {
 					expectedPods = burstReplicas
 				}
-				validateSyncReplication(t, &fakePodControl, 0, expectedPods, 0)
+				validateSyncReplication(t, &fakePodControl, 0, expectedPods)
 
 				// To accurately simulate a watch we must delete the exact pods
 				// the rc is waiting for.
@@ -765,7 +753,7 @@ func doTestControllerBurstReplicas(t *testing.T, burstReplicas, numReplicas int)
 			// Check that the rc didn't take any action for all the above pods
 			fakePodControl.Clear()
 			manager.syncReplicationController(getKey(controllerSpec, t))
-			validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+			validateSyncReplication(t, &fakePodControl, 0, 0)
 
 			// Create/Delete the last pod
 			// The last add pod will decrease the expectation of the rc to 0,
@@ -843,7 +831,7 @@ func TestRCSyncExpectations(t *testing.T) {
 		},
 	})
 	manager.syncReplicationController(getKey(controllerSpec, t))
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 }
 
 func TestDeleteControllerAndExpectations(t *testing.T) {
@@ -859,7 +847,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 
 	// This should set expectations for the rc
 	manager.syncReplicationController(getKey(rc, t))
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 1, 0)
 	fakePodControl.Clear()
 
 	// Get the RC key
@@ -885,7 +873,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 	podExp.Add(-1, 0)
 	manager.podStore.Indexer.Replace(make([]interface{}, 0), "0")
 	manager.syncReplicationController(getKey(rc, t))
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 }
 
 func TestRCManagerNotReady(t *testing.T) {
@@ -903,7 +891,7 @@ func TestRCManagerNotReady(t *testing.T) {
 
 	rcKey := getKey(controllerSpec, t)
 	manager.syncReplicationController(rcKey)
-	validateSyncReplication(t, &fakePodControl, 0, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 0, 0)
 	queueRC, _ := manager.queue.Get()
 	if queueRC != rcKey {
 		t.Fatalf("Expected to find key %v in queue, found %v", rcKey, queueRC)
@@ -911,7 +899,7 @@ func TestRCManagerNotReady(t *testing.T) {
 
 	manager.podStoreSynced = alwaysReady
 	manager.syncReplicationController(rcKey)
-	validateSyncReplication(t, &fakePodControl, 1, 0, 0)
+	validateSyncReplication(t, &fakePodControl, 1, 0)
 }
 
 // shuffle returns a new shuffled list of container controllers.
@@ -1127,194 +1115,4 @@ func BenchmarkGetPodControllerSingleNS(b *testing.B) {
 			manager.getPodController(&pod)
 		}
 	}
-}
-
-// setupManagerWithGCEnabled creates a RC manager with a fakePodControl and with garbageCollectorEnabled set to true
-func setupManagerWithGCEnabled() (manager *ReplicationManager, fakePodControl *controller.FakePodControl) {
-	c := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
-	fakePodControl = &controller.FakePodControl{}
-	manager = NewReplicationManagerFromClient(c, controller.NoResyncPeriodFunc, BurstReplicas, 0)
-	manager.garbageCollectorEnabled = true
-	manager.podStoreSynced = alwaysReady
-	manager.podControl = fakePodControl
-	return manager, fakePodControl
-}
-
-func TestDoNotPatchPodWithOtherControlRef(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	var trueVar = true
-	otherControllerReference := api.OwnerReference{UID: util.NewUUID(), APIVersion: "v1", Kind: "ReplicationController", Name: "AnotherRC", Controller: &trueVar}
-	// add to podStore a matching Pod controlled by another controller. Expect no patch.
-	pod := newPod("pod", rc, api.PodRunning)
-	pod.OwnerReferences = []api.OwnerReference{otherControllerReference}
-	manager.podStore.Indexer.Add(pod)
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// because the matching pod already has a controller, so 2 pods should be created.
-	validateSyncReplication(t, fakePodControl, 2, 0, 0)
-}
-
-func TestPatchPodWithOtherOwnerRef(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	// add to podStore one more matching pod that doesn't have a controller
-	// ref, but has an owner ref pointing to other object. Expect a patch to
-	// take control of it.
-	unrelatedOwnerReference := api.OwnerReference{UID: util.NewUUID(), APIVersion: "batch/v1", Kind: "Job", Name: "Job"}
-	pod := newPod("pod", rc, api.PodRunning)
-	pod.OwnerReferences = []api.OwnerReference{unrelatedOwnerReference}
-	manager.podStore.Indexer.Add(pod)
-
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// 1 patch to take control of pod, and 1 create of new pod.
-	validateSyncReplication(t, fakePodControl, 1, 0, 1)
-}
-
-func TestPatchPodWithCorrectOwnerRef(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	// add to podStore a matching pod that has an ownerRef pointing to the rc,
-	// but ownerRef.Controller is false. Expect a patch to take control it.
-	rcOwnerReference := api.OwnerReference{UID: rc.UID, APIVersion: "v1", Kind: "ReplicationController", Name: rc.Name}
-	pod := newPod("pod", rc, api.PodRunning)
-	pod.OwnerReferences = []api.OwnerReference{rcOwnerReference}
-	manager.podStore.Indexer.Add(pod)
-
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// 1 patch to take control of pod, and 1 create of new pod.
-	validateSyncReplication(t, fakePodControl, 1, 0, 1)
-}
-
-func TestPatchPodFails(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	// add to podStore two matching pods. Expect two patches to take control
-	// them.
-	manager.podStore.Indexer.Add(newPod("pod1", rc, api.PodRunning))
-	manager.podStore.Indexer.Add(newPod("pod2", rc, api.PodRunning))
-	// let both patches fail. The rc manager will assume it fails to take
-	// control of the pods and create new ones.
-	fakePodControl.Err = fmt.Errorf("Fake Error")
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// 2 patches to take control of pod1 and pod2 (both fail), 2 creates.
-	validateSyncReplication(t, fakePodControl, 2, 0, 2)
-}
-
-func TestPatchExtraPodsThenDelete(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	// add to podStore three matching pods. Expect three patches to take control
-	// them, and later delete one of them.
-	manager.podStore.Indexer.Add(newPod("pod1", rc, api.PodRunning))
-	manager.podStore.Indexer.Add(newPod("pod2", rc, api.PodRunning))
-	manager.podStore.Indexer.Add(newPod("pod3", rc, api.PodRunning))
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// 3 patches to take control of the pods, and 1 deletion because there is an extra pod.
-	validateSyncReplication(t, fakePodControl, 0, 1, 3)
-}
-
-func TestUpdateLabelsRemoveControllerRef(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	manager.rcStore.Indexer.Add(rc)
-	// put one pod in the podStore
-	pod := newPod("pod", rc, api.PodRunning)
-	var trueVar = true
-	rcOwnerReference := api.OwnerReference{UID: rc.UID, APIVersion: "v1", Kind: "ReplicationController", Name: rc.Name, Controller: &trueVar}
-	pod.OwnerReferences = []api.OwnerReference{rcOwnerReference}
-	updatedPod := *pod
-	// reset the labels
-	updatedPod.Labels = make(map[string]string)
-	// add the updatedPod to the store. This is consistent with the behavior of
-	// the Informer: Informer updates the store before call the handler
-	// (updatePod() in this case).
-	manager.podStore.Indexer.Add(&updatedPod)
-	// send a update of the same pod with modified labels
-	manager.updatePod(pod, &updatedPod)
-	// verifies that rc is added to the queue
-	rcKey := getKey(rc, t)
-	queueRC, _ := manager.queue.Get()
-	if queueRC != rcKey {
-		t.Fatalf("Expected to find key %v in queue, found %v", rcKey, queueRC)
-	}
-	manager.queue.Done(queueRC)
-	err := manager.syncReplicationController(rcKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// expect 1 patch to be sent to remove the controllerRef for the pod.
-	// expect 2 creates because the rc.Spec.Replicas=2 and there exists no
-	// matching pod.
-	validateSyncReplication(t, fakePodControl, 2, 0, 1)
-	fakePodControl.Clear()
-}
-
-func TestUpdateSelectorControllerRef(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	// put 2 pods in the podStore
-	newPodList(manager.podStore.Indexer, 2, api.PodRunning, rc, "pod")
-	// update the RC so that its selector no longer matches the pods
-	updatedRC := *rc
-	updatedRC.Spec.Selector = map[string]string{"foo": "baz"}
-	// put the updatedRC into the store. This is consistent with the behavior of
-	// the Informer: Informer updates the store before call the handler
-	// (updateRC() in this case).
-	manager.rcStore.Indexer.Add(&updatedRC)
-	manager.updateRC(rc, &updatedRC)
-	// verifies that the rc is added to the queue
-	rcKey := getKey(rc, t)
-	queueRC, _ := manager.queue.Get()
-	if queueRC != rcKey {
-		t.Fatalf("Expected to find key %v in queue, found %v", rcKey, queueRC)
-	}
-	manager.queue.Done(queueRC)
-	err := manager.syncReplicationController(rcKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// expect 2 patches to be sent to remove the controllerRef for the pods.
-	// expect 2 creates because the rc.Spec.Replicas=2 and there exists no
-	// matching pod.
-	validateSyncReplication(t, fakePodControl, 2, 0, 2)
-	fakePodControl.Clear()
-}
-
-// RC manager shouldn't adopt or create more pods if the rc is about to be
-// deleted.
-func TestDoNotAdoptOrCreateIfBeingDeleted(t *testing.T) {
-	manager, fakePodControl := setupManagerWithGCEnabled()
-	rc := newReplicationController(2)
-	now := unversioned.Now()
-	rc.DeletionTimestamp = &now
-	manager.rcStore.Indexer.Add(rc)
-	pod1 := newPod("pod1", rc, api.PodRunning)
-	manager.podStore.Indexer.Add(pod1)
-
-	// no patch, no create
-	err := manager.syncReplicationController(getKey(rc, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	validateSyncReplication(t, fakePodControl, 0, 0, 0)
 }


### PR DESCRIPTION
It is not easy to understand "Expected 1 call but got 0", suitable to modify to "unexpected timeout from result channel"
