### PR TITLE
Optimize owner.dependentsLock.RUnlock() in orphanFinalizer()

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -320,11 +320,11 @@ func (gc *GarbageCollector) orphanFinalizer() {
 	}
 	// we don't need to lock each element, because they never get updated
 	owner.dependentsLock.RLock()
+	defer owner.dependentsLock.RUnlock()
 	dependents := make([]*node, 0, len(owner.dependents))
 	for dependent := range owner.dependents {
 		dependents = append(dependents, dependent)
 	}
-	owner.dependentsLock.RUnlock()
 
 	err := gc.orhpanDependents(owner.identity, dependents)
 	if err != nil {


### PR DESCRIPTION
use defer to replace "owner.dependentsLock.RLock()" thus exec the operation before all returns including normal and unnormal
