### PR TITLE
pause a deployment automatically

### DIFF
--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -254,6 +254,13 @@ type RollingUpdateDeployment struct {
 	// new RC can be scaled up further, ensuring that total number of pods running
 	// at any time during the update is atmost 130% of original pods.
 	MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
+
+	// The maximum replica numbers of new RC can be scaled up before the deployment is paused
+	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
+	// Absolute number is calculated from percentage by rounding up.
+	// Example: when this is set to 30%, the new RC can be scaled up by at most 30%, then
+	// the deployment will be pause and will not be processed by the deployment controller.
+	PauseWhen *intstr.IntOrString `json:"pauseWhen,omitempty"`
 }
 
 type DeploymentStatus struct {

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -488,6 +488,10 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 		return dc.syncStatusOnly(d)
 	}
 
+	if shouldPause := dc.ShouldDeploymentPause(deployment); !deployment.Spec.Paused && shouldPause {
+		return dc.pauseDeployment(deployment)
+	}
+
 	if d.Spec.Paused {
 		return dc.sync(d)
 	}


### PR DESCRIPTION
#### use case:
- A/B Deployment
#### Why not set deployment.spec.paused=true manually
- It's racy: for example, we want 50% new pods and 50% old pods for A/B test, when user observe newRS scale up by 50% and then set `deployment.spec.paused=true` manually, deployment controller may has scaled up newRS in a further step.

Just a initial implementation, if this idea and the API looks good, will update auto generation files and write e2e test.

@janetkuo @kargakis @ironcladlou

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29663)

<!-- Reviewable:end -->
