### PR TITLE
Optimise the getConntrackMax function

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -335,12 +335,13 @@ func (s *ProxyServer) Run() error {
 }
 
 func getConntrackMax(config *options.ProxyServerConfig) (int, error) {
-	if config.ConntrackMax > 0 && config.ConntrackMaxPerCore > 0 {
-		return -1, fmt.Errorf("invalid config: ConntrackMax and ConntrackMaxPerCore are mutually exclusive")
-	}
 	if config.ConntrackMax > 0 {
+		if config.ConntrackMaxPerCore > 0 {
+			return -1, fmt.Errorf("invalid config: ConntrackMax and ConntrackMaxPerCore are mutually exclusive")
+		}
 		return int(config.ConntrackMax), nil
-	} else if config.ConntrackMaxPerCore > 0 {
+	}
+	if config.ConntrackMaxPerCore > 0 {
 		return (int(config.ConntrackMaxPerCore) * runtime.NumCPU()), nil
 	}
 	return 0, nil


### PR DESCRIPTION
The PR optimise the getConntrackMax function, make it more concise.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29732)

<!-- Reviewable:end -->
