### PR TITLE
Fixed merging of host's and dns' search lines

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -87,6 +88,120 @@ func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
 	}
 	_, supported := kl.cloud.Routes()
 	return supported
+}
+
+func omitDuplicates(kl *Kubelet, pod *v1.Pod, combinedSearch []string) []string {
+	uniqueDomains := map[string]bool{}
+
+	for _, dnsDomain := range combinedSearch {
+		if _, exists := uniqueDomains[dnsDomain]; !exists {
+			combinedSearch[len(uniqueDomains)] = dnsDomain
+			uniqueDomains[dnsDomain] = true
+		} else {
+			log := fmt.Sprintf("Found and omitted duplicated dns domain in host search line: '%s' during merging with cluster dns domains", dnsDomain)
+			kl.recorder.Event(pod, v1.EventTypeWarning, "DNSSearchForming", log)
+			glog.Error(log)
+		}
+	}
+	return combinedSearch[:len(uniqueDomains)]
+}
+
+func formDNSSearchFitsLimits(kl *Kubelet, pod *v1.Pod, composedSearch []string) []string {
+	// resolver file Search line current limitations
+	resolvSearchLineDNSDomainsLimit := 6
+	resolvSearchLineLenLimit := 255
+	limitsExceeded := false
+
+	if len(composedSearch) > resolvSearchLineDNSDomainsLimit {
+		composedSearch = composedSearch[:resolvSearchLineDNSDomainsLimit]
+		limitsExceeded = true
+	}
+
+	if resolvSearchhLineStrLen := len(strings.Join(composedSearch, " ")); resolvSearchhLineStrLen > resolvSearchLineLenLimit {
+		cutDomainsNum := 0
+		cutDoaminsLen := 0
+		for i := len(composedSearch) - 1; i >= 0; i-- {
+			cutDoaminsLen += len(composedSearch[i]) + 1
+			cutDomainsNum++
+
+			if (resolvSearchhLineStrLen - cutDoaminsLen) <= resolvSearchLineLenLimit {
+				break
+			}
+		}
+
+		composedSearch = composedSearch[:(len(composedSearch) - cutDomainsNum)]
+		limitsExceeded = true
+	}
+
+	if limitsExceeded {
+		log := fmt.Sprintf("Search Line limits were exceeded, some dns names have been omitted, the applied search line is: %s", strings.Join(composedSearch, " "))
+		kl.recorder.Event(pod, v1.EventTypeWarning, "DNSSearchForming", log)
+		glog.Error(log)
+	}
+	return composedSearch
+}
+
+func (kl *Kubelet) formDNSSearchForDNSDefault(hostSearch []string, pod *v1.Pod) []string {
+	return formDNSSearchFitsLimits(kl, pod, hostSearch)
+}
+
+func (kl *Kubelet) formDNSSearch(hostSearch []string, pod *v1.Pod) []string {
+	if kl.clusterDomain == "" {
+		formDNSSearchFitsLimits(kl, pod, hostSearch)
+		return hostSearch
+	}
+
+	nsSvcDomain := fmt.Sprintf("%s.svc.%s", pod.Namespace, kl.clusterDomain)
+	svcDomain := fmt.Sprintf("svc.%s", kl.clusterDomain)
+	dnsSearch := []string{nsSvcDomain, svcDomain, kl.clusterDomain}
+
+	combinedSearch := append(dnsSearch, hostSearch...)
+
+	combinedSearch = omitDuplicates(kl, pod, combinedSearch)
+	return formDNSSearchFitsLimits(kl, pod, combinedSearch)
+}
+
+func (kl *Kubelet) checkLimitsForResolvConf() {
+	// resolver file Search line current limitations
+	resolvSearchLineDNSDomainsLimit := 6
+	resolvSearchLineLenLimit := 255
+
+	f, err := os.Open(kl.resolverConfig)
+	if err != nil {
+		kl.recorder.Event(kl.nodeRef, v1.EventTypeWarning, "checkLimitsForResolvConf", err.Error())
+		glog.Error("checkLimitsForResolvConf: " + err.Error())
+		return
+	}
+	defer f.Close()
+
+	_, hostSearch, err := kl.parseResolvConf(f)
+	if err != nil {
+		kl.recorder.Event(kl.nodeRef, v1.EventTypeWarning, "checkLimitsForResolvConf", err.Error())
+		glog.Error("checkLimitsForResolvConf: " + err.Error())
+		return
+	}
+
+	domainCntLimit := resolvSearchLineDNSDomainsLimit
+
+	if kl.clusterDomain != "" {
+		domainCntLimit -= 3
+	}
+
+	if len(hostSearch) > domainCntLimit {
+		log := fmt.Sprintf("Resolv.conf file '%s' contains search line consisting of more than %d domains!", kl.resolverConfig, domainCntLimit)
+		kl.recorder.Event(kl.nodeRef, v1.EventTypeWarning, "checkLimitsForResolvConf", log)
+		glog.Error("checkLimitsForResolvConf: " + log)
+		return
+	}
+
+	if len(strings.Join(hostSearch, " ")) > resolvSearchLineLenLimit {
+		log := fmt.Sprintf("Resolv.conf file '%s' contains search line which length is more than allowed %d chars!", kl.resolverConfig, resolvSearchLineLenLimit)
+		kl.recorder.Event(kl.nodeRef, v1.EventTypeWarning, "checkLimitsForResolvConf", log)
+		glog.Error("checkLimitsForResolvConf: " + log)
+		return
+	}
+
+	return
 }
 
 // parseResolveConf reads a resolv.conf file from the given reader, and parses

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -210,7 +210,11 @@ func TestGenerateRunContainerOptions_DNSConfigurationParams(t *testing.T) {
 	} else if options[0].DNS[0] != clusterNS {
 		t.Errorf("expected nameserver %s, got %v", clusterNS, options[0].DNS[0])
 	}
-	if len(options[0].DNSSearch) != len(options[1].DNSSearch)+3 {
+	expLength := len(options[1].DNSSearch) + 3
+	if expLength > 6 {
+		expLength = 6
+	}
+	if len(options[0].DNSSearch) != expLength {
 		t.Errorf("expected prepend of cluster domain, got %+v", options[0].DNSSearch)
 	} else if options[0].DNSSearch[0] != ".svc."+kubelet.clusterDomain {
 		t.Errorf("expected domain %s, got %s", ".svc."+kubelet.clusterDomain, options[0].DNSSearch)


### PR DESCRIPTION
Fixed forming of pod's Search line in resolv.conf:
 - exclude duplicates while merging of host's and dns' search lines to form pod's one
 - truncate pod's search line if it exceeds resolver limits: is > 255 chars and containes > 6 searches
 - monitoring the resolv.conf file which is used by kubelet (set thru --resolv-conf="") and logging and eventing if search line in it consists of more than 3 entries (or 6 if Cluster Domain is set) or its lenght is > 255 chars
 - logging and eventing when a pod's search line is > 255 chars or containes > 6 searches during forming

Fixes #29270

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fixed forming resolver search line for pods: exclude duplicates, obey libc limitations, logging and eventing appropriately.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29666)

<!-- Reviewable:end -->
