### PR TITLE
Added ability to auto-ignore labels when exposing

### DIFF
--- a/pkg/client/unversioned/clientcmd/api/helpers.go
+++ b/pkg/client/unversioned/clientcmd/api/helpers.go
@@ -36,7 +36,7 @@ func IsConfigEmpty(config *Config) bool {
 	return len(config.AuthInfos) == 0 && len(config.Clusters) == 0 && len(config.Contexts) == 0 &&
 		len(config.CurrentContext) == 0 &&
 		len(config.Preferences.Extensions) == 0 && !config.Preferences.Colors &&
-		len(config.Extensions) == 0
+		len(config.Extensions) == 0 && len(config.Preferences.VersionLabels) == 0
 }
 
 // MinifyConfig read the current context and uses that to keep only the relevant pieces of config

--- a/pkg/client/unversioned/clientcmd/api/types.go
+++ b/pkg/client/unversioned/clientcmd/api/types.go
@@ -52,6 +52,8 @@ type Config struct {
 // IMPORTANT if you add fields to this struct, please update IsConfigEmpty()
 type Preferences struct {
 	Colors bool `json:"colors,omitempty"`
+	// VersionLabels are labels that denote version and should not be used to create selector for services
+	VersionLabels string `json:"version-labels,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`
 }
@@ -68,6 +70,8 @@ type Cluster struct {
 	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
 	// CertificateAuthority is the path to a cert file for the certificate authority.
 	CertificateAuthority string `json:"certificate-authority,omitempty"`
+	// VersionLabels
+	VersionLabels string `json:"version-labels,omitempty"`
 	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority
 	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields

--- a/pkg/client/unversioned/clientcmd/api/v1/types.go
+++ b/pkg/client/unversioned/clientcmd/api/v1/types.go
@@ -49,7 +49,8 @@ type Config struct {
 }
 
 type Preferences struct {
-	Colors bool `json:"colors,omitempty"`
+	Colors        bool   `json:"colors,omitempty"`
+	VersionLabels string `json:"version-labels,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions []NamedExtension `json:"extensions,omitempty"`
 }

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -247,7 +247,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 			Message: "Basic Commands (Beginner):",
 			Commands: []*cobra.Command{
 				NewCmdCreate(f, out),
-				NewCmdExposeService(f, out),
+				NewCmdExposeService(f, out, clientcmd.NewDefaultPathOptions()),
 				NewCmdRun(f, in, out, err),
 				set.NewCmdSet(f, out),
 			},

--- a/pkg/kubectl/cmd/config/navigation_step_parser.go
+++ b/pkg/kubectl/cmd/config/navigation_step_parser.go
@@ -134,7 +134,6 @@ func getPotentialTypeValues(typeValue reflect.Type) (map[string]reflect.Type, er
 		fieldType := typeValue.Field(fieldIndex)
 		yamlTag := fieldType.Tag.Get("json")
 		yamlTagName := strings.Split(yamlTag, ",")[0]
-
 		ret[yamlTagName] = fieldType.Type
 	}
 

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -450,7 +451,7 @@ func TestRunExposeService(t *testing.T) {
 		tf.Namespace = test.ns
 		buf := bytes.NewBuffer([]byte{})
 
-		cmd := NewCmdExposeService(f, buf)
+		cmd := NewCmdExposeService(f, buf, clientcmd.NewDefaultPathOptions())
 		cmd.SetOutput(buf)
 		for flag, value := range test.flags {
 			cmd.Flags().Set(flag, value)


### PR DESCRIPTION
A new `kubectl config` option was added `version-labels`. Using it one can
specify labels that are used to specify revisions of pods. This way
these labels are ignored when using `kubectl-expose` and can be
succesfully used in `rolling-upgrade`

Fixes: #17902

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29603)

<!-- Reviewable:end -->
