### PR TITLE
Explain use of different IAM Roles and Policies for Kubernetes cluser

### DIFF
--- a/cluster/aws/templates/iam/README.md
+++ b/cluster/aws/templates/iam/README.md
@@ -6,13 +6,15 @@ In lieu of comments support in JSON, this document describes the IAM Roles and P
 
 ### kubernetes-master-role.json
 
-This establishes the trust relationship between the minion role and EC2 service. The Role describes `ec2.amazonaws.com` can assume the role of `KubernetesMinionRole`.
+This establishes the trust relationship between the master role and EC2 service. The Role describes `ec2.amazonaws.com` can assume the role of `KubernetesMasterRole`.
 
 ### kubernetes-master-policy.json
 
 `ec2:Describe*` is used reading instance metadata such as instance size and AZ information.
 
-`elasticloadbalancing:*`, `route53:*` are used for Ingress support.
+`elasticloadbalancing:*` are used for services with [Type=LoadBalancer](http://kubernetes.io/docs/user-guide/services/#type-loadbalancer).
+
+`route53:*` are used for federation.
 
 `s3:*` on `arn:aws:s3:::kubernetes-*` is specific to `kube-up` where kube binaries are stored in S3. This is not required for other setups.
 
@@ -32,6 +34,6 @@ Specific policies are granted to allow kubelet to perform various AWS-related ta
 
 `ec2:AttachVolume` and `ec2:DetachVolume` are used for EBS support. This is not required for newer versions of Kubernetes on the minion as the logic has been moved to the controller.
 
-`route53:*` is used for Ingress support.
+`route53:*` are used for federation.
 
 `ecr:*` are used for pulling images from EC2 Container Registry. This is not required for those not using ECR.

--- a/cluster/aws/templates/iam/README.md
+++ b/cluster/aws/templates/iam/README.md
@@ -1,0 +1,37 @@
+# IAM Roles and Policies for Kubernetes Master and Minion EC2 Nodes
+
+In lieu of comments support in JSON, this document describes the IAM Roles and Policies required
+
+## Master
+
+### kubernetes-master-role.json
+
+This establishes the trust relationship between the minion role and EC2 service. The Role describes `ec2.amazonaws.com` can assume the role of `KubernetesMinionRole`.
+
+### kubernetes-master-policy.json
+
+`ec2:Describe*` is used reading instance metadata such as instance size and AZ information.
+
+`elasticloadbalancing:*`, `route53:*` are used for Ingress support.
+
+`s3:*` on `arn:aws:s3:::kubernetes-*` is specific to `kube-up` where kube binaries are stored in S3. This is not required for other setups.
+
+## Minion
+
+### kubernetes-minion-role.json
+
+This establishes the trust relationship between the minion role and EC2 service. The Role describes `ec2.amazonaws.com` can assume the role of `KubernetesMinionRole`.
+
+### kubernetes-minion-policy.json
+
+Specific policies are granted to allow kubelet to perform various AWS-related tasks:
+
+`s3:*` on `arn:aws:s3:::kubernetes-*` is specific to `kube-up` where kube binaries are stored in S3. This is not required for other setups.
+
+`ec2:Describe*` is used reading instance metadata such as instance size and AZ information.
+
+`ec2:AttachVolume` and `ec2:DetachVolume` are used for EBS support. This is not required for newer versions of Kubernetes on the minion as the logic has been moved to the controller.
+
+`route53:*` is used for Ingress support.
+
+`ecr:*` are used for pulling images from EC2 Container Registry. This is not required for those not using ECR.


### PR DESCRIPTION
A discussion in SIG AWS realized that there are no documentation around the use and need of different IAM Roles and Policies in the Kubernetes cluster setup for AWS. In lieu of comments support in JSON, this PR adds a document as a first attempt to describe the use of individual policies and roles.

@justinsb

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29689)

<!-- Reviewable:end -->
