### PR TITLE
pod reflector should not run before rc cache synced

### DIFF
--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -65,6 +65,10 @@ const (
 	// avoid a hot loop, we'll wait this long between checks.
 	PodStoreSyncedPollPeriod = 100 * time.Millisecond
 
+	// We must avoid counting pods until the pod store has synced. If it hasn't synced, to
+	// avoid a hot loop, we'll wait this long between checks.
+	rcStoreSyncedPollPeriod = 100 * time.Millisecond
+
 	// The number of times we retry updating a replication controller's status.
 	statusUpdateRetries = 1
 )
@@ -108,6 +112,9 @@ type ReplicationManager struct {
 	// podStoreSynced returns true if the pod store has been synced at least once.
 	// Added as a member to the struct to allow injection for testing.
 	podStoreSynced func() bool
+	// rcStoreSynced returns true if the rc store has been synced at least once.
+	// Added as a member to the struct to allow injection for testing.
+	rcStoreSynced func() bool
 
 	lookupCache *controller.MatchingCache
 
@@ -183,6 +190,7 @@ func newReplicationManager(eventRecorder record.EventRecorder, podInformer frame
 
 	rm.syncHandler = rm.syncReplicationController
 	rm.podStoreSynced = rm.podController.HasSynced
+	rm.rcStoreSynced = rm.rcController.HasSynced
 	rm.lookupCache = controller.NewMatchingCache(lookupCacheSize)
 	return rm
 }
@@ -219,7 +227,16 @@ func (rm *ReplicationManager) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	glog.Infof("Starting RC Manager")
 	go rm.rcController.Run(stopCh)
-	go rm.podController.Run(stopCh)
+	go func() {
+		for {
+			if rm.rcStoreSynced() {
+				break
+			}
+			// Sleep so we give the rc reflector goroutine a chance to run.
+			time.Sleep(rcStoreSyncedPollPeriod)
+		}
+		rm.podController.Run(stopCh)
+	}()
 	for i := 0; i < workers; i++ {
 		go wait.Until(rm.worker, time.Second, stopCh)
 	}


### PR DESCRIPTION
#### Problem:
- pod reflector should not run before rc cache synced, otherwise pod informer may add wrong rc into workqueue
- actually controller works fine even if we insert wrong rc into workqueue, since when controller pop a rc from workqueue and sync it, the pod cache has been synced, so it will still make correct  decision. But it's really misleading to start pod reflector before rc cache synced.

@bprashanth @wojtek-t  @hongchaodeng

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29719)

<!-- Reviewable:end -->
