### PR TITLE
Add "make help" to list all make targets and help info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ KUBE_GOGCFLAGS = $(GOGCFLAGS)
 # This controls the verbosity of the build.  Higher numbers mean more output.
 KUBE_VERBOSE ?= 1
 
+define ALL_HELP_INFO
 # Build code.
 #
 # Args:
@@ -74,18 +75,32 @@ KUBE_VERBOSE ?= 1
 #     Note: Use the -N -l options to disable compiler optimizations an inlining.
 #           Using these build options allows you to subsequently use source
 #           debugging tools like delve.
+endef
 .PHONY: all
+ifeq ($(PRINT_HELP),y)
+all:
+	@echo "$$ALL_HELP_INFO"
+else
 all: generated_files
 	hack/make-rules/build.sh $(WHAT)
+endif
 
+define GINKGO_HELP_INFO
 # Build ginkgo
 #
 # Example:
 # make ginkgo
+endef
 .PHONY: ginkgo
+ifeq ($(PRINT_HELP),y)
+ginkgo:
+	@echo "$$GINKGO_HELP_INFO"
+else
 ginkgo:
 	hack/make-rules/build.sh vendor/github.com/onsi/ginkgo/ginkgo
+endif
 
+define VERIFY_HELP_INFO
 # Runs all the presubmission verifications.
 #
 # Args:
@@ -94,19 +109,33 @@ ginkgo:
 # Example:
 #   make verify
 #   make verify BRANCH=branch_x
+endef
 .PHONY: verify
+ifeq ($(PRINT_HELP),y)
+verify:
+	@echo "$$VERIFY_HELP_INFO"
+else
 verify: verify_generated_files
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh -v
 	hack/make-rules/vet.sh
+endif
 
+define UPDATE_HELP_INFO
 # Runs all the generated updates.
 #
 # Example:
 # make update
+endef
 .PHONY: update
+ifeq ($(PRINT_HELP),y)
+update:
+	@echo "$$UPDATE_HELP_INFO"
+else
 update:
 	hack/update-all.sh
+endif
 
+define CHECK_TEST_HELP_INFO
 # Build and run tests.
 #
 # Args:
@@ -121,10 +150,17 @@ update:
 #   make check
 #   make test
 #   make check WHAT=pkg/kubelet GOFLAGS=-v
+endef
 .PHONY: check test
+ifeq ($(PRINT_HELP),y)
+check test:
+	@echo "$$CHECK_TEST_HELP_INFO"
+else
 check test: generated_files
 	hack/make-rules/test.sh $(WHAT) $(TESTS)
+endif
 
+define TEST_IT_HELP_INFO
 # Build and run integration tests.
 #
 # Args:
@@ -133,18 +169,32 @@ check test: generated_files
 #
 # Example:
 #   make test-integration
+endef
 .PHONY: test-integration
+ifeq ($(PRINT_HELP),y)
+test-integration:
+	@echo "$$TEST_IT_HELP_INFO"
+else
 test-integration: generated_files
 	hack/make-rules/test-integration.sh $(WHAT)
+endif
 
+define TEST_E2E_HELP_INFO
 # Build and run end-to-end tests.
 #
 # Example:
 #   make test-e2e
+endef
 .PHONY: test-e2e
+ifeq ($(PRINT_HELP),y)
+test-e2e:
+	@echo "$$TEST_E2E_HELP_INFO"
+else
 test-e2e: ginkgo generated_files
 	go run hack/e2e.go -v --build --up --test --down
+endif
 
+define TEST_E2E_NODE_HELP_INFO
 # Build and run node end-to-end tests.
 #
 # Args:
@@ -183,48 +233,83 @@ test-e2e: ginkgo generated_files
 #   make test-e2e-node REMOTE=true DELETE_INSTANCES=true
 #   make test-e2e-node TEST_ARGS="--experimental-cgroups-per-qos=true"
 # Build and run tests.
+endef
 .PHONY: test-e2e-node
+ifeq ($(PRINT_HELP),y)
+test-e2e-node:
+	@echo "$$TEST_E2E_NODE_HELP_INFO"
+else
 test-e2e-node: ginkgo generated_files
 	hack/make-rules/test-e2e-node.sh
+endif
 
+define TEST_CMD_HELP_INFO
 # Build and run cmdline tests.
 #
 # Example:
 #   make test-cmd
+endef
 .PHONY: test-cmd
