### PR TITLE
make the resource prefix in etcd configurable for cohabitation

### DIFF
--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -168,5 +168,6 @@ func createRESTOptionsOrDie(s *genericoptions.ServerRunOptions, g *genericapiser
 		Storage:                 storage,
 		Decorator:               g.StorageDecorator(),
 		DeleteCollectionWorkers: s.DeleteCollectionWorkers,
+		ResourcePrefix:          f.ResourcePrefix(resource),
 	}
 }

--- a/pkg/controller/serviceaccount/tokengetter.go
+++ b/pkg/controller/serviceaccount/tokengetter.go
@@ -69,9 +69,9 @@ func (r *registryGetter) GetSecret(namespace, name string) (*api.Secret, error) 
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(s storage.Interface) serviceaccount.ServiceAccountTokenGetter {
+func NewGetterFromStorageInterface(s storage.Interface, saPrefix, secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
 	return NewGetterFromRegistries(
-		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
-		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
+		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix})),
+		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix})),
 	)
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -731,6 +731,7 @@ func (m *Master) GetRESTOptionsOrDie(c *Config, resource unversioned.GroupResour
 		Storage:                 storage,
 		Decorator:               m.StorageDecorator(),
 		DeleteCollectionWorkers: m.deleteCollectionWorkers,
+		ResourcePrefix:          c.StorageFactory.ResourcePrefix(resource),
 	}
 }
 

--- a/pkg/registry/clusterrole/etcd/etcd.go
+++ b/pkg/registry/clusterrole/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterroles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/clusterrolebinding/etcd/etcd.go
+++ b/pkg/registry/clusterrolebinding/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterrolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/configmap/etcd/etcd.go
+++ b/pkg/registry/configmap/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/configmaps"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ConfigMapList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/controller/etcd/etcd.go
+++ b/pkg/registry/controller/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/controllers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ReplicationControllerList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/daemonset/etcd/etcd.go
+++ b/pkg/registry/daemonset/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/daemonsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DaemonSetList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/deployment/etcd/etcd.go
+++ b/pkg/registry/deployment/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *RollbackREST) {
-	prefix := "/deployments"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DeploymentList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/deployment/etcd/etcd_test.go
+++ b/pkg/registry/deployment/etcd/etcd_test.go
@@ -41,7 +41,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*DeploymentStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "deployments"}
 	deploymentStorage := NewStorage(restOptions)
 	return &deploymentStorage, server
 }

--- a/pkg/registry/endpoint/etcd/etcd.go
+++ b/pkg/registry/endpoint/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/services/endpoints"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.EndpointsList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/event/etcd/etcd.go
+++ b/pkg/registry/event/etcd/etcd.go
@@ -30,7 +30,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against events.
 func NewREST(opts generic.RESTOptions, ttl uint64) *REST {
-	prefix := "/events"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here - switching on Cacher
 	// for events will lead to too high memory consumption.

--- a/pkg/registry/experimental/controller/etcd/etcd_test.go
+++ b/pkg/registry/experimental/controller/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 
 func newStorage(t *testing.T) (*ScaleREST, *etcdtesting.EtcdTestServer, storage.Interface) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "controllers"}
 	return NewStorage(restOptions).Scale, server, etcdStorage
 }
 

--- a/pkg/registry/generic/options.go
+++ b/pkg/registry/generic/options.go
@@ -25,4 +25,6 @@ type RESTOptions struct {
 	Storage                 pkgstorage.Interface
 	Decorator               StorageDecorator
 	DeleteCollectionWorkers int
+
+	ResourcePrefix string
 }

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/horizontalpodautoscalers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/ingress/etcd/etcd.go
+++ b/pkg/registry/ingress/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/ingress"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.IngressList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/job/etcd/etcd.go
+++ b/pkg/registry/job/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/jobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.JobList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/limitrange/etcd/etcd.go
+++ b/pkg/registry/limitrange/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/limitranges"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.LimitRangeList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -50,7 +50,7 @@ type FinalizeREST struct {
 
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *FinalizeREST) {
-	prefix := "/namespaces"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NamespaceList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -31,7 +31,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
 	namespaceStorage, _, _ := NewREST(restOptions)
 	return namespaceStorage, server
 }

