### PR TITLE
Fix error reporting during vagrant provisioning

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -43,15 +43,6 @@ if [[ -z "$NETWORK_IF_NAME" ]]; then
   NETWORK_IF_NAME=${DEFAULT_NETWORK_IF_NAME}
 fi
 
-function release_not_found() {
-  echo "It looks as if you don't have a compiled version of Kubernetes.  If you" >&2
-  echo "are running from a clone of the git repo, please run 'make quick-release'." >&2
-  echo "Note that this requires having Docker installed.  If you are running " >&2
-  echo "from a release tarball, something is wrong.  Look at " >&2
-  echo "http://kubernetes.io/ for information on how to contact the development team for help." >&2
-  exit 1
-}
-
 # Setup hosts file to support ping by hostname to each node in the cluster from apiserver
 for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
   node=${NODE_NAMES[$i]}

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -94,6 +94,15 @@ grains:
 EOF
 }
 
+function release_not_found() {
+  echo "It looks as if you don't have a compiled version of Kubernetes.  If you" >&2
+  echo "are running from a clone of the git repo, please run 'make quick-release'." >&2
+  echo "Note that this requires having Docker installed.  If you are running " >&2
+  echo "from a release tarball, something is wrong.  Look at " >&2
+  echo "http://kubernetes.io/ for information on how to contact the development team for help." >&2
+  exit 1
+}
+
 function install-salt() {
   server_binary_tar="/vagrant/server/kubernetes-server-linux-amd64.tar.gz"
   if [[ ! -f "$server_binary_tar" ]]; then


### PR DESCRIPTION
<!--
Checklist for submitting a Pull Request

Please remove this comment block before submitting.

1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. If you want this PR to automatically close an issue when it is merged,
   add `fixes #<issue number>` or `fixes #<issue number>, fixes #<issue number>`
   to close multiple issues (see: https://github.com/blog/1506-closing-issues-via-pull-requests).
4. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.
-->

`release_not_found` shell function can be used both while running
`provision-master.sh` and `privision-node.sh` (it's used by `install-salt`
function in `provision-utils.sh`, but it was defined in `provision-master.sh`.
Because of this, one of my colleagues got the following diagnostic:

```
==> master: Succeeded: 52 (changed=8)
==> master: Failed:     0
==> master: -------------
==> master: Total states run:     52
==> node-1: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> node-1: flag to force provisioning. Provisioners marked to run always will still run.
==> node-1: Running provisioner: shell...
    node-1: Running: /tmp/vagrant-shell20160726-19144-hahnl1.sh
==> node-1: Prepare package manager
==> node-1: Provisioning network on node
==> node-1: Network configuration verified
==> node-1: /tmp/vagrant-shell: line 134: release_not_found: command not found
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

... which is rather confusing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29610)

<!-- Reviewable:end -->
