### PR TITLE
pkg/various: plug leaky time.New{Timer,Ticker}s

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -363,6 +363,7 @@ func checkEvents(t *testing.T, expectedEvents []string, ctrl *PersistentVolumeCo
 	// Read recorded events - wait up to 1 minute to get all the expected ones
 	// (just in case some goroutines are slower with writing)
 	timer := time.NewTimer(time.Minute)
+	defer timer.Stop()
 
 	fakeRecorder := ctrl.eventRecorder.(*record.FakeRecorder)
 	gotEvents := []string{}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2072,7 +2072,9 @@ func (kl *Kubelet) syncLoop(updates <-chan kubetypes.PodUpdate, handler SyncHand
 	// that need to be sync'd. A one-second period is sufficient because the
 	// sync interval is defaulted to 10s.
 	syncTicker := time.NewTicker(time.Second)
+	defer syncTicker.Stop()
 	housekeepingTicker := time.NewTicker(housekeepingPeriod)
+	defer housekeepingTicker.Stop()
 	plegCh := kl.pleg.Watch()
 	for {
 		if rs := kl.runtimeState.errors(); len(rs) != 0 {

--- a/pkg/kubelet/server/remotecommand/httpstream.go
+++ b/pkg/kubelet/server/remotecommand/httpstream.go
@@ -184,6 +184,7 @@ func createHttpStreamStreams(req *http.Request, w http.ResponseWriter, opts *opt
 	}
 
 	expired := time.NewTimer(streamCreationTimeout)
+	defer expired.Stop()
 
 	ctx, err := handler.waitForStreams(streamCh, opts.expectedStreams, expired.C)
 	if err != nil {

--- a/pkg/util/goroutinemap/goroutinemap_test.go
+++ b/pkg/util/goroutinemap/goroutinemap_test.go
@@ -484,6 +484,7 @@ func retryWithExponentialBackOff(initialDuration time.Duration, fn wait.Conditio
 
 func waitChannelWithTimeout(ch <-chan interface{}, timeout time.Duration) error {
 	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	select {
 	case <-ch:

--- a/pkg/util/httpstream/spdy/connection_test.go
+++ b/pkg/util/httpstream/spdy/connection_test.go
@@ -146,6 +146,7 @@ func TestConnectionCloseIsImmediateThroughAProxy(t *testing.T) {
 	}
 
 	expired := time.NewTimer(15 * time.Second)
+	defer expired.Stop()
 	i := 0
 	for {
 		select {

--- a/pkg/volume/util/nestedpendingoperations/nestedpendingoperations_test.go
+++ b/pkg/volume/util/nestedpendingoperations/nestedpendingoperations_test.go
@@ -558,6 +558,7 @@ func retryWithExponentialBackOff(initialDuration time.Duration, fn wait.Conditio
 
 func waitChannelWithTimeout(ch <-chan interface{}, timeout time.Duration) error {
 	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	select {
 	case <-ch:


### PR DESCRIPTION
According to the documentation for Go package time, `time.Ticker` and
`time.Timer` are uncollectable by garbage collector finalizers.  They
leak until otherwise stopped.  This commit ensures that all remaining
instances are stopped upon departure from their relative scopes.

Similar efforts were incrementally done in #29439 and #29114.

``` release-note
* pkg/various: plugged various time.Ticker and time.Timer leaks.
```
