### PR TITLE
Add rules for kube-scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,14 @@ cross:
 $(notdir $(abspath $(wildcard cmd/*/))): generated_files
 	hack/make-rules/build.sh cmd/$@
 
+# Add rules for all directories in plugin/cmd/
+#
+# Example:
+#   make kube-scheduler
+.PHONY: $(notdir $(abspath $(wildcard plugin/cmd/*/)))
+$(notdir $(abspath $(wildcard plugin/cmd/*/))): generated_files
+	hack/make-rules/build.sh plugin/cmd/$@
+
 # Add rules for all directories in federation/cmd/
 #
 # Example:


### PR DESCRIPTION
Just find that we have also missed the rule for `kube-scheduler`. I don't want to mix the rule with #29683 (make help) now. Will merge them finally if #29683 can be merged.
