### PR TITLE
[GarbageCollector] GC waits for all reflectors to be synced before starting workers

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -684,9 +684,21 @@ func (gc *GarbageCollector) processItem(item *node) error {
 }
 
 func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
+	glog.Infof("Garbage Collector: Initializing")
 	for _, monitor := range gc.monitors {
 		go monitor.controller.Run(stopCh)
 	}
+
+	wait.PollInfinite(10*time.Second, func() (bool, error) {
+		for _, monitor := range gc.monitors {
+			if !monitor.controller.HasSynced() {
+				glog.Infof("Garbage Collector: Waiting for resource monitors to be synced...")
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	glog.Infof("Garbage Collector: All monitored resources synced. Proceeding to collect garbage")
 
 	// worker
 	go wait.Until(gc.propagator.processEvent, 0, stopCh)
@@ -696,7 +708,7 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(gc.orphanFinalizer, 0, stopCh)
 	}
 	<-stopCh
-	glog.Infof("Shutting down garbage collector")
+	glog.Infof("Garbage Collector: Shutting down")
 	gc.dirtyQueue.ShutDown()
 	gc.orphanQueue.ShutDown()
 	gc.propagator.eventQueue.ShutDown()


### PR DESCRIPTION
Fix 28713. See https://github.com/kubernetes/kubernetes/issues/28713#issuecomment-234826276 for details on the cause of the flake. The test has passed 100 times locally.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29550)

<!-- Reviewable:end -->
