### PR TITLE
Fix kubectl help command

### DIFF
--- a/pkg/kubectl/cmd/help.go
+++ b/pkg/kubectl/cmd/help.go
@@ -41,7 +41,7 @@ func NewCmdHelp(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunHelp(cmd *cobra.Command, args []string) {
-	foundCmd, a, err := cmd.Root().Find(args)
+	foundCmd, _, err := cmd.Root().Find(args)
 
 	// NOTE(andreykurilin): actually, I did not find any cases when foundCmd can be nil,
 	//   but let's make this check since it is included in original code of initHelpCmd
@@ -69,10 +69,11 @@ func RunHelp(cmd *cobra.Command, args []string) {
 			// if nothing is found, just print usage
 			cmd.Root().Usage()
 		}
-	} else if len(a) == 0 {
-		// help message for help command :)
-		cmd.Root().Usage()
 	} else {
+		if len(args) == 0 {
+			// help message for help command :)
+			foundCmd = cmd
+		}
 		helpFunc := foundCmd.HelpFunc()
 		helpFunc(foundCmd, args)
 	}


### PR DESCRIPTION
PR 48d47b1027c40be3dbab3f2e0fbe296e4b883330 broke `kubectl help` command due
to wrong check `help for help cmd` .

Fixes #29736
