### PR TITLE
Combine two "for" loops in "mergeAPIResourceConfigs" function

### DIFF
--- a/pkg/genericapiserver/default_storage_factory_builder.go
+++ b/pkg/genericapiserver/default_storage_factory_builder.go
@@ -77,14 +77,14 @@ func mergeAPIResourceConfigs(defaultAPIResourceConfig *ResourceConfig, resourceC
 
 	// "<resourceSpecifier>={true|false} allows users to enable/disable API.
 	// This takes preference over api/all and api/legacy, if specified.
-	// Iterate through all group/version overrides specified in runtimeConfig.
 	for key := range overrides {
 		if key == "api/all" || key == "api/legacy" {
 			// Have already handled them above. Can skip them here.
 			continue
 		}
 		tokens := strings.Split(key, "/")
-		if len(tokens) != 2 {
+		length := len(tokens)
+		if length != 2 && length != 3 {
 			continue
 		}
 		groupVersionString := tokens[0] + "/" + tokens[1]
@@ -101,51 +101,34 @@ func mergeAPIResourceConfigs(defaultAPIResourceConfig *ResourceConfig, resourceC
 		if !registered.IsRegisteredVersion(groupVersion) {
 			return nil, fmt.Errorf("group version %s that has not been registered", groupVersion.String())
 		}
-		enabled, err := getRuntimeConfigValue(overrides, key, false)
-		if err != nil {
-			return nil, err
-		}
-		if enabled {
-			resourceConfig.EnableVersions(groupVersion)
+
+		// Iterate through all group/version overrides specified in runtimeConfig.
+		if length == 2 {
+			enabled, err := getRuntimeConfigValue(overrides, key, false)
+			if err != nil {
+				return nil, err
+			}
+			if enabled {
+				resourceConfig.EnableVersions(groupVersion)
+			} else {
+				resourceConfig.DisableVersions(groupVersion)
+			}
 		} else {
-			resourceConfig.DisableVersions(groupVersion)
-		}
-	}
+			// Iterate through all group/version/resource overrides specified in runtimeConfig.
+			if !resourceConfig.AnyResourcesForVersionEnabled(groupVersion) {
+				return nil, fmt.Errorf("%v is disabled, you cannot configure its resources individually", groupVersion)
+			}
 
-	// Iterate through all group/version/resource overrides specified in runtimeConfig.
-	for key := range overrides {
-		tokens := strings.Split(key, "/")
-		if len(tokens) != 3 {
-			continue
-		}
-		groupVersionString := tokens[0] + "/" + tokens[1]
-		// HACK: Hack for "v1" legacy group version.
-		// Remove when we stop supporting the legacy group version.
-		if groupVersionString == "api/v1" {
-			groupVersionString = "v1"
-		}
-		groupVersion, err := unversioned.ParseGroupVersion(groupVersionString)
-		if err != nil {
-			return nil, fmt.Errorf("invalid key %s", key)
-		}
-		resource := tokens[2]
-		// Verify that the groupVersion is registered.
-		if !registered.IsRegisteredVersion(groupVersion) {
-			return nil, fmt.Errorf("group version %s that has not been registered", groupVersion.String())
-		}
-
-		if !resourceConfig.AnyResourcesForVersionEnabled(groupVersion) {
-			return nil, fmt.Errorf("%v is disabled, you cannot configure its resources individually", groupVersion)
-		}
-
-		enabled, err := getRuntimeConfigValue(overrides, key, false)
-		if err != nil {
-			return nil, err
-		}
-		if enabled {
-			resourceConfig.EnableResources(groupVersion.WithResource(resource))
-		} else {
-			resourceConfig.DisableResources(groupVersion.WithResource(resource))
+			resource := tokens[2]
+			enabled, err := getRuntimeConfigValue(overrides, key, false)
+			if err != nil {
+				return nil, err
+			}
+			if enabled {
+				resourceConfig.EnableResources(groupVersion.WithResource(resource))
+			} else {
+				resourceConfig.DisableResources(groupVersion.WithResource(resource))
+			}
 		}
 	}
 	return resourceConfig, nil


### PR DESCRIPTION
The PR combine two "for" loops in "mergeAPIResourceConfigs" function, it needn't loop twice, and I think it will be more effective.
