### PR TITLE
add port validate when --port is set or --expose=true

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -112,7 +112,7 @@ func addRunFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("rm", false, "If true, delete resources created in this command for attached containers.")
 	cmd.Flags().String("overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")
 	cmd.Flags().StringSlice("env", []string{}, "Environment variables to set in the container")
-	cmd.Flags().Int("port", -1, "The port that this container exposes.  If --expose is true, this is also the port used by the service that is created.")
+	cmd.Flags().String("port", "", "The port that this container exposes.  If --expose is true, this is also the port used by the service that is created.")
 	cmd.Flags().Int("hostport", -1, "The host port mapping for the container port. To demonstrate a single-machine container.")
 	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the pod(s).")
 	cmd.Flags().BoolP("stdin", "i", false, "Keep stdin open on the container(s) in the pod, even if nothing is attached.")
@@ -536,9 +536,9 @@ func generateService(f *cmdutil.Factory, cmd *cobra.Command, args []string, serv
 	}
 	names := generator.ParamNames()
 
-	port := cmdutil.GetFlagInt(cmd, "port")
-	if port < 1 {
-		return fmt.Errorf("--port must be a positive integer when exposing a service")
+	port := cmdutil.GetFlagString(cmd, "port")
+	if len(port) == 0 {
+		return fmt.Errorf("--port must be set when exposing a service")
 	}
 
 	params := map[string]interface{}{}

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -796,7 +796,7 @@ func updatePodPorts(params map[string]string, podSpec *api.PodSpec) (err error) 
 	}
 
 	// Don't include the port if it was not specified.
-	if port > 0 {
+	if len(params["port"]) > 0 {
 		podSpec.Containers[0].Ports = []api.ContainerPort{
 			{
 				ContainerPort: int32(port),

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -39,7 +39,7 @@ func TestGenerate(t *testing.T) {
 				"image":             "someimage",
 				"image-pull-policy": "Always",
 				"replicas":          "1",
-				"port":              "-1",
+				"port":              "",
 			},
 			expected: &api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{
@@ -72,7 +72,7 @@ func TestGenerate(t *testing.T) {
 				"name":     "foo",
 				"image":    "someimage",
 				"replicas": "1",
-				"port":     "-1",
+				"port":     "",
 				"env":      []string{"a=b", "c=d"},
 			},
 			expected: &api.ReplicationController{
@@ -116,7 +116,7 @@ func TestGenerate(t *testing.T) {
 				"image":             "someimage",
 				"image-pull-policy": "Never",
 				"replicas":          "1",
-				"port":              "-1",
+				"port":              "",
 				"args":              []string{"bar", "baz", "blah"},
 			},
 			expected: &api.ReplicationController{
@@ -150,7 +150,7 @@ func TestGenerate(t *testing.T) {
 				"name":     "foo",
 				"image":    "someimage",
 				"replicas": "1",
-				"port":     "-1",
+				"port":     "",
 				"args":     []string{"bar", "baz", "blah"},
 				"command":  "true",
 			},
@@ -410,7 +410,7 @@ func TestGeneratePod(t *testing.T) {
 			params: map[string]interface{}{
 				"name":  "foo",
 				"image": "someimage",
-				"port":  "-1",
+				"port":  "",
 			},
 			expected: &api.Pod{
 				ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
``` shell
$ kubectl run nginx --image=nginx --port=88888 --expose=true
The Deployment "nginx" is invalid.
spec.template.spec.containers[0].ports[0].containerPort: Invalid value: 88888: must be between 1 and 65535, inclusive
$ kubectl run nginx --image=nginx --port=0 --expose=true
error: --port must be a positive integer when exposing a service
```
1. when port is greater than 65535, port is required between 1 and 65535 and deployment 'nginx' can not be created.
2. when port is less than 1, port is not validated and deployment 'nginx' can be created. But service will be created failed.

so i add this change:
when --port is set or --expose=true, validate port range so that error reported can be the same when port is greater than 65535 or less than 1.
And this can also find the port  range error before creating the deployment other than during creating the deployment.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29605)

<!-- Reviewable:end -->
