### PR TITLE
add DefaultServiceNodePortRange const

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -283,8 +283,7 @@ func setDefaults(c *Config) {
 		// We should probably allow this for clouds that don't require NodePort to do load-balancing (GCE)
 		// but then that breaks the strict nestedness of ServiceType.
 		// Review post-v1
-		defaultServiceNodePortRange := utilnet.PortRange{Base: 30000, Size: 2768}
-		c.ServiceNodePortRange = defaultServiceNodePortRange
+		c.ServiceNodePortRange = options.DefaultServiceNodePortRange
 		glog.Infof("Node port range unspecified. Defaulting to %v.", c.ServiceNodePortRange)
 	}
 	if c.MasterCount == 0 {

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -46,6 +46,8 @@ const (
 	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
 )
 
+var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
+
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
 	APIGroupPrefix             string
@@ -133,7 +135,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		MinRequestTimeout:       1800,
 		RuntimeConfig:           make(config.ConfigurationMap),
 		SecurePort:              6443,
-		ServiceNodePortRange:    utilnet.PortRange{Base: 30000, Size: 2768},
+		ServiceNodePortRange:    DefaultServiceNodePortRange,
 		StorageVersions:         registered.AllPreferredGroupVersions(),
 	}
 }


### PR DESCRIPTION
The PR add DefaultServiceNodePortRange const in server_run_options.go, and use it in genericapiserver.go and server_run_options.go.
