### PR TITLE
the observed usage should match those that have hard constraints

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -289,6 +289,10 @@ func (rq *ResourceQuotaController) syncResourceQuota(resourceQuota api.ResourceQ
 		used[key] = value
 	}
 
+	// ensure set of used values match those that have hard constraints
+	hardResources := quota.ResourceNames(hardLimits)
+	used = quota.Mask(used, hardResources)
+
 	// Create a usage object that is based on the quota resource version that will handle updates
 	// by default, we preserve the past usage observation, and set hard to the current spec
 	usage := api.ResourceQuota{


### PR DESCRIPTION
in the sync process, the quota will be replenished, the new observed usage will be sumed from each evaluator, if the previousUsed set is not be cleared, the new usage will be dirty, maybe some unusage resource still in ,  as the code below
    newUsage = quota.Mask(newUsage, matchedResources)
    for key, value := range newUsage {
        usage.Status.Used[key] = value
    }
so i think here shoul not set value previousUsed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29653)

<!-- Reviewable:end -->
