### PR TITLE
Add handling empty index key that may cause panic issue

### DIFF
--- a/pkg/client/cache/index.go
+++ b/pkg/client/cache/index.go
@@ -55,6 +55,9 @@ func IndexFuncToKeyFuncAdapter(indexFunc IndexFunc) KeyFunc {
 		if len(indexKeys) > 1 {
 			return "", fmt.Errorf("too many keys: %v", indexKeys)
 		}
+		if len(indexKeys) == 0 {
+			return "", fmt.Errorf("unexpected empty indexKeys")
+		}
 		return indexKeys[0], nil
 	}
 }


### PR DESCRIPTION
if len(indexKeys) == 0, "return indexKeys[0]" will cause unexpected result.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29672)

<!-- Reviewable:end -->
