### PR TITLE
Wrong path for log_handler.go

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -51,7 +51,7 @@ var AWSRegions = [...]string{
 const registryURLTemplate = "*.dkr.ecr.%s.amazonaws.com"
 
 // awsHandlerLogger is a handler that logs all AWS SDK requests
-// Copied from cloudprovider/aws/log_handler.go
+// Copied from pkg/cloudprovider/providers/aws/log_handler.go
 func awsHandlerLogger(req *request.Request) {
 	service := req.ClientInfo.ServiceName
 	region := req.Config.Region


### PR DESCRIPTION
Wrong path for log_handler.go

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29664)

<!-- Reviewable:end -->
