### PR TITLE
WIP: Scheduling algorithms ReplicaSet Controller uses: predicates & priorities

### DIFF
--- a/federation/plugin/pkg/federated-scheduler/algorithm/doc.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package federated-scheduler contains a generic Scheduler interface and several
+// implementations.
+package algorithm

--- a/federation/plugin/pkg/federated-scheduler/algorithm/listers.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/listers.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	federation "k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+var _ ReplicaSetLister = &EmptyReplicaSetLister{}
+
+//ClusterLister interface represents anything that can list clusters for a federated-scheduler.
+type ClusterLister interface {
+	List() (list federation.ClusterList, err error)
+}
+
+// FakeClusterLister implements ClusterLister on a []string for test purposes.
+type FakeClusterLister federation.ClusterList
+
+// List returns clusters as a []string.
+func (f FakeClusterLister) List() (federation.ClusterList, error) {
+	return federation.ClusterList(f), nil
+}
+
+// FakeControllerLister implements ControllerLister on []extensions.ReplicaSet for test purposes.
+type FakeControllerLister []extensions.ReplicaSet
+
+// List returns []extensions.ReplicaSet, the list of all ReplicationControllers.
+func (f FakeControllerLister) List() ([]extensions.ReplicaSet, error) {
+	return f, nil
+}
+
+// ReplicaSetLister interface represents anything that can produce a list of ReplicaSet; the list is consumed by a federated-scheduler.
+type ReplicaSetLister interface {
+	// Lists all the replicasets
+	List() ([]extensions.ReplicaSet, error)
+}
+
+// EmptyReplicaSetLister implements ReplicaSetLister on []extensions.ReplicaSet returning empty data
+type EmptyReplicaSetLister struct{}
+
+// List returns nil
+func (f EmptyReplicaSetLister) List() ([]extensions.ReplicaSet, error) {
+	return nil, nil
+}
+
+// FakeReplicaSetLister implements ControllerLister on []extensions.ReplicaSet for test purposes.
+type FakeReplicaSetLister []extensions.ReplicaSet
+
+// List returns []extensions.ReplicaSet, the list of all ReplicaSets.
+func (f FakeReplicaSetLister) List() ([]extensions.ReplicaSet, error) {
+	return f, nil
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithm/predicates/predicates.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/predicates/predicates.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/federation/apis/federation/unversioned"
+	federation "k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+	"k8s.io/kubernetes/federation/client/clientset_generated/release_1_3"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/schedulercache"
+	"k8s.io/kubernetes/pkg/api/v1"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/cache"
+)
+
+type ClusterInfo interface {
+	GetClusterInfo(clusterName string) (*federation.Cluster, error)
+}
+
+type StaticClusterInfo struct {
+	*federation.ClusterList
+}
+
+func (clusters StaticClusterInfo) GetClusterInfo(clusterName string) (*federation.Cluster, error) {
+	for ix := range clusters.Items {
+		if clusters.Items[ix].Name == clusterName {
+			return &clusters.Items[ix], nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find cluster: %s, %#v", clusterName, clusters)
+}
+
+type ClientClusterInfo struct {
+	*release_1_3.Clientset
+}
+
+func (clusters ClientClusterInfo) GetClusterInfo(clusterName string) (*federation.Cluster, error) {
+	return clusters.Clusters().Get(clusterName)
+}
+
+type CachedClusterInfo struct {
+	*cache.StoreToClusterLister
+}
+
+// GetClusterInfo returns cached data for the cluster 'id'.
+func (c *CachedClusterInfo) GetClusterInfo(id string) (*federation.Cluster, error) {
+	cluster, exists, err := c.Get(&federation.Cluster{ObjectMeta: v1.ObjectMeta{Name: id}})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving cluster '%v' from cache: %v", id, err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("cluster '%v' is not in cache", id)
+	}
+
+	return cluster.(*federation.Cluster), nil
+}
+
+func NewSelectorMatchPredicate(info ClusterInfo) algorithm.FitPredicate {
+	selector := &ClusterSelector{
+		info: info,
+	}
+	return selector.RSAnnotationMatches
+}
+
+func rsMatchesClusterName(rs *extensions.ReplicaSet, cluster *federation.Cluster) bool {
+	clusterSelection, ok := rs.Annotations[unversioned.ClusterSelectorKey]
+	if !ok || clusterSelection == "" {
+		glog.V(4).Infof("no target cluster is specified, any cluster can be scheduling candidate, return true.")
+		return true
+	}
+	selectedClusters := parseClusterSelectorAnnotation(clusterSelection)
+	for i := range selectedClusters {
+		if selectedClusters[i] == cluster.Name {
+			glog.V(4).Infof("target cluster is specified and found, return true.")
+			return true
+		}
+	}
+	return false
+}
+
+type ClusterSelector struct {
+	info ClusterInfo
+}
+
+//Example of ReplicaSet with cluster selector annotation
+//	apiVersion: v1
+//	kind: ReplicaSet
+//	metadata:
+//		name: nginx-controller
+//	annotations:
+//		ubernetes.kubernetes.io/cluster-name: Foo, Bar
+func parseClusterSelectorAnnotation(selectorAnnotationString string) []string {
+	//assume ube-apiserver covers the validation, and the value should be a string of "Foo, Bar"
+	targets := strings.Split(selectorAnnotationString, ",")
+	results := []string{}
+	for i := range targets {
+		results = append(results, strings.TrimSpace(targets[i]))
+	}
+	return results
+}
+
+func (c *ClusterSelector) RSAnnotationMatches(rs *extensions.ReplicaSet, clusterName string, clusterInfo *schedulercache.ClusterInfo) (bool, error) {
+	cluster, err := c.info.GetClusterInfo(clusterName)
+	if err != nil {
+		return false, err
+	}
+	return rsMatchesClusterName(rs, cluster), nil
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithm/priorities/priorities.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/priorities/priorities.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+import (
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm"
+	schedulerapi "k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/api"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/schedulercache"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+
+	"math/rand"
+)
+
+type ClusterRandom struct {
+	clusterLister algorithm.ClusterLister
+}
+
+func NewRandomChoosePriority(clusterLister algorithm.ClusterLister) algorithm.PriorityFunction {
+	clusterRandom := &ClusterRandom{
+		clusterLister: clusterLister,
+	}
+	return clusterRandom.CalculateRandomPriority
+}
+
+// RandomChoosePriority is a priority function that randomly choose target from candidate.
+// it get a random index between 0 and len(clusters) - 1
+func (c *ClusterRandom) CalculateRandomPriority(rc *extensions.ReplicaSet, clusterNameToInfo map[string]*schedulercache.ClusterInfo, clusterLister algorithm.ClusterLister) (schedulerapi.ClusterPriorityList, error) {
+	chosenPriority := 100
+	clusters, err := clusterLister.List()
+	if err != nil {
+		return schedulerapi.ClusterPriorityList{}, err
+	}
+	index := rand.Intn(len(clusters.Items))
+	list := schedulerapi.ClusterPriorityList{}
+	cluster := clusters.Items[index]
+	list = append(list,
+		schedulerapi.ClusterPriority{
+			Cluster: cluster.Name,
+			Score:   chosenPriority,
+		},
+	)
+	return list, nil
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithm/scheduler_interface.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/scheduler_interface.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+// ScheduleAlgorithm is an interface implemented by things that know how to schedule replicasets
+// onto machines.
+type ScheduleAlgorithm interface {
+	Schedule(*extensions.ReplicaSet, ClusterLister) (selectedCluster string, err error)
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithm/types.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithm/types.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	schedulerapi "k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/api"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/schedulercache"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+// FitPredicate is a function that indicates if a replicaset fits into an existing cluster.
+type FitPredicate func(rc *extensions.ReplicaSet, clusterName string, clusterInfo *schedulercache.ClusterInfo) (bool, error)
+
+type PriorityFunction func(rc *extensions.ReplicaSet, clusterNameToInfo map[string]*schedulercache.ClusterInfo, clusterLister ClusterLister) (schedulerapi.ClusterPriorityList, error)
+
+type PriorityConfig struct {
+	Function PriorityFunction
+	Weight   int
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithmprovider/defaults/defaults.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithmprovider/defaults/defaults.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is the default algorithm provider for the federated-scheduler.
+package defaults
+
+import (
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm/priorities"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/factory"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func init() {
+	factory.RegisterAlgorithmProvider(factory.DefaultProvider, defaultPredicates(), defaultPriorities())
+}
+
+func defaultPredicates() sets.String {
+	return sets.NewString(
+		// Fit is determined by cluster selector query.
+		factory.RegisterFitPredicateFactory(
+			"MatchClusterSelector",
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewSelectorMatchPredicate(args.ClusterInfo)
+			},
+		),
+	)
+}
+
+func defaultPriorities() sets.String {
+	return sets.NewString(
+		factory.RegisterPriorityConfigFactory(
+			"RandomChoosePriority",
+			factory.PriorityConfigFactory{
+				Function: func(args factory.PluginFactoryArgs) algorithm.PriorityFunction {
+					return priorities.NewRandomChoosePriority(args.ClusterLister)
+				},
+				Weight: 1,
+			},
+		),
+	)
+}

--- a/federation/plugin/pkg/federated-scheduler/algorithmprovider/plugins.go
+++ b/federation/plugin/pkg/federated-scheduler/algorithmprovider/plugins.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package is used to register algorithm provider plugins.
+package algorithmprovider
+
+import (
+	_ "k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithmprovider/defaults"
+)

--- a/federation/plugin/pkg/federated-scheduler/generic_scheduler.go
+++ b/federation/plugin/pkg/federated-scheduler/generic_scheduler.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"sync"
+
+	federation "k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/algorithm"
+	schedulerapi "k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/api"
+	"k8s.io/kubernetes/federation/plugin/pkg/federated-scheduler/schedulercache"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
+)
+
+type FailedPredicateMap map[string]sets.String
+
+type FitError struct {
+	Rc               *extensions.ReplicaSet
+	FailedPredicates FailedPredicateMap
+}
+
+var ErrNoClustersAvailable = fmt.Errorf("no clusters available to schedule rcs")
+
+// Error returns detailed information of why the replicaSet failed to fit on each cluster
+func (f *FitError) Error() string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("replicaSet (%s) failed to fit in any cluster\n", f.Rc.Name))
+	for cluster, predicateList := range f.FailedPredicates {
+		reason := fmt.Sprintf("fit failure on cluster (%s): %s\n", cluster, strings.Join(predicateList.List(), ","))
+		buf.WriteString(reason)
+	}
+	return buf.String()
+}
+
+type genericScheduler struct {
+	cache            schedulercache.Cache
+	predicates       map[string]algorithm.FitPredicate
+	prioritizers     []algorithm.PriorityConfig
+	random           *rand.Rand
+	randomLock       sync.Mutex
+	lastClusterIndex uint64
+}
+
+// Schedule tries to schedule the given replicaSet to one of cluster in the cluster list.
+// If it succeeds, it will return the name of the cluster.
+// If it fails, it will return a Fiterror error with reasons.
+func (g *genericScheduler) Schedule(rc *extensions.ReplicaSet, clusterLister algorithm.ClusterLister) (string, error) {
+	clusters, err := clusterLister.List()
+	if err != nil {
+		return "", err
+	}
+	if len(clusters.Items) == 0 {
+		return "", ErrNoClustersAvailable
+	}
+
+	// Used for all fit and priority funcs.
+	clusterNameToInfo, err := g.cache.GetClusterNameToInfoMap()
+	if err != nil {
+		return "", err
+	}
+
+	filteredClusters, failedPredicateMap, err := findClustersThatFit(rc, clusterNameToInfo, g.predicates, clusters)
+	if err != nil {
+		return "", err
+	}
+
+	if len(filteredClusters.Items) == 0 {
+		return "", &FitError{
+			Rc:               rc,
+			FailedPredicates: failedPredicateMap,
+		}
+	}
+
+	priorityList, err := PrioritizeClusters(rc, clusterNameToInfo, g.prioritizers, algorithm.FakeClusterLister(filteredClusters))
+	if err != nil {
+		return "", err
+	}
+
+	return g.selectClusters(priorityList)
+}
+
+// selectCluster takes a prioritized list of clusters and then picks one
+// randomly from the clusters that had the highest score.
+// in phase I, only one cluster will be picked and in later phase, the replicaset will be sp
+func (g *genericScheduler) selectClusters(priorityList schedulerapi.ClusterPriorityList) (string, error) {
+	if len(priorityList) == 0 {
+		return "", fmt.Errorf("empty priorityList")
+	}
+
+	sort.Sort(sort.Reverse(priorityList))
+	maxScore := priorityList[0].Score
+	firstAfterMaxScore := sort.Search(len(priorityList), func(i int) bool { return priorityList[i].Score < maxScore })
+
+	g.randomLock.Lock()
+	ix := int(g.lastClusterIndex % uint64(firstAfterMaxScore))
+	g.lastClusterIndex++
+	g.randomLock.Unlock()
+
+	return priorityList[ix].Cluster, nil
+}
+
+// Filters the clusters to find the ones that fit based on the given predicate functions
+// Each clusters is passed through the predicate functions to determine if it is a fit
+func findClustersThatFit(rc *extensions.ReplicaSet, clusterNameToInfo map[string]*schedulercache.ClusterInfo, predicateFuncs map[string]algorithm.FitPredicate, clusters federation.ClusterList) (federation.ClusterList, FailedPredicateMap, error) {
+	filtered := []federation.Cluster{}
+	failedPredicateMap := FailedPredicateMap{}
+
+	for _, cluster := range clusters.Items {
+		fits := true
+		for name, predicate := range predicateFuncs {
+			fit, err := predicate(rc, cluster.Name, clusterNameToInfo[cluster.Name])
+			if err != nil {
+				return federation.ClusterList{}, FailedPredicateMap{}, err
+			}
+			if !fit {
+				fits = false
+				if _, found := failedPredicateMap[cluster.Name]; !found {
+					failedPredicateMap[cluster.Name] = sets.String{}
+				}
+				failedPredicateMap[cluster.Name].Insert(name)
+				break
+			}
+		}
+		if fits {
+			filtered = append(filtered, cluster)
+		}
+	}
+
+	return federation.ClusterList{Items: filtered}, failedPredicateMap, nil
+}
+
+// Prioritizes the clusters by running the individual priority functions in parallel.
+// Each priority function is expected to set a score of 0-10
+// 0 is the lowest priority score (least preferred clusters) and 10 is the highest
+// Each priority function can also have its own weight
+// The clusters scores returned by the priority function are multiplied by the weights to get weighted scores
+// All scores are finally combined (added) to get the total weighted scores of all clusters
+func PrioritizeClusters(
+	rc *extensions.ReplicaSet,
+	clusterNameToInfo map[string]*schedulercache.ClusterInfo,
+	priorityConfigs []algorithm.PriorityConfig,
+	clusterLister algorithm.ClusterLister,
+) (schedulerapi.ClusterPriorityList, error) {
+	result := schedulerapi.ClusterPriorityList{}
+
+	// If no priority configs are provided, then the EqualPriority function is applied
+	// This is required to generate the priority list in the required format
+	if len(priorityConfigs) == 0 {
+		return EqualPriority(rc, clusterNameToInfo, clusterLister)
+	}
+
+	var (
+		mu             = sync.Mutex{}
+		wg             = sync.WaitGroup{}
+		combinedScores = map[string]int{}
+		errs           []error
+	)
+
+	for _, priorityConfig := range priorityConfigs {
+		// skip the priority function if the weight is specified as 0
+		if priorityConfig.Weight == 0 {
+			continue
+		}
+
+		wg.Add(1)
+		go func(config algorithm.PriorityConfig) {
+			defer wg.Done()
+			weight := config.Weight
+			priorityFunc := config.Function
+			prioritizedList, err := priorityFunc(rc, clusterNameToInfo, clusterLister)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			for i := range prioritizedList {
+				cluster, score := prioritizedList[i].Cluster, prioritizedList[i].Score
+				combinedScores[cluster] += score * weight
+			}
+			mu.Unlock()
+		}(priorityConfig)
+	}
+	if len(errs) != 0 {
+		return schedulerapi.ClusterPriorityList{}, errors.NewAggregate(errs)
+	}
+	// wait for all go routines to finish
+	wg.Wait()
+
+	for cluster, score := range combinedScores {
+		glog.V(10).Infof("Cluster %s Score %d", cluster, score)
+		result = append(result, schedulerapi.ClusterPriority{Cluster: cluster, Score: score})
+	}
+	return result, nil
+}
+
+// EqualPriority is a prioritizer function that gives an equal weight of one to all clusters
+func EqualPriority(_ *extensions.ReplicaSet, clusterNameToInfo map[string]*schedulercache.ClusterInfo, clusterLister algorithm.ClusterLister) (schedulerapi.ClusterPriorityList, error) {
+	clusters, err := clusterLister.List()
+	if err != nil {
+		glog.Errorf("Failed to list clusters: %v", err)
+		return []schedulerapi.ClusterPriority{}, err
+	}
+
+	result := []schedulerapi.ClusterPriority{}
+	for _, cluster := range clusters.Items {
+		result = append(result, schedulerapi.ClusterPriority{
+			Cluster: cluster.Name,
+			Score:   1,
+		})
+	}
+	return result, nil
+}
+
+func NewGenericScheduler(cache schedulercache.Cache, predicates map[string]algorithm.FitPredicate, prioritizers []algorithm.PriorityConfig, random *rand.Rand) algorithm.ScheduleAlgorithm {
+	return &genericScheduler{
+		cache:        cache,
+		predicates:   predicates,
+		prioritizers: prioritizers,
+		random:       random,
+	}
+}


### PR DESCRIPTION
- Scheduling algorithms are called by ReplicaSet Controller (FRSC)
- They take Federated ReplicaSet (FRS) as input, return Local ReplicaSets (LRS's) and their bindings as output
