### PR TITLE
HyperLink not found and can't redirect

### DIFF
--- a/docs/design/indexed-job.md
+++ b/docs/design/indexed-job.md
@@ -866,7 +866,7 @@ list of parameters.  However, some popular base images do not include
 that does not support array syntax.
 
 Kubelet does support [expanding varaibles without a
-shell](http://kubernetes.io/v1.1/docs/design/expansion.html).  But it does not
+shell](http://kubernetes.io/kubernetes/v1.1/docs/design/expansion.html).  But it does not
 allow for recursive substitution, which is required to extract the correct
 parameter from a list based on the completion index of the pod.  The syntax
 could be extended, but doing so seems complex and will be an unfamiliar syntax


### PR DESCRIPTION
HyperLink "http://kubernetes.io/v1.1/docs/design/expansion.html" not found and can't redirected, should be changed to "http://kubernetes.io/kubernetes/v1.1/docs/design/expansion.html"

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29609)

<!-- Reviewable:end -->
