### PR TITLE
Disable flaky unit test in admission plugin in NamespaceAutoProvision

### DIFF
--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -62,33 +62,33 @@ func TestAdmission(t *testing.T) {
 }
 
 // TestAdmissionNamespaceExists verifies that no client call is made when a namespace already exists
-func TestAdmissionNamespaceExists(t *testing.T) {
-	namespace := "test"
-	mockClient := &fake.Clientset{}
-	informerFactory := informers.NewSharedInformerFactory(mockClient, 5*time.Minute)
-	informerFactory.Namespaces().Informer().GetStore().Add(&api.Namespace{
-		ObjectMeta: api.ObjectMeta{Name: namespace},
-	})
-	informerFactory.Start(wait.NeverStop)
-	handler := &provision{
-		client:          mockClient,
-		informerFactory: informerFactory,
-	}
-	pod := api.Pod{
-		ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
-		Spec: api.PodSpec{
-			Volumes:    []api.Volume{{Name: "vol"}},
-			Containers: []api.Container{{Name: "ctr", Image: "image"}},
-		},
-	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
-	if err != nil {
-		t.Errorf("Unexpected error returned from admission handler")
-	}
-	if len(mockClient.Actions()) != 0 {
-		t.Errorf("No client request should have been made")
-	}
-}
+// func TestAdmissionNamespaceExists(t *testing.T) {
+// 	namespace := "test"
+// 	mockClient := &fake.Clientset{}
+// 	informerFactory := informers.NewSharedInformerFactory(mockClient, 5*time.Minute)
+// 	informerFactory.Namespaces().Informer().GetStore().Add(&api.Namespace{
+// 		ObjectMeta: api.ObjectMeta{Name: namespace},
+// 	})
+// 	informerFactory.Start(wait.NeverStop)
+// 	handler := &provision{
+// 		client:          mockClient,
+// 		informerFactory: informerFactory,
+// 	}
+// 	pod := api.Pod{
+// 		ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+// 		Spec: api.PodSpec{
+// 			Volumes:    []api.Volume{{Name: "vol"}},
+// 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
+// 		},
+// 	}
+// 	err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+// 	if err != nil {
+// 		t.Errorf("Unexpected error returned from admission handler")
+// 	}
+// 	if len(mockClient.Actions()) != 0 {
+// 		t.Errorf("No client request should have been made")
+// 	}
+// }
 
 // TestIgnoreAdmission validates that a request is ignored if its not a create
 func TestIgnoreAdmission(t *testing.T) {


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/29473

Disables the test until the full fix is resolved in https://github.com/kubernetes/kubernetes/pull/29634

This admission controller is not in our default set, but is flaking and is a p0.

/cc @ncdc @liggitt @hodovska 
