### PR TITLE
pkg/util/goroutinemap: apply idiomatic Go cleanups

### DIFF
--- a/pkg/util/goroutinemap/goroutinemap.go
+++ b/pkg/util/goroutinemap/goroutinemap.go
@@ -36,11 +36,11 @@ const (
 	// that GoRoutineMap will refuse to allow another operation to start with
 	// the same operation name (if exponentialBackOffOnError is enabled). Each
 	// successive error results in a wait 2x times the previous.
-	initialDurationBeforeRetry time.Duration = 500 * time.Millisecond
+	initialDurationBeforeRetry = 500 * time.Millisecond
 
 	// maxDurationBeforeRetry is the maximum amount of time that
 	// durationBeforeRetry will grow to due to exponential backoff.
-	maxDurationBeforeRetry time.Duration = 2 * time.Minute
+	maxDurationBeforeRetry = 2 * time.Minute
 )
 
 // GoRoutineMap defines the supported set of operations.
@@ -65,10 +65,9 @@ func NewGoRoutineMap(exponentialBackOffOnError bool) GoRoutineMap {
 	g := &goRoutineMap{
 		operations:                make(map[string]operation),
 		exponentialBackOffOnError: exponentialBackOffOnError,
-		lock: &sync.Mutex{},
 	}
 
-	g.cond = sync.NewCond(g.lock)
+	g.cond = sync.NewCond(&g.lock)
 	return g
 }
 
@@ -76,7 +75,7 @@ type goRoutineMap struct {
 	operations                map[string]operation
 	exponentialBackOffOnError bool
 	cond                      *sync.Cond
-	lock                      *sync.Mutex
+	lock                      sync.Mutex
 }
 
 type operation struct {

--- a/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
+++ b/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
@@ -65,9 +65,8 @@ func NewNestedPendingOperations(exponentialBackOffOnError bool) NestedPendingOpe
 	g := &nestedPendingOperations{
 		operations:                []operation{},
 		exponentialBackOffOnError: exponentialBackOffOnError,
-		lock: &sync.Mutex{},
 	}
-	g.cond = sync.NewCond(g.lock)
+	g.cond = sync.NewCond(&g.lock)
 	return g
 }
 
@@ -75,7 +74,7 @@ type nestedPendingOperations struct {
 	operations                []operation
 	exponentialBackOffOnError bool
 	cond                      *sync.Cond
-	lock                      *sync.Mutex
+	lock                      sync.Mutex
 }
 
 type operation struct {


### PR DESCRIPTION
Package goroutinemap can be structurally simplified to be more
idiomatic, concise, and free of error potential.  No structural changes
are made.

It is unconventional declare `sync.Mutex` directly as a pointerized
field in a parent structure.  The `sync.Mutex` operates on pointer
receivers of itself; and by relying on that, the types that contain
those fields can be safely constructed using
https://golang.org/ref/spec#The_zero_value semantic.

The duration constants are already of type `time.Duration`, so
re-declaring that is redundant.

/CC: @saad-ali 
