### PR TITLE
Optimise the style for parseReservation function

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -985,14 +985,14 @@ func parseReservation(kubeReserved, systemReserved utilconfig.ConfigurationMap) 
 	reservation := new(kubetypes.Reservation)
 	if rl, err := parseResourceList(kubeReserved); err != nil {
 		return nil, err
-	} else {
-		reservation.Kubernetes = rl
 	}
+	reservation.Kubernetes = rl
+
 	if rl, err := parseResourceList(systemReserved); err != nil {
 		return nil, err
-	} else {
-		reservation.System = rl
 	}
+	reservation.System = rl
+
 	return reservation, nil
 }
 


### PR DESCRIPTION
The PR modified the style for the parseReservation function according to the go style guide advises, and it seems more concise.