+ifeq ($(PRINT_HELP),y)
+test-cmd:
+	@echo "$$TEST_CMD_HELP_INFO"
+else
 test-cmd: generated_files
 	hack/make-rules/test-kubeadm-cmd.sh
 	hack/make-rules/test-cmd.sh
+endif
 
+define CLEAN_HELP_INFO
 # Remove all build artifacts.
 #
 # Example:
 #   make clean
 #
 # TODO(thockin): call clean_generated when we stop committing generated code.
+endef
 .PHONY: clean
+ifeq ($(PRINT_HELP),y)
+clean:
+	@echo "$$CLEAN_HELP_INFO"
+else
 clean: clean_meta
 	build-tools/make-clean.sh
 	rm -rf $(OUT_DIR)
 	rm -rf Godeps/_workspace # Just until we are sure it is gone
+endif
 
+define CLEAN_META_HELP_INFO
 # Remove make-related metadata files.
 #
 # Example:
 #   make clean_meta
+endef
 .PHONY: clean_meta
+ifeq ($(PRINT_HELP),y)
+clean_meta:
+	@echo "$$CLEAN_META_HELP_INFO"
+else
 clean_meta:
 	rm -rf $(META_DIR)
+endif
 
+define CLEAN_GENERATED_HELP_INFO
 # Remove all auto-generated artifacts. Generated artifacts in staging folder should not be removed as they are not
 # generated using generated_files.
 #
 # Example:
 #   make clean_generated
+endef
 .PHONY: clean_generated
+ifeq ($(PRINT_HELP),y)
+clean_generated:
+	@echo "$$CLEAN_GENERATED_HELP_INFO"
+else
 clean_generated:
 	find . -type f -name $(GENERATED_FILE_PREFIX)\* | grep -v "[.]/staging/.*" | xargs rm -f
+endif
 
+define VET_HELP_INFO
 # Run 'go vet'.
 #
 # Args:
@@ -235,70 +320,150 @@ clean_generated:
 # Example:
 #   make vet
 #   make vet WHAT=pkg/kubelet
+endef
 .PHONY: vet
+ifeq ($(PRINT_HELP),y)
+vet:
+	@echo "$$VET_HELP_INFO"
+else
 vet:
 	hack/make-rules/vet.sh $(WHAT)
+endif
 
+define RELEASE_HELP_INFO
 # Build a release
 #
 # Example:
 #   make release
+endef
 .PHONY: release
+ifeq ($(PRINT_HELP),y)
+release:
+	@echo "$$RELEASE_HELP_INFO"
+else
 release:
 	build-tools/release.sh
+endif
 
+define RELEASE_SKIP_TESTS_HELP_INFO
 # Build a release, but skip tests
 #
 # Example:
 #   make release-skip-tests
+endef
 .PHONY: release-skip-tests quick-release
+ifeq ($(PRINT_HELP),y)
+release-skip-tests quick-release:
+	@echo "$$RELEASE_SKIP_TESTS_HELP_INFO"
+else
 release-skip-tests quick-release:
 	KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build-tools/release.sh
+endif
 
+define CROSS_HELP_INFO
 # Cross-compile for all platforms
 #
 # Example:
 #   make cross
+endef
 .PHONY: cross
+ifeq ($(PRINT_HELP),y)
+cross:
+	@echo "$$CROSS_HELP_INFO"
+else
 cross:
 	hack/make-rules/cross.sh
+endif
 
+define CMD_HELP_INFO
 # Add rules for all directories in cmd/
 #
 # Example:
 #   make kubectl kube-proxy