--- a/pkg/registry/networkpolicy/etcd/etcd.go
+++ b/pkg/registry/networkpolicy/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/networkpolicies"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensionsapi.NetworkPolicyList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/node/etcd/etcd.go
+++ b/pkg/registry/node/etcd/etcd.go
@@ -66,7 +66,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 
 // NewREST returns a RESTStorage object that will work against nodes.
 func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper) NodeStorage {
-	prefix := "/minions"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/pkg/registry/persistentvolume/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumes"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumeclaims"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeClaimList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/petset/etcd/etcd.go
+++ b/pkg/registry/petset/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/petsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &appsapi.PetSetList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/petset/etcd/etcd_test.go
+++ b/pkg/registry/petset/etcd/etcd_test.go
@@ -33,7 +33,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, apps.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "petsets"}
 	petSetStorage, statusStorage := NewREST(restOptions)
 	return petSetStorage, statusStorage, server
 }

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -57,7 +57,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against pods.
 func NewStorage(opts generic.RESTOptions, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper) PodStorage {
-	prefix := "/pods"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/poddisruptionbudget/etcd/etcd.go
+++ b/pkg/registry/poddisruptionbudget/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/poddisruptionbudgets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
+++ b/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
@@ -34,7 +34,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, policy.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "poddisruptionbudgets"}
 	podDisruptionBudgetStorage, statusStorage := NewREST(restOptions)
 	return podDisruptionBudgetStorage, statusStorage, server
 }

--- a/pkg/registry/podsecuritypolicy/etcd/etcd.go
+++ b/pkg/registry/podsecuritypolicy/etcd/etcd.go
@@ -31,16 +31,16 @@ type REST struct {
 	*registry.Store
 }
 
-const Prefix = "/podsecuritypolicies"
-
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(opts generic.RESTOptions) *REST {
+	prefix := "/" + opts.ResourcePrefix
+
 	newListFunc := func() runtime.Object { return &extensions.PodSecurityPolicyList{} }
 	storageInterface := opts.Decorator(
 		opts.Storage,
 		100,
 		&extensions.PodSecurityPolicy{},
-		Prefix,
+		prefix,
 		podsecuritypolicy.Strategy,
 		newListFunc,
 		storage.NoTriggerPublisher,
@@ -50,10 +50,10 @@ func NewREST(opts generic.RESTOptions) *REST {
 		NewFunc:     func() runtime.Object { return &extensions.PodSecurityPolicy{} },
 		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
-			return Prefix
+			return prefix
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, Prefix, name)
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*extensions.PodSecurityPolicy).Name, nil

--- a/pkg/registry/podtemplate/etcd/etcd.go
+++ b/pkg/registry/podtemplate/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/podtemplates"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodTemplateList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/replicaset/etcd/etcd.go
+++ b/pkg/registry/replicaset/etcd/etcd.go
@@ -58,7 +58,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/replicasets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.ReplicaSetList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/replicaset/etcd/etcd_test.go
+++ b/pkg/registry/replicaset/etcd/etcd_test.go
@@ -38,7 +38,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*ReplicaSetStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "replicasets"}
 	replicaSetStorage := NewStorage(restOptions)
 	return &replicaSetStorage, server
 }

--- a/pkg/registry/resourcequota/etcd/etcd.go
+++ b/pkg/registry/resourcequota/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/resourcequotas"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ResourceQuotaList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/role/etcd/etcd.go
+++ b/pkg/registry/role/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/roles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/rolebinding/etcd/etcd.go
+++ b/pkg/registry/rolebinding/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/rolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/scheduledjob/etcd/etcd.go
+++ b/pkg/registry/scheduledjob/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ScheduledJobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/scheduledjobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.ScheduledJobList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/secret/etcd/etcd.go
+++ b/pkg/registry/secret/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/secrets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.SecretList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/service/etcd/etcd.go
+++ b/pkg/registry/service/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/services/specs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/serviceaccount/etcd/etcd.go
+++ b/pkg/registry/serviceaccount/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/serviceaccounts"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceAccountList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/thirdpartyresource/etcd/etcd.go
+++ b/pkg/registry/thirdpartyresource/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a registry which will store ThirdPartyResource in the given helper
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/thirdpartyresources"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here yet.
 	storageInterface := opts.Storage

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -81,7 +81,7 @@ func newRBACAuthorizer(t *testing.T, superUser string, config *master.Config) au
 		if err != nil {
 			t.Fatalf("failed to get storage: %v", err)
 		}
-		return generic.RESTOptions{Storage: storageInterface, Decorator: generic.UndecoratedStorage}
+		return generic.RESTOptions{Storage: storageInterface, Decorator: generic.UndecoratedStorage, ResourcePrefix: resource}
 	}
 
 	roleRegistry := role.NewRegistry(roleetcd.NewREST(newRESTOptions("roles")))


### PR DESCRIPTION
This looks big, its not as bad as it seems.

When you have different resources cohabiting, the resource name used for the etcd directory needs to be configurable.  HPA in two different groups worked fine before.  Now we're looking at something like RC<->RS.  They normally store into two different etcd directories.  This code allows them to be configured to store into the same location.

To maintain consistency across all resources, I allowed the `StorageFactory` to indicate which `ResourcePrefix` should be used inside `RESTOptions` which already contains storage information.

@lavalamp affects cohabitation.
@smarterclayton @mfojtik prereq for our rc<->rs and d<->dc story.
