### PR TITLE
kubectl container - Extract version better

### DIFF
--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -27,7 +27,7 @@ kubectl:
 	cp ../../_output/local/bin/$(GOOS)/$(GOARCH)/kubectl .
 
 .tag: kubectl
-	./kubectl version -c | grep -o 'GitVersion:"[^"]*"' | cut -f 2 -d '"' > .tag
+	./kubectl version --client | grep -o 'GitVersion:"[^"]*"' | sed 's/[^"]*"\([^"+]*\).*/\1/' > .tag
 
 tag: .tag
 	@echo "Suggest using TAG=$(shell cat .tag)"


### PR DESCRIPTION
1. Use --client since -c is deprecated now
2. The command (./kubectl version --client | grep -o 'GitVersion:"[^"]*"')
   now returns:
     GitVersion:"v1.4.0-alpha.1.784+ed3a29bd6aeb98-dirty"
   so parse out the version better using sed

Related to #23708