-.PHONY: $(notdir $(abspath $(wildcard cmd/*/)))
-$(notdir $(abspath $(wildcard cmd/*/))): generated_files
+endef
+#TODO: make EXCLUDE_TARGET auto-generated when there are other files in cmd/
+#TODO: should we exclude the target "libs" but include "cmd/libs/go2idl/*"?
+EXCLUDE_TARGET=OWNERS
+.PHONY: $(filter-out %$(EXCLUDE_TARGET),$(notdir $(abspath $(wildcard cmd/*/))))
+ifeq ($(PRINT_HELP),y)
+$(filter-out %$(EXCLUDE_TARGET),$(notdir $(abspath $(wildcard cmd/*/)))):
+	@echo "$$CMD_HELP_INFO"
+else
+$(filter-out %$(EXCLUDE_TARGET),$(notdir $(abspath $(wildcard cmd/*/)))): generated_files
 	hack/make-rules/build.sh cmd/$@
+endif
 
+define PLUGIN_CMD_HELP_INFO
 # Add rules for all directories in plugin/cmd/
 #
 # Example:
 #   make kube-scheduler
+endef
 .PHONY: $(notdir $(abspath $(wildcard plugin/cmd/*/)))
+ifeq ($(PRINT_HELP),y)
+$(notdir $(abspath $(wildcard plugin/cmd/*/))):
+	@echo "$$PLUGIN_CMD_HELP_INFO"
+else
 $(notdir $(abspath $(wildcard plugin/cmd/*/))): generated_files
 	hack/make-rules/build.sh plugin/cmd/$@
+endif
 
+define FED_CMD_HELP_INFO
 # Add rules for all directories in federation/cmd/
 #
 # Example:
 #   make federation-apiserver federation-controller-manager
+endef
 .PHONY: $(notdir $(abspath $(wildcard federation/cmd/*/)))
+ifeq ($(PRINT_HELP),y)
+$(notdir $(abspath $(wildcard federation/cmd/*/))):
+	@echo "$$FED_CMD_HELP_INFO"
+else
 $(notdir $(abspath $(wildcard federation/cmd/*/))): generated_files
 	hack/make-rules/build.sh federation/cmd/$@
+endif
 
+define GENERATED_FILES_HELP_INFO
 # Produce auto-generated files needed for the build.
 #
 # Example:
 #   make generated_files
+endef
 .PHONY: generated_files
+ifeq ($(PRINT_HELP),y)
+generated_files:
+	@echo "$$GENERATED_FILES_HELP_INFO"
+else
 generated_files:
 	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
+endif
 
+define VERIFY_GENERATED_FILES_HELP_INFO
 # Verify auto-generated files needed for the build.
 #
 # Example:
 #   make verify_generated_files
+endef
 .PHONY: verify_generated_files
+ifeq ($(PRINT_HELP),y)
+verify_generated_files:
+	@echo "$$VERIFY_GENERATED_FILES_HELP_INFO"
+else
 verify_generated_files:
 	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
+endif
+
+define HELP_INFO
+# Print make targets and help info
+#
+# Example:
+# make help
+endef
+.PHONY: help
+ifeq ($(PRINT_HELP),y)
+help:
+	@echo "$$HELP_INFO"
+else
+help:
+	hack/make-rules/make-help.sh
+endif

--- a/hack/make-rules/make-help.sh
+++ b/hack/make-rules/make-help.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+red='\E[1;31m'
+reset='\E[0m'
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+ALL_TARGETS=$(make -C "${KUBE_ROOT}" PRINT_HELP=y -rpn | sed -n -e '/^$/ { n ; /^[^ .#][^ ]*:/ { s/:.*$// ; p ; } ; }' | sort)
+CMD_TARGETS=$(ls -l "${KUBE_ROOT}/cmd" |awk '/^d/ {print $NF}')
+PLUGIN_CMD_TARGETS=$(ls -l "${KUBE_ROOT}/plugin/cmd" |awk '/^d/ {print $NF}')
+FED_CMD_TARGETS=$(ls -l "${KUBE_ROOT}/federation/cmd" |awk '/^d/ {print $NF}')
+CMD_FLAG=false
+PLUGIN_CMD_FLAG=false
+FED_CMD_FLAG=false
+
+echo "--------------------------------------------------------------------------------"
+for tar in $ALL_TARGETS; do
+	for cmdtar in $CMD_TARGETS; do
+		if [ $tar = $cmdtar ]; then
+			if [ $CMD_FLAG = true ]; then
+				continue 2;
+			fi
+
+			echo -e "${red}${CMD_TARGETS}${reset}"
+			make -C "${KUBE_ROOT}" $tar PRINT_HELP=y
+			echo "---------------------------------------------------------------------------------"
+
+			CMD_FLAG=true
+			continue 2
+		fi
+	done
+
+	for plugincmdtar in $PLUGIN_CMD_TARGETS; do
+		if [ $tar = $plugincmdtar ]; then
+			if [ $PLUGIN_CMD_FLAG = true ]; then
+				continue 2;
+			fi
+
+			echo -e "${red}${PLUGIN_CMD_TARGETS}${reset}"
+			make -C "${KUBE_ROOT}" $tar PRINT_HELP=y
+			echo "---------------------------------------------------------------------------------"
+
+			PLUGIN_CMD_FLAG=true
+			continue 2
+		fi
+	done
+
+	for fedcmdtar in $FED_CMD_TARGETS; do
+		if [ $tar = $fedcmdtar ]; then
+			if [ $FED_CMD_FLAG = true ]; then
+				continue 2;
+			fi
+
+			echo -e "${red}${FED_CMD_TARGETS}${reset}"
+			make -C "${KUBE_ROOT}" $tar PRINT_HELP=y
+			echo "---------------------------------------------------------------------------------"
+
+			FED_CMD_FLAG=true
+			continue 2
+		fi
+	done
+
+	echo -e "${red}${tar}${reset}"
+	make -C "${KUBE_ROOT}" $tar PRINT_HELP=y
+	echo "---------------------------------------------------------------------------------"
+done


### PR DESCRIPTION
As discussed in [PR#29320comment](https://github.com/kubernetes/kubernetes/pull/29320#issuecomment-234420145), add a `make help` to make the use of `make` easy. Though it works well on my Ubuntu now (see the output as below, not sure if it still works on other systems), I believe the scripts are somewhat ugly, so, any suggestion for optimization is welcome.

BTW, I intended to list targets by groups, but it's hard to do that automatically. So I just list them in alphabetical order. I think this may be enough.

There are still some TODOs (also mentioned in the Makefile):
1. make EXCLUDE_TARGET auto-generated when there are other files in cmd/
2. should we exclude the target "cmd/libs" but include "cmd/libs/go2idl/*"?
3. should we let `help` be the first/default target? It will show the help when we just type `make`.

1 and 2 are to exclude the invalid targets generated by `$(notdir $(abspath $(wildcard cmd/*/)))`:
- OWNERS is just a file, it can't be a target
- libs itself cannot be built

/cc @thockin @jfrazelle @MHBauer @dims 

Output:

```
root@vm:/home/paas/zxp/code/k8s/fork/kubernetes# make help
--------------------------------------------------------------------------------
all
# Build code.
#
# Args:
#   WHAT: Directory names to build.  If any of these directories has a 'main'
#     package, the build will produce executable files under _output/go/bin.
#     If not specified, "everything" will be built.
#   GOFLAGS: Extra flags to pass to 'go' when building.
#   GOLDFLAGS: Extra linking flags passed to 'go' when building.
#   GOGCFLAGS: Additional go compile flags passed to 'go' when building.
#
# Example:
#   make
#   make all
#   make all WHAT=cmd/kubelet GOFLAGS=-v
#   make all GOGCFLAGS="-N -l"
#     Note: Use the -N -l options to disable compiler optimizations an inlining.
#           Using these build options allows you to subsequently use source
#           debugging tools like delve.
---------------------------------------------------------------------------------
check
# Build and run tests.
#
# Args:
#   WHAT: Directory names to test.  All *_test.go files under these
#     directories will be run.  If not specified, "everything" will be tested.
#   TESTS: Same as WHAT.
#   GOFLAGS: Extra flags to pass to 'go' when building.
#   GOLDFLAGS: Extra linking flags to pass to 'go' when building.
#   GOGCFLAGS: Additional go compile flags passed to 'go' when building.
#
# Example:
#   make check
#   make test
#   make check WHAT=pkg/kubelet GOFLAGS=-v
---------------------------------------------------------------------------------
clean
# Remove all build artifacts.
#
# Example:
#   make clean
#
# TODO(thockin): call clean_generated when we stop committing generated code.
---------------------------------------------------------------------------------
clean_generated
# Remove all auto-generated artifacts.
#
# Example:
#   make clean_generated
---------------------------------------------------------------------------------
clean_meta
# Remove make-related metadata files.
#
# Example:
#   make clean_meta
---------------------------------------------------------------------------------
cross
# Cross-compile for all platforms
#
# Example:
#   make cross
---------------------------------------------------------------------------------
federation-apiserver
federation-controller-manager
genfeddocs
# Add rules for all directories in federation/cmd/
#
# Example:
#   make federation-apiserver federation-controller-manager
---------------------------------------------------------------------------------
gendocs
genkubedocs
genman
genswaggertypedocs
genutils
genyaml
hyperkube
kube-apiserver
kube-controller-manager
kubectl
kube-dns
kubelet
kubemark
kube-proxy
kubernetes-discovery
libs
linkcheck
mungedocs
# Add rules for all directories in cmd/
#
# Example:
#   make kubectl kube-proxy
---------------------------------------------------------------------------------
generated_files
# Produce auto-generated files needed for the build.
#
# Example:
#   make generated_files
---------------------------------------------------------------------------------
ginkgo
# Build ginkgo
#
# Example:
# make ginkgo
---------------------------------------------------------------------------------
help
# Print make targets and help info
#
# Example:
# make help
---------------------------------------------------------------------------------
quick-release
# Build a release, but skip tests
#
# Example:
#   make release-skip-tests
---------------------------------------------------------------------------------
release
# Build a release
#
# Example:
#   make release
---------------------------------------------------------------------------------
release-skip-tests
# Build a release, but skip tests
#
# Example:
#   make release-skip-tests
---------------------------------------------------------------------------------
test
# Build and run tests.
#
# Args:
#   WHAT: Directory names to test.  All *_test.go files under these
#     directories will be run.  If not specified, "everything" will be tested.
#   TESTS: Same as WHAT.
#   GOFLAGS: Extra flags to pass to 'go' when building.
#   GOLDFLAGS: Extra linking flags to pass to 'go' when building.
#   GOGCFLAGS: Additional go compile flags passed to 'go' when building.
#
# Example:
#   make check
#   make test
#   make check WHAT=pkg/kubelet GOFLAGS=-v
---------------------------------------------------------------------------------
test-cmd
# Build and run cmdline tests.
#
# Example:
#   make test-cmd
---------------------------------------------------------------------------------
test-e2e
# Build and run end-to-end tests.
#
# Example:
#   make test-e2e
---------------------------------------------------------------------------------
test-e2e-node
# Build and run node end-to-end tests.
#
# Args:
#  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
#  SKIP: Regexp that matches the tests that needs to be skipped.  Defaults
#    to "".
#  RUN_UNTIL_FAILURE: If true, pass --untilItFails to ginkgo so tests are run
#    repeatedly until they fail.  Defaults to false.
#  REMOTE: If true, run the tests on a remote host instance on GCE.  Defaults
#    to false.
#  IMAGES: For REMOTE=true only.  Comma delimited list of images for creating
#    remote hosts to run tests against.  Defaults to a recent image.
#  LIST_IMAGES: If true, don't run tests.  Just output the list of available
#    images for testing.  Defaults to false.
#  HOSTS: For REMOTE=true only.  Comma delimited list of running gce hosts to
#    run tests against.  Defaults to "".
#  DELETE_INSTANCES: For REMOTE=true only.  Delete any instances created as
#    part of this test run.  Defaults to false.
#  ARTIFACTS: For REMOTE=true only.  Local directory to scp test artifacts into
#    from the remote hosts.  Defaults to ""/tmp/_artifacts".
#  REPORT: For REMOTE=false only.  Local directory to write juntil xml results
#    to.  Defaults to "/tmp/".
#  CLEANUP: For REMOTE=true only.  If false, do not stop processes or delete
#    test files on remote hosts.  Defaults to true.
#  IMAGE_PROJECT: For REMOTE=true only.  Project containing images provided to
#  IMAGES.  Defaults to "kubernetes-node-e2e-images".
#  INSTANCE_PREFIX: For REMOTE=true only.  Instances created from images will
#    have the name "-".  Defaults to "test".
#  INSTANCE_METADATA: For REMOTE=true and running on GCE only.
#
# Example:
#   make test-e2e-node FOCUS=Kubelet SKIP=container
#   make test-e2e-node REMOTE=true DELETE_INSTANCES=true
#   make test-e2e-node TEST_ARGS="--cgroups-per-qos=true"
# Build and run tests.
---------------------------------------------------------------------------------
test-integration
# Build and run integration tests.
#
# Example:
#   make test-integration
---------------------------------------------------------------------------------
verify
# Runs all the presubmission verifications.
#
# Args:
#   BRANCH: Branch to be passed to verify-godeps.sh script.
#
# Example:
#   make verify
#   make verify BRANCH=branch_x
---------------------------------------------------------------------------------
vet
# Run 'go vet'.
#
# Args:
#   WHAT: Directory names to vet.  All *.go files under these
#     directories will be vetted.  If not specified, "everything" will be
#     vetted.
#
# Example:
#   make vet
#   make vet WHAT=pkg/kubelet
---------------------------------------------------------------------------------
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29683)

<!-- Reviewable:end -->
