### PR TITLE
Update acquire to use newer JitterUntil vs. sleep 

### DIFF
--- a/pkg/client/leaderelection/OWNERS
+++ b/pkg/client/leaderelection/OWNERS
@@ -1,2 +1,3 @@
 assignees:
   - mikedanese
+  - timothysc


### PR DESCRIPTION
Fix to prevent https://github.com/kubernetes/kubernetes/issues/26782 which could have had a race on a 0 timer the way it was written before due to changes in wait. 

I will likely make a PR for some of the recent changes in wait as well. 
