### PR TITLE
cluster/images/hyperkube: re-add hyperkube busybox style symlinks

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -72,6 +72,14 @@ COPY cni /opt/cni
 COPY cni-conf /etc/cni/net.d
 
 # Create symlinks for each hyperkube server
-# TODO: this is unreliable for now (e.g. running "/kubelet" panics)
-# Also, it doesn't work for other architectures
+# TODO: replace manual symlink creation with --make-symlink command once
+# cross-building with qemu supports go binaries. See #28702
 # RUN /hyperkube --make-symlinks
+RUN ln -s /hyperkube /apiserver \
+ && ln -s /hyperkube /controller-manager \
+ && ln -s /hyperkube /federation-apiserver \
+ && ln -s /hyperkube /federation-controller-manager \
+ && ln -s /hyperkube /kubectl \
+ && ln -s /hyperkube /kubelet \
+ && ln -s /hyperkube /proxy \
+ && ln -s /hyperkube /scheduler


### PR DESCRIPTION
Originally symlinks were added with a `--make-symlinks` command discussed in https://github.com/kubernetes/kubernetes/issues/24510 and implemented in https://github.com/kubernetes/kubernetes/pull/24511.

It was backed out in https://github.com/kubernetes/kubernetes/pull/25693 because go binaries don't run in qemu and this breaks cross-building the Dockerfile for arm. In this case, due to running `hyperkube --make-symlinks`.

Lets just add the symlinks manually until the upstream bug is fixed (qemu).

fixes #28702

@mikedanese @thockin @yifan-gu @euank

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29591)

<!-- Reviewable:end -->
