### PR TITLE
Fix "make release" to fall back to "copy" when "link" fails while building on filesystems that do not support hard links

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -862,7 +862,13 @@ function kube::release::create_docker_images_for_server() {
 
         rm -rf ${docker_build_path}
         mkdir -p ${docker_build_path}
-        ln ${binary_dir}/${binary_name} ${docker_build_path}/${binary_name}
+        ln ${binary_dir}/${binary_name} ${docker_build_path}/${binary_name} && rc=$? || rc=$?
+        if [ $rc != 0 ]; then
+            # Handle filesystems that do not support hard links
+            #  (e.g. cross-partition directory trees, vagrant virtualbox shared mounts)
+            echo "Hard link unsuccessful.  Creating copy"
+            cp ${binary_dir}/${binary_name} ${docker_build_path}/${binary_name}
+        fi
         printf " FROM ${base_image} \n ADD ${binary_name} /usr/local/bin/${binary_name}\n" > ${docker_file_path}
 
         if [[ ${arch} == "amd64" ]]; then


### PR DESCRIPTION
``` release-note
If the hard link fails during docker build, warn the user and do a copy instead.

Running the build scripts will fail when building on filesystems that do not support hard links (e.g. cross-partition directory trees, vagrant virtualbox shared mounts).  If the attempt to set a hard link fails, then fall back to use "cp" instead of "ln".
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29680)

<!-- Reviewable:end -->
