### PR TITLE
Add CloudStack cloud provider (extended and refactored)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2124,6 +2124,11 @@
 			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
+			"ImportPath": "github.com/xanzy/go-cloudstack/cloudstack",
+			"Comment": "v2.1.1-1-g1e2cbf6",
+			"Rev": "1e2cbf647e57fa90353612074fdfc42faf5073bf"
+		},
+		{
 			"ImportPath": "github.com/xiang90/probing",
 			"Rev": "6a0cc1ae81b4cc11db5e491e030e4b98fba79c19"
 		},

--- a/Godeps/LICENSES
+++ b/Godeps/LICENSES
@@ -65587,6 +65587,215 @@ SOFTWARE.
 
 
 ================================================================================
+= vendor/github.com/xanzy/go-cloudstack/cloudstack licensed under: =
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+= vendor/github.com/xanzy/go-cloudstack/LICENSE 136e4f49dbf29942c572a3a8f6e88a77  -
+================================================================================
+
+
+================================================================================
 = vendor/github.com/xiang90/probing licensed under: =
 
 The MIT License (MIT)

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -80,6 +80,7 @@ pkg/client/unversioned/auth
 pkg/client/unversioned/remotecommand
 pkg/cloudprovider/providers
 pkg/cloudprovider/providers/azure
+pkg/cloudprovider/providers/cloudstack
 pkg/controller/framework
 pkg/controller/volume
 pkg/controller/volume/attachdetach/cache

--- a/pkg/cloudprovider/providers/cloudstack/OWNERS
+++ b/pkg/cloudprovider/providers/cloudstack/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+  - ngtuna
+  - runseb

--- a/pkg/cloudprovider/providers/cloudstack/OWNERS
+++ b/pkg/cloudprovider/providers/cloudstack/OWNERS
@@ -1,3 +1,0 @@
-assignees:
-  - ngtuna
-  - runseb

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -1,34 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cloudstack
 
 import (
 	"fmt"
 	"io"
-	"gopkg.in/gcfg.v1"
-	"github.com/xanzy/go-cloudstack/cloudstack"
-	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/api"
-	 //"github.com/kubernetes/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/service"
-	 //"github.com/kubernetes/kubernetes/pkg/api/service"
+
 	"github.com/golang/glog"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+	"gopkg.in/gcfg.v1"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
+// ProviderName is the name of this cloud provider.
 const ProviderName = "cloudstack"
 
-type Config struct {
+// CSConfig wraps the config for the CloudStack cloud provider.
+type CSConfig struct {
 	Global struct {
-		       APIUrl     string `gcfg:"api-url"`
-		       APIKey     string `gcfg:"api-key"`
-		       SecretKey  string `gcfg:"secret-key"`
-		       VerifySSL  bool `gcfg:"verify-ssl"`
-	       }
+		APIURL      string `gcfg:"api-url"`
+		APIKey      string `gcfg:"api-key"`
+		SecretKey   string `gcfg:"secret-key"`
+		SSLNoVerify bool   `gcfg:"ssl-no-verify"`
+		ProjectID   string `gcfg:"project-id"`
+		Zone        string `gcfg:"zone"`
+	}
 }
 
-// CSCloud is an implementation of cloud provider Interface for CloudStack.
+// CSCloud is an implementation of Interface for CloudStack.
 type CSCloud struct {
-	client *cloudstack.CloudStackClient
-	// InstanceID of the server where this CloudStack object is instantiated.
-	localInstanceID string
+	client    *cloudstack.CloudStackClient
+	projectID string // If non-"", all resources will be created within this project
+	zone      string
 }
 
 func init() {
@@ -37,69 +54,59 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+
 		return newCSCloud(cfg)
 	})
 }
 
-func readConfig(config io.Reader) (Config, error) {
+func readConfig(config io.Reader) (*CSConfig, error) {
 	if config == nil {
 		err := fmt.Errorf("no cloud provider config given")
-		return Config{}, err
+		return nil, err
 	}
 
-	cfg := Config{}
-	if err := gcfg.ReadInto(&cfg, config); err != nil {
+	cfg := &CSConfig{}
+	if err := gcfg.ReadInto(cfg, config); err != nil {
 		glog.Errorf("Couldn't parse config: %v", err)
-		return Config{}, err
+		return nil, err
 	}
 
 	return cfg, nil
 }
 
-// newCSCloud creates a new instance of CSCloud
-func newCSCloud(cfg Config) (*CSCloud, error) {
-	client := cloudstack.NewAsyncClient(cfg.Global.APIUrl, cfg.Global.APIKey, cfg.Global.SecretKey, cfg.Global.VerifySSL)
+// newCSCloud creates a new instance of CSCloud.
+func newCSCloud(cfg *CSConfig) (*CSCloud, error) {
+	client := cloudstack.NewAsyncClient(cfg.Global.APIURL, cfg.Global.APIKey, cfg.Global.SecretKey, !cfg.Global.SSLNoVerify)
 
-	id, err := readInstanceID()
-	if err != nil {
-		return nil, err
-	}
-
-	cs := CSCloud{
-		client:        client,
-		localInstanceID: id,
-	}
-
-	return &cs, nil
-}
-
-func readInstanceID() (string, error) {
-	// TODO: get instanceID from virtual router metadata
-	return "", nil
+	return &CSCloud{client, cfg.Global.ProjectID, cfg.Global.Zone}, nil
 }
 
 // LoadBalancer returns an implementation of LoadBalancer for CloudStack.
 func (cs *CSCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
-	glog.V(4).Info("cloudstack.LoadBalancer() called")
-	return &LoadBalancer{cs}, true
+	return cs, true
 }
 
-func (cs *CSCloud) Clusters() (cloudprovider.Clusters, bool) {
-	return nil, false
-}
-
+// Instances returns an implementation of Instances for CloudStack.
 func (cs *CSCloud) Instances() (cloudprovider.Instances, bool) {
-	return &Instances{cs}, true
-}
-
-func (cs *CSCloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Zones returns an implementation of Zones for CloudStack.
 func (cs *CSCloud) Zones() (cloudprovider.Zones, bool) {
 	return cs, true
 }
 
+// Clusters returns an implementation of Clusters for CloudStack.
+func (cs *CSCloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// Routes returns an implementation of Routes for CloudStack.
+func (cs *CSCloud) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+// ProviderName returns the cloud provider ID.
 func (cs *CSCloud) ProviderName() string {
 	return ProviderName
 }
@@ -109,380 +116,8 @@ func (cs *CSCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 	return nameservers, searches
 }
 
-func (i *Instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
-	return fmt.Errorf("unimplemented")
-}
-
+// GetZone returns the Zone containing the region that the program is running in.
 func (cs *CSCloud) GetZone() (cloudprovider.Zone, error) {
-	glog.V(1).Infof("Current zone is null")
-
-	return cloudprovider.Zone{Region: ""}, nil
-}
-
-func (i *Instances) CurrentNodeName(hostname string) (string, error) {
-	return hostname, nil
-}
-
-// ExternalID returns the cloud provider ID of the specified instance (deprecated).
-func (i *Instances) ExternalID(name string) (string, error) {
-	var lb LoadBalancer
-	var hosts []string
-	hosts = append(hosts, name)
-	vmIDs, err := lb.getVirtualMachineIds(hosts)
-	if  err != nil {
-		return "", err
-	}
-	return vmIDs[0], nil
-}
-
-// InstanceID returns the cloud provider ID of the specified instance.
-// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
-func (i *Instances) InstanceID(name string) (string, error) {
-	var lb LoadBalancer
-	var hosts []string
-	hosts = append(hosts, name)
-	vmIDs, err := lb.getVirtualMachineIds(hosts)
-	if  err != nil {
-		return "", cloudprovider.InstanceNotFound
-	}
-	return vmIDs[0], nil
-}
-
-// InstanceType returns the type of the specified instance.
-func (i *Instances) InstanceType(name string) (string, error) {
-	return "", nil
-}
-// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
-func (i *Instances) List(name_filter string) ([]string, error) {
-	vmParams := i.cs.client.VirtualMachine.NewListVirtualMachinesParams()
-	vmParams.SetName(name_filter)
-	vmParamsResponse, err := i.cs.client.VirtualMachine.ListVirtualMachines(vmParams)
-	if err != nil {
-		return nil, err
-	}
-	var vms []string
-	for _, vm := range vmParamsResponse.VirtualMachines {
-		vms = append(vms, vm.Name)
-	}
-	return vms, nil
-}
-// NodeAddresses returns the addresses of the specified instance.
-// TODO(roberthbailey): This currently is only used in such a way that it
-// returns the address of the calling instance. We should do a rename to
-// make this clearer.
-func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
-	vmParams := i.cs.client.VirtualMachine.NewListVirtualMachinesParams()
-	vmParams.SetName(name)
-	vmParamsResponse, err := i.cs.client.VirtualMachine.ListVirtualMachines(vmParams)
-	if err != nil {
-		return nil, err
-	}
-
-	addrs := []api.NodeAddress{}
-	publicIP := vmParamsResponse.VirtualMachines[0].Publicip
-	addrs = append(addrs, api.NodeAddress{Type: api.NodeExternalIP, Address: publicIP})
-
-	for _, nic := range vmParamsResponse.VirtualMachines[0].Nic {
-		addrs = append(addrs, api.NodeAddress{Type: api.NodeInternalIP, Address: nic.Ipaddress})
-		addrs = append(addrs, api.NodeAddress{Type: api.NodeLegacyHostIP, Address: nic.Ipaddress})
-	}
-
-	return addrs, nil
-}
-
-type LoadBalancer struct {
-	cs	*CSCloud
-}
-
-type Instances struct {
-	cs 	*CSCloud
-}
-
-func (lb *LoadBalancer) GetLoadBalancer(apiService *api.Service) (*api.LoadBalancerStatus, bool, error) {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
-	loadBalancer, _, err := lb.cs.client.LoadBalancer.GetLoadBalancerByName(loadBalancerName)
-
-	if err != nil {
-		return nil, false, nil
-	}
-
-	vip := loadBalancer.Sourceipaddress
-	status := &api.LoadBalancerStatus{}
-	status.Ingress = []api.LoadBalancerIngress{{IP: vip}}
-
-	return status, true, err
-}
-
-func (lb *LoadBalancer) EnsureLoadBalancer(apiService *api.Service, hosts []string, annotations map[string]string) (*api.LoadBalancerStatus, error) {
-	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v)", apiService.Namespace, apiService.Name, apiService.Spec.LoadBalancerIP, apiService.Spec.Ports, hosts, annotations)
-
-	sourceRanges, err := service.GetLoadBalancerSourceRanges(annotations)
-	if err != nil {
-		return nil, err
-	}
-
-	if !service.IsAllowAll(sourceRanges) {
-		return nil, fmt.Errorf("Source range restrictions are not supported for CloudStack load balancers")
-	}
-
-	glog.V(2).Infof("Checking if CloudStack load balancer already exists: %s", cloudprovider.GetLoadBalancerName(apiService))
-	_, exists, err := lb.GetLoadBalancer(apiService)
-	if err != nil {
-		return nil, fmt.Errorf("error checking if CloudStack load balancer already exists: %v", err)
-	}
-
-	// TODO: Implement a more efficient update strategy for common changes than delete & create
-	if exists {
-		err := lb.EnsureLoadBalancerDeleted(apiService)
-		if err != nil {
-			return nil, fmt.Errorf("error deleting existing CloudStack load balancer: %v", err)
-		}
-	}
-
-	//Config algorithm for the new LB
-	var algorithm string
-	switch apiService.Spec.SessionAffinity {
-	case api.ServiceAffinityNone:
-		algorithm = "roundrobin"
-	case api.ServiceAffinityClientIP:
-		algorithm = "source"
-	default:
-		return nil, fmt.Errorf("unsupported load balancer affinity: %v", apiService.Spec.SessionAffinity)
-	}
-
-	//Get public IP address will be associated to the new LB
-	lbIpAddr := apiService.Spec.LoadBalancerIP
-	if lbIpAddr == "" {
-		return nil, fmt.Errorf("unsupported service without predefined Load Balancer IPaddress")
-	}
-	publicIpId, err := lb.getPublicIpId(lbIpAddr)
-	if err != nil {
-		return nil, fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
-	}
-
-	//Config name for new LB
-	lbName := apiService.ObjectMeta.Name
-	if lbName == "" {
-		return nil, fmt.Errorf("name is a required field for a CloudStack load balancer")
-	}
-
-	ports := apiService.Spec.Ports
-	if len(ports) == 0 {
-		return nil, fmt.Errorf("no ports provided to CloudStack load balancer")
-	}
-
-	//support multiple ports
-	for _, port := range ports {
-		//Init a new LB configuration
-		lbParams := lb.cs.client.LoadBalancer.NewCreateLoadBalancerRuleParams(
-			algorithm,
-			lbName,
-			port.NodePort,
-			port.Port,
-		)
-
-		//Config protocol for new LB
-		switch port.Protocol {
-		case api.ProtocolTCP:
-			lbParams.SetProtocol("TCP")
-		case api.ProtocolUDP:
-			lbParams.SetProtocol("UDP")
-		}
-
-		//Config LB IP
-		lbParams.SetPublicipid(publicIpId)
-
-		//Do not create corresponding firewall rule
-		lbParams.SetOpenfirewall(false)
-
-		// create a Load Balancer rule
-		createLBRuleResponse, err := lb.cs.client.LoadBalancer.CreateLoadBalancerRule(lbParams)
-		if err != nil {
-			return nil, err
-		}
-
-		// associate vms to new LB
-		assignLbParams := lb.cs.client.LoadBalancer.NewAssignToLoadBalancerRuleParams(createLBRuleResponse.Id)
-		vmIds, err := lb.getVirtualMachineIds(hosts)
-		if err != nil {
-			return nil, fmt.Errorf("error getting list of vms associated with CloudStack load balancer")
-		}
-		assignLbParams.SetVirtualmachineids(vmIds)
-		assignLBRuleResponse, err := lb.cs.client.LoadBalancer.AssignToLoadBalancerRule(assignLbParams)
-
-		if err != nil || !assignLBRuleResponse.Success {
-			return nil, err
-		}
-	}
-
-	status := &api.LoadBalancerStatus{}
-	status.Ingress = []api.LoadBalancerIngress{{IP: lbIpAddr}}
-
-	return status, nil
-}
-
-func (lb *LoadBalancer) UpdateLoadBalancer(apiService *api.Service, hosts []string) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
-	glog.V(4).Infof("UpdateLoadBalancer(%v, %v)", loadBalancerName, hosts)
-
-	lbParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRulesParams()
-
-	//Get new list of vms associated with LB of service
-	//Set of member (addresses) that _should_ exist
-	vmIds, err := lb.getVirtualMachineIds(hosts)
-	if err != nil {
-		return fmt.Errorf("error getting list of vms associated with CloudStack load balancer")
-	}
-	vms := map[string]bool{}
-	for _, vmId := range vmIds {
-		vms[vmId] = true
-	}
-
-	//Now get the current list of vms. And then make comparison to update the list.
-	//Public IPaddress associated with LB of service
-	lbIpAddr := apiService.Spec.LoadBalancerIP
-	if lbIpAddr == "" {
-		return fmt.Errorf("unsupported service without predefined Load Balancer IPaddress")
-	}
-
-	//list all LB rules associated with this public IPaddress
-	publicIpId, err := lb.getPublicIpId(lbIpAddr)
-	if err != nil {
-		return fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
-	}
-	lbParams.SetPublicipid(publicIpId)
-	lbRulesResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRules(lbParams)
-	if err != nil {
-		return err
-	}
-	lbRuleId := lbRulesResponse.LoadBalancerRules[0].Id
-	lbInstancesParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRuleInstancesParams(lbRuleId)
-	lbInstancesParams.SetLbvmips(true)
-
-	//list out all VMs currently associated to this LB
-	lbInstancesResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRuleInstances(lbInstancesParams)
-	if err != nil {
-		return err
-	}
-
-	var oldvmIds []string
-	for _, lbInstance := range lbInstancesResponse.LoadBalancerRuleInstances {
-		oldvmIds = append(oldvmIds, lbInstance.Loadbalancerruleinstance.Id)
-	}
-
-	//Compare two list of vms to thus update LB
-	var removedVmIds []string
-	for _, oldvmId := range oldvmIds {
-		if _, found := vms[oldvmId]; found {
-			delete(vms, oldvmId)
-		} else {
-			removedVmIds = append(removedVmIds, oldvmId)
-		}
-	}
-
-	//remove old vms from all LB rules associated with the public IP
-	for _, lbRule := range lbRulesResponse.LoadBalancerRules {
-		removeFromLbRuleParams := lb.cs.client.LoadBalancer.NewRemoveFromLoadBalancerRuleParams(lbRule.Id)
-		removeFromLbRuleParams.SetVirtualmachineids(removedVmIds)
-		_, err := lb.cs.client.LoadBalancer.RemoveFromLoadBalancerRule(removeFromLbRuleParams)
-		if err != nil {
-			return err
-		}
-	}
-
-	//assign new vms (the rest of vms map) to all LB rules associated with the public IP
-	var assignVmIds []string
-	for vm := range vms {
-		assignVmIds = append(assignVmIds, vm)
-	}
-
-	for _, lbRule := range lbRulesResponse.LoadBalancerRules {
-		assignToLbRuleParams := lb.cs.client.LoadBalancer.NewAssignToLoadBalancerRuleParams(lbRule.Id)
-		assignToLbRuleParams.SetVirtualmachineids(assignVmIds)
-		_, err := lb.cs.client.LoadBalancer.AssignToLoadBalancerRule(assignToLbRuleParams)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (lb *LoadBalancer) EnsureLoadBalancerDeleted(apiService *api.Service) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
-	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v)", loadBalancerName)
-
-
-	lbIpAddr := apiService.Spec.LoadBalancerIP
-	if lbIpAddr != "" {
-		//list all LB rules associated to this public ipaddress.
-		listLBParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRulesParams()
-		publicIpId, err := lb.getPublicIpId(lbIpAddr)
-		if err != nil {
-			return fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
-		}
-		listLBParams.SetPublicipid(publicIpId)
-		listLoadBalancerResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRules(listLBParams)
-		if err != nil {
-			return err
-		}
-		lbRules := listLoadBalancerResponse.LoadBalancerRules
-
-		//delete all found load balancer rules associated to this public ipaddress.
-		for _, lbRule := range lbRules {
-			lbParams := lb.cs.client.LoadBalancer.NewDeleteLoadBalancerRuleParams(lbRule.Id)
-			_, err := lb.cs.client.LoadBalancer.DeleteLoadBalancerRule(lbParams)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		//only support delete load balancer with existing IP address
-		return nil
-	}
-
-	return nil
-}
-
-func (lb *LoadBalancer) getPublicIpId(lbIP string) (string, error) {
-	addressParams := lb.cs.client.Address.NewListPublicIpAddressesParams()
-	addressParams.SetIpaddress(lbIP)
-	addressResponse, err := lb.cs.client.Address.ListPublicIpAddresses(addressParams)
-	if err != nil {
-		return "", err
-	}
-
-	if addressResponse.Count > 1 {
-		return "", fmt.Errorf("Found more than one address objects with IP = %s", lbIP)
-	} else if addressResponse.Count == 0 {
-		//TODO: acquire new IP address with lbIP from CloudStack
-	}
-
-	return addressResponse.PublicIpAddresses[0].Id, nil
-}
-
-func (lb *LoadBalancer) getVirtualMachineIds(hosts []string) ([]string, error) {
-	var vmIDs []string
-	ipAddrs := map[string]bool{}
-	for _, host := range hosts {
-		ipAddrs[host] = true
-	}
-
-	//list all vms
-	listVMParams := lb.cs.client.VirtualMachine.NewListVirtualMachinesParams()
-	listVMParams.SetListall(true)
-	listVMResponse, err := lb.cs.client.VirtualMachine.ListVirtualMachines(listVMParams)
-	if err != nil {
-		return nil, err
-	}
-
-	//check if ipaddress belongs to the hosts slice, then add the corresponding vmid
-	for i := 0; i < listVMResponse.Count; i++ {
-		//check only the first Nic
-		ipAddr := listVMResponse.VirtualMachines[i].Nic[0].Ipaddress
-		if _, found := ipAddrs[ipAddr]; found {
-			vmIDs = append(vmIDs, listVMResponse.VirtualMachines[i].Id)
-		}
-	}
-
-	return vmIDs, nil
+	glog.V(2).Infof("Current zone is %v", cs.zone)
+	return cloudprovider.Zone{Region: cs.zone}, nil
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -1,0 +1,488 @@
+package cloudstack
+
+import (
+	"fmt"
+	"io"
+	"gopkg.in/gcfg.v1"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/api"
+	 //"github.com/kubernetes/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/service"
+	 //"github.com/kubernetes/kubernetes/pkg/api/service"
+	"github.com/golang/glog"
+)
+
+const ProviderName = "cloudstack"
+
+type Config struct {
+	Global struct {
+		       APIUrl     string `gcfg:"api-url"`
+		       APIKey     string `gcfg:"api-key"`
+		       SecretKey  string `gcfg:"secret-key"`
+		       VerifySSL  bool `gcfg:"verify-ssl"`
+	       }
+}
+
+// CSCloud is an implementation of cloud provider Interface for CloudStack.
+type CSCloud struct {
+	client *cloudstack.CloudStackClient
+	// InstanceID of the server where this CloudStack object is instantiated.
+	localInstanceID string
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		cfg, err := readConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		return newCSCloud(cfg)
+	})
+}
+
+func readConfig(config io.Reader) (Config, error) {
+	if config == nil {
+		err := fmt.Errorf("no cloud provider config given")
+		return Config{}, err
+	}
+
+	cfg := Config{}
+	if err := gcfg.ReadInto(&cfg, config); err != nil {
+		glog.Errorf("Couldn't parse config: %v", err)
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+// newCSCloud creates a new instance of CSCloud
+func newCSCloud(cfg Config) (*CSCloud, error) {
+	client := cloudstack.NewAsyncClient(cfg.Global.APIUrl, cfg.Global.APIKey, cfg.Global.SecretKey, cfg.Global.VerifySSL)
+
+	id, err := readInstanceID()
+	if err != nil {
+		return nil, err
+	}
+
+	cs := CSCloud{
+		client:        client,
+		localInstanceID: id,
+	}
+
+	return &cs, nil
+}
+
+func readInstanceID() (string, error) {
+	// TODO: get instanceID from virtual router metadata
+	return "", nil
+}
+
+// LoadBalancer returns an implementation of LoadBalancer for CloudStack.
+func (cs *CSCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	glog.V(4).Info("cloudstack.LoadBalancer() called")
+	return &LoadBalancer{cs}, true
+}
+
+func (cs *CSCloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+func (cs *CSCloud) Instances() (cloudprovider.Instances, bool) {
+	return &Instances{cs}, true
+}
+
+func (cs *CSCloud) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+func (cs *CSCloud) Zones() (cloudprovider.Zones, bool) {
+	return cs, true
+}
+
+func (cs *CSCloud) ProviderName() string {
+	return ProviderName
+}
+
+// ScrubDNS filters DNS settings for pods.
+func (cs *CSCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
+func (i *Instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
+	return fmt.Errorf("unimplemented")
+}
+
+func (cs *CSCloud) GetZone() (cloudprovider.Zone, error) {
+	glog.V(1).Infof("Current zone is null")
+
+	return cloudprovider.Zone{Region: ""}, nil
+}
+
+func (i *Instances) CurrentNodeName(hostname string) (string, error) {
+	return hostname, nil
+}
+
+// ExternalID returns the cloud provider ID of the specified instance (deprecated).
+func (i *Instances) ExternalID(name string) (string, error) {
+	var lb LoadBalancer
+	var hosts []string
+	hosts = append(hosts, name)
+	vmIDs, err := lb.getVirtualMachineIds(hosts)
+	if  err != nil {
+		return "", err
+	}
+	return vmIDs[0], nil
+}
+
+// InstanceID returns the cloud provider ID of the specified instance.
+// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
+func (i *Instances) InstanceID(name string) (string, error) {
+	var lb LoadBalancer
+	var hosts []string
+	hosts = append(hosts, name)
+	vmIDs, err := lb.getVirtualMachineIds(hosts)
+	if  err != nil {
+		return "", cloudprovider.InstanceNotFound
+	}
+	return vmIDs[0], nil
+}
+
+// InstanceType returns the type of the specified instance.
+func (i *Instances) InstanceType(name string) (string, error) {
+	return "", nil
+}
+// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
+func (i *Instances) List(name_filter string) ([]string, error) {
+	vmParams := i.cs.client.VirtualMachine.NewListVirtualMachinesParams()
+	vmParams.SetName(name_filter)
+	vmParamsResponse, err := i.cs.client.VirtualMachine.ListVirtualMachines(vmParams)
+	if err != nil {
+		return nil, err
+	}
+	var vms []string
+	for _, vm := range vmParamsResponse.VirtualMachines {
+		vms = append(vms, vm.Name)
+	}
+	return vms, nil
+}
+// NodeAddresses returns the addresses of the specified instance.
+// TODO(roberthbailey): This currently is only used in such a way that it
+// returns the address of the calling instance. We should do a rename to
+// make this clearer.
+func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
+	vmParams := i.cs.client.VirtualMachine.NewListVirtualMachinesParams()
+	vmParams.SetName(name)
+	vmParamsResponse, err := i.cs.client.VirtualMachine.ListVirtualMachines(vmParams)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := []api.NodeAddress{}
+	publicIP := vmParamsResponse.VirtualMachines[0].Publicip
+	addrs = append(addrs, api.NodeAddress{Type: api.NodeExternalIP, Address: publicIP})
+
+	for _, nic := range vmParamsResponse.VirtualMachines[0].Nic {
+		addrs = append(addrs, api.NodeAddress{Type: api.NodeInternalIP, Address: nic.Ipaddress})
+		addrs = append(addrs, api.NodeAddress{Type: api.NodeLegacyHostIP, Address: nic.Ipaddress})
+	}
+
+	return addrs, nil
+}
+
+type LoadBalancer struct {
+	cs	*CSCloud
+}
+
+type Instances struct {
+	cs 	*CSCloud
+}
+
+func (lb *LoadBalancer) GetLoadBalancer(apiService *api.Service) (*api.LoadBalancerStatus, bool, error) {
+	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
+	loadBalancer, _, err := lb.cs.client.LoadBalancer.GetLoadBalancerByName(loadBalancerName)
+
+	if err != nil {
+		return nil, false, nil
+	}
+
+	vip := loadBalancer.Sourceipaddress
+	status := &api.LoadBalancerStatus{}
+	status.Ingress = []api.LoadBalancerIngress{{IP: vip}}
+
+	return status, true, err
+}
+
+func (lb *LoadBalancer) EnsureLoadBalancer(apiService *api.Service, hosts []string, annotations map[string]string) (*api.LoadBalancerStatus, error) {
+	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v)", apiService.Namespace, apiService.Name, apiService.Spec.LoadBalancerIP, apiService.Spec.Ports, hosts, annotations)
+
+	sourceRanges, err := service.GetLoadBalancerSourceRanges(annotations)
+	if err != nil {
+		return nil, err
+	}
+
+	if !service.IsAllowAll(sourceRanges) {
+		return nil, fmt.Errorf("Source range restrictions are not supported for CloudStack load balancers")
+	}
+
+	glog.V(2).Infof("Checking if CloudStack load balancer already exists: %s", cloudprovider.GetLoadBalancerName(apiService))
+	_, exists, err := lb.GetLoadBalancer(apiService)
+	if err != nil {
+		return nil, fmt.Errorf("error checking if CloudStack load balancer already exists: %v", err)
+	}
+
+	// TODO: Implement a more efficient update strategy for common changes than delete & create
+	if exists {
+		err := lb.EnsureLoadBalancerDeleted(apiService)
+		if err != nil {
+			return nil, fmt.Errorf("error deleting existing CloudStack load balancer: %v", err)
+		}
+	}
+
+	//Config algorithm for the new LB
+	var algorithm string
+	switch apiService.Spec.SessionAffinity {
+	case api.ServiceAffinityNone:
+		algorithm = "roundrobin"
+	case api.ServiceAffinityClientIP:
+		algorithm = "source"
+	default:
+		return nil, fmt.Errorf("unsupported load balancer affinity: %v", apiService.Spec.SessionAffinity)
+	}
+
+	//Get public IP address will be associated to the new LB
+	lbIpAddr := apiService.Spec.LoadBalancerIP
+	if lbIpAddr == "" {
+		return nil, fmt.Errorf("unsupported service without predefined Load Balancer IPaddress")
+	}
+	publicIpId, err := lb.getPublicIpId(lbIpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
+	}
+
+	//Config name for new LB
+	lbName := apiService.ObjectMeta.Name
+	if lbName == "" {
+		return nil, fmt.Errorf("name is a required field for a CloudStack load balancer")
+	}
+
+	ports := apiService.Spec.Ports
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("no ports provided to CloudStack load balancer")
+	}
+
+	//support multiple ports
+	for _, port := range ports {
+		//Init a new LB configuration
+		lbParams := lb.cs.client.LoadBalancer.NewCreateLoadBalancerRuleParams(
+			algorithm,
+			lbName,
+			port.NodePort,
+			port.Port,
+		)
+
+		//Config protocol for new LB
+		switch port.Protocol {
+		case api.ProtocolTCP:
+			lbParams.SetProtocol("TCP")
+		case api.ProtocolUDP:
+			lbParams.SetProtocol("UDP")
+		}
+
+		//Config LB IP
+		lbParams.SetPublicipid(publicIpId)
+
+		//Do not create corresponding firewall rule
+		lbParams.SetOpenfirewall(false)
+
+		// create a Load Balancer rule
+		createLBRuleResponse, err := lb.cs.client.LoadBalancer.CreateLoadBalancerRule(lbParams)
+		if err != nil {
+			return nil, err
+		}
+
+		// associate vms to new LB
+		assignLbParams := lb.cs.client.LoadBalancer.NewAssignToLoadBalancerRuleParams(createLBRuleResponse.Id)
+		vmIds, err := lb.getVirtualMachineIds(hosts)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of vms associated with CloudStack load balancer")
+		}
+		assignLbParams.SetVirtualmachineids(vmIds)
+		assignLBRuleResponse, err := lb.cs.client.LoadBalancer.AssignToLoadBalancerRule(assignLbParams)
+
+		if err != nil || !assignLBRuleResponse.Success {
+			return nil, err
+		}
+	}
+
+	status := &api.LoadBalancerStatus{}
+	status.Ingress = []api.LoadBalancerIngress{{IP: lbIpAddr}}
+
+	return status, nil
+}
+
+func (lb *LoadBalancer) UpdateLoadBalancer(apiService *api.Service, hosts []string) error {
+	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
+	glog.V(4).Infof("UpdateLoadBalancer(%v, %v)", loadBalancerName, hosts)
+
+	lbParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRulesParams()
+
+	//Get new list of vms associated with LB of service
+	//Set of member (addresses) that _should_ exist
+	vmIds, err := lb.getVirtualMachineIds(hosts)
+	if err != nil {
+		return fmt.Errorf("error getting list of vms associated with CloudStack load balancer")
+	}
+	vms := map[string]bool{}
+	for _, vmId := range vmIds {
+		vms[vmId] = true
+	}
+
+	//Now get the current list of vms. And then make comparison to update the list.
+	//Public IPaddress associated with LB of service
+	lbIpAddr := apiService.Spec.LoadBalancerIP
+	if lbIpAddr == "" {
+		return fmt.Errorf("unsupported service without predefined Load Balancer IPaddress")
+	}
+
+	//list all LB rules associated with this public IPaddress
+	publicIpId, err := lb.getPublicIpId(lbIpAddr)
+	if err != nil {
+		return fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
+	}
+	lbParams.SetPublicipid(publicIpId)
+	lbRulesResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRules(lbParams)
+	if err != nil {
+		return err
+	}
+	lbRuleId := lbRulesResponse.LoadBalancerRules[0].Id
+	lbInstancesParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRuleInstancesParams(lbRuleId)
+	lbInstancesParams.SetLbvmips(true)
+
+	//list out all VMs currently associated to this LB
+	lbInstancesResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRuleInstances(lbInstancesParams)
+	if err != nil {
+		return err
+	}
+
+	var oldvmIds []string
+	for _, lbInstance := range lbInstancesResponse.LoadBalancerRuleInstances {
+		oldvmIds = append(oldvmIds, lbInstance.Loadbalancerruleinstance.Id)
+	}
+
+	//Compare two list of vms to thus update LB
+	var removedVmIds []string
+	for _, oldvmId := range oldvmIds {
+		if _, found := vms[oldvmId]; found {
+			delete(vms, oldvmId)
+		} else {
+			removedVmIds = append(removedVmIds, oldvmId)
+		}
+	}
+
+	//remove old vms from all LB rules associated with the public IP
+	for _, lbRule := range lbRulesResponse.LoadBalancerRules {
+		removeFromLbRuleParams := lb.cs.client.LoadBalancer.NewRemoveFromLoadBalancerRuleParams(lbRule.Id)
+		removeFromLbRuleParams.SetVirtualmachineids(removedVmIds)
+		_, err := lb.cs.client.LoadBalancer.RemoveFromLoadBalancerRule(removeFromLbRuleParams)
+		if err != nil {
+			return err
+		}
+	}
+
+	//assign new vms (the rest of vms map) to all LB rules associated with the public IP
+	var assignVmIds []string
+	for vm := range vms {
+		assignVmIds = append(assignVmIds, vm)
+	}
+
+	for _, lbRule := range lbRulesResponse.LoadBalancerRules {
+		assignToLbRuleParams := lb.cs.client.LoadBalancer.NewAssignToLoadBalancerRuleParams(lbRule.Id)
+		assignToLbRuleParams.SetVirtualmachineids(assignVmIds)
+		_, err := lb.cs.client.LoadBalancer.AssignToLoadBalancerRule(assignToLbRuleParams)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (lb *LoadBalancer) EnsureLoadBalancerDeleted(apiService *api.Service) error {
+	loadBalancerName := cloudprovider.GetLoadBalancerName(apiService)
+	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v)", loadBalancerName)
+
+
+	lbIpAddr := apiService.Spec.LoadBalancerIP
+	if lbIpAddr != "" {
+		//list all LB rules associated to this public ipaddress.
+		listLBParams := lb.cs.client.LoadBalancer.NewListLoadBalancerRulesParams()
+		publicIpId, err := lb.getPublicIpId(lbIpAddr)
+		if err != nil {
+			return fmt.Errorf("error getting public IP address information for creating CloudStack load balancer")
+		}
+		listLBParams.SetPublicipid(publicIpId)
+		listLoadBalancerResponse, err := lb.cs.client.LoadBalancer.ListLoadBalancerRules(listLBParams)
+		if err != nil {
+			return err
+		}
+		lbRules := listLoadBalancerResponse.LoadBalancerRules
+
+		//delete all found load balancer rules associated to this public ipaddress.
+		for _, lbRule := range lbRules {
+			lbParams := lb.cs.client.LoadBalancer.NewDeleteLoadBalancerRuleParams(lbRule.Id)
+			_, err := lb.cs.client.LoadBalancer.DeleteLoadBalancerRule(lbParams)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		//only support delete load balancer with existing IP address
+		return nil
+	}
+
+	return nil
+}
+
+func (lb *LoadBalancer) getPublicIpId(lbIP string) (string, error) {
+	addressParams := lb.cs.client.Address.NewListPublicIpAddressesParams()
+	addressParams.SetIpaddress(lbIP)
+	addressResponse, err := lb.cs.client.Address.ListPublicIpAddresses(addressParams)
+	if err != nil {
+		return "", err
+	}
+
+	if addressResponse.Count > 1 {
+		return "", fmt.Errorf("Found more than one address objects with IP = %s", lbIP)
+	} else if addressResponse.Count == 0 {
+		//TODO: acquire new IP address with lbIP from CloudStack
+	}
+
+	return addressResponse.PublicIpAddresses[0].Id, nil
+}
+
+func (lb *LoadBalancer) getVirtualMachineIds(hosts []string) ([]string, error) {
+	var vmIDs []string
+	ipAddrs := map[string]bool{}
+	for _, host := range hosts {
+		ipAddrs[host] = true
+	}
+
+	//list all vms
+	listVMParams := lb.cs.client.VirtualMachine.NewListVirtualMachinesParams()
+	listVMParams.SetListall(true)
+	listVMResponse, err := lb.cs.client.VirtualMachine.ListVirtualMachines(listVMParams)
+	if err != nil {
+		return nil, err
+	}
+
+	//check if ipaddress belongs to the hosts slice, then add the corresponding vmid
+	for i := 0; i < listVMResponse.Count; i++ {
+		//check only the first Nic
+		ipAddr := listVMResponse.VirtualMachines[i].Nic[0].Ipaddress
+		if _, found := ipAddrs[ipAddr]; found {
+			vmIDs = append(vmIDs, listVMResponse.VirtualMachines[i].Id)
+		}
+	}
+
+	return vmIDs, nil
+}

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
@@ -1,0 +1,543 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudstack
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type loadBalancer struct {
+	*cloudstack.CloudStackClient
+
+	name      string
+	algorithm string
+	hostIDs   []string
+	ipAddr    string
+	ipAddrID  string
+	networkID string
+	projectID string
+	rules     map[string]*cloudstack.LoadBalancerRule
+}
+
+// GetLoadBalancer returns whether the specified load balancer exists, and if so, what its status is.
+func (cs *CSCloud) GetLoadBalancer(clusterName string, service *api.Service) (*api.LoadBalancerStatus, bool, error) {
+	glog.V(4).Infof("GetLoadBalancer(%v, %v, %v)", clusterName, service.Namespace, service.Name)
+
+	// Get the load balancer details and existing rules.
+	lb, err := cs.getLoadBalancer(service)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// If we don't have any rules, the load balancer does not exist.
+	if len(lb.rules) == 0 {
+		return nil, false, nil
+	}
+
+	glog.V(4).Infof("Found a load balancer associated with IP %v", lb.ipAddr)
+
+	status := &api.LoadBalancerStatus{}
+	status.Ingress = append(status.Ingress, api.LoadBalancerIngress{IP: lb.ipAddr})
+
+	return status, true, nil
+}
+
+// EnsureLoadBalancer creates a new load balancer, or updates the existing one. Returns the status of the balancer.
+func (cs *CSCloud) EnsureLoadBalancer(clusterName string, service *api.Service, hosts []string) (status *api.LoadBalancerStatus, err error) {
+	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v)", clusterName, service.Namespace, service.Name, service.Spec.LoadBalancerIP, service.Spec.Ports, hosts)
+
+	if len(service.Spec.Ports) == 0 {
+		return nil, fmt.Errorf("requested load balancer with no ports")
+	}
+
+	// Get the load balancer details and existing rules.
+	lb, err := cs.getLoadBalancer(service)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the load balancer algorithm.
+	switch service.Spec.SessionAffinity {
+	case api.ServiceAffinityNone:
+		lb.algorithm = "roundrobin"
+	case api.ServiceAffinityClientIP:
+		lb.algorithm = "source"
+	default:
+		return nil, fmt.Errorf("unsupported load balancer affinity: %v", service.Spec.SessionAffinity)
+	}
+
+	// Verify that all the hosts belong to the same network, and retrieve their ID's.
+	lb.hostIDs, lb.networkID, err = cs.verifyHosts(hosts)
+	if err != nil {
+		return nil, err
+	}
+
+	if !lb.hasLoadBalancerIP() {
+		// Create or retrieve the load balancer IP.
+		if err := lb.getLoadBalancerIP(service.Spec.LoadBalancerIP); err != nil {
+			return nil, err
+		}
+
+		if lb.ipAddr != "" && lb.ipAddr != service.Spec.LoadBalancerIP {
+			defer func(lb *loadBalancer) {
+				if err != nil {
+					if err := lb.releaseLoadBalancerIP(); err != nil {
+						glog.Errorf(err.Error())
+					}
+				}
+			}(lb)
+		}
+	}
+
+	glog.V(4).Infof("Load balancer %v is associated with IP %v", lb.name, lb.ipAddr)
+
+	for _, port := range service.Spec.Ports {
+		// All ports have their own load balancer rule, so add the port to lbName to keep the names unique.
+		lbRuleName := fmt.Sprintf("%s-%d", lb.name, port.Port)
+
+		// If the load balancer rule exists and is up-to-date, we move on to the next rule.
+		exists, needsUpdate, err := lb.checkLoadBalancerRule(lbRuleName, port)
+		if err != nil {
+			return nil, err
+		}
+		if exists && !needsUpdate {
+			glog.V(4).Infof("Load balancer rule %v is up-to-date", lbRuleName)
+			// Delete the rule from the map, to prevent it being deleted.
+			delete(lb.rules, lbRuleName)
+			continue
+		}
+
+		if needsUpdate {
+			glog.V(4).Infof("Updating load balancer rule: %v", lbRuleName)
+			if err := lb.updateLoadBalancerRule(lbRuleName); err != nil {
+				return nil, err
+			}
+			// Delete the rule from the map, to prevent it being deleted.
+			delete(lb.rules, lbRuleName)
+			continue
+		}
+
+		glog.V(4).Infof("Creating load balancer rule: %v", lbRuleName)
+		lbRule, err := lb.createLoadBalancerRule(lbRuleName, port)
+		if err != nil {
+			return nil, err
+		}
+
+		glog.V(4).Infof("Assigning hosts (%v) to load balancer rule: %v", lb.hostIDs, lbRuleName)
+		if err = lb.assignHostsToRule(lbRule, lb.hostIDs); err != nil {
+			return nil, err
+		}
+
+	}
+
+	// Cleanup any rules that are now still in the rules map, as they are no longer needed.
+	for _, lbRule := range lb.rules {
+		glog.V(4).Infof("Deleting obsolete load balancer rule: %v", lbRule.Name)
+		if err := lb.deleteLoadBalancerRule(lbRule); err != nil {
+			return nil, err
+		}
+	}
+
+	status = &api.LoadBalancerStatus{}
+	status.Ingress = []api.LoadBalancerIngress{{IP: lb.ipAddr}}
+
+	return status, nil
+}
+
+// UpdateLoadBalancer updates hosts under the specified load balancer.
+func (cs *CSCloud) UpdateLoadBalancer(clusterName string, service *api.Service, hosts []string) error {
+	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v)", clusterName, service.Namespace, service.Name, hosts)
+
+	// Get the load balancer details and existing rules.
+	lb, err := cs.getLoadBalancer(service)
+	if err != nil {
+		return err
+	}
+
+	// Verify that all the hosts belong to the same network, and retrieve their ID's.
+	lb.hostIDs, _, err = cs.verifyHosts(hosts)
+	if err != nil {
+		return err
+	}
+
+	for _, lbRule := range lb.rules {
+		p := lb.LoadBalancer.NewListLoadBalancerRuleInstancesParams(lbRule.Id)
+
+		// Retrieve all VMs currently associated to this load balancer rule.
+		l, err := lb.LoadBalancer.ListLoadBalancerRuleInstances(p)
+		if err != nil {
+			return fmt.Errorf("error retrieving associated instances: %v", err)
+		}
+
+		assign, remove := symmetricDifference(lb.hostIDs, l.LoadBalancerRuleInstances)
+
+		if len(assign) > 0 {
+			glog.V(4).Infof("Assigning new hosts (%v) to load balancer rule: %v", assign, lbRule.Name)
+			if err := lb.assignHostsToRule(lbRule, assign); err != nil {
+				return err
+			}
+		}
+
+		if len(remove) > 0 {
+			glog.V(4).Infof("Removing old hosts (%v) from load balancer rule: %v", assign, lbRule.Name)
+			if err := lb.removeHostsFromRule(lbRule, remove); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// EnsureLoadBalancerDeleted deletes the specified load balancer if it exists, returning
+// nil if the load balancer specified either didn't exist or was successfully deleted.
+func (cs *CSCloud) EnsureLoadBalancerDeleted(clusterName string, service *api.Service) error {
+	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v)", clusterName, service.Namespace, service.Name)
+
+	// Get the load balancer details and existing rules.
+	lb, err := cs.getLoadBalancer(service)
+	if err != nil {
+		return err
+	}
+
+	for _, lbRule := range lb.rules {
+		glog.V(4).Infof("Deleting load balancer rule: %v", lbRule.Name)
+		if err := lb.deleteLoadBalancerRule(lbRule); err != nil {
+			return err
+		}
+	}
+
+	if lb.ipAddr != service.Spec.LoadBalancerIP {
+		glog.V(4).Infof("Releasing load balancer IP: %v", lb.ipAddr)
+		if err := lb.releaseLoadBalancerIP(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getLoadBalancer retrieves the IP address and ID and all the existing rules it can find.
+func (cs *CSCloud) getLoadBalancer(service *api.Service) (*loadBalancer, error) {
+	lb := &loadBalancer{
+		CloudStackClient: cs.client,
+		name:             cloudprovider.GetLoadBalancerName(service),
+		projectID:        cs.projectID,
+		rules:            make(map[string]*cloudstack.LoadBalancerRule),
+	}
+
+	p := cs.client.LoadBalancer.NewListLoadBalancerRulesParams()
+	p.SetKeyword(lb.name)
+	p.SetListall(true)
+
+	if cs.projectID != "" {
+		p.SetProjectid(cs.projectID)
+	}
+
+	l, err := cs.client.LoadBalancer.ListLoadBalancerRules(p)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving load balancer rules: %v", err)
+	}
+
+	for _, lbRule := range l.LoadBalancerRules {
+		lb.rules[lbRule.Name] = lbRule
+
+		if lb.ipAddr != "" && lb.ipAddr != lbRule.Publicip {
+			glog.Warningf("Load balancer for service %v/%v has rules associated with different IP's: %v, %v", service.Namespace, service.Name, lb.ipAddr, lbRule.Publicip)
+		}
+
+		lb.ipAddr = lbRule.Publicip
+		lb.ipAddrID = lbRule.Publicipid
+	}
+
+	glog.V(4).Infof("Load balancer %v contains %d rule(s)", lb.name, len(lb.rules))
+
+	return lb, nil
+}
+
+// verifyHosts verifies if all hosts belong to the same network, and returns the network and host ID's.
+func (cs *CSCloud) verifyHosts(hosts []string) ([]string, string, error) {
+	ipAddrs := map[string]bool{}
+	for _, host := range hosts {
+		ipAddrs[host] = true
+	}
+
+	p := cs.client.VirtualMachine.NewListVirtualMachinesParams()
+	p.SetListall(true)
+
+	if cs.projectID != "" {
+		p.SetProjectid(cs.projectID)
+	}
+
+	l, err := cs.client.VirtualMachine.ListVirtualMachines(p)
+	if err != nil {
+		return nil, "", fmt.Errorf("error retrieving a list of hosts: %v", err)
+	}
+
+	var hostIDs []string
+	var networkID string
+
+	// Check if the address belongs to the hosts slice, then add the corresponding vm ID.
+	for _, vm := range l.VirtualMachines {
+		// We only check the primary NIC.
+		if ipAddrs[vm.Nic[0].Ipaddress] {
+			if networkID != "" && networkID != vm.Nic[0].Networkid {
+				return nil, "", fmt.Errorf("found hosts that belong to different networks")
+			}
+
+			networkID = vm.Nic[0].Networkid
+			hostIDs = append(hostIDs, vm.Id)
+		}
+	}
+
+	return hostIDs, networkID, nil
+}
+
+// getLoadBalancerIP retieves an existing IP or associates a new IP and returns the address and it's ID.
+func (lb *loadBalancer) hasLoadBalancerIP() bool {
+	return lb.ipAddr != "" && lb.ipAddrID != ""
+}
+
+// getLoadBalancerIP retieves an existing IP or associates a new IP and returns the address and it's ID.
+func (lb *loadBalancer) getLoadBalancerIP(loadBalancerIP string) error {
+	if loadBalancerIP != "" {
+		return lb.getPublicIPAddress(loadBalancerIP)
+	}
+
+	return lb.associatePublicIPAddress()
+}
+
+// getPublicIPAddressID retrieves the ID of the given IP, and returns the address and it's ID.
+func (lb *loadBalancer) getPublicIPAddress(loadBalancerIP string) error {
+	glog.V(4).Infof("Retrieve load balancer IP details: %v", loadBalancerIP)
+
+	p := lb.Address.NewListPublicIpAddressesParams()
+	p.SetIpaddress(loadBalancerIP)
+	p.SetListall(true)
+
+	if lb.projectID != "" {
+		p.SetProjectid(lb.projectID)
+	}
+
+	l, err := lb.Address.ListPublicIpAddresses(p)
+	if err != nil {
+		return fmt.Errorf("error retrieving the IP address: %v", err)
+	}
+
+	if l.Count != 1 {
+		return fmt.Errorf("could not find IP address %v", loadBalancerIP)
+	}
+
+	lb.ipAddr = l.PublicIpAddresses[0].Ipaddress
+	lb.ipAddrID = l.PublicIpAddresses[0].Id
+
+	return nil
+}
+
+// associatePublicIPAddress associates a new IP and returns the address and it's ID.
+func (lb *loadBalancer) associatePublicIPAddress() error {
+	glog.V(4).Infof("Allocate new IP for load balancer: %v", lb.name)
+	// If a network belongs to a VPC, the IP address needs to be associated with
+	// the VPC instead of with the network.
+	network, count, err := lb.Network.GetNetworkByID(lb.networkID, cloudstack.WithProject(lb.projectID))
+	if err != nil {
+		if count == 0 {
+			return fmt.Errorf("could not find network %v", lb.networkID)
+		}
+		return fmt.Errorf("error retrieving network: %v", err)
+	}
+
+	p := lb.Address.NewAssociateIpAddressParams()
+
+	if network.Vpcid != "" {
+		p.SetVpcid(network.Vpcid)
+	} else {
+		p.SetNetworkid(lb.networkID)
+	}
+
+	if lb.projectID != "" {
+		p.SetProjectid(lb.projectID)
+	}
+
+	// Associate a new IP address
+	r, err := lb.Address.AssociateIpAddress(p)
+	if err != nil {
+		return fmt.Errorf("error associating a new IP address: %v", err)
+	}
+
+	lb.ipAddr = r.Ipaddress
+	lb.ipAddrID = r.Id
+
+	return nil
+}
+
+// releasePublicIPAddress releases an associated IP.
+func (lb *loadBalancer) releaseLoadBalancerIP() error {
+	p := lb.Address.NewDisassociateIpAddressParams(lb.ipAddrID)
+
+	if _, err := lb.Address.DisassociateIpAddress(p); err != nil {
+		return fmt.Errorf("error releasing load balancer IP %v: %v", lb.ipAddr, err)
+	}
+
+	return nil
+}
+
+// checkLoadBalancerRule checks if the rule already exists and if it does, if it can be updated. If
+// it does exist but cannot be updated, it will delete the existing rule so it can be created again.
+func (lb *loadBalancer) checkLoadBalancerRule(lbRuleName string, port api.ServicePort) (bool, bool, error) {
+	lbRule, ok := lb.rules[lbRuleName]
+	if !ok {
+		return false, false, nil
+	}
+
+	// Check if any of the values we cannot update (those that require a new load balancer rule) are changed.
+	if lbRule.Publicip == lb.ipAddr && lbRule.Privateport == strconv.Itoa(int(port.NodePort)) && lbRule.Publicport == strconv.Itoa(int(port.Port)) {
+		return true, lbRule.Algorithm != lb.algorithm, nil
+	}
+
+	// Delete the load balancer rule so we can create a new one using the new values.
+	if err := lb.deleteLoadBalancerRule(lbRule); err != nil {
+		return false, false, err
+	}
+
+	return false, false, nil
+}
+
+// updateLoadBalancerRule updates a load balancer rule.
+func (lb *loadBalancer) updateLoadBalancerRule(lbRuleName string) error {
+	lbRule := lb.rules[lbRuleName]
+
+	p := lb.LoadBalancer.NewUpdateLoadBalancerRuleParams(lbRule.Id)
+	p.SetAlgorithm(lb.algorithm)
+
+	_, err := lb.LoadBalancer.UpdateLoadBalancerRule(p)
+	return err
+}
+
+// createLoadBalancerRule creates a new load balancer rule and returns it's ID.
+func (lb *loadBalancer) createLoadBalancerRule(lbRuleName string, port api.ServicePort) (*cloudstack.LoadBalancerRule, error) {
+	p := lb.LoadBalancer.NewCreateLoadBalancerRuleParams(
+		lb.algorithm,
+		lbRuleName,
+		int(port.NodePort),
+		int(port.Port),
+	)
+
+	p.SetNetworkid(lb.networkID)
+	p.SetPublicipid(lb.ipAddrID)
+
+	switch port.Protocol {
+	case api.ProtocolTCP:
+		p.SetProtocol("TCP")
+	case api.ProtocolUDP:
+		p.SetProtocol("UDP")
+	default:
+		return nil, fmt.Errorf("unsupported load balancer protocol: %v", port.Protocol)
+	}
+
+	// Do not create corresponding firewall rule.
+	p.SetOpenfirewall(false)
+
+	// Create a new load balancer rule.
+	r, err := lb.LoadBalancer.CreateLoadBalancerRule(p)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the load balancer rule %v: %v", lbRuleName, err)
+	}
+
+	lbRule := &cloudstack.LoadBalancerRule{
+		Id:          r.Id,
+		Algorithm:   r.Algorithm,
+		Cidrlist:    r.Cidrlist,
+		Name:        r.Name,
+		Networkid:   r.Networkid,
+		Privateport: r.Privateport,
+		Publicport:  r.Publicport,
+		Publicip:    r.Publicip,
+		Publicipid:  r.Publicipid,
+	}
+
+	return lbRule, nil
+}
+
+// deleteLoadBalancerRule deletes a load balancer rule.
+func (lb *loadBalancer) deleteLoadBalancerRule(lbRule *cloudstack.LoadBalancerRule) error {
+	p := lb.LoadBalancer.NewDeleteLoadBalancerRuleParams(lbRule.Id)
+
+	if _, err := lb.LoadBalancer.DeleteLoadBalancerRule(p); err != nil {
+		return fmt.Errorf("error deleting load balancer rule %v: %v", lbRule.Name, err)
+	}
+
+	// Delete the rule from the map as it no longer exists
+	delete(lb.rules, lbRule.Name)
+
+	return nil
+}
+
+// assignHostsToRule assigns hosts to a load balancer rule.
+func (lb *loadBalancer) assignHostsToRule(lbRule *cloudstack.LoadBalancerRule, hostIDs []string) error {
+	p := lb.LoadBalancer.NewAssignToLoadBalancerRuleParams(lbRule.Id)
+	p.SetVirtualmachineids(hostIDs)
+
+	if _, err := lb.LoadBalancer.AssignToLoadBalancerRule(p); err != nil {
+		return fmt.Errorf("error assigning hosts to load balancer rule %v: %v", lbRule.Name, err)
+	}
+
+	return nil
+}
+
+// removeHostsFromRule removes hosts from a load balancer rule.
+func (lb *loadBalancer) removeHostsFromRule(lbRule *cloudstack.LoadBalancerRule, hostIDs []string) error {
+	p := lb.LoadBalancer.NewRemoveFromLoadBalancerRuleParams(lbRule.Id)
+	p.SetVirtualmachineids(hostIDs)
+
+	if _, err := lb.LoadBalancer.RemoveFromLoadBalancerRule(p); err != nil {
+		return fmt.Errorf("error removing hosts from load balancer rule %v: %v", lbRule.Name, err)
+	}
+
+	return nil
+}
+
+// symmetricDifference returns the symmetric difference between the old (existing) and new (wanted) host ID's.
+func symmetricDifference(hostIDs []string, lbInstances []*cloudstack.VirtualMachine) ([]string, []string) {
+	new := make(map[string]bool)
+	for _, hostID := range hostIDs {
+		new[hostID] = true
+	}
+
+	var remove []string
+	for _, instance := range lbInstances {
+		if new[instance.Id] {
+			delete(new, instance.Id)
+			continue
+		}
+
+		remove = append(remove, instance.Id)
+	}
+
+	var assign []string
+	for hostID := range new {
+		assign = append(assign, hostID)
+	}
+
+	return assign, remove
+}

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_test.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudstack
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+const testClusterName = "testCluster"
+
+func TestReadConfig(t *testing.T) {
+	_, err := readConfig(nil)
+	if err == nil {
+		t.Errorf("Should fail when no config is provided: %v", err)
+	}
+
+	cfg, err := readConfig(strings.NewReader(`
+ [Global]
+ api-url				= https://cloudstack.url
+ api-key				= a-valid-api-key
+ secret-key			= a-valid-secret-key
+ ssl-no-verify	= true
+ project-id			= a-valid-project-id
+ zone						= a-valid-zone
+ `))
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %v", err)
+	}
+
+	if cfg.Global.APIURL != "https://cloudstack.url" {
+		t.Errorf("incorrect api-url: %s", cfg.Global.APIURL)
+	}
+	if cfg.Global.APIKey != "a-valid-api-key" {
+		t.Errorf("incorrect api-key: %s", cfg.Global.APIKey)
+	}
+	if cfg.Global.SecretKey != "a-valid-secret-key" {
+		t.Errorf("incorrect secret-key: %s", cfg.Global.SecretKey)
+	}
+	if !cfg.Global.SSLNoVerify {
+		t.Errorf("incorrect ssl-no-verify: %t", cfg.Global.SSLNoVerify)
+	}
+	if cfg.Global.Zone != "a-valid-zone" {
+		t.Errorf("incorrect zone: %s", cfg.Global.Zone)
+	}
+}
+
+// This allows acceptance testing against an existing CloudStack environment.
+func configFromEnv() (*CSConfig, bool) {
+	cfg := &CSConfig{}
+
+	cfg.Global.APIURL = os.Getenv("CS_API_URL")
+	cfg.Global.APIKey = os.Getenv("CS_API_KEY")
+	cfg.Global.SecretKey = os.Getenv("CS_SECRET_KEY")
+	cfg.Global.ProjectID = os.Getenv("CS_PROJECT_ID")
+	cfg.Global.Zone = os.Getenv("CS_ZONE")
+
+	// It is save to ignore the error here. If the input cannot be parsed SSLNoVerify
+	// will still be a bool with it's zero value (false) which is the expected default.
+	cfg.Global.SSLNoVerify, _ = strconv.ParseBool(os.Getenv("CS_SSL_NO_VERIFY"))
+
+	// Check if we have the minimum required info to be able to connect to CloudStack.
+	ok := cfg.Global.APIURL != "" && cfg.Global.APIKey != "" && cfg.Global.SecretKey != ""
+
+	return cfg, ok
+}
+
+func TestNewCSCloud(t *testing.T) {
+	cfg, ok := configFromEnv()
+	if !ok {
+		t.Skipf("No config found in environment")
+	}
+
+	_, err := newCSCloud(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate CloudStack: %v", err)
+	}
+}
+
+func TestLoadBalancer(t *testing.T) {
+	cfg, ok := configFromEnv()
+	if !ok {
+		t.Skipf("No config found in environment")
+	}
+
+	cs, err := newCSCloud(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate CloudStack: %v", err)
+	}
+
+	lb, ok := cs.LoadBalancer()
+	if !ok {
+		t.Fatalf("LoadBalancer() returned false")
+	}
+
+	_, exists, err := lb.GetLoadBalancer(testClusterName, &api.Service{ObjectMeta: api.ObjectMeta{Name: "noexist"}})
+	if err != nil {
+		t.Fatalf("GetLoadBalancer(\"noexist\") returned error: %s", err)
+	}
+	if exists {
+		t.Fatalf("GetLoadBalancer(\"noexist\") returned exists")
+	}
+}
+
+func TestZones(t *testing.T) {
+	cs := &CSCloud{
+		zone: "myRegion",
+	}
+
+	z, ok := cs.Zones()
+	if !ok {
+		t.Fatalf("Zones() returned false")
+	}
+
+	zone, err := z.GetZone()
+	if err != nil {
+		t.Fatalf("GetZone() returned error: %s", err)
+	}
+
+	if zone.Region != "myRegion" {
+		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
+	}
+}

--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -20,11 +20,11 @@ import (
 	// Cloud providers
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack"
 )

--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -26,4 +26,5 @@ import (
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack"
 )

--- a/vendor/github.com/xanzy/go-cloudstack/LICENSE
+++ b/vendor/github.com/xanzy/go-cloudstack/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/APIDiscoveryService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/APIDiscoveryService.go
@@ -1,0 +1,96 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type ListApisParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListApisParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *ListApisParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new ListApisParams instance,
+// as then you are sure you have configured all required params
+func (s *APIDiscoveryService) NewListApisParams() *ListApisParams {
+	p := &ListApisParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// lists all available apis on the server, provided by the Api Discovery plugin
+func (s *APIDiscoveryService) ListApis(p *ListApisParams) (*ListApisResponse, error) {
+	resp, err := s.cs.newRequest("listApis", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListApisResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListApisResponse struct {
+	Count int    `json:"count"`
+	Apis  []*Api `json:"api"`
+}
+
+type Api struct {
+	Description string `json:"description,omitempty"`
+	Isasync     bool   `json:"isasync,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Params      []struct {
+		Description string `json:"description,omitempty"`
+		Length      int    `json:"length,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Related     string `json:"related,omitempty"`
+		Required    bool   `json:"required,omitempty"`
+		Since       string `json:"since,omitempty"`
+		Type        string `json:"type,omitempty"`
+	} `json:"params,omitempty"`
+	Related  string `json:"related,omitempty"`
+	Response []struct {
+		Description string   `json:"description,omitempty"`
+		Name        string   `json:"name,omitempty"`
+		Response    []string `json:"response,omitempty"`
+		Type        string   `json:"type,omitempty"`
+	} `json:"response,omitempty"`
+	Since string `json:"since,omitempty"`
+	Type  string `json:"type,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AccountService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AccountService.go
@@ -1,0 +1,1903 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accountdetails"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["email"]; found {
+		u.Set("email", v.(string))
+	}
+	if v, found := p.p["firstname"]; found {
+		u.Set("firstname", v.(string))
+	}
+	if v, found := p.p["lastname"]; found {
+		u.Set("lastname", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	if v, found := p.p["userid"]; found {
+		u.Set("userid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *CreateAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetAccountdetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountdetails"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetAccounttype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetEmail(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["email"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetFirstname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["firstname"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetLastname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lastname"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetUserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userid"] = v
+	return
+}
+
+func (p *CreateAccountParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new CreateAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewCreateAccountParams(accounttype int, email string, firstname string, lastname string, password string, username string) *CreateAccountParams {
+	p := &CreateAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["accounttype"] = accounttype
+	p.p["email"] = email
+	p.p["firstname"] = firstname
+	p.p["lastname"] = lastname
+	p.p["password"] = password
+	p.p["username"] = username
+	return p
+}
+
+// Creates an account
+func (s *AccountService) CreateAccount(p *CreateAccountParams) (*CreateAccountResponse, error) {
+	resp, err := s.cs.newRequest("createAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateAccountResponse struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type DeleteAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAccountParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewDeleteAccountParams(id string) *DeleteAccountParams {
+	p := &DeleteAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a account, and all users associated with this account
+func (s *AccountService) DeleteAccount(p *DeleteAccountParams) (*DeleteAccountResponse, error) {
+	resp, err := s.cs.newRequest("deleteAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAccountResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accountdetails"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["newname"]; found {
+		u.Set("newname", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateAccountParams) SetAccountdetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountdetails"] = v
+	return
+}
+
+func (p *UpdateAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UpdateAccountParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateAccountParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *UpdateAccountParams) SetNewname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["newname"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewUpdateAccountParams(newname string) *UpdateAccountParams {
+	p := &UpdateAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["newname"] = newname
+	return p
+}
+
+// Updates account information for the authenticated user
+func (s *AccountService) UpdateAccount(p *UpdateAccountParams) (*UpdateAccountResponse, error) {
+	resp, err := s.cs.newRequest("updateAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateAccountResponse struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type DisableAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *DisableAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["lock"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("lock", vv)
+	}
+	return u
+}
+
+func (p *DisableAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DisableAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DisableAccountParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DisableAccountParams) SetLock(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lock"] = v
+	return
+}
+
+// You should always use this function to get a new DisableAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewDisableAccountParams(lock bool) *DisableAccountParams {
+	p := &DisableAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["lock"] = lock
+	return p
+}
+
+// Disables an account
+func (s *AccountService) DisableAccount(p *DisableAccountParams) (*DisableAccountResponse, error) {
+	resp, err := s.cs.newRequest("disableAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DisableAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DisableAccountResponse struct {
+	JobID                     string            `json:"jobid,omitempty"`
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type EnableAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *EnableAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *EnableAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *EnableAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *EnableAccountParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new EnableAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewEnableAccountParams() *EnableAccountParams {
+	p := &EnableAccountParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Enables an account
+func (s *AccountService) EnableAccount(p *EnableAccountParams) (*EnableAccountResponse, error) {
+	resp, err := s.cs.newRequest("enableAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r EnableAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type EnableAccountResponse struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type LockAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *LockAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	return u
+}
+
+func (p *LockAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *LockAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+// You should always use this function to get a new LockAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewLockAccountParams(account string, domainid string) *LockAccountParams {
+	p := &LockAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["domainid"] = domainid
+	return p
+}
+
+// This deprecated function used to locks an account. Look for the API DisableAccount instead
+func (s *AccountService) LockAccount(p *LockAccountParams) (*LockAccountResponse, error) {
+	resp, err := s.cs.newRequest("lockAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LockAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LockAccountResponse struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type ListAccountsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAccountsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["iscleanuprequired"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("iscleanuprequired", vv)
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *ListAccountsParams) SetAccounttype(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetIscleanuprequired(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iscleanuprequired"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAccountsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new ListAccountsParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewListAccountsParams() *ListAccountsParams {
+	p := &ListAccountsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AccountService) GetAccountID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListAccountsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListAccounts(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Accounts[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Accounts {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AccountService) GetAccountByName(name string, opts ...OptionFunc) (*Account, int, error) {
+	id, count, err := s.GetAccountID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetAccountByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AccountService) GetAccountByID(id string, opts ...OptionFunc) (*Account, int, error) {
+	p := &ListAccountsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAccounts(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Accounts[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Account UUID: %s!", id)
+}
+
+// Lists accounts and provides detailed account information for listed accounts
+func (s *AccountService) ListAccounts(p *ListAccountsParams) (*ListAccountsResponse, error) {
+	resp, err := s.cs.newRequest("listAccounts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAccountsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAccountsResponse struct {
+	Count    int        `json:"count"`
+	Accounts []*Account `json:"account"`
+}
+
+type Account struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type MarkDefaultZoneForAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *MarkDefaultZoneForAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *MarkDefaultZoneForAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *MarkDefaultZoneForAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *MarkDefaultZoneForAccountParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new MarkDefaultZoneForAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewMarkDefaultZoneForAccountParams(account string, domainid string, zoneid string) *MarkDefaultZoneForAccountParams {
+	p := &MarkDefaultZoneForAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["domainid"] = domainid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Marks a default zone for this account
+func (s *AccountService) MarkDefaultZoneForAccount(p *MarkDefaultZoneForAccountParams) (*MarkDefaultZoneForAccountResponse, error) {
+	resp, err := s.cs.newRequest("markDefaultZoneForAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r MarkDefaultZoneForAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type MarkDefaultZoneForAccountResponse struct {
+	JobID                     string            `json:"jobid,omitempty"`
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}
+
+type AddAccountToProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddAccountToProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["email"]; found {
+		u.Set("email", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *AddAccountToProjectParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AddAccountToProjectParams) SetEmail(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["email"] = v
+	return
+}
+
+func (p *AddAccountToProjectParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new AddAccountToProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewAddAccountToProjectParams(projectid string) *AddAccountToProjectParams {
+	p := &AddAccountToProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["projectid"] = projectid
+	return p
+}
+
+// Adds account to a project
+func (s *AccountService) AddAccountToProject(p *AddAccountToProjectParams) (*AddAccountToProjectResponse, error) {
+	resp, err := s.cs.newRequest("addAccountToProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddAccountToProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddAccountToProjectResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteAccountFromProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAccountFromProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAccountFromProjectParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DeleteAccountFromProjectParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAccountFromProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewDeleteAccountFromProjectParams(account string, projectid string) *DeleteAccountFromProjectParams {
+	p := &DeleteAccountFromProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["projectid"] = projectid
+	return p
+}
+
+// Deletes account from the project
+func (s *AccountService) DeleteAccountFromProject(p *DeleteAccountFromProjectParams) (*DeleteAccountFromProjectResponse, error) {
+	resp, err := s.cs.newRequest("deleteAccountFromProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAccountFromProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAccountFromProjectResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListProjectAccountsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListProjectAccountsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["role"]; found {
+		u.Set("role", v.(string))
+	}
+	return u
+}
+
+func (p *ListProjectAccountsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListProjectAccountsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListProjectAccountsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListProjectAccountsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListProjectAccountsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListProjectAccountsParams) SetRole(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["role"] = v
+	return
+}
+
+// You should always use this function to get a new ListProjectAccountsParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewListProjectAccountsParams(projectid string) *ListProjectAccountsParams {
+	p := &ListProjectAccountsParams{}
+	p.p = make(map[string]interface{})
+	p.p["projectid"] = projectid
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AccountService) GetProjectAccountID(keyword string, projectid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListProjectAccountsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+	p.p["projectid"] = projectid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListProjectAccounts(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.ProjectAccounts[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.ProjectAccounts {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// Lists project's accounts
+func (s *AccountService) ListProjectAccounts(p *ListProjectAccountsParams) (*ListProjectAccountsResponse, error) {
+	resp, err := s.cs.newRequest("listProjectAccounts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListProjectAccountsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListProjectAccountsResponse struct {
+	Count           int               `json:"count"`
+	ProjectAccounts []*ProjectAccount `json:"projectaccount"`
+}
+
+type ProjectAccount struct {
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type GetSolidFireAccountIdParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetSolidFireAccountIdParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	return u
+}
+
+func (p *GetSolidFireAccountIdParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *GetSolidFireAccountIdParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+// You should always use this function to get a new GetSolidFireAccountIdParams instance,
+// as then you are sure you have configured all required params
+func (s *AccountService) NewGetSolidFireAccountIdParams(accountid string, storageid string) *GetSolidFireAccountIdParams {
+	p := &GetSolidFireAccountIdParams{}
+	p.p = make(map[string]interface{})
+	p.p["accountid"] = accountid
+	p.p["storageid"] = storageid
+	return p
+}
+
+// Get SolidFire Account ID
+func (s *AccountService) GetSolidFireAccountId(p *GetSolidFireAccountIdParams) (*GetSolidFireAccountIdResponse, error) {
+	resp, err := s.cs.newRequest("getSolidFireAccountId", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetSolidFireAccountIdResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetSolidFireAccountIdResponse struct {
+	SolidFireAccountId int64 `json:"solidFireAccountId,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AddressService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AddressService.go
@@ -1,0 +1,811 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AssociateIpAddressParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssociateIpAddressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["isportable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isportable", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["regionid"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("regionid", vv)
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AssociateIpAddressParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetIsportable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isportable"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetRegionid(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["regionid"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *AssociateIpAddressParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AssociateIpAddressParams instance,
+// as then you are sure you have configured all required params
+func (s *AddressService) NewAssociateIpAddressParams() *AssociateIpAddressParams {
+	p := &AssociateIpAddressParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Acquires and associates a public IP to an account.
+func (s *AddressService) AssociateIpAddress(p *AssociateIpAddressParams) (*AssociateIpAddressResponse, error) {
+	resp, err := s.cs.newRequest("associateIpAddress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateIpAddressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AssociateIpAddressResponse struct {
+	JobID                 string `json:"jobid,omitempty"`
+	Account               string `json:"account,omitempty"`
+	Allocated             string `json:"allocated,omitempty"`
+	Associatednetworkid   string `json:"associatednetworkid,omitempty"`
+	Associatednetworkname string `json:"associatednetworkname,omitempty"`
+	Domain                string `json:"domain,omitempty"`
+	Domainid              string `json:"domainid,omitempty"`
+	Fordisplay            bool   `json:"fordisplay,omitempty"`
+	Forvirtualnetwork     bool   `json:"forvirtualnetwork,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Ipaddress             string `json:"ipaddress,omitempty"`
+	Isportable            bool   `json:"isportable,omitempty"`
+	Issourcenat           bool   `json:"issourcenat,omitempty"`
+	Isstaticnat           bool   `json:"isstaticnat,omitempty"`
+	Issystem              bool   `json:"issystem,omitempty"`
+	Networkid             string `json:"networkid,omitempty"`
+	Physicalnetworkid     string `json:"physicalnetworkid,omitempty"`
+	Project               string `json:"project,omitempty"`
+	Projectid             string `json:"projectid,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	State                 string `json:"state,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vlanid                    string `json:"vlanid,omitempty"`
+	Vlanname                  string `json:"vlanname,omitempty"`
+	Vmipaddress               string `json:"vmipaddress,omitempty"`
+	Vpcid                     string `json:"vpcid,omitempty"`
+	Zoneid                    string `json:"zoneid,omitempty"`
+	Zonename                  string `json:"zonename,omitempty"`
+}
+
+type DisassociateIpAddressParams struct {
+	p map[string]interface{}
+}
+
+func (p *DisassociateIpAddressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DisassociateIpAddressParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DisassociateIpAddressParams instance,
+// as then you are sure you have configured all required params
+func (s *AddressService) NewDisassociateIpAddressParams(id string) *DisassociateIpAddressParams {
+	p := &DisassociateIpAddressParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Disassociates an IP address from the account.
+func (s *AddressService) DisassociateIpAddress(p *DisassociateIpAddressParams) (*DisassociateIpAddressResponse, error) {
+	resp, err := s.cs.newRequest("disassociateIpAddress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DisassociateIpAddressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DisassociateIpAddressResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListPublicIpAddressesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPublicIpAddressesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["allocatedonly"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("allocatedonly", vv)
+	}
+	if v, found := p.p["associatednetworkid"]; found {
+		u.Set("associatednetworkid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["forloadbalancing"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forloadbalancing", vv)
+	}
+	if v, found := p.p["forvirtualnetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvirtualnetwork", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["issourcenat"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("issourcenat", vv)
+	}
+	if v, found := p.p["isstaticnat"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isstaticnat", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["vlanid"]; found {
+		u.Set("vlanid", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListPublicIpAddressesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetAllocatedonly(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocatedonly"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetAssociatednetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["associatednetworkid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetForloadbalancing(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forloadbalancing"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetForvirtualnetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvirtualnetwork"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetIssourcenat(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["issourcenat"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetIsstaticnat(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isstaticnat"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetVlanid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlanid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *ListPublicIpAddressesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPublicIpAddressesParams instance,
+// as then you are sure you have configured all required params
+func (s *AddressService) NewListPublicIpAddressesParams() *ListPublicIpAddressesParams {
+	p := &ListPublicIpAddressesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AddressService) GetPublicIpAddressByID(id string, opts ...OptionFunc) (*PublicIpAddress, int, error) {
+	p := &ListPublicIpAddressesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPublicIpAddresses(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.PublicIpAddresses[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for PublicIpAddress UUID: %s!", id)
+}
+
+// Lists all public ip addresses
+func (s *AddressService) ListPublicIpAddresses(p *ListPublicIpAddressesParams) (*ListPublicIpAddressesResponse, error) {
+	resp, err := s.cs.newRequest("listPublicIpAddresses", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPublicIpAddressesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPublicIpAddressesResponse struct {
+	Count             int                `json:"count"`
+	PublicIpAddresses []*PublicIpAddress `json:"publicipaddress"`
+}
+
+type PublicIpAddress struct {
+	Account               string `json:"account,omitempty"`
+	Allocated             string `json:"allocated,omitempty"`
+	Associatednetworkid   string `json:"associatednetworkid,omitempty"`
+	Associatednetworkname string `json:"associatednetworkname,omitempty"`
+	Domain                string `json:"domain,omitempty"`
+	Domainid              string `json:"domainid,omitempty"`
+	Fordisplay            bool   `json:"fordisplay,omitempty"`
+	Forvirtualnetwork     bool   `json:"forvirtualnetwork,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Ipaddress             string `json:"ipaddress,omitempty"`
+	Isportable            bool   `json:"isportable,omitempty"`
+	Issourcenat           bool   `json:"issourcenat,omitempty"`
+	Isstaticnat           bool   `json:"isstaticnat,omitempty"`
+	Issystem              bool   `json:"issystem,omitempty"`
+	Networkid             string `json:"networkid,omitempty"`
+	Physicalnetworkid     string `json:"physicalnetworkid,omitempty"`
+	Project               string `json:"project,omitempty"`
+	Projectid             string `json:"projectid,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	State                 string `json:"state,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vlanid                    string `json:"vlanid,omitempty"`
+	Vlanname                  string `json:"vlanname,omitempty"`
+	Vmipaddress               string `json:"vmipaddress,omitempty"`
+	Vpcid                     string `json:"vpcid,omitempty"`
+	Zoneid                    string `json:"zoneid,omitempty"`
+	Zonename                  string `json:"zonename,omitempty"`
+}
+
+type UpdateIpAddressParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateIpAddressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateIpAddressParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateIpAddressParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateIpAddressParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateIpAddressParams instance,
+// as then you are sure you have configured all required params
+func (s *AddressService) NewUpdateIpAddressParams(id string) *UpdateIpAddressParams {
+	p := &UpdateIpAddressParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an IP address
+func (s *AddressService) UpdateIpAddress(p *UpdateIpAddressParams) (*UpdateIpAddressResponse, error) {
+	resp, err := s.cs.newRequest("updateIpAddress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateIpAddressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateIpAddressResponse struct {
+	JobID                 string `json:"jobid,omitempty"`
+	Account               string `json:"account,omitempty"`
+	Allocated             string `json:"allocated,omitempty"`
+	Associatednetworkid   string `json:"associatednetworkid,omitempty"`
+	Associatednetworkname string `json:"associatednetworkname,omitempty"`
+	Domain                string `json:"domain,omitempty"`
+	Domainid              string `json:"domainid,omitempty"`
+	Fordisplay            bool   `json:"fordisplay,omitempty"`
+	Forvirtualnetwork     bool   `json:"forvirtualnetwork,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Ipaddress             string `json:"ipaddress,omitempty"`
+	Isportable            bool   `json:"isportable,omitempty"`
+	Issourcenat           bool   `json:"issourcenat,omitempty"`
+	Isstaticnat           bool   `json:"isstaticnat,omitempty"`
+	Issystem              bool   `json:"issystem,omitempty"`
+	Networkid             string `json:"networkid,omitempty"`
+	Physicalnetworkid     string `json:"physicalnetworkid,omitempty"`
+	Project               string `json:"project,omitempty"`
+	Projectid             string `json:"projectid,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	State                 string `json:"state,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vlanid                    string `json:"vlanid,omitempty"`
+	Vlanname                  string `json:"vlanname,omitempty"`
+	Vmipaddress               string `json:"vmipaddress,omitempty"`
+	Vpcid                     string `json:"vpcid,omitempty"`
+	Zoneid                    string `json:"zoneid,omitempty"`
+	Zonename                  string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AffinityGroupService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AffinityGroupService.go
@@ -1,0 +1,887 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateAffinityGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateAffinityGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *CreateAffinityGroupParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateAffinityGroupParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateAffinityGroupParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateAffinityGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateAffinityGroupParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateAffinityGroupParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinityGroupType"] = v
+	return
+}
+
+// You should always use this function to get a new CreateAffinityGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AffinityGroupService) NewCreateAffinityGroupParams(name string, affinityGroupType string) *CreateAffinityGroupParams {
+	p := &CreateAffinityGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["affinityGroupType"] = affinityGroupType
+	return p
+}
+
+// Creates an affinity/anti-affinity group
+func (s *AffinityGroupService) CreateAffinityGroup(p *CreateAffinityGroupParams) (*CreateAffinityGroupResponse, error) {
+	resp, err := s.cs.newRequest("createAffinityGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateAffinityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateAffinityGroupResponse struct {
+	JobID             string   `json:"jobid,omitempty"`
+	Account           string   `json:"account,omitempty"`
+	Description       string   `json:"description,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+}
+
+type DeleteAffinityGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAffinityGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAffinityGroupParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DeleteAffinityGroupParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DeleteAffinityGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DeleteAffinityGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *DeleteAffinityGroupParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAffinityGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AffinityGroupService) NewDeleteAffinityGroupParams() *DeleteAffinityGroupParams {
+	p := &DeleteAffinityGroupParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Deletes affinity group
+func (s *AffinityGroupService) DeleteAffinityGroup(p *DeleteAffinityGroupParams) (*DeleteAffinityGroupResponse, error) {
+	resp, err := s.cs.newRequest("deleteAffinityGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAffinityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAffinityGroupResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListAffinityGroupsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAffinityGroupsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *ListAffinityGroupsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinityGroupType"] = v
+	return
+}
+
+func (p *ListAffinityGroupsParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new ListAffinityGroupsParams instance,
+// as then you are sure you have configured all required params
+func (s *AffinityGroupService) NewListAffinityGroupsParams() *ListAffinityGroupsParams {
+	p := &ListAffinityGroupsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AffinityGroupService) GetAffinityGroupID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListAffinityGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListAffinityGroups(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.AffinityGroups[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.AffinityGroups {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AffinityGroupService) GetAffinityGroupByName(name string, opts ...OptionFunc) (*AffinityGroup, int, error) {
+	id, count, err := s.GetAffinityGroupID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetAffinityGroupByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AffinityGroupService) GetAffinityGroupByID(id string, opts ...OptionFunc) (*AffinityGroup, int, error) {
+	p := &ListAffinityGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAffinityGroups(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.AffinityGroups[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for AffinityGroup UUID: %s!", id)
+}
+
+// Lists affinity groups
+func (s *AffinityGroupService) ListAffinityGroups(p *ListAffinityGroupsParams) (*ListAffinityGroupsResponse, error) {
+	resp, err := s.cs.newRequest("listAffinityGroups", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAffinityGroupsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAffinityGroupsResponse struct {
+	Count          int              `json:"count"`
+	AffinityGroups []*AffinityGroup `json:"affinitygroup"`
+}
+
+type AffinityGroup struct {
+	Account           string   `json:"account,omitempty"`
+	Description       string   `json:"description,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+}
+
+type UpdateVMAffinityGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVMAffinityGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["affinitygroupids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("affinitygroupids", vv)
+	}
+	if v, found := p.p["affinitygroupnames"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("affinitygroupnames", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVMAffinityGroupParams) SetAffinitygroupids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupids"] = v
+	return
+}
+
+func (p *UpdateVMAffinityGroupParams) SetAffinitygroupnames(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupnames"] = v
+	return
+}
+
+func (p *UpdateVMAffinityGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVMAffinityGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AffinityGroupService) NewUpdateVMAffinityGroupParams(id string) *UpdateVMAffinityGroupParams {
+	p := &UpdateVMAffinityGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for the new properties to take effect.
+func (s *AffinityGroupService) UpdateVMAffinityGroup(p *UpdateVMAffinityGroupParams) (*UpdateVMAffinityGroupResponse, error) {
+	resp, err := s.cs.newRequest("updateVMAffinityGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVMAffinityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVMAffinityGroupResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListAffinityGroupTypesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAffinityGroupTypesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListAffinityGroupTypesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAffinityGroupTypesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAffinityGroupTypesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListAffinityGroupTypesParams instance,
+// as then you are sure you have configured all required params
+func (s *AffinityGroupService) NewListAffinityGroupTypesParams() *ListAffinityGroupTypesParams {
+	p := &ListAffinityGroupTypesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists affinity group types available
+func (s *AffinityGroupService) ListAffinityGroupTypes(p *ListAffinityGroupTypesParams) (*ListAffinityGroupTypesResponse, error) {
+	resp, err := s.cs.newRequest("listAffinityGroupTypes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAffinityGroupTypesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAffinityGroupTypesResponse struct {
+	Count              int                  `json:"count"`
+	AffinityGroupTypes []*AffinityGroupType `json:"affinitygrouptype"`
+}
+
+type AffinityGroupType struct {
+	Type string `json:"type,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AlertService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AlertService.go
@@ -1,0 +1,505 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListAlertsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAlertsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *ListAlertsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAlertsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAlertsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListAlertsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAlertsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAlertsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["alertType"] = v
+	return
+}
+
+// You should always use this function to get a new ListAlertsParams instance,
+// as then you are sure you have configured all required params
+func (s *AlertService) NewListAlertsParams() *ListAlertsParams {
+	p := &ListAlertsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AlertService) GetAlertID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListAlertsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListAlerts(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Alerts[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Alerts {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AlertService) GetAlertByName(name string, opts ...OptionFunc) (*Alert, int, error) {
+	id, count, err := s.GetAlertID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetAlertByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AlertService) GetAlertByID(id string, opts ...OptionFunc) (*Alert, int, error) {
+	p := &ListAlertsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAlerts(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Alerts[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Alert UUID: %s!", id)
+}
+
+// Lists all alerts.
+func (s *AlertService) ListAlerts(p *ListAlertsParams) (*ListAlertsResponse, error) {
+	resp, err := s.cs.newRequest("listAlerts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAlertsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAlertsResponse struct {
+	Count  int      `json:"count"`
+	Alerts []*Alert `json:"alert"`
+}
+
+type Alert struct {
+	Description string `json:"description,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Sent        string `json:"sent,omitempty"`
+	Type        int    `json:"type,omitempty"`
+}
+
+type ArchiveAlertsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ArchiveAlertsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *ArchiveAlertsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *ArchiveAlertsParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+func (p *ArchiveAlertsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *ArchiveAlertsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["alertType"] = v
+	return
+}
+
+// You should always use this function to get a new ArchiveAlertsParams instance,
+// as then you are sure you have configured all required params
+func (s *AlertService) NewArchiveAlertsParams() *ArchiveAlertsParams {
+	p := &ArchiveAlertsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Archive one or more alerts.
+func (s *AlertService) ArchiveAlerts(p *ArchiveAlertsParams) (*ArchiveAlertsResponse, error) {
+	resp, err := s.cs.newRequest("archiveAlerts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ArchiveAlertsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ArchiveAlertsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type DeleteAlertsParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAlertsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAlertsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *DeleteAlertsParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+func (p *DeleteAlertsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *DeleteAlertsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["alertType"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAlertsParams instance,
+// as then you are sure you have configured all required params
+func (s *AlertService) NewDeleteAlertsParams() *DeleteAlertsParams {
+	p := &DeleteAlertsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Delete one or more alerts.
+func (s *AlertService) DeleteAlerts(p *DeleteAlertsParams) (*DeleteAlertsResponse, error) {
+	resp, err := s.cs.newRequest("deleteAlerts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAlertsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteAlertsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type GenerateAlertParams struct {
+	p map[string]interface{}
+}
+
+func (p *GenerateAlertParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("type", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *GenerateAlertParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *GenerateAlertParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *GenerateAlertParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *GenerateAlertParams) SetType(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["alertType"] = v
+	return
+}
+
+func (p *GenerateAlertParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new GenerateAlertParams instance,
+// as then you are sure you have configured all required params
+func (s *AlertService) NewGenerateAlertParams(description string, name string, alertType int) *GenerateAlertParams {
+	p := &GenerateAlertParams{}
+	p.p = make(map[string]interface{})
+	p.p["description"] = description
+	p.p["name"] = name
+	p.p["alertType"] = alertType
+	return p
+}
+
+// Generates an alert
+func (s *AlertService) GenerateAlert(p *GenerateAlertParams) (*GenerateAlertResponse, error) {
+	resp, err := s.cs.newRequest("generateAlert", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GenerateAlertResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type GenerateAlertResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AsyncjobService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AsyncjobService.go
@@ -1,0 +1,239 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type QueryAsyncJobResultParams struct {
+	p map[string]interface{}
+}
+
+func (p *QueryAsyncJobResultParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["jobid"]; found {
+		u.Set("jobid", v.(string))
+	}
+	return u
+}
+
+func (p *QueryAsyncJobResultParams) SetJobid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["jobid"] = v
+	return
+}
+
+// You should always use this function to get a new QueryAsyncJobResultParams instance,
+// as then you are sure you have configured all required params
+func (s *AsyncjobService) NewQueryAsyncJobResultParams(jobid string) *QueryAsyncJobResultParams {
+	p := &QueryAsyncJobResultParams{}
+	p.p = make(map[string]interface{})
+	p.p["jobid"] = jobid
+	return p
+}
+
+// Retrieves the current status of asynchronous job.
+func (s *AsyncjobService) QueryAsyncJobResult(p *QueryAsyncJobResultParams) (*QueryAsyncJobResultResponse, error) {
+	var resp json.RawMessage
+	var err error
+
+	// We should be able to retry on failure as this call is idempotent
+	for i := 0; i < 3; i++ {
+		resp, err = s.cs.newRequest("queryAsyncJobResult", p.toURLValues())
+		if err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var r QueryAsyncJobResultResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type QueryAsyncJobResultResponse struct {
+	Accountid       string          `json:"accountid,omitempty"`
+	Cmd             string          `json:"cmd,omitempty"`
+	Created         string          `json:"created,omitempty"`
+	Jobinstanceid   string          `json:"jobinstanceid,omitempty"`
+	Jobinstancetype string          `json:"jobinstancetype,omitempty"`
+	Jobprocstatus   int             `json:"jobprocstatus,omitempty"`
+	Jobresult       json.RawMessage `json:"jobresult,omitempty"`
+	Jobresultcode   int             `json:"jobresultcode,omitempty"`
+	Jobresulttype   string          `json:"jobresulttype,omitempty"`
+	Jobstatus       int             `json:"jobstatus,omitempty"`
+	Userid          string          `json:"userid,omitempty"`
+}
+
+type ListAsyncJobsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAsyncJobsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	return u
+}
+
+func (p *ListAsyncJobsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAsyncJobsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+// You should always use this function to get a new ListAsyncJobsParams instance,
+// as then you are sure you have configured all required params
+func (s *AsyncjobService) NewListAsyncJobsParams() *ListAsyncJobsParams {
+	p := &ListAsyncJobsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all pending asynchronous jobs for the account.
+func (s *AsyncjobService) ListAsyncJobs(p *ListAsyncJobsParams) (*ListAsyncJobsResponse, error) {
+	resp, err := s.cs.newRequest("listAsyncJobs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAsyncJobsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAsyncJobsResponse struct {
+	Count     int         `json:"count"`
+	AsyncJobs []*AsyncJob `json:"asyncjobs"`
+}
+
+type AsyncJob struct {
+	Accountid       string          `json:"accountid,omitempty"`
+	Cmd             string          `json:"cmd,omitempty"`
+	Created         string          `json:"created,omitempty"`
+	Jobinstanceid   string          `json:"jobinstanceid,omitempty"`
+	Jobinstancetype string          `json:"jobinstancetype,omitempty"`
+	Jobprocstatus   int             `json:"jobprocstatus,omitempty"`
+	Jobresult       json.RawMessage `json:"jobresult,omitempty"`
+	Jobresultcode   int             `json:"jobresultcode,omitempty"`
+	Jobresulttype   string          `json:"jobresulttype,omitempty"`
+	Jobstatus       int             `json:"jobstatus,omitempty"`
+	Userid          string          `json:"userid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AuthenticationService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AuthenticationService.go
@@ -1,0 +1,156 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type LoginParams struct {
+	p map[string]interface{}
+}
+
+func (p *LoginParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["domain"]; found {
+		u.Set("domain", v.(string))
+	}
+	if v, found := p.p["domainId"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("domainId", vv)
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *LoginParams) SetDomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domain"] = v
+	return
+}
+
+func (p *LoginParams) SetDomainId(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainId"] = v
+	return
+}
+
+func (p *LoginParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *LoginParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new LoginParams instance,
+// as then you are sure you have configured all required params
+func (s *AuthenticationService) NewLoginParams(password string, username string) *LoginParams {
+	p := &LoginParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["username"] = username
+	return p
+}
+
+// Logs a user into the CloudStack. A successful login attempt will generate a JSESSIONID cookie value that can be passed in subsequent Query command calls until the "logout" command has been issued or the session has expired.
+func (s *AuthenticationService) Login(p *LoginParams) (*LoginResponse, error) {
+	resp, err := s.cs.newRequest("login", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LoginResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LoginResponse struct {
+	Account    string `json:"account,omitempty"`
+	Domainid   string `json:"domainid,omitempty"`
+	Firstname  string `json:"firstname,omitempty"`
+	Lastname   string `json:"lastname,omitempty"`
+	Registered string `json:"registered,omitempty"`
+	Sessionkey string `json:"sessionkey,omitempty"`
+	Timeout    int    `json:"timeout,omitempty"`
+	Timezone   string `json:"timezone,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Userid     string `json:"userid,omitempty"`
+	Username   string `json:"username,omitempty"`
+}
+
+type LogoutParams struct {
+	p map[string]interface{}
+}
+
+func (p *LogoutParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new LogoutParams instance,
+// as then you are sure you have configured all required params
+func (s *AuthenticationService) NewLogoutParams() *LogoutParams {
+	p := &LogoutParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Logs out the user
+func (s *AuthenticationService) Logout(p *LogoutParams) (*LogoutResponse, error) {
+	resp, err := s.cs.newRequest("logout", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LogoutResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LogoutResponse struct {
+	Description string `json:"description,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/AutoScaleService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/AutoScaleService.go
@@ -1,0 +1,2759 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateCounterParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateCounterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["source"]; found {
+		u.Set("source", v.(string))
+	}
+	if v, found := p.p["value"]; found {
+		u.Set("value", v.(string))
+	}
+	return u
+}
+
+func (p *CreateCounterParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateCounterParams) SetSource(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["source"] = v
+	return
+}
+
+func (p *CreateCounterParams) SetValue(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["value"] = v
+	return
+}
+
+// You should always use this function to get a new CreateCounterParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewCreateCounterParams(name string, source string, value string) *CreateCounterParams {
+	p := &CreateCounterParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["source"] = source
+	p.p["value"] = value
+	return p
+}
+
+// Adds metric counter
+func (s *AutoScaleService) CreateCounter(p *CreateCounterParams) (*CreateCounterResponse, error) {
+	resp, err := s.cs.newRequest("createCounter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateCounterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateCounterResponse struct {
+	JobID  string `json:"jobid,omitempty"`
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type CreateConditionParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateConditionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["counterid"]; found {
+		u.Set("counterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["relationaloperator"]; found {
+		u.Set("relationaloperator", v.(string))
+	}
+	if v, found := p.p["threshold"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("threshold", vv)
+	}
+	return u
+}
+
+func (p *CreateConditionParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateConditionParams) SetCounterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["counterid"] = v
+	return
+}
+
+func (p *CreateConditionParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateConditionParams) SetRelationaloperator(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["relationaloperator"] = v
+	return
+}
+
+func (p *CreateConditionParams) SetThreshold(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["threshold"] = v
+	return
+}
+
+// You should always use this function to get a new CreateConditionParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewCreateConditionParams(counterid string, relationaloperator string, threshold int64) *CreateConditionParams {
+	p := &CreateConditionParams{}
+	p.p = make(map[string]interface{})
+	p.p["counterid"] = counterid
+	p.p["relationaloperator"] = relationaloperator
+	p.p["threshold"] = threshold
+	return p
+}
+
+// Creates a condition
+func (s *AutoScaleService) CreateCondition(p *CreateConditionParams) (*CreateConditionResponse, error) {
+	resp, err := s.cs.newRequest("createCondition", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateConditionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateConditionResponse struct {
+	JobID              string   `json:"jobid,omitempty"`
+	Account            string   `json:"account,omitempty"`
+	Counter            []string `json:"counter,omitempty"`
+	Domain             string   `json:"domain,omitempty"`
+	Domainid           string   `json:"domainid,omitempty"`
+	Id                 string   `json:"id,omitempty"`
+	Project            string   `json:"project,omitempty"`
+	Projectid          string   `json:"projectid,omitempty"`
+	Relationaloperator string   `json:"relationaloperator,omitempty"`
+	Threshold          int64    `json:"threshold,omitempty"`
+	Zoneid             string   `json:"zoneid,omitempty"`
+}
+
+type CreateAutoScalePolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateAutoScalePolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["action"]; found {
+		u.Set("action", v.(string))
+	}
+	if v, found := p.p["conditionids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("conditionids", vv)
+	}
+	if v, found := p.p["duration"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("duration", vv)
+	}
+	if v, found := p.p["quiettime"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("quiettime", vv)
+	}
+	return u
+}
+
+func (p *CreateAutoScalePolicyParams) SetAction(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["action"] = v
+	return
+}
+
+func (p *CreateAutoScalePolicyParams) SetConditionids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["conditionids"] = v
+	return
+}
+
+func (p *CreateAutoScalePolicyParams) SetDuration(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["duration"] = v
+	return
+}
+
+func (p *CreateAutoScalePolicyParams) SetQuiettime(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["quiettime"] = v
+	return
+}
+
+// You should always use this function to get a new CreateAutoScalePolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewCreateAutoScalePolicyParams(action string, conditionids []string, duration int) *CreateAutoScalePolicyParams {
+	p := &CreateAutoScalePolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["action"] = action
+	p.p["conditionids"] = conditionids
+	p.p["duration"] = duration
+	return p
+}
+
+// Creates an autoscale policy for a provision or deprovision action, the action is taken when the all the conditions evaluates to true for the specified duration. The policy is in effect once it is attached to a autscale vm group.
+func (s *AutoScaleService) CreateAutoScalePolicy(p *CreateAutoScalePolicyParams) (*CreateAutoScalePolicyResponse, error) {
+	resp, err := s.cs.newRequest("createAutoScalePolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateAutoScalePolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateAutoScalePolicyResponse struct {
+	JobID      string   `json:"jobid,omitempty"`
+	Account    string   `json:"account,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Conditions []string `json:"conditions,omitempty"`
+	Domain     string   `json:"domain,omitempty"`
+	Domainid   string   `json:"domainid,omitempty"`
+	Duration   int      `json:"duration,omitempty"`
+	Id         string   `json:"id,omitempty"`
+	Project    string   `json:"project,omitempty"`
+	Projectid  string   `json:"projectid,omitempty"`
+	Quiettime  int      `json:"quiettime,omitempty"`
+}
+
+type CreateAutoScaleVmProfileParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateAutoScaleVmProfileParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["autoscaleuserid"]; found {
+		u.Set("autoscaleuserid", v.(string))
+	}
+	if v, found := p.p["counterparam"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("counterparam[%d].key", i), k)
+			u.Set(fmt.Sprintf("counterparam[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["destroyvmgraceperiod"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("destroyvmgraceperiod", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["otherdeployparams"]; found {
+		u.Set("otherdeployparams", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["autoscaleuserid"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["counterparam"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["destroyvmgraceperiod"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetOtherdeployparams(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["otherdeployparams"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmProfileParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateAutoScaleVmProfileParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewCreateAutoScaleVmProfileParams(serviceofferingid string, templateid string, zoneid string) *CreateAutoScaleVmProfileParams {
+	p := &CreateAutoScaleVmProfileParams{}
+	p.p = make(map[string]interface{})
+	p.p["serviceofferingid"] = serviceofferingid
+	p.p["templateid"] = templateid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a profile that contains information about the virtual machine which will be provisioned automatically by autoscale feature.
+func (s *AutoScaleService) CreateAutoScaleVmProfile(p *CreateAutoScaleVmProfileParams) (*CreateAutoScaleVmProfileResponse, error) {
+	resp, err := s.cs.newRequest("createAutoScaleVmProfile", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateAutoScaleVmProfileResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateAutoScaleVmProfileResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Autoscaleuserid      string `json:"autoscaleuserid,omitempty"`
+	Destroyvmgraceperiod int    `json:"destroyvmgraceperiod,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Otherdeployparams    string `json:"otherdeployparams,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Serviceofferingid    string `json:"serviceofferingid,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type CreateAutoScaleVmGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateAutoScaleVmGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["interval"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("interval", vv)
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["maxmembers"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxmembers", vv)
+	}
+	if v, found := p.p["minmembers"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("minmembers", vv)
+	}
+	if v, found := p.p["scaledownpolicyids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("scaledownpolicyids", vv)
+	}
+	if v, found := p.p["scaleuppolicyids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("scaleuppolicyids", vv)
+	}
+	if v, found := p.p["vmprofileid"]; found {
+		u.Set("vmprofileid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetInterval(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["interval"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetMaxmembers(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxmembers"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetMinmembers(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["minmembers"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scaledownpolicyids"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scaleuppolicyids"] = v
+	return
+}
+
+func (p *CreateAutoScaleVmGroupParams) SetVmprofileid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmprofileid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateAutoScaleVmGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewCreateAutoScaleVmGroupParams(lbruleid string, maxmembers int, minmembers int, scaledownpolicyids []string, scaleuppolicyids []string, vmprofileid string) *CreateAutoScaleVmGroupParams {
+	p := &CreateAutoScaleVmGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbruleid"] = lbruleid
+	p.p["maxmembers"] = maxmembers
+	p.p["minmembers"] = minmembers
+	p.p["scaledownpolicyids"] = scaledownpolicyids
+	p.p["scaleuppolicyids"] = scaleuppolicyids
+	p.p["vmprofileid"] = vmprofileid
+	return p
+}
+
+// Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.
+func (s *AutoScaleService) CreateAutoScaleVmGroup(p *CreateAutoScaleVmGroupParams) (*CreateAutoScaleVmGroupResponse, error) {
+	resp, err := s.cs.newRequest("createAutoScaleVmGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateAutoScaleVmGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateAutoScaleVmGroupResponse struct {
+	JobID             string   `json:"jobid,omitempty"`
+	Account           string   `json:"account,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Fordisplay        bool     `json:"fordisplay,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Interval          int      `json:"interval,omitempty"`
+	Lbruleid          string   `json:"lbruleid,omitempty"`
+	Maxmembers        int      `json:"maxmembers,omitempty"`
+	Minmembers        int      `json:"minmembers,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Scaledownpolicies []string `json:"scaledownpolicies,omitempty"`
+	Scaleuppolicies   []string `json:"scaleuppolicies,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Vmprofileid       string   `json:"vmprofileid,omitempty"`
+}
+
+type DeleteCounterParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteCounterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteCounterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteCounterParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDeleteCounterParams(id string) *DeleteCounterParams {
+	p := &DeleteCounterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a counter
+func (s *AutoScaleService) DeleteCounter(p *DeleteCounterParams) (*DeleteCounterResponse, error) {
+	resp, err := s.cs.newRequest("deleteCounter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteCounterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteCounterResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteConditionParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteConditionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteConditionParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteConditionParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDeleteConditionParams(id string) *DeleteConditionParams {
+	p := &DeleteConditionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes a condition
+func (s *AutoScaleService) DeleteCondition(p *DeleteConditionParams) (*DeleteConditionResponse, error) {
+	resp, err := s.cs.newRequest("deleteCondition", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteConditionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteConditionResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteAutoScalePolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAutoScalePolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAutoScalePolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAutoScalePolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDeleteAutoScalePolicyParams(id string) *DeleteAutoScalePolicyParams {
+	p := &DeleteAutoScalePolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a autoscale policy.
+func (s *AutoScaleService) DeleteAutoScalePolicy(p *DeleteAutoScalePolicyParams) (*DeleteAutoScalePolicyResponse, error) {
+	resp, err := s.cs.newRequest("deleteAutoScalePolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAutoScalePolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAutoScalePolicyResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteAutoScaleVmProfileParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAutoScaleVmProfileParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAutoScaleVmProfileParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAutoScaleVmProfileParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDeleteAutoScaleVmProfileParams(id string) *DeleteAutoScaleVmProfileParams {
+	p := &DeleteAutoScaleVmProfileParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a autoscale vm profile.
+func (s *AutoScaleService) DeleteAutoScaleVmProfile(p *DeleteAutoScaleVmProfileParams) (*DeleteAutoScaleVmProfileResponse, error) {
+	resp, err := s.cs.newRequest("deleteAutoScaleVmProfile", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAutoScaleVmProfileResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAutoScaleVmProfileResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteAutoScaleVmGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteAutoScaleVmGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteAutoScaleVmGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteAutoScaleVmGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDeleteAutoScaleVmGroupParams(id string) *DeleteAutoScaleVmGroupParams {
+	p := &DeleteAutoScaleVmGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a autoscale vm group.
+func (s *AutoScaleService) DeleteAutoScaleVmGroup(p *DeleteAutoScaleVmGroupParams) (*DeleteAutoScaleVmGroupResponse, error) {
+	resp, err := s.cs.newRequest("deleteAutoScaleVmGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteAutoScaleVmGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteAutoScaleVmGroupResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListCountersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListCountersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["source"]; found {
+		u.Set("source", v.(string))
+	}
+	return u
+}
+
+func (p *ListCountersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListCountersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListCountersParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListCountersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListCountersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListCountersParams) SetSource(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["source"] = v
+	return
+}
+
+// You should always use this function to get a new ListCountersParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewListCountersParams() *ListCountersParams {
+	p := &ListCountersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetCounterID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListCountersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListCounters(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Counters[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Counters {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetCounterByName(name string, opts ...OptionFunc) (*Counter, int, error) {
+	id, count, err := s.GetCounterID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetCounterByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetCounterByID(id string, opts ...OptionFunc) (*Counter, int, error) {
+	p := &ListCountersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListCounters(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Counters[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Counter UUID: %s!", id)
+}
+
+// List the counters
+func (s *AutoScaleService) ListCounters(p *ListCountersParams) (*ListCountersResponse, error) {
+	resp, err := s.cs.newRequest("listCounters", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListCountersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListCountersResponse struct {
+	Count    int        `json:"count"`
+	Counters []*Counter `json:"counter"`
+}
+
+type Counter struct {
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type ListConditionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListConditionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["counterid"]; found {
+		u.Set("counterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["policyid"]; found {
+		u.Set("policyid", v.(string))
+	}
+	return u
+}
+
+func (p *ListConditionsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetCounterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["counterid"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListConditionsParams) SetPolicyid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["policyid"] = v
+	return
+}
+
+// You should always use this function to get a new ListConditionsParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewListConditionsParams() *ListConditionsParams {
+	p := &ListConditionsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetConditionByID(id string, opts ...OptionFunc) (*Condition, int, error) {
+	p := &ListConditionsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListConditions(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Conditions[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Condition UUID: %s!", id)
+}
+
+// List Conditions for the specific user
+func (s *AutoScaleService) ListConditions(p *ListConditionsParams) (*ListConditionsResponse, error) {
+	resp, err := s.cs.newRequest("listConditions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListConditionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListConditionsResponse struct {
+	Count      int          `json:"count"`
+	Conditions []*Condition `json:"condition"`
+}
+
+type Condition struct {
+	Account            string   `json:"account,omitempty"`
+	Counter            []string `json:"counter,omitempty"`
+	Domain             string   `json:"domain,omitempty"`
+	Domainid           string   `json:"domainid,omitempty"`
+	Id                 string   `json:"id,omitempty"`
+	Project            string   `json:"project,omitempty"`
+	Projectid          string   `json:"projectid,omitempty"`
+	Relationaloperator string   `json:"relationaloperator,omitempty"`
+	Threshold          int64    `json:"threshold,omitempty"`
+	Zoneid             string   `json:"zoneid,omitempty"`
+}
+
+type ListAutoScalePoliciesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAutoScalePoliciesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["action"]; found {
+		u.Set("action", v.(string))
+	}
+	if v, found := p.p["conditionid"]; found {
+		u.Set("conditionid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["vmgroupid"]; found {
+		u.Set("vmgroupid", v.(string))
+	}
+	return u
+}
+
+func (p *ListAutoScalePoliciesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetAction(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["action"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetConditionid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["conditionid"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAutoScalePoliciesParams) SetVmgroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmgroupid"] = v
+	return
+}
+
+// You should always use this function to get a new ListAutoScalePoliciesParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewListAutoScalePoliciesParams() *ListAutoScalePoliciesParams {
+	p := &ListAutoScalePoliciesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetAutoScalePolicyByID(id string, opts ...OptionFunc) (*AutoScalePolicy, int, error) {
+	p := &ListAutoScalePoliciesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAutoScalePolicies(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.AutoScalePolicies[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for AutoScalePolicy UUID: %s!", id)
+}
+
+// Lists autoscale policies.
+func (s *AutoScaleService) ListAutoScalePolicies(p *ListAutoScalePoliciesParams) (*ListAutoScalePoliciesResponse, error) {
+	resp, err := s.cs.newRequest("listAutoScalePolicies", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAutoScalePoliciesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAutoScalePoliciesResponse struct {
+	Count             int                `json:"count"`
+	AutoScalePolicies []*AutoScalePolicy `json:"autoscalepolicy"`
+}
+
+type AutoScalePolicy struct {
+	Account    string   `json:"account,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Conditions []string `json:"conditions,omitempty"`
+	Domain     string   `json:"domain,omitempty"`
+	Domainid   string   `json:"domainid,omitempty"`
+	Duration   int      `json:"duration,omitempty"`
+	Id         string   `json:"id,omitempty"`
+	Project    string   `json:"project,omitempty"`
+	Projectid  string   `json:"projectid,omitempty"`
+	Quiettime  int      `json:"quiettime,omitempty"`
+}
+
+type ListAutoScaleVmProfilesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAutoScaleVmProfilesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["otherdeployparams"]; found {
+		u.Set("otherdeployparams", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetOtherdeployparams(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["otherdeployparams"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmProfilesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListAutoScaleVmProfilesParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewListAutoScaleVmProfilesParams() *ListAutoScaleVmProfilesParams {
+	p := &ListAutoScaleVmProfilesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetAutoScaleVmProfileByID(id string, opts ...OptionFunc) (*AutoScaleVmProfile, int, error) {
+	p := &ListAutoScaleVmProfilesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAutoScaleVmProfiles(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.AutoScaleVmProfiles[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for AutoScaleVmProfile UUID: %s!", id)
+}
+
+// Lists autoscale vm profiles.
+func (s *AutoScaleService) ListAutoScaleVmProfiles(p *ListAutoScaleVmProfilesParams) (*ListAutoScaleVmProfilesResponse, error) {
+	resp, err := s.cs.newRequest("listAutoScaleVmProfiles", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAutoScaleVmProfilesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAutoScaleVmProfilesResponse struct {
+	Count               int                   `json:"count"`
+	AutoScaleVmProfiles []*AutoScaleVmProfile `json:"autoscalevmprofile"`
+}
+
+type AutoScaleVmProfile struct {
+	Account              string `json:"account,omitempty"`
+	Autoscaleuserid      string `json:"autoscaleuserid,omitempty"`
+	Destroyvmgraceperiod int    `json:"destroyvmgraceperiod,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Otherdeployparams    string `json:"otherdeployparams,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Serviceofferingid    string `json:"serviceofferingid,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type ListAutoScaleVmGroupsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListAutoScaleVmGroupsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["policyid"]; found {
+		u.Set("policyid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vmprofileid"]; found {
+		u.Set("vmprofileid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetPolicyid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["policyid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetVmprofileid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmprofileid"] = v
+	return
+}
+
+func (p *ListAutoScaleVmGroupsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListAutoScaleVmGroupsParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewListAutoScaleVmGroupsParams() *ListAutoScaleVmGroupsParams {
+	p := &ListAutoScaleVmGroupsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *AutoScaleService) GetAutoScaleVmGroupByID(id string, opts ...OptionFunc) (*AutoScaleVmGroup, int, error) {
+	p := &ListAutoScaleVmGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListAutoScaleVmGroups(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.AutoScaleVmGroups[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for AutoScaleVmGroup UUID: %s!", id)
+}
+
+// Lists autoscale vm groups.
+func (s *AutoScaleService) ListAutoScaleVmGroups(p *ListAutoScaleVmGroupsParams) (*ListAutoScaleVmGroupsResponse, error) {
+	resp, err := s.cs.newRequest("listAutoScaleVmGroups", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAutoScaleVmGroupsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListAutoScaleVmGroupsResponse struct {
+	Count             int                 `json:"count"`
+	AutoScaleVmGroups []*AutoScaleVmGroup `json:"autoscalevmgroup"`
+}
+
+type AutoScaleVmGroup struct {
+	Account           string   `json:"account,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Fordisplay        bool     `json:"fordisplay,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Interval          int      `json:"interval,omitempty"`
+	Lbruleid          string   `json:"lbruleid,omitempty"`
+	Maxmembers        int      `json:"maxmembers,omitempty"`
+	Minmembers        int      `json:"minmembers,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Scaledownpolicies []string `json:"scaledownpolicies,omitempty"`
+	Scaleuppolicies   []string `json:"scaleuppolicies,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Vmprofileid       string   `json:"vmprofileid,omitempty"`
+}
+
+type EnableAutoScaleVmGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *EnableAutoScaleVmGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *EnableAutoScaleVmGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new EnableAutoScaleVmGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewEnableAutoScaleVmGroupParams(id string) *EnableAutoScaleVmGroupParams {
+	p := &EnableAutoScaleVmGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Enables an AutoScale Vm Group
+func (s *AutoScaleService) EnableAutoScaleVmGroup(p *EnableAutoScaleVmGroupParams) (*EnableAutoScaleVmGroupResponse, error) {
+	resp, err := s.cs.newRequest("enableAutoScaleVmGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r EnableAutoScaleVmGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type EnableAutoScaleVmGroupResponse struct {
+	JobID             string   `json:"jobid,omitempty"`
+	Account           string   `json:"account,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Fordisplay        bool     `json:"fordisplay,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Interval          int      `json:"interval,omitempty"`
+	Lbruleid          string   `json:"lbruleid,omitempty"`
+	Maxmembers        int      `json:"maxmembers,omitempty"`
+	Minmembers        int      `json:"minmembers,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Scaledownpolicies []string `json:"scaledownpolicies,omitempty"`
+	Scaleuppolicies   []string `json:"scaleuppolicies,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Vmprofileid       string   `json:"vmprofileid,omitempty"`
+}
+
+type DisableAutoScaleVmGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *DisableAutoScaleVmGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DisableAutoScaleVmGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DisableAutoScaleVmGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewDisableAutoScaleVmGroupParams(id string) *DisableAutoScaleVmGroupParams {
+	p := &DisableAutoScaleVmGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Disables an AutoScale Vm Group
+func (s *AutoScaleService) DisableAutoScaleVmGroup(p *DisableAutoScaleVmGroupParams) (*DisableAutoScaleVmGroupResponse, error) {
+	resp, err := s.cs.newRequest("disableAutoScaleVmGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DisableAutoScaleVmGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DisableAutoScaleVmGroupResponse struct {
+	JobID             string   `json:"jobid,omitempty"`
+	Account           string   `json:"account,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Fordisplay        bool     `json:"fordisplay,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Interval          int      `json:"interval,omitempty"`
+	Lbruleid          string   `json:"lbruleid,omitempty"`
+	Maxmembers        int      `json:"maxmembers,omitempty"`
+	Minmembers        int      `json:"minmembers,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Scaledownpolicies []string `json:"scaledownpolicies,omitempty"`
+	Scaleuppolicies   []string `json:"scaleuppolicies,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Vmprofileid       string   `json:"vmprofileid,omitempty"`
+}
+
+type UpdateAutoScalePolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateAutoScalePolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["conditionids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("conditionids", vv)
+	}
+	if v, found := p.p["duration"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("duration", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["quiettime"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("quiettime", vv)
+	}
+	return u
+}
+
+func (p *UpdateAutoScalePolicyParams) SetConditionids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["conditionids"] = v
+	return
+}
+
+func (p *UpdateAutoScalePolicyParams) SetDuration(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["duration"] = v
+	return
+}
+
+func (p *UpdateAutoScalePolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateAutoScalePolicyParams) SetQuiettime(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["quiettime"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateAutoScalePolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewUpdateAutoScalePolicyParams(id string) *UpdateAutoScalePolicyParams {
+	p := &UpdateAutoScalePolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an existing autoscale policy.
+func (s *AutoScaleService) UpdateAutoScalePolicy(p *UpdateAutoScalePolicyParams) (*UpdateAutoScalePolicyResponse, error) {
+	resp, err := s.cs.newRequest("updateAutoScalePolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateAutoScalePolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateAutoScalePolicyResponse struct {
+	JobID      string   `json:"jobid,omitempty"`
+	Account    string   `json:"account,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Conditions []string `json:"conditions,omitempty"`
+	Domain     string   `json:"domain,omitempty"`
+	Domainid   string   `json:"domainid,omitempty"`
+	Duration   int      `json:"duration,omitempty"`
+	Id         string   `json:"id,omitempty"`
+	Project    string   `json:"project,omitempty"`
+	Projectid  string   `json:"projectid,omitempty"`
+	Quiettime  int      `json:"quiettime,omitempty"`
+}
+
+type UpdateAutoScaleVmProfileParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateAutoScaleVmProfileParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["autoscaleuserid"]; found {
+		u.Set("autoscaleuserid", v.(string))
+	}
+	if v, found := p.p["counterparam"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("counterparam[%d].key", i), k)
+			u.Set(fmt.Sprintf("counterparam[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["destroyvmgraceperiod"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("destroyvmgraceperiod", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["autoscaleuserid"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["counterparam"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["destroyvmgraceperiod"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmProfileParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateAutoScaleVmProfileParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewUpdateAutoScaleVmProfileParams(id string) *UpdateAutoScaleVmProfileParams {
+	p := &UpdateAutoScaleVmProfileParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an existing autoscale vm profile.
+func (s *AutoScaleService) UpdateAutoScaleVmProfile(p *UpdateAutoScaleVmProfileParams) (*UpdateAutoScaleVmProfileResponse, error) {
+	resp, err := s.cs.newRequest("updateAutoScaleVmProfile", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateAutoScaleVmProfileResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateAutoScaleVmProfileResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Autoscaleuserid      string `json:"autoscaleuserid,omitempty"`
+	Destroyvmgraceperiod int    `json:"destroyvmgraceperiod,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Otherdeployparams    string `json:"otherdeployparams,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Serviceofferingid    string `json:"serviceofferingid,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type UpdateAutoScaleVmGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateAutoScaleVmGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["interval"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("interval", vv)
+	}
+	if v, found := p.p["maxmembers"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxmembers", vv)
+	}
+	if v, found := p.p["minmembers"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("minmembers", vv)
+	}
+	if v, found := p.p["scaledownpolicyids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("scaledownpolicyids", vv)
+	}
+	if v, found := p.p["scaleuppolicyids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("scaleuppolicyids", vv)
+	}
+	return u
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetInterval(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["interval"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetMaxmembers(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxmembers"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetMinmembers(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["minmembers"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scaledownpolicyids"] = v
+	return
+}
+
+func (p *UpdateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scaleuppolicyids"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateAutoScaleVmGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *AutoScaleService) NewUpdateAutoScaleVmGroupParams(id string) *UpdateAutoScaleVmGroupParams {
+	p := &UpdateAutoScaleVmGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an existing autoscale vm group.
+func (s *AutoScaleService) UpdateAutoScaleVmGroup(p *UpdateAutoScaleVmGroupParams) (*UpdateAutoScaleVmGroupResponse, error) {
+	resp, err := s.cs.newRequest("updateAutoScaleVmGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateAutoScaleVmGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateAutoScaleVmGroupResponse struct {
+	JobID             string   `json:"jobid,omitempty"`
+	Account           string   `json:"account,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Domainid          string   `json:"domainid,omitempty"`
+	Fordisplay        bool     `json:"fordisplay,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Interval          int      `json:"interval,omitempty"`
+	Lbruleid          string   `json:"lbruleid,omitempty"`
+	Maxmembers        int      `json:"maxmembers,omitempty"`
+	Minmembers        int      `json:"minmembers,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	Projectid         string   `json:"projectid,omitempty"`
+	Scaledownpolicies []string `json:"scaledownpolicies,omitempty"`
+	Scaleuppolicies   []string `json:"scaleuppolicies,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Vmprofileid       string   `json:"vmprofileid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/BaremetalService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/BaremetalService.go
@@ -1,0 +1,918 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type AddBaremetalPxeKickStartServerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["pxeservertype"]; found {
+		u.Set("pxeservertype", v.(string))
+	}
+	if v, found := p.p["tftpdir"]; found {
+		u.Set("tftpdir", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetPxeservertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pxeservertype"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetTftpdir(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tftpdir"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddBaremetalPxeKickStartServerParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewAddBaremetalPxeKickStartServerParams(password string, physicalnetworkid string, pxeservertype string, tftpdir string, url string, username string) *AddBaremetalPxeKickStartServerParams {
+	p := &AddBaremetalPxeKickStartServerParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["pxeservertype"] = pxeservertype
+	p.p["tftpdir"] = tftpdir
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// add a baremetal pxe server
+func (s *BaremetalService) AddBaremetalPxeKickStartServer(p *AddBaremetalPxeKickStartServerParams) (*AddBaremetalPxeKickStartServerResponse, error) {
+	resp, err := s.cs.newRequest("addBaremetalPxeKickStartServer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddBaremetalPxeKickStartServerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddBaremetalPxeKickStartServerResponse struct {
+	JobID   string `json:"jobid,omitempty"`
+	Tftpdir string `json:"tftpdir,omitempty"`
+}
+
+type AddBaremetalPxePingServerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddBaremetalPxePingServerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["pingcifspassword"]; found {
+		u.Set("pingcifspassword", v.(string))
+	}
+	if v, found := p.p["pingcifsusername"]; found {
+		u.Set("pingcifsusername", v.(string))
+	}
+	if v, found := p.p["pingdir"]; found {
+		u.Set("pingdir", v.(string))
+	}
+	if v, found := p.p["pingstorageserverip"]; found {
+		u.Set("pingstorageserverip", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["pxeservertype"]; found {
+		u.Set("pxeservertype", v.(string))
+	}
+	if v, found := p.p["tftpdir"]; found {
+		u.Set("tftpdir", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPingcifspassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pingcifspassword"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPingcifsusername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pingcifsusername"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPingdir(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pingdir"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPingstorageserverip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pingstorageserverip"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetPxeservertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pxeservertype"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetTftpdir(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tftpdir"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddBaremetalPxePingServerParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddBaremetalPxePingServerParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewAddBaremetalPxePingServerParams(password string, physicalnetworkid string, pingdir string, pingstorageserverip string, pxeservertype string, tftpdir string, url string, username string) *AddBaremetalPxePingServerParams {
+	p := &AddBaremetalPxePingServerParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["pingdir"] = pingdir
+	p.p["pingstorageserverip"] = pingstorageserverip
+	p.p["pxeservertype"] = pxeservertype
+	p.p["tftpdir"] = tftpdir
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// add a baremetal ping pxe server
+func (s *BaremetalService) AddBaremetalPxePingServer(p *AddBaremetalPxePingServerParams) (*AddBaremetalPxePingServerResponse, error) {
+	resp, err := s.cs.newRequest("addBaremetalPxePingServer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddBaremetalPxePingServerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddBaremetalPxePingServerResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Pingdir             string `json:"pingdir,omitempty"`
+	Pingstorageserverip string `json:"pingstorageserverip,omitempty"`
+	Tftpdir             string `json:"tftpdir,omitempty"`
+}
+
+type AddBaremetalDhcpParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddBaremetalDhcpParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["dhcpservertype"]; found {
+		u.Set("dhcpservertype", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddBaremetalDhcpParams) SetDhcpservertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dhcpservertype"] = v
+	return
+}
+
+func (p *AddBaremetalDhcpParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddBaremetalDhcpParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddBaremetalDhcpParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddBaremetalDhcpParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewAddBaremetalDhcpParams(dhcpservertype string, password string, physicalnetworkid string, url string, username string) *AddBaremetalDhcpParams {
+	p := &AddBaremetalDhcpParams{}
+	p.p = make(map[string]interface{})
+	p.p["dhcpservertype"] = dhcpservertype
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// adds a baremetal dhcp server
+func (s *BaremetalService) AddBaremetalDhcp(p *AddBaremetalDhcpParams) (*AddBaremetalDhcpResponse, error) {
+	resp, err := s.cs.newRequest("addBaremetalDhcp", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddBaremetalDhcpResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddBaremetalDhcpResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Dhcpservertype    string `json:"dhcpservertype,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Url               string `json:"url,omitempty"`
+}
+
+type ListBaremetalDhcpParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListBaremetalDhcpParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["dhcpservertype"]; found {
+		u.Set("dhcpservertype", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("id", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListBaremetalDhcpParams) SetDhcpservertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dhcpservertype"] = v
+	return
+}
+
+func (p *ListBaremetalDhcpParams) SetId(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListBaremetalDhcpParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListBaremetalDhcpParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListBaremetalDhcpParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListBaremetalDhcpParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewListBaremetalDhcpParams(physicalnetworkid string) *ListBaremetalDhcpParams {
+	p := &ListBaremetalDhcpParams{}
+	p.p = make(map[string]interface{})
+	p.p["physicalnetworkid"] = physicalnetworkid
+	return p
+}
+
+// list baremetal dhcp servers
+func (s *BaremetalService) ListBaremetalDhcp(p *ListBaremetalDhcpParams) (*ListBaremetalDhcpResponse, error) {
+	resp, err := s.cs.newRequest("listBaremetalDhcp", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListBaremetalDhcpResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListBaremetalDhcpResponse struct {
+	Count         int              `json:"count"`
+	BaremetalDhcp []*BaremetalDhcp `json:"baremetaldhcp"`
+}
+
+type BaremetalDhcp struct {
+	Dhcpservertype    string `json:"dhcpservertype,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Url               string `json:"url,omitempty"`
+}
+
+type ListBaremetalPxeServersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListBaremetalPxeServersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("id", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListBaremetalPxeServersParams) SetId(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListBaremetalPxeServersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListBaremetalPxeServersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListBaremetalPxeServersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListBaremetalPxeServersParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListBaremetalPxeServersParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewListBaremetalPxeServersParams(physicalnetworkid string) *ListBaremetalPxeServersParams {
+	p := &ListBaremetalPxeServersParams{}
+	p.p = make(map[string]interface{})
+	p.p["physicalnetworkid"] = physicalnetworkid
+	return p
+}
+
+// list baremetal pxe server
+func (s *BaremetalService) ListBaremetalPxeServers(p *ListBaremetalPxeServersParams) (*ListBaremetalPxeServersResponse, error) {
+	resp, err := s.cs.newRequest("listBaremetalPxeServers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListBaremetalPxeServersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListBaremetalPxeServersResponse struct {
+	Count               int                   `json:"count"`
+	BaremetalPxeServers []*BaremetalPxeServer `json:"baremetalpxeserver"`
+}
+
+type BaremetalPxeServer struct {
+	Id                string `json:"id,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Url               string `json:"url,omitempty"`
+}
+
+type AddBaremetalRctParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddBaremetalRctParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["baremetalrcturl"]; found {
+		u.Set("baremetalrcturl", v.(string))
+	}
+	return u
+}
+
+func (p *AddBaremetalRctParams) SetBaremetalrcturl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["baremetalrcturl"] = v
+	return
+}
+
+// You should always use this function to get a new AddBaremetalRctParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewAddBaremetalRctParams(baremetalrcturl string) *AddBaremetalRctParams {
+	p := &AddBaremetalRctParams{}
+	p.p = make(map[string]interface{})
+	p.p["baremetalrcturl"] = baremetalrcturl
+	return p
+}
+
+// adds baremetal rack configuration text
+func (s *BaremetalService) AddBaremetalRct(p *AddBaremetalRctParams) (*AddBaremetalRctResponse, error) {
+	resp, err := s.cs.newRequest("addBaremetalRct", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddBaremetalRctResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddBaremetalRctResponse struct {
+	JobID string `json:"jobid,omitempty"`
+	Id    string `json:"id,omitempty"`
+	Url   string `json:"url,omitempty"`
+}
+
+type DeleteBaremetalRctParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteBaremetalRctParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteBaremetalRctParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteBaremetalRctParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewDeleteBaremetalRctParams(id string) *DeleteBaremetalRctParams {
+	p := &DeleteBaremetalRctParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// deletes baremetal rack configuration text
+func (s *BaremetalService) DeleteBaremetalRct(p *DeleteBaremetalRctParams) (*DeleteBaremetalRctResponse, error) {
+	resp, err := s.cs.newRequest("deleteBaremetalRct", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteBaremetalRctResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteBaremetalRctResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListBaremetalRctParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListBaremetalRctParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListBaremetalRctParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListBaremetalRctParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListBaremetalRctParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListBaremetalRctParams instance,
+// as then you are sure you have configured all required params
+func (s *BaremetalService) NewListBaremetalRctParams() *ListBaremetalRctParams {
+	p := &ListBaremetalRctParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// list baremetal rack configuration
+func (s *BaremetalService) ListBaremetalRct(p *ListBaremetalRctParams) (*ListBaremetalRctResponse, error) {
+	resp, err := s.cs.newRequest("listBaremetalRct", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListBaremetalRctResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListBaremetalRctResponse struct {
+	Count        int             `json:"count"`
+	BaremetalRct []*BaremetalRct `json:"baremetalrct"`
+}
+
+type BaremetalRct struct {
+	Id  string `json:"id,omitempty"`
+	Url string `json:"url,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/CertificateService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/CertificateService.go
@@ -1,0 +1,140 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type UploadCustomCertificateParams struct {
+	p map[string]interface{}
+}
+
+func (p *UploadCustomCertificateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["certificate"]; found {
+		u.Set("certificate", v.(string))
+	}
+	if v, found := p.p["domainsuffix"]; found {
+		u.Set("domainsuffix", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("id", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["privatekey"]; found {
+		u.Set("privatekey", v.(string))
+	}
+	return u
+}
+
+func (p *UploadCustomCertificateParams) SetCertificate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["certificate"] = v
+	return
+}
+
+func (p *UploadCustomCertificateParams) SetDomainsuffix(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainsuffix"] = v
+	return
+}
+
+func (p *UploadCustomCertificateParams) SetId(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UploadCustomCertificateParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UploadCustomCertificateParams) SetPrivatekey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privatekey"] = v
+	return
+}
+
+// You should always use this function to get a new UploadCustomCertificateParams instance,
+// as then you are sure you have configured all required params
+func (s *CertificateService) NewUploadCustomCertificateParams(certificate string, domainsuffix string) *UploadCustomCertificateParams {
+	p := &UploadCustomCertificateParams{}
+	p.p = make(map[string]interface{})
+	p.p["certificate"] = certificate
+	p.p["domainsuffix"] = domainsuffix
+	return p
+}
+
+// Uploads a custom certificate for the console proxy VMs to use for SSL. Can be used to upload a single certificate signed by a known CA. Can also be used, through multiple calls, to upload a chain of certificates from CA to the custom certificate itself.
+func (s *CertificateService) UploadCustomCertificate(p *UploadCustomCertificateParams) (*UploadCustomCertificateResponse, error) {
+	resp, err := s.cs.newRequest("uploadCustomCertificate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UploadCustomCertificateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UploadCustomCertificateResponse struct {
+	JobID   string `json:"jobid,omitempty"`
+	Message string `json:"message,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/CloudIdentifierService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/CloudIdentifierService.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type GetCloudIdentifierParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetCloudIdentifierParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["userid"]; found {
+		u.Set("userid", v.(string))
+	}
+	return u
+}
+
+func (p *GetCloudIdentifierParams) SetUserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userid"] = v
+	return
+}
+
+// You should always use this function to get a new GetCloudIdentifierParams instance,
+// as then you are sure you have configured all required params
+func (s *CloudIdentifierService) NewGetCloudIdentifierParams(userid string) *GetCloudIdentifierParams {
+	p := &GetCloudIdentifierParams{}
+	p.p = make(map[string]interface{})
+	p.p["userid"] = userid
+	return p
+}
+
+// Retrieves a cloud identifier.
+func (s *CloudIdentifierService) GetCloudIdentifier(p *GetCloudIdentifierParams) (*GetCloudIdentifierResponse, error) {
+	resp, err := s.cs.newRequest("getCloudIdentifier", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetCloudIdentifierResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetCloudIdentifierResponse struct {
+	Cloudidentifier string `json:"cloudidentifier,omitempty"`
+	Signature       string `json:"signature,omitempty"`
+	Userid          string `json:"userid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ClusterService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ClusterService.go
@@ -1,0 +1,1059 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AddClusterParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddClusterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["clustername"]; found {
+		u.Set("clustername", v.(string))
+	}
+	if v, found := p.p["clustertype"]; found {
+		u.Set("clustertype", v.(string))
+	}
+	if v, found := p.p["guestvswitchname"]; found {
+		u.Set("guestvswitchname", v.(string))
+	}
+	if v, found := p.p["guestvswitchtype"]; found {
+		u.Set("guestvswitchtype", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["ovm3cluster"]; found {
+		u.Set("ovm3cluster", v.(string))
+	}
+	if v, found := p.p["ovm3pool"]; found {
+		u.Set("ovm3pool", v.(string))
+	}
+	if v, found := p.p["ovm3vip"]; found {
+		u.Set("ovm3vip", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["publicvswitchname"]; found {
+		u.Set("publicvswitchname", v.(string))
+	}
+	if v, found := p.p["publicvswitchtype"]; found {
+		u.Set("publicvswitchtype", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["vsmipaddress"]; found {
+		u.Set("vsmipaddress", v.(string))
+	}
+	if v, found := p.p["vsmpassword"]; found {
+		u.Set("vsmpassword", v.(string))
+	}
+	if v, found := p.p["vsmusername"]; found {
+		u.Set("vsmusername", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddClusterParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *AddClusterParams) SetClustername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustername"] = v
+	return
+}
+
+func (p *AddClusterParams) SetClustertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustertype"] = v
+	return
+}
+
+func (p *AddClusterParams) SetGuestvswitchname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestvswitchname"] = v
+	return
+}
+
+func (p *AddClusterParams) SetGuestvswitchtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestvswitchtype"] = v
+	return
+}
+
+func (p *AddClusterParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *AddClusterParams) SetOvm3cluster(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ovm3cluster"] = v
+	return
+}
+
+func (p *AddClusterParams) SetOvm3pool(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ovm3pool"] = v
+	return
+}
+
+func (p *AddClusterParams) SetOvm3vip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ovm3vip"] = v
+	return
+}
+
+func (p *AddClusterParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddClusterParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *AddClusterParams) SetPublicvswitchname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicvswitchname"] = v
+	return
+}
+
+func (p *AddClusterParams) SetPublicvswitchtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicvswitchtype"] = v
+	return
+}
+
+func (p *AddClusterParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddClusterParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *AddClusterParams) SetVsmipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vsmipaddress"] = v
+	return
+}
+
+func (p *AddClusterParams) SetVsmpassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vsmpassword"] = v
+	return
+}
+
+func (p *AddClusterParams) SetVsmusername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vsmusername"] = v
+	return
+}
+
+func (p *AddClusterParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddClusterParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewAddClusterParams(clustername string, clustertype string, hypervisor string, podid string, zoneid string) *AddClusterParams {
+	p := &AddClusterParams{}
+	p.p = make(map[string]interface{})
+	p.p["clustername"] = clustername
+	p.p["clustertype"] = clustertype
+	p.p["hypervisor"] = hypervisor
+	p.p["podid"] = podid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Adds a new cluster
+func (s *ClusterService) AddCluster(p *AddClusterParams) (*AddClusterResponse, error) {
+	resp, err := s.cs.newRequest("addCluster", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddClusterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddClusterResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Clustertype           string `json:"clustertype,omitempty"`
+	Cpuovercommitratio    string `json:"cpuovercommitratio,omitempty"`
+	Hypervisortype        string `json:"hypervisortype,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Managedstate          string `json:"managedstate,omitempty"`
+	Memoryovercommitratio string `json:"memoryovercommitratio,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	Ovm3vip               string `json:"ovm3vip,omitempty"`
+	Podid                 string `json:"podid,omitempty"`
+	Podname               string `json:"podname,omitempty"`
+	Zoneid                string `json:"zoneid,omitempty"`
+	Zonename              string `json:"zonename,omitempty"`
+}
+
+type DeleteClusterParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteClusterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteClusterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteClusterParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewDeleteClusterParams(id string) *DeleteClusterParams {
+	p := &DeleteClusterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a cluster.
+func (s *ClusterService) DeleteCluster(p *DeleteClusterParams) (*DeleteClusterResponse, error) {
+	resp, err := s.cs.newRequest("deleteCluster", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteClusterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteClusterResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type UpdateClusterParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateClusterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["clustername"]; found {
+		u.Set("clustername", v.(string))
+	}
+	if v, found := p.p["clustertype"]; found {
+		u.Set("clustertype", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["managedstate"]; found {
+		u.Set("managedstate", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateClusterParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *UpdateClusterParams) SetClustername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustername"] = v
+	return
+}
+
+func (p *UpdateClusterParams) SetClustertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustertype"] = v
+	return
+}
+
+func (p *UpdateClusterParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *UpdateClusterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateClusterParams) SetManagedstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managedstate"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateClusterParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewUpdateClusterParams(id string) *UpdateClusterParams {
+	p := &UpdateClusterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an existing cluster
+func (s *ClusterService) UpdateCluster(p *UpdateClusterParams) (*UpdateClusterResponse, error) {
+	resp, err := s.cs.newRequest("updateCluster", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateClusterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateClusterResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Clustertype           string `json:"clustertype,omitempty"`
+	Cpuovercommitratio    string `json:"cpuovercommitratio,omitempty"`
+	Hypervisortype        string `json:"hypervisortype,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Managedstate          string `json:"managedstate,omitempty"`
+	Memoryovercommitratio string `json:"memoryovercommitratio,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	Ovm3vip               string `json:"ovm3vip,omitempty"`
+	Podid                 string `json:"podid,omitempty"`
+	Podname               string `json:"podname,omitempty"`
+	Zoneid                string `json:"zoneid,omitempty"`
+	Zonename              string `json:"zonename,omitempty"`
+}
+
+type ListClustersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListClustersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["clustertype"]; found {
+		u.Set("clustertype", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["managedstate"]; found {
+		u.Set("managedstate", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["showcapacities"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showcapacities", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListClustersParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *ListClustersParams) SetClustertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustertype"] = v
+	return
+}
+
+func (p *ListClustersParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListClustersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListClustersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListClustersParams) SetManagedstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managedstate"] = v
+	return
+}
+
+func (p *ListClustersParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListClustersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListClustersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListClustersParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListClustersParams) SetShowcapacities(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showcapacities"] = v
+	return
+}
+
+func (p *ListClustersParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListClustersParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewListClustersParams() *ListClustersParams {
+	p := &ListClustersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ClusterService) GetClusterID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListClustersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListClusters(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Clusters[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Clusters {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ClusterService) GetClusterByName(name string, opts ...OptionFunc) (*Cluster, int, error) {
+	id, count, err := s.GetClusterID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetClusterByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ClusterService) GetClusterByID(id string, opts ...OptionFunc) (*Cluster, int, error) {
+	p := &ListClustersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListClusters(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Clusters[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Cluster UUID: %s!", id)
+}
+
+// Lists clusters.
+func (s *ClusterService) ListClusters(p *ListClustersParams) (*ListClustersResponse, error) {
+	resp, err := s.cs.newRequest("listClusters", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListClustersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListClustersResponse struct {
+	Count    int        `json:"count"`
+	Clusters []*Cluster `json:"cluster"`
+}
+
+type Cluster struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Clustertype           string `json:"clustertype,omitempty"`
+	Cpuovercommitratio    string `json:"cpuovercommitratio,omitempty"`
+	Hypervisortype        string `json:"hypervisortype,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Managedstate          string `json:"managedstate,omitempty"`
+	Memoryovercommitratio string `json:"memoryovercommitratio,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	Ovm3vip               string `json:"ovm3vip,omitempty"`
+	Podid                 string `json:"podid,omitempty"`
+	Podname               string `json:"podname,omitempty"`
+	Zoneid                string `json:"zoneid,omitempty"`
+	Zonename              string `json:"zonename,omitempty"`
+}
+
+type DedicateClusterParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicateClusterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	return u
+}
+
+func (p *DedicateClusterParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicateClusterParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *DedicateClusterParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+// You should always use this function to get a new DedicateClusterParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewDedicateClusterParams(clusterid string, domainid string) *DedicateClusterParams {
+	p := &DedicateClusterParams{}
+	p.p = make(map[string]interface{})
+	p.p["clusterid"] = clusterid
+	p.p["domainid"] = domainid
+	return p
+}
+
+// Dedicate an existing cluster
+func (s *ClusterService) DedicateCluster(p *DedicateClusterParams) (*DedicateClusterResponse, error) {
+	resp, err := s.cs.newRequest("dedicateCluster", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicateClusterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DedicateClusterResponse struct {
+	JobID           string `json:"jobid,omitempty"`
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Clusterid       string `json:"clusterid,omitempty"`
+	Clustername     string `json:"clustername,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+}
+
+type ReleaseDedicatedClusterParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseDedicatedClusterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseDedicatedClusterParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseDedicatedClusterParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewReleaseDedicatedClusterParams(clusterid string) *ReleaseDedicatedClusterParams {
+	p := &ReleaseDedicatedClusterParams{}
+	p.p = make(map[string]interface{})
+	p.p["clusterid"] = clusterid
+	return p
+}
+
+// Release the dedication for cluster
+func (s *ClusterService) ReleaseDedicatedCluster(p *ReleaseDedicatedClusterParams) (*ReleaseDedicatedClusterResponse, error) {
+	resp, err := s.cs.newRequest("releaseDedicatedCluster", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseDedicatedClusterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseDedicatedClusterResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDedicatedClustersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDedicatedClustersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupid"]; found {
+		u.Set("affinitygroupid", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDedicatedClustersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetAffinitygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupid"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDedicatedClustersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDedicatedClustersParams instance,
+// as then you are sure you have configured all required params
+func (s *ClusterService) NewListDedicatedClustersParams() *ListDedicatedClustersParams {
+	p := &ListDedicatedClustersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists dedicated clusters.
+func (s *ClusterService) ListDedicatedClusters(p *ListDedicatedClustersParams) (*ListDedicatedClustersResponse, error) {
+	resp, err := s.cs.newRequest("listDedicatedClusters", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDedicatedClustersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDedicatedClustersResponse struct {
+	Count             int                 `json:"count"`
+	DedicatedClusters []*DedicatedCluster `json:"dedicatedcluster"`
+}
+
+type DedicatedCluster struct {
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Clusterid       string `json:"clusterid,omitempty"`
+	Clustername     string `json:"clustername,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ConfigurationService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ConfigurationService.go
@@ -1,0 +1,633 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type UpdateConfigurationParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateConfigurationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["value"]; found {
+		u.Set("value", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateConfigurationParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *UpdateConfigurationParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *UpdateConfigurationParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateConfigurationParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *UpdateConfigurationParams) SetValue(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["value"] = v
+	return
+}
+
+func (p *UpdateConfigurationParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateConfigurationParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewUpdateConfigurationParams(name string) *UpdateConfigurationParams {
+	p := &UpdateConfigurationParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Updates a configuration.
+func (s *ConfigurationService) UpdateConfiguration(p *UpdateConfigurationParams) (*UpdateConfigurationResponse, error) {
+	resp, err := s.cs.newRequest("updateConfiguration", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateConfigurationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateConfigurationResponse struct {
+	Category    string `json:"category,omitempty"`
+	Description string `json:"description,omitempty"`
+	Id          int64  `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	Value       string `json:"value,omitempty"`
+}
+
+type ListConfigurationsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListConfigurationsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["category"]; found {
+		u.Set("category", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListConfigurationsParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetCategory(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["category"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListConfigurationsParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewListConfigurationsParams() *ListConfigurationsParams {
+	p := &ListConfigurationsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all configurations.
+func (s *ConfigurationService) ListConfigurations(p *ListConfigurationsParams) (*ListConfigurationsResponse, error) {
+	resp, err := s.cs.newRequest("listConfigurations", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListConfigurationsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListConfigurationsResponse struct {
+	Count          int              `json:"count"`
+	Configurations []*Configuration `json:"configuration"`
+}
+
+type Configuration struct {
+	Category    string `json:"category,omitempty"`
+	Description string `json:"description,omitempty"`
+	Id          int64  `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	Value       string `json:"value,omitempty"`
+}
+
+type ListCapabilitiesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListCapabilitiesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new ListCapabilitiesParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewListCapabilitiesParams() *ListCapabilitiesParams {
+	p := &ListCapabilitiesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists capabilities
+func (s *ConfigurationService) ListCapabilities(p *ListCapabilitiesParams) (*ListCapabilitiesResponse, error) {
+	resp, err := s.cs.newRequest("listCapabilities", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListCapabilitiesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListCapabilitiesResponse struct {
+	Count        int           `json:"count"`
+	Capabilities []*Capability `json:"capability"`
+}
+
+type Capability struct {
+	Allowusercreateprojects   bool   `json:"allowusercreateprojects,omitempty"`
+	Allowuserexpungerecovervm bool   `json:"allowuserexpungerecovervm,omitempty"`
+	Allowuserviewdestroyedvm  bool   `json:"allowuserviewdestroyedvm,omitempty"`
+	Apilimitinterval          int    `json:"apilimitinterval,omitempty"`
+	Apilimitmax               int    `json:"apilimitmax,omitempty"`
+	Cloudstackversion         string `json:"cloudstackversion,omitempty"`
+	Customdiskofferingmaxsize int64  `json:"customdiskofferingmaxsize,omitempty"`
+	Customdiskofferingminsize int64  `json:"customdiskofferingminsize,omitempty"`
+	Kvmsnapshotenabled        bool   `json:"kvmsnapshotenabled,omitempty"`
+	Projectinviterequired     bool   `json:"projectinviterequired,omitempty"`
+	Regionsecondaryenabled    bool   `json:"regionsecondaryenabled,omitempty"`
+	Securitygroupsenabled     bool   `json:"securitygroupsenabled,omitempty"`
+	SupportELB                string `json:"supportELB,omitempty"`
+	Userpublictemplateenabled bool   `json:"userpublictemplateenabled,omitempty"`
+}
+
+type ListDeploymentPlannersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDeploymentPlannersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDeploymentPlannersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDeploymentPlannersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDeploymentPlannersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDeploymentPlannersParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewListDeploymentPlannersParams() *ListDeploymentPlannersParams {
+	p := &ListDeploymentPlannersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all DeploymentPlanners available.
+func (s *ConfigurationService) ListDeploymentPlanners(p *ListDeploymentPlannersParams) (*ListDeploymentPlannersResponse, error) {
+	resp, err := s.cs.newRequest("listDeploymentPlanners", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDeploymentPlannersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDeploymentPlannersResponse struct {
+	Count              int                  `json:"count"`
+	DeploymentPlanners []*DeploymentPlanner `json:"deploymentplanner"`
+}
+
+type DeploymentPlanner struct {
+	Name string `json:"name,omitempty"`
+}
+
+type ListLdapConfigurationsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLdapConfigurationsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostname"]; found {
+		u.Set("hostname", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["port"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("port", vv)
+	}
+	return u
+}
+
+func (p *ListLdapConfigurationsParams) SetHostname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostname"] = v
+	return
+}
+
+func (p *ListLdapConfigurationsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLdapConfigurationsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLdapConfigurationsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListLdapConfigurationsParams) SetPort(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["port"] = v
+	return
+}
+
+// You should always use this function to get a new ListLdapConfigurationsParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewListLdapConfigurationsParams() *ListLdapConfigurationsParams {
+	p := &ListLdapConfigurationsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all LDAP configurations
+func (s *ConfigurationService) ListLdapConfigurations(p *ListLdapConfigurationsParams) (*ListLdapConfigurationsResponse, error) {
+	resp, err := s.cs.newRequest("listLdapConfigurations", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLdapConfigurationsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLdapConfigurationsResponse struct {
+	Count              int                  `json:"count"`
+	LdapConfigurations []*LdapConfiguration `json:"ldapconfiguration"`
+}
+
+type LdapConfiguration struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+type AddLdapConfigurationParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddLdapConfigurationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostname"]; found {
+		u.Set("hostname", v.(string))
+	}
+	if v, found := p.p["port"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("port", vv)
+	}
+	return u
+}
+
+func (p *AddLdapConfigurationParams) SetHostname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostname"] = v
+	return
+}
+
+func (p *AddLdapConfigurationParams) SetPort(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["port"] = v
+	return
+}
+
+// You should always use this function to get a new AddLdapConfigurationParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewAddLdapConfigurationParams(hostname string, port int) *AddLdapConfigurationParams {
+	p := &AddLdapConfigurationParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostname"] = hostname
+	p.p["port"] = port
+	return p
+}
+
+// Add a new Ldap Configuration
+func (s *ConfigurationService) AddLdapConfiguration(p *AddLdapConfigurationParams) (*AddLdapConfigurationResponse, error) {
+	resp, err := s.cs.newRequest("addLdapConfiguration", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddLdapConfigurationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddLdapConfigurationResponse struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+type DeleteLdapConfigurationParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteLdapConfigurationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostname"]; found {
+		u.Set("hostname", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteLdapConfigurationParams) SetHostname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostname"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteLdapConfigurationParams instance,
+// as then you are sure you have configured all required params
+func (s *ConfigurationService) NewDeleteLdapConfigurationParams(hostname string) *DeleteLdapConfigurationParams {
+	p := &DeleteLdapConfigurationParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostname"] = hostname
+	return p
+}
+
+// Remove an Ldap Configuration
+func (s *ConfigurationService) DeleteLdapConfiguration(p *DeleteLdapConfigurationParams) (*DeleteLdapConfigurationResponse, error) {
+	resp, err := s.cs.newRequest("deleteLdapConfiguration", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteLdapConfigurationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteLdapConfigurationResponse struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/DiskOfferingService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/DiskOfferingService.go
@@ -1,0 +1,688 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateDiskOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateDiskOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bytesreadrate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("bytesreadrate", vv)
+	}
+	if v, found := p.p["byteswriterate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("byteswriterate", vv)
+	}
+	if v, found := p.p["customized"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("customized", vv)
+	}
+	if v, found := p.p["customizediops"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("customizediops", vv)
+	}
+	if v, found := p.p["disksize"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("disksize", vv)
+	}
+	if v, found := p.p["displayoffering"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayoffering", vv)
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hypervisorsnapshotreserve"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("hypervisorsnapshotreserve", vv)
+	}
+	if v, found := p.p["iopsreadrate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("iopsreadrate", vv)
+	}
+	if v, found := p.p["iopswriterate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("iopswriterate", vv)
+	}
+	if v, found := p.p["maxiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("maxiops", vv)
+	}
+	if v, found := p.p["miniops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("miniops", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["provisioningtype"]; found {
+		u.Set("provisioningtype", v.(string))
+	}
+	if v, found := p.p["storagetype"]; found {
+		u.Set("storagetype", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		u.Set("tags", v.(string))
+	}
+	return u
+}
+
+func (p *CreateDiskOfferingParams) SetBytesreadrate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bytesreadrate"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetByteswriterate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["byteswriterate"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetCustomized(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customized"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetCustomizediops(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customizediops"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetDisksize(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["disksize"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetDisplayoffering(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayoffering"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetHypervisorsnapshotreserve(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisorsnapshotreserve"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetIopsreadrate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iopsreadrate"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetIopswriterate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iopswriterate"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetMaxiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxiops"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetMiniops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["miniops"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetProvisioningtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provisioningtype"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetStoragetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storagetype"] = v
+	return
+}
+
+func (p *CreateDiskOfferingParams) SetTags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new CreateDiskOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *DiskOfferingService) NewCreateDiskOfferingParams(displaytext string, name string) *CreateDiskOfferingParams {
+	p := &CreateDiskOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	return p
+}
+
+// Creates a disk offering.
+func (s *DiskOfferingService) CreateDiskOffering(p *CreateDiskOfferingParams) (*CreateDiskOfferingResponse, error) {
+	resp, err := s.cs.newRequest("createDiskOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateDiskOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateDiskOfferingResponse struct {
+	CacheMode                 string `json:"cacheMode,omitempty"`
+	Created                   string `json:"created,omitempty"`
+	DiskBytesReadRate         int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64  `json:"diskIopsWriteRate,omitempty"`
+	Disksize                  int64  `json:"disksize,omitempty"`
+	Displayoffering           bool   `json:"displayoffering,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Hypervisorsnapshotreserve int    `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Iscustomized              bool   `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool   `json:"iscustomizediops,omitempty"`
+	Maxiops                   int64  `json:"maxiops,omitempty"`
+	Miniops                   int64  `json:"miniops,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Provisioningtype          string `json:"provisioningtype,omitempty"`
+	Storagetype               string `json:"storagetype,omitempty"`
+	Tags                      string `json:"tags,omitempty"`
+}
+
+type UpdateDiskOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateDiskOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["displayoffering"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayoffering", vv)
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	return u
+}
+
+func (p *UpdateDiskOfferingParams) SetDisplayoffering(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayoffering"] = v
+	return
+}
+
+func (p *UpdateDiskOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateDiskOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateDiskOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateDiskOfferingParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateDiskOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *DiskOfferingService) NewUpdateDiskOfferingParams(id string) *UpdateDiskOfferingParams {
+	p := &UpdateDiskOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a disk offering.
+func (s *DiskOfferingService) UpdateDiskOffering(p *UpdateDiskOfferingParams) (*UpdateDiskOfferingResponse, error) {
+	resp, err := s.cs.newRequest("updateDiskOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateDiskOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateDiskOfferingResponse struct {
+	CacheMode                 string `json:"cacheMode,omitempty"`
+	Created                   string `json:"created,omitempty"`
+	DiskBytesReadRate         int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64  `json:"diskIopsWriteRate,omitempty"`
+	Disksize                  int64  `json:"disksize,omitempty"`
+	Displayoffering           bool   `json:"displayoffering,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Hypervisorsnapshotreserve int    `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Iscustomized              bool   `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool   `json:"iscustomizediops,omitempty"`
+	Maxiops                   int64  `json:"maxiops,omitempty"`
+	Miniops                   int64  `json:"miniops,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Provisioningtype          string `json:"provisioningtype,omitempty"`
+	Storagetype               string `json:"storagetype,omitempty"`
+	Tags                      string `json:"tags,omitempty"`
+}
+
+type DeleteDiskOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteDiskOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteDiskOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteDiskOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *DiskOfferingService) NewDeleteDiskOfferingParams(id string) *DeleteDiskOfferingParams {
+	p := &DeleteDiskOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a disk offering.
+func (s *DiskOfferingService) DeleteDiskOffering(p *DeleteDiskOfferingParams) (*DeleteDiskOfferingResponse, error) {
+	resp, err := s.cs.newRequest("deleteDiskOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteDiskOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteDiskOfferingResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListDiskOfferingsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDiskOfferingsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDiskOfferingsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDiskOfferingsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDiskOfferingsParams instance,
+// as then you are sure you have configured all required params
+func (s *DiskOfferingService) NewListDiskOfferingsParams() *ListDiskOfferingsParams {
+	p := &ListDiskOfferingsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DiskOfferingService) GetDiskOfferingID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListDiskOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListDiskOfferings(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.DiskOfferings[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.DiskOfferings {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DiskOfferingService) GetDiskOfferingByName(name string, opts ...OptionFunc) (*DiskOffering, int, error) {
+	id, count, err := s.GetDiskOfferingID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetDiskOfferingByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DiskOfferingService) GetDiskOfferingByID(id string, opts ...OptionFunc) (*DiskOffering, int, error) {
+	p := &ListDiskOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListDiskOfferings(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.DiskOfferings[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for DiskOffering UUID: %s!", id)
+}
+
+// Lists all available disk offerings.
+func (s *DiskOfferingService) ListDiskOfferings(p *ListDiskOfferingsParams) (*ListDiskOfferingsResponse, error) {
+	resp, err := s.cs.newRequest("listDiskOfferings", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDiskOfferingsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDiskOfferingsResponse struct {
+	Count         int             `json:"count"`
+	DiskOfferings []*DiskOffering `json:"diskoffering"`
+}
+
+type DiskOffering struct {
+	CacheMode                 string `json:"cacheMode,omitempty"`
+	Created                   string `json:"created,omitempty"`
+	DiskBytesReadRate         int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64  `json:"diskIopsWriteRate,omitempty"`
+	Disksize                  int64  `json:"disksize,omitempty"`
+	Displayoffering           bool   `json:"displayoffering,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Hypervisorsnapshotreserve int    `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Iscustomized              bool   `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool   `json:"iscustomizediops,omitempty"`
+	Maxiops                   int64  `json:"maxiops,omitempty"`
+	Miniops                   int64  `json:"miniops,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Provisioningtype          string `json:"provisioningtype,omitempty"`
+	Storagetype               string `json:"storagetype,omitempty"`
+	Tags                      string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/DomainService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/DomainService.go
@@ -1,0 +1,951 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateDomainParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateDomainParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["parentdomainid"]; found {
+		u.Set("parentdomainid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateDomainParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateDomainParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateDomainParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *CreateDomainParams) SetParentdomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["parentdomainid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateDomainParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewCreateDomainParams(name string) *CreateDomainParams {
+	p := &CreateDomainParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Creates a domain
+func (s *DomainService) CreateDomain(p *CreateDomainParams) (*CreateDomainResponse, error) {
+	resp, err := s.cs.newRequest("createDomain", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateDomainResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateDomainResponse struct {
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Haschild                  bool   `json:"haschild,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Level                     int    `json:"level,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networkdomain             string `json:"networkdomain,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Parentdomainid            string `json:"parentdomainid,omitempty"`
+	Parentdomainname          string `json:"parentdomainname,omitempty"`
+	Path                      string `json:"path,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string `json:"projectavailable,omitempty"`
+	Projectlimit              string `json:"projectlimit,omitempty"`
+	Projecttotal              int64  `json:"projecttotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Templateavailable         string `json:"templateavailable,omitempty"`
+	Templatelimit             string `json:"templatelimit,omitempty"`
+	Templatetotal             int64  `json:"templatetotal,omitempty"`
+	Vmavailable               string `json:"vmavailable,omitempty"`
+	Vmlimit                   string `json:"vmlimit,omitempty"`
+	Vmtotal                   int64  `json:"vmtotal,omitempty"`
+	Volumeavailable           string `json:"volumeavailable,omitempty"`
+	Volumelimit               string `json:"volumelimit,omitempty"`
+	Volumetotal               int64  `json:"volumetotal,omitempty"`
+	Vpcavailable              string `json:"vpcavailable,omitempty"`
+	Vpclimit                  string `json:"vpclimit,omitempty"`
+	Vpctotal                  int64  `json:"vpctotal,omitempty"`
+}
+
+type UpdateDomainParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateDomainParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateDomainParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateDomainParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateDomainParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateDomainParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewUpdateDomainParams(id string) *UpdateDomainParams {
+	p := &UpdateDomainParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a domain with a new name
+func (s *DomainService) UpdateDomain(p *UpdateDomainParams) (*UpdateDomainResponse, error) {
+	resp, err := s.cs.newRequest("updateDomain", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateDomainResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateDomainResponse struct {
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Haschild                  bool   `json:"haschild,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Level                     int    `json:"level,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networkdomain             string `json:"networkdomain,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Parentdomainid            string `json:"parentdomainid,omitempty"`
+	Parentdomainname          string `json:"parentdomainname,omitempty"`
+	Path                      string `json:"path,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string `json:"projectavailable,omitempty"`
+	Projectlimit              string `json:"projectlimit,omitempty"`
+	Projecttotal              int64  `json:"projecttotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Templateavailable         string `json:"templateavailable,omitempty"`
+	Templatelimit             string `json:"templatelimit,omitempty"`
+	Templatetotal             int64  `json:"templatetotal,omitempty"`
+	Vmavailable               string `json:"vmavailable,omitempty"`
+	Vmlimit                   string `json:"vmlimit,omitempty"`
+	Vmtotal                   int64  `json:"vmtotal,omitempty"`
+	Volumeavailable           string `json:"volumeavailable,omitempty"`
+	Volumelimit               string `json:"volumelimit,omitempty"`
+	Volumetotal               int64  `json:"volumetotal,omitempty"`
+	Vpcavailable              string `json:"vpcavailable,omitempty"`
+	Vpclimit                  string `json:"vpclimit,omitempty"`
+	Vpctotal                  int64  `json:"vpctotal,omitempty"`
+}
+
+type DeleteDomainParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteDomainParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cleanup"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("cleanup", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteDomainParams) SetCleanup(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cleanup"] = v
+	return
+}
+
+func (p *DeleteDomainParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteDomainParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewDeleteDomainParams(id string) *DeleteDomainParams {
+	p := &DeleteDomainParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a specified domain
+func (s *DomainService) DeleteDomain(p *DeleteDomainParams) (*DeleteDomainResponse, error) {
+	resp, err := s.cs.newRequest("deleteDomain", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteDomainResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteDomainResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDomainsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDomainsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["level"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("level", vv)
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDomainsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetLevel(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["level"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDomainsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDomainsParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewListDomainsParams() *ListDomainsParams {
+	p := &ListDomainsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListDomainsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListDomains(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Domains[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Domains {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainByName(name string, opts ...OptionFunc) (*Domain, int, error) {
+	id, count, err := s.GetDomainID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetDomainByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainByID(id string, opts ...OptionFunc) (*Domain, int, error) {
+	p := &ListDomainsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListDomains(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Domains[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Domain UUID: %s!", id)
+}
+
+// Lists domains and provides detailed information for listed domains
+func (s *DomainService) ListDomains(p *ListDomainsParams) (*ListDomainsResponse, error) {
+	resp, err := s.cs.newRequest("listDomains", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDomainsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDomainsResponse struct {
+	Count   int       `json:"count"`
+	Domains []*Domain `json:"domain"`
+}
+
+type Domain struct {
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Haschild                  bool   `json:"haschild,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Level                     int    `json:"level,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networkdomain             string `json:"networkdomain,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Parentdomainid            string `json:"parentdomainid,omitempty"`
+	Parentdomainname          string `json:"parentdomainname,omitempty"`
+	Path                      string `json:"path,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string `json:"projectavailable,omitempty"`
+	Projectlimit              string `json:"projectlimit,omitempty"`
+	Projecttotal              int64  `json:"projecttotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Templateavailable         string `json:"templateavailable,omitempty"`
+	Templatelimit             string `json:"templatelimit,omitempty"`
+	Templatetotal             int64  `json:"templatetotal,omitempty"`
+	Vmavailable               string `json:"vmavailable,omitempty"`
+	Vmlimit                   string `json:"vmlimit,omitempty"`
+	Vmtotal                   int64  `json:"vmtotal,omitempty"`
+	Volumeavailable           string `json:"volumeavailable,omitempty"`
+	Volumelimit               string `json:"volumelimit,omitempty"`
+	Volumetotal               int64  `json:"volumetotal,omitempty"`
+	Vpcavailable              string `json:"vpcavailable,omitempty"`
+	Vpclimit                  string `json:"vpclimit,omitempty"`
+	Vpctotal                  int64  `json:"vpctotal,omitempty"`
+}
+
+type ListDomainChildrenParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDomainChildrenParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDomainChildrenParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDomainChildrenParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDomainChildrenParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewListDomainChildrenParams() *ListDomainChildrenParams {
+	p := &ListDomainChildrenParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainChildrenID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListDomainChildrenParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListDomainChildren(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.DomainChildren[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.DomainChildren {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainChildrenByName(name string, opts ...OptionFunc) (*DomainChildren, int, error) {
+	id, count, err := s.GetDomainChildrenID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetDomainChildrenByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *DomainService) GetDomainChildrenByID(id string, opts ...OptionFunc) (*DomainChildren, int, error) {
+	p := &ListDomainChildrenParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListDomainChildren(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.DomainChildren[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for DomainChildren UUID: %s!", id)
+}
+
+// Lists all children domains belonging to a specified domain
+func (s *DomainService) ListDomainChildren(p *ListDomainChildrenParams) (*ListDomainChildrenResponse, error) {
+	resp, err := s.cs.newRequest("listDomainChildren", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDomainChildrenResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDomainChildrenResponse struct {
+	Count          int               `json:"count"`
+	DomainChildren []*DomainChildren `json:"domainchildren"`
+}
+
+type DomainChildren struct {
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Haschild                  bool   `json:"haschild,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Level                     int    `json:"level,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networkdomain             string `json:"networkdomain,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Parentdomainid            string `json:"parentdomainid,omitempty"`
+	Parentdomainname          string `json:"parentdomainname,omitempty"`
+	Path                      string `json:"path,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string `json:"projectavailable,omitempty"`
+	Projectlimit              string `json:"projectlimit,omitempty"`
+	Projecttotal              int64  `json:"projecttotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Templateavailable         string `json:"templateavailable,omitempty"`
+	Templatelimit             string `json:"templatelimit,omitempty"`
+	Templatetotal             int64  `json:"templatetotal,omitempty"`
+	Vmavailable               string `json:"vmavailable,omitempty"`
+	Vmlimit                   string `json:"vmlimit,omitempty"`
+	Vmtotal                   int64  `json:"vmtotal,omitempty"`
+	Volumeavailable           string `json:"volumeavailable,omitempty"`
+	Volumelimit               string `json:"volumelimit,omitempty"`
+	Volumetotal               int64  `json:"volumetotal,omitempty"`
+	Vpcavailable              string `json:"vpcavailable,omitempty"`
+	Vpclimit                  string `json:"vpclimit,omitempty"`
+	Vpctotal                  int64  `json:"vpctotal,omitempty"`
+}
+
+type LinkDomainToLdapParams struct {
+	p map[string]interface{}
+}
+
+func (p *LinkDomainToLdapParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["admin"]; found {
+		u.Set("admin", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *LinkDomainToLdapParams) SetAccounttype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *LinkDomainToLdapParams) SetAdmin(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["admin"] = v
+	return
+}
+
+func (p *LinkDomainToLdapParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *LinkDomainToLdapParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *LinkDomainToLdapParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainType"] = v
+	return
+}
+
+// You should always use this function to get a new LinkDomainToLdapParams instance,
+// as then you are sure you have configured all required params
+func (s *DomainService) NewLinkDomainToLdapParams(accounttype int, domainid string, name string, domainType string) *LinkDomainToLdapParams {
+	p := &LinkDomainToLdapParams{}
+	p.p = make(map[string]interface{})
+	p.p["accounttype"] = accounttype
+	p.p["domainid"] = domainid
+	p.p["name"] = name
+	p.p["domainType"] = domainType
+	return p
+}
+
+// link an existing cloudstack domain to group or OU in ldap
+func (s *DomainService) LinkDomainToLdap(p *LinkDomainToLdapParams) (*LinkDomainToLdapResponse, error) {
+	resp, err := s.cs.newRequest("linkDomainToLdap", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LinkDomainToLdapResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LinkDomainToLdapResponse struct {
+	Accountid   string `json:"accountid,omitempty"`
+	Accounttype int    `json:"accounttype,omitempty"`
+	Domainid    int64  `json:"domainid,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/EventService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/EventService.go
@@ -1,0 +1,495 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListEventsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListEventsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["duration"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("duration", vv)
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["entrytime"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("entrytime", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["level"]; found {
+		u.Set("level", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *ListEventsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListEventsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListEventsParams) SetDuration(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["duration"] = v
+	return
+}
+
+func (p *ListEventsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *ListEventsParams) SetEntrytime(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["entrytime"] = v
+	return
+}
+
+func (p *ListEventsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListEventsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListEventsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListEventsParams) SetLevel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["level"] = v
+	return
+}
+
+func (p *ListEventsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListEventsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListEventsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListEventsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListEventsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *ListEventsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["eventType"] = v
+	return
+}
+
+// You should always use this function to get a new ListEventsParams instance,
+// as then you are sure you have configured all required params
+func (s *EventService) NewListEventsParams() *ListEventsParams {
+	p := &ListEventsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *EventService) GetEventByID(id string, opts ...OptionFunc) (*Event, int, error) {
+	p := &ListEventsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListEvents(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Events[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Event UUID: %s!", id)
+}
+
+// A command to list events.
+func (s *EventService) ListEvents(p *ListEventsParams) (*ListEventsResponse, error) {
+	resp, err := s.cs.newRequest("listEvents", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListEventsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListEventsResponse struct {
+	Count  int      `json:"count"`
+	Events []*Event `json:"event"`
+}
+
+type Event struct {
+	Account     string `json:"account,omitempty"`
+	Created     string `json:"created,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Level       string `json:"level,omitempty"`
+	Parentid    string `json:"parentid,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	State       string `json:"state,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Username    string `json:"username,omitempty"`
+}
+
+type ListEventTypesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListEventTypesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new ListEventTypesParams instance,
+// as then you are sure you have configured all required params
+func (s *EventService) NewListEventTypesParams() *ListEventTypesParams {
+	p := &ListEventTypesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List Event Types
+func (s *EventService) ListEventTypes(p *ListEventTypesParams) (*ListEventTypesResponse, error) {
+	resp, err := s.cs.newRequest("listEventTypes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListEventTypesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListEventTypesResponse struct {
+	Count      int          `json:"count"`
+	EventTypes []*EventType `json:"eventtype"`
+}
+
+type EventType struct {
+	Name string `json:"name,omitempty"`
+}
+
+type ArchiveEventsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ArchiveEventsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *ArchiveEventsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *ArchiveEventsParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+func (p *ArchiveEventsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *ArchiveEventsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["eventType"] = v
+	return
+}
+
+// You should always use this function to get a new ArchiveEventsParams instance,
+// as then you are sure you have configured all required params
+func (s *EventService) NewArchiveEventsParams() *ArchiveEventsParams {
+	p := &ArchiveEventsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Archive one or more events.
+func (s *EventService) ArchiveEvents(p *ArchiveEventsParams) (*ArchiveEventsResponse, error) {
+	resp, err := s.cs.newRequest("archiveEvents", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ArchiveEventsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ArchiveEventsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type DeleteEventsParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteEventsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteEventsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *DeleteEventsParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+func (p *DeleteEventsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *DeleteEventsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["eventType"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteEventsParams instance,
+// as then you are sure you have configured all required params
+func (s *EventService) NewDeleteEventsParams() *DeleteEventsParams {
+	p := &DeleteEventsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Delete one or more events.
+func (s *EventService) DeleteEvents(p *DeleteEventsParams) (*DeleteEventsResponse, error) {
+	resp, err := s.cs.newRequest("deleteEvents", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteEventsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteEventsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/FirewallService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/FirewallService.go
@@ -1,0 +1,2587 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Helper function for maintaining backwards compatibility
+func convertFirewallServiceResponse(b []byte) ([]byte, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, err
+	}
+
+	if _, ok := raw["firewallrule"]; ok {
+		return convertFirewallServiceListResponse(b)
+	}
+
+	for _, k := range []string{"endport", "startport"} {
+		if sVal, ok := raw[k].(string); ok {
+			iVal, err := strconv.Atoi(sVal)
+			if err != nil {
+				return nil, err
+			}
+			raw[k] = iVal
+		}
+	}
+
+	return json.Marshal(raw)
+}
+
+// Helper function for maintaining backwards compatibility
+func convertFirewallServiceListResponse(b []byte) ([]byte, error) {
+	var rawList struct {
+		Count         int                      `json:"count"`
+		FirewallRules []map[string]interface{} `json:"firewallrule"`
+	}
+
+	if err := json.Unmarshal(b, &rawList); err != nil {
+		return nil, err
+	}
+
+	for _, r := range rawList.FirewallRules {
+		for _, k := range []string{"endport", "startport"} {
+			if sVal, ok := r[k].(string); ok {
+				iVal, err := strconv.Atoi(sVal)
+				if err != nil {
+					return nil, err
+				}
+				r[k] = iVal
+			}
+		}
+	}
+
+	return json.Marshal(rawList)
+}
+
+type ListPortForwardingRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPortForwardingRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListPortForwardingRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListPortForwardingRulesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListPortForwardingRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewListPortForwardingRulesParams() *ListPortForwardingRulesParams {
+	p := &ListPortForwardingRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *FirewallService) GetPortForwardingRuleByID(id string, opts ...OptionFunc) (*PortForwardingRule, int, error) {
+	p := &ListPortForwardingRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPortForwardingRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.PortForwardingRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for PortForwardingRule UUID: %s!", id)
+}
+
+// Lists all port forwarding rules for an IP address.
+func (s *FirewallService) ListPortForwardingRules(p *ListPortForwardingRulesParams) (*ListPortForwardingRulesResponse, error) {
+	resp, err := s.cs.newRequest("listPortForwardingRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPortForwardingRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPortForwardingRulesResponse struct {
+	Count               int                   `json:"count"`
+	PortForwardingRules []*PortForwardingRule `json:"portforwardingrule"`
+}
+
+type PortForwardingRule struct {
+	Cidrlist       string `json:"cidrlist,omitempty"`
+	Fordisplay     bool   `json:"fordisplay,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Ipaddress      string `json:"ipaddress,omitempty"`
+	Ipaddressid    string `json:"ipaddressid,omitempty"`
+	Networkid      string `json:"networkid,omitempty"`
+	Privateendport string `json:"privateendport,omitempty"`
+	Privateport    string `json:"privateport,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	Publicendport  string `json:"publicendport,omitempty"`
+	Publicport     string `json:"publicport,omitempty"`
+	State          string `json:"state,omitempty"`
+	Tags           []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vmguestip                 string `json:"vmguestip,omitempty"`
+}
+
+type CreatePortForwardingRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreatePortForwardingRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["openfirewall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("openfirewall", vv)
+	}
+	if v, found := p.p["privateendport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("privateendport", vv)
+	}
+	if v, found := p.p["privateport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("privateport", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["publicendport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("publicendport", vv)
+	}
+	if v, found := p.p["publicport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("publicport", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["vmguestip"]; found {
+		u.Set("vmguestip", v.(string))
+	}
+	return u
+}
+
+func (p *CreatePortForwardingRuleParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetOpenfirewall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["openfirewall"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetPrivateendport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privateendport"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetPrivateport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privateport"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetPublicendport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicendport"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetPublicport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicport"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *CreatePortForwardingRuleParams) SetVmguestip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmguestip"] = v
+	return
+}
+
+// You should always use this function to get a new CreatePortForwardingRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewCreatePortForwardingRuleParams(ipaddressid string, privateport int, protocol string, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams {
+	p := &CreatePortForwardingRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["ipaddressid"] = ipaddressid
+	p.p["privateport"] = privateport
+	p.p["protocol"] = protocol
+	p.p["publicport"] = publicport
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Creates a port forwarding rule
+func (s *FirewallService) CreatePortForwardingRule(p *CreatePortForwardingRuleParams) (*CreatePortForwardingRuleResponse, error) {
+	resp, err := s.cs.newRequest("createPortForwardingRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreatePortForwardingRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreatePortForwardingRuleResponse struct {
+	JobID          string `json:"jobid,omitempty"`
+	Cidrlist       string `json:"cidrlist,omitempty"`
+	Fordisplay     bool   `json:"fordisplay,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Ipaddress      string `json:"ipaddress,omitempty"`
+	Ipaddressid    string `json:"ipaddressid,omitempty"`
+	Networkid      string `json:"networkid,omitempty"`
+	Privateendport string `json:"privateendport,omitempty"`
+	Privateport    string `json:"privateport,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	Publicendport  string `json:"publicendport,omitempty"`
+	Publicport     string `json:"publicport,omitempty"`
+	State          string `json:"state,omitempty"`
+	Tags           []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vmguestip                 string `json:"vmguestip,omitempty"`
+}
+
+type DeletePortForwardingRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePortForwardingRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePortForwardingRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePortForwardingRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewDeletePortForwardingRuleParams(id string) *DeletePortForwardingRuleParams {
+	p := &DeletePortForwardingRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a port forwarding rule
+func (s *FirewallService) DeletePortForwardingRule(p *DeletePortForwardingRuleParams) (*DeletePortForwardingRuleResponse, error) {
+	resp, err := s.cs.newRequest("deletePortForwardingRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePortForwardingRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeletePortForwardingRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdatePortForwardingRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdatePortForwardingRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["privateport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("privateport", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["vmguestip"]; found {
+		u.Set("vmguestip", v.(string))
+	}
+	return u
+}
+
+func (p *UpdatePortForwardingRuleParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdatePortForwardingRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdatePortForwardingRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdatePortForwardingRuleParams) SetPrivateport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privateport"] = v
+	return
+}
+
+func (p *UpdatePortForwardingRuleParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *UpdatePortForwardingRuleParams) SetVmguestip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmguestip"] = v
+	return
+}
+
+// You should always use this function to get a new UpdatePortForwardingRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewUpdatePortForwardingRuleParams(id string) *UpdatePortForwardingRuleParams {
+	p := &UpdatePortForwardingRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a port forwarding rule. Only the private port and the virtual machine can be updated.
+func (s *FirewallService) UpdatePortForwardingRule(p *UpdatePortForwardingRuleParams) (*UpdatePortForwardingRuleResponse, error) {
+	resp, err := s.cs.newRequest("updatePortForwardingRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdatePortForwardingRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdatePortForwardingRuleResponse struct {
+	JobID          string `json:"jobid,omitempty"`
+	Cidrlist       string `json:"cidrlist,omitempty"`
+	Fordisplay     bool   `json:"fordisplay,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Ipaddress      string `json:"ipaddress,omitempty"`
+	Ipaddressid    string `json:"ipaddressid,omitempty"`
+	Networkid      string `json:"networkid,omitempty"`
+	Privateendport string `json:"privateendport,omitempty"`
+	Privateport    string `json:"privateport,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	Publicendport  string `json:"publicendport,omitempty"`
+	Publicport     string `json:"publicport,omitempty"`
+	State          string `json:"state,omitempty"`
+	Tags           []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vmguestip                 string `json:"vmguestip,omitempty"`
+}
+
+type CreateFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *CreateFirewallRuleParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *CreateFirewallRuleParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["firewallType"] = v
+	return
+}
+
+// You should always use this function to get a new CreateFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewCreateFirewallRuleParams(ipaddressid string, protocol string) *CreateFirewallRuleParams {
+	p := &CreateFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["ipaddressid"] = ipaddressid
+	p.p["protocol"] = protocol
+	return p
+}
+
+// Creates a firewall rule for a given IP address
+func (s *FirewallService) CreateFirewallRule(p *CreateFirewallRuleParams) (*CreateFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("createFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type DeleteFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteFirewallRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewDeleteFirewallRuleParams(id string) *DeleteFirewallRuleParams {
+	p := &DeleteFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a firewall rule
+func (s *FirewallService) DeleteFirewallRule(p *DeleteFirewallRuleParams) (*DeleteFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("deleteFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListFirewallRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListFirewallRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListFirewallRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListFirewallRulesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListFirewallRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewListFirewallRulesParams() *ListFirewallRulesParams {
+	p := &ListFirewallRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *FirewallService) GetFirewallRuleByID(id string, opts ...OptionFunc) (*FirewallRule, int, error) {
+	p := &ListFirewallRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListFirewallRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.FirewallRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for FirewallRule UUID: %s!", id)
+}
+
+// Lists all firewall rules for an IP address.
+func (s *FirewallService) ListFirewallRules(p *ListFirewallRulesParams) (*ListFirewallRulesResponse, error) {
+	resp, err := s.cs.newRequest("listFirewallRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListFirewallRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListFirewallRulesResponse struct {
+	Count         int             `json:"count"`
+	FirewallRules []*FirewallRule `json:"firewallrule"`
+}
+
+type FirewallRule struct {
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type UpdateFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateFirewallRuleParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateFirewallRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateFirewallRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewUpdateFirewallRuleParams(id string) *UpdateFirewallRuleParams {
+	p := &UpdateFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates firewall rule
+func (s *FirewallService) UpdateFirewallRule(p *UpdateFirewallRuleParams) (*UpdateFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("updateFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type CreateEgressFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateEgressFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *CreateEgressFirewallRuleParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *CreateEgressFirewallRuleParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["firewallType"] = v
+	return
+}
+
+// You should always use this function to get a new CreateEgressFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewCreateEgressFirewallRuleParams(networkid string, protocol string) *CreateEgressFirewallRuleParams {
+	p := &CreateEgressFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["networkid"] = networkid
+	p.p["protocol"] = protocol
+	return p
+}
+
+// Creates a egress firewall rule for a given network
+func (s *FirewallService) CreateEgressFirewallRule(p *CreateEgressFirewallRuleParams) (*CreateEgressFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("createEgressFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateEgressFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateEgressFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type DeleteEgressFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteEgressFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteEgressFirewallRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteEgressFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewDeleteEgressFirewallRuleParams(id string) *DeleteEgressFirewallRuleParams {
+	p := &DeleteEgressFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an egress firewall rule
+func (s *FirewallService) DeleteEgressFirewallRule(p *DeleteEgressFirewallRuleParams) (*DeleteEgressFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("deleteEgressFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteEgressFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteEgressFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListEgressFirewallRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListEgressFirewallRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListEgressFirewallRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListEgressFirewallRulesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListEgressFirewallRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewListEgressFirewallRulesParams() *ListEgressFirewallRulesParams {
+	p := &ListEgressFirewallRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *FirewallService) GetEgressFirewallRuleByID(id string, opts ...OptionFunc) (*EgressFirewallRule, int, error) {
+	p := &ListEgressFirewallRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListEgressFirewallRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.EgressFirewallRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for EgressFirewallRule UUID: %s!", id)
+}
+
+// Lists all egress firewall rules for network ID.
+func (s *FirewallService) ListEgressFirewallRules(p *ListEgressFirewallRulesParams) (*ListEgressFirewallRulesResponse, error) {
+	resp, err := s.cs.newRequest("listEgressFirewallRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListEgressFirewallRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListEgressFirewallRulesResponse struct {
+	Count               int                   `json:"count"`
+	EgressFirewallRules []*EgressFirewallRule `json:"firewallrule"`
+}
+
+type EgressFirewallRule struct {
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type UpdateEgressFirewallRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateEgressFirewallRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateEgressFirewallRuleParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateEgressFirewallRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateEgressFirewallRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateEgressFirewallRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewUpdateEgressFirewallRuleParams(id string) *UpdateEgressFirewallRuleParams {
+	p := &UpdateEgressFirewallRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates egress firewall rule
+func (s *FirewallService) UpdateEgressFirewallRule(p *UpdateEgressFirewallRuleParams) (*UpdateEgressFirewallRuleResponse, error) {
+	resp, err := s.cs.newRequest("updateEgressFirewallRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateEgressFirewallRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateEgressFirewallRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Endport     int    `json:"endport,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Icmpcode    int    `json:"icmpcode,omitempty"`
+	Icmptype    int    `json:"icmptype,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipaddressid string `json:"ipaddressid,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Startport   int    `json:"startport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type AddPaloAltoFirewallParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddPaloAltoFirewallParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["networkdevicetype"]; found {
+		u.Set("networkdevicetype", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddPaloAltoFirewallParams) SetNetworkdevicetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdevicetype"] = v
+	return
+}
+
+func (p *AddPaloAltoFirewallParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddPaloAltoFirewallParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddPaloAltoFirewallParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddPaloAltoFirewallParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddPaloAltoFirewallParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewAddPaloAltoFirewallParams(networkdevicetype string, password string, physicalnetworkid string, url string, username string) *AddPaloAltoFirewallParams {
+	p := &AddPaloAltoFirewallParams{}
+	p.p = make(map[string]interface{})
+	p.p["networkdevicetype"] = networkdevicetype
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// Adds a Palo Alto firewall device
+func (s *FirewallService) AddPaloAltoFirewall(p *AddPaloAltoFirewallParams) (*AddPaloAltoFirewallResponse, error) {
+	resp, err := s.cs.newRequest("addPaloAltoFirewall", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddPaloAltoFirewallResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddPaloAltoFirewallResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Fwdevicecapacity  int64  `json:"fwdevicecapacity,omitempty"`
+	Fwdeviceid        string `json:"fwdeviceid,omitempty"`
+	Fwdevicename      string `json:"fwdevicename,omitempty"`
+	Fwdevicestate     string `json:"fwdevicestate,omitempty"`
+	Ipaddress         string `json:"ipaddress,omitempty"`
+	Numretries        string `json:"numretries,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Privateinterface  string `json:"privateinterface,omitempty"`
+	Privatezone       string `json:"privatezone,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Publicinterface   string `json:"publicinterface,omitempty"`
+	Publiczone        string `json:"publiczone,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	Usageinterface    string `json:"usageinterface,omitempty"`
+	Username          string `json:"username,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}
+
+type DeletePaloAltoFirewallParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePaloAltoFirewallParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fwdeviceid"]; found {
+		u.Set("fwdeviceid", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePaloAltoFirewallParams) SetFwdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fwdeviceid"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePaloAltoFirewallParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewDeletePaloAltoFirewallParams(fwdeviceid string) *DeletePaloAltoFirewallParams {
+	p := &DeletePaloAltoFirewallParams{}
+	p.p = make(map[string]interface{})
+	p.p["fwdeviceid"] = fwdeviceid
+	return p
+}
+
+//  delete a Palo Alto firewall device
+func (s *FirewallService) DeletePaloAltoFirewall(p *DeletePaloAltoFirewallParams) (*DeletePaloAltoFirewallResponse, error) {
+	resp, err := s.cs.newRequest("deletePaloAltoFirewall", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePaloAltoFirewallResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeletePaloAltoFirewallResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ConfigurePaloAltoFirewallParams struct {
+	p map[string]interface{}
+}
+
+func (p *ConfigurePaloAltoFirewallParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fwdevicecapacity"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("fwdevicecapacity", vv)
+	}
+	if v, found := p.p["fwdeviceid"]; found {
+		u.Set("fwdeviceid", v.(string))
+	}
+	return u
+}
+
+func (p *ConfigurePaloAltoFirewallParams) SetFwdevicecapacity(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fwdevicecapacity"] = v
+	return
+}
+
+func (p *ConfigurePaloAltoFirewallParams) SetFwdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fwdeviceid"] = v
+	return
+}
+
+// You should always use this function to get a new ConfigurePaloAltoFirewallParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewConfigurePaloAltoFirewallParams(fwdeviceid string) *ConfigurePaloAltoFirewallParams {
+	p := &ConfigurePaloAltoFirewallParams{}
+	p.p = make(map[string]interface{})
+	p.p["fwdeviceid"] = fwdeviceid
+	return p
+}
+
+// Configures a Palo Alto firewall device
+func (s *FirewallService) ConfigurePaloAltoFirewall(p *ConfigurePaloAltoFirewallParams) (*ConfigurePaloAltoFirewallResponse, error) {
+	resp, err := s.cs.newRequest("configurePaloAltoFirewall", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ConfigurePaloAltoFirewallResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = convertFirewallServiceResponse(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ConfigurePaloAltoFirewallResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Fwdevicecapacity  int64  `json:"fwdevicecapacity,omitempty"`
+	Fwdeviceid        string `json:"fwdeviceid,omitempty"`
+	Fwdevicename      string `json:"fwdevicename,omitempty"`
+	Fwdevicestate     string `json:"fwdevicestate,omitempty"`
+	Ipaddress         string `json:"ipaddress,omitempty"`
+	Numretries        string `json:"numretries,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Privateinterface  string `json:"privateinterface,omitempty"`
+	Privatezone       string `json:"privatezone,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Publicinterface   string `json:"publicinterface,omitempty"`
+	Publiczone        string `json:"publiczone,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	Usageinterface    string `json:"usageinterface,omitempty"`
+	Username          string `json:"username,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}
+
+type ListPaloAltoFirewallsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPaloAltoFirewallsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fwdeviceid"]; found {
+		u.Set("fwdeviceid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListPaloAltoFirewallsParams) SetFwdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fwdeviceid"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallsParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPaloAltoFirewallsParams instance,
+// as then you are sure you have configured all required params
+func (s *FirewallService) NewListPaloAltoFirewallsParams() *ListPaloAltoFirewallsParams {
+	p := &ListPaloAltoFirewallsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// lists Palo Alto firewall devices in a physical network
+func (s *FirewallService) ListPaloAltoFirewalls(p *ListPaloAltoFirewallsParams) (*ListPaloAltoFirewallsResponse, error) {
+	resp, err := s.cs.newRequest("listPaloAltoFirewalls", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = convertFirewallServiceResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPaloAltoFirewallsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPaloAltoFirewallsResponse struct {
+	Count             int                 `json:"count"`
+	PaloAltoFirewalls []*PaloAltoFirewall `json:"paloaltofirewall"`
+}
+
+type PaloAltoFirewall struct {
+	Fwdevicecapacity  int64  `json:"fwdevicecapacity,omitempty"`
+	Fwdeviceid        string `json:"fwdeviceid,omitempty"`
+	Fwdevicename      string `json:"fwdevicename,omitempty"`
+	Fwdevicestate     string `json:"fwdevicestate,omitempty"`
+	Ipaddress         string `json:"ipaddress,omitempty"`
+	Numretries        string `json:"numretries,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Privateinterface  string `json:"privateinterface,omitempty"`
+	Privatezone       string `json:"privatezone,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	Publicinterface   string `json:"publicinterface,omitempty"`
+	Publiczone        string `json:"publiczone,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	Usageinterface    string `json:"usageinterface,omitempty"`
+	Username          string `json:"username,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/GuestOSService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/GuestOSService.go
@@ -1,0 +1,1046 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListOsTypesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListOsTypesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["oscategoryid"]; found {
+		u.Set("oscategoryid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListOsTypesParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *ListOsTypesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListOsTypesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListOsTypesParams) SetOscategoryid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["oscategoryid"] = v
+	return
+}
+
+func (p *ListOsTypesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListOsTypesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListOsTypesParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewListOsTypesParams() *ListOsTypesParams {
+	p := &ListOsTypesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *GuestOSService) GetOsTypeByID(id string, opts ...OptionFunc) (*OsType, int, error) {
+	p := &ListOsTypesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListOsTypes(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.OsTypes[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for OsType UUID: %s!", id)
+}
+
+// Lists all supported OS types for this cloud.
+func (s *GuestOSService) ListOsTypes(p *ListOsTypesParams) (*ListOsTypesResponse, error) {
+	resp, err := s.cs.newRequest("listOsTypes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListOsTypesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListOsTypesResponse struct {
+	Count   int       `json:"count"`
+	OsTypes []*OsType `json:"ostype"`
+}
+
+type OsType struct {
+	Description   string `json:"description,omitempty"`
+	Id            string `json:"id,omitempty"`
+	Isuserdefined string `json:"isuserdefined,omitempty"`
+	Oscategoryid  string `json:"oscategoryid,omitempty"`
+}
+
+type ListOsCategoriesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListOsCategoriesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListOsCategoriesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListOsCategoriesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListOsCategoriesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListOsCategoriesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListOsCategoriesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListOsCategoriesParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewListOsCategoriesParams() *ListOsCategoriesParams {
+	p := &ListOsCategoriesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *GuestOSService) GetOsCategoryID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListOsCategoriesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListOsCategories(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.OsCategories[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.OsCategories {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *GuestOSService) GetOsCategoryByName(name string, opts ...OptionFunc) (*OsCategory, int, error) {
+	id, count, err := s.GetOsCategoryID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetOsCategoryByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *GuestOSService) GetOsCategoryByID(id string, opts ...OptionFunc) (*OsCategory, int, error) {
+	p := &ListOsCategoriesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListOsCategories(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.OsCategories[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for OsCategory UUID: %s!", id)
+}
+
+// Lists all supported OS categories for this cloud.
+func (s *GuestOSService) ListOsCategories(p *ListOsCategoriesParams) (*ListOsCategoriesResponse, error) {
+	resp, err := s.cs.newRequest("listOsCategories", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListOsCategoriesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListOsCategoriesResponse struct {
+	Count        int           `json:"count"`
+	OsCategories []*OsCategory `json:"oscategory"`
+}
+
+type OsCategory struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type AddGuestOsParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddGuestOsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["oscategoryid"]; found {
+		u.Set("oscategoryid", v.(string))
+	}
+	if v, found := p.p["osdisplayname"]; found {
+		u.Set("osdisplayname", v.(string))
+	}
+	return u
+}
+
+func (p *AddGuestOsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *AddGuestOsParams) SetOscategoryid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["oscategoryid"] = v
+	return
+}
+
+func (p *AddGuestOsParams) SetOsdisplayname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["osdisplayname"] = v
+	return
+}
+
+// You should always use this function to get a new AddGuestOsParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewAddGuestOsParams(oscategoryid string, osdisplayname string) *AddGuestOsParams {
+	p := &AddGuestOsParams{}
+	p.p = make(map[string]interface{})
+	p.p["oscategoryid"] = oscategoryid
+	p.p["osdisplayname"] = osdisplayname
+	return p
+}
+
+// Add a new guest OS type
+func (s *GuestOSService) AddGuestOs(p *AddGuestOsParams) (*AddGuestOsResponse, error) {
+	resp, err := s.cs.newRequest("addGuestOs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddGuestOsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddGuestOsResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Id            string `json:"id,omitempty"`
+	Isuserdefined string `json:"isuserdefined,omitempty"`
+	Oscategoryid  string `json:"oscategoryid,omitempty"`
+}
+
+type UpdateGuestOsParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateGuestOsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["osdisplayname"]; found {
+		u.Set("osdisplayname", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateGuestOsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateGuestOsParams) SetOsdisplayname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["osdisplayname"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateGuestOsParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewUpdateGuestOsParams(id string, osdisplayname string) *UpdateGuestOsParams {
+	p := &UpdateGuestOsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["osdisplayname"] = osdisplayname
+	return p
+}
+
+// Updates the information about Guest OS
+func (s *GuestOSService) UpdateGuestOs(p *UpdateGuestOsParams) (*UpdateGuestOsResponse, error) {
+	resp, err := s.cs.newRequest("updateGuestOs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateGuestOsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateGuestOsResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Id            string `json:"id,omitempty"`
+	Isuserdefined string `json:"isuserdefined,omitempty"`
+	Oscategoryid  string `json:"oscategoryid,omitempty"`
+}
+
+type RemoveGuestOsParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveGuestOsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveGuestOsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveGuestOsParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewRemoveGuestOsParams(id string) *RemoveGuestOsParams {
+	p := &RemoveGuestOsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes a Guest OS from listing.
+func (s *GuestOSService) RemoveGuestOs(p *RemoveGuestOsParams) (*RemoveGuestOsResponse, error) {
+	resp, err := s.cs.newRequest("removeGuestOs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveGuestOsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveGuestOsResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListGuestOsMappingParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListGuestOsMappingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["hypervisorversion"]; found {
+		u.Set("hypervisorversion", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListGuestOsMappingParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetHypervisorversion(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisorversion"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListGuestOsMappingParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListGuestOsMappingParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewListGuestOsMappingParams() *ListGuestOsMappingParams {
+	p := &ListGuestOsMappingParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *GuestOSService) GetGuestOsMappingByID(id string, opts ...OptionFunc) (*GuestOsMapping, int, error) {
+	p := &ListGuestOsMappingParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListGuestOsMapping(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.GuestOsMapping[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for GuestOsMapping UUID: %s!", id)
+}
+
+// Lists all available OS mappings for given hypervisor
+func (s *GuestOSService) ListGuestOsMapping(p *ListGuestOsMappingParams) (*ListGuestOsMappingResponse, error) {
+	resp, err := s.cs.newRequest("listGuestOsMapping", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListGuestOsMappingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListGuestOsMappingResponse struct {
+	Count          int               `json:"count"`
+	GuestOsMapping []*GuestOsMapping `json:"guestosmapping"`
+}
+
+type GuestOsMapping struct {
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Hypervisorversion   string `json:"hypervisorversion,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Isuserdefined       string `json:"isuserdefined,omitempty"`
+	Osdisplayname       string `json:"osdisplayname,omitempty"`
+	Osnameforhypervisor string `json:"osnameforhypervisor,omitempty"`
+	Ostypeid            string `json:"ostypeid,omitempty"`
+}
+
+type AddGuestOsMappingParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddGuestOsMappingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["hypervisorversion"]; found {
+		u.Set("hypervisorversion", v.(string))
+	}
+	if v, found := p.p["osdisplayname"]; found {
+		u.Set("osdisplayname", v.(string))
+	}
+	if v, found := p.p["osnameforhypervisor"]; found {
+		u.Set("osnameforhypervisor", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	return u
+}
+
+func (p *AddGuestOsMappingParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *AddGuestOsMappingParams) SetHypervisorversion(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisorversion"] = v
+	return
+}
+
+func (p *AddGuestOsMappingParams) SetOsdisplayname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["osdisplayname"] = v
+	return
+}
+
+func (p *AddGuestOsMappingParams) SetOsnameforhypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["osnameforhypervisor"] = v
+	return
+}
+
+func (p *AddGuestOsMappingParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+// You should always use this function to get a new AddGuestOsMappingParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewAddGuestOsMappingParams(hypervisor string, hypervisorversion string, osnameforhypervisor string) *AddGuestOsMappingParams {
+	p := &AddGuestOsMappingParams{}
+	p.p = make(map[string]interface{})
+	p.p["hypervisor"] = hypervisor
+	p.p["hypervisorversion"] = hypervisorversion
+	p.p["osnameforhypervisor"] = osnameforhypervisor
+	return p
+}
+
+// Adds a guest OS name to hypervisor OS name mapping
+func (s *GuestOSService) AddGuestOsMapping(p *AddGuestOsMappingParams) (*AddGuestOsMappingResponse, error) {
+	resp, err := s.cs.newRequest("addGuestOsMapping", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddGuestOsMappingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddGuestOsMappingResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Hypervisorversion   string `json:"hypervisorversion,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Isuserdefined       string `json:"isuserdefined,omitempty"`
+	Osdisplayname       string `json:"osdisplayname,omitempty"`
+	Osnameforhypervisor string `json:"osnameforhypervisor,omitempty"`
+	Ostypeid            string `json:"ostypeid,omitempty"`
+}
+
+type UpdateGuestOsMappingParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateGuestOsMappingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["osnameforhypervisor"]; found {
+		u.Set("osnameforhypervisor", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateGuestOsMappingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateGuestOsMappingParams) SetOsnameforhypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["osnameforhypervisor"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateGuestOsMappingParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewUpdateGuestOsMappingParams(id string, osnameforhypervisor string) *UpdateGuestOsMappingParams {
+	p := &UpdateGuestOsMappingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["osnameforhypervisor"] = osnameforhypervisor
+	return p
+}
+
+// Updates the information about Guest OS to Hypervisor specific name mapping
+func (s *GuestOSService) UpdateGuestOsMapping(p *UpdateGuestOsMappingParams) (*UpdateGuestOsMappingResponse, error) {
+	resp, err := s.cs.newRequest("updateGuestOsMapping", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateGuestOsMappingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateGuestOsMappingResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Hypervisorversion   string `json:"hypervisorversion,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Isuserdefined       string `json:"isuserdefined,omitempty"`
+	Osdisplayname       string `json:"osdisplayname,omitempty"`
+	Osnameforhypervisor string `json:"osnameforhypervisor,omitempty"`
+	Ostypeid            string `json:"ostypeid,omitempty"`
+}
+
+type RemoveGuestOsMappingParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveGuestOsMappingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveGuestOsMappingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveGuestOsMappingParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewRemoveGuestOsMappingParams(id string) *RemoveGuestOsMappingParams {
+	p := &RemoveGuestOsMappingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes a Guest OS Mapping.
+func (s *GuestOSService) RemoveGuestOsMapping(p *RemoveGuestOsMappingParams) (*RemoveGuestOsMappingResponse, error) {
+	resp, err := s.cs.newRequest("removeGuestOsMapping", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveGuestOsMappingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveGuestOsMappingResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/HostService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/HostService.go
@@ -1,0 +1,2296 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AddHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["clustername"]; found {
+		u.Set("clustername", v.(string))
+	}
+	if v, found := p.p["hosttags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("hosttags", vv)
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddHostParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *AddHostParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *AddHostParams) SetClustername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustername"] = v
+	return
+}
+
+func (p *AddHostParams) SetHosttags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hosttags"] = v
+	return
+}
+
+func (p *AddHostParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *AddHostParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddHostParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *AddHostParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddHostParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *AddHostParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewAddHostParams(hypervisor string, password string, podid string, url string, username string, zoneid string) *AddHostParams {
+	p := &AddHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["hypervisor"] = hypervisor
+	p.p["password"] = password
+	p.p["podid"] = podid
+	p.p["url"] = url
+	p.p["username"] = username
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Adds a new host.
+func (s *HostService) AddHost(p *AddHostParams) (*AddHostResponse, error) {
+	resp, err := s.cs.newRequest("addHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddHostResponse struct {
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ReconnectHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReconnectHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ReconnectHostParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ReconnectHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewReconnectHostParams(id string) *ReconnectHostParams {
+	p := &ReconnectHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Reconnects a host.
+func (s *HostService) ReconnectHost(p *ReconnectHostParams) (*ReconnectHostResponse, error) {
+	resp, err := s.cs.newRequest("reconnectHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReconnectHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReconnectHostResponse struct {
+	JobID                   string            `json:"jobid,omitempty"`
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type UpdateHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["hosttags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("hosttags", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["oscategoryid"]; found {
+		u.Set("oscategoryid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateHostParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *UpdateHostParams) SetHosttags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hosttags"] = v
+	return
+}
+
+func (p *UpdateHostParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateHostParams) SetOscategoryid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["oscategoryid"] = v
+	return
+}
+
+func (p *UpdateHostParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewUpdateHostParams(id string) *UpdateHostParams {
+	p := &UpdateHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a host.
+func (s *HostService) UpdateHost(p *UpdateHostParams) (*UpdateHostResponse, error) {
+	resp, err := s.cs.newRequest("updateHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateHostResponse struct {
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type DeleteHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["forcedestroylocalstorage"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forcedestroylocalstorage", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteHostParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *DeleteHostParams) SetForcedestroylocalstorage(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forcedestroylocalstorage"] = v
+	return
+}
+
+func (p *DeleteHostParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewDeleteHostParams(id string) *DeleteHostParams {
+	p := &DeleteHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a host.
+func (s *HostService) DeleteHost(p *DeleteHostParams) (*DeleteHostResponse, error) {
+	resp, err := s.cs.newRequest("deleteHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteHostResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type PrepareHostForMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *PrepareHostForMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *PrepareHostForMaintenanceParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new PrepareHostForMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewPrepareHostForMaintenanceParams(id string) *PrepareHostForMaintenanceParams {
+	p := &PrepareHostForMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Prepares a host for maintenance.
+func (s *HostService) PrepareHostForMaintenance(p *PrepareHostForMaintenanceParams) (*PrepareHostForMaintenanceResponse, error) {
+	resp, err := s.cs.newRequest("prepareHostForMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r PrepareHostForMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type PrepareHostForMaintenanceResponse struct {
+	JobID                   string            `json:"jobid,omitempty"`
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type CancelHostMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *CancelHostMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *CancelHostMaintenanceParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new CancelHostMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewCancelHostMaintenanceParams(id string) *CancelHostMaintenanceParams {
+	p := &CancelHostMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Cancels host maintenance.
+func (s *HostService) CancelHostMaintenance(p *CancelHostMaintenanceParams) (*CancelHostMaintenanceResponse, error) {
+	resp, err := s.cs.newRequest("cancelHostMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CancelHostMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CancelHostMaintenanceResponse struct {
+	JobID                   string            `json:"jobid,omitempty"`
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ListHostsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListHostsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("details", vv)
+	}
+	if v, found := p.p["hahost"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("hahost", vv)
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["resourcestate"]; found {
+		u.Set("resourcestate", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListHostsParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListHostsParams) SetDetails(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ListHostsParams) SetHahost(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hahost"] = v
+	return
+}
+
+func (p *ListHostsParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListHostsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListHostsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListHostsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListHostsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListHostsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListHostsParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListHostsParams) SetResourcestate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcestate"] = v
+	return
+}
+
+func (p *ListHostsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListHostsParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostType"] = v
+	return
+}
+
+func (p *ListHostsParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *ListHostsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListHostsParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewListHostsParams() *ListHostsParams {
+	p := &ListHostsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *HostService) GetHostID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListHostsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListHosts(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Hosts[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Hosts {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *HostService) GetHostByName(name string, opts ...OptionFunc) (*Host, int, error) {
+	id, count, err := s.GetHostID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetHostByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *HostService) GetHostByID(id string, opts ...OptionFunc) (*Host, int, error) {
+	p := &ListHostsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListHosts(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Hosts[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Host UUID: %s!", id)
+}
+
+// Lists hosts.
+func (s *HostService) ListHosts(p *ListHostsParams) (*ListHostsResponse, error) {
+	resp, err := s.cs.newRequest("listHosts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListHostsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListHostsResponse struct {
+	Count int     `json:"count"`
+	Hosts []*Host `json:"host"`
+}
+
+type Host struct {
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ListHostTagsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListHostTagsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListHostTagsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListHostTagsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListHostTagsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListHostTagsParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewListHostTagsParams() *ListHostTagsParams {
+	p := &ListHostTagsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *HostService) GetHostTagID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListHostTagsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListHostTags(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.HostTags[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.HostTags {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// Lists host tags
+func (s *HostService) ListHostTags(p *ListHostTagsParams) (*ListHostTagsResponse, error) {
+	resp, err := s.cs.newRequest("listHostTags", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListHostTagsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListHostTagsResponse struct {
+	Count    int        `json:"count"`
+	HostTags []*HostTag `json:"hosttag"`
+}
+
+type HostTag struct {
+	Hostid int64  `json:"hostid,omitempty"`
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+}
+
+type FindHostsForMigrationParams struct {
+	p map[string]interface{}
+}
+
+func (p *FindHostsForMigrationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *FindHostsForMigrationParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *FindHostsForMigrationParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *FindHostsForMigrationParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *FindHostsForMigrationParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new FindHostsForMigrationParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewFindHostsForMigrationParams(virtualmachineid string) *FindHostsForMigrationParams {
+	p := &FindHostsForMigrationParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Find hosts suitable for migrating a virtual machine.
+func (s *HostService) FindHostsForMigration(p *FindHostsForMigrationParams) (*FindHostsForMigrationResponse, error) {
+	resp, err := s.cs.newRequest("findHostsForMigration", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r FindHostsForMigrationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type FindHostsForMigrationResponse struct {
+	Averageload             int64  `json:"averageload,omitempty"`
+	Capabilities            string `json:"capabilities,omitempty"`
+	Clusterid               string `json:"clusterid,omitempty"`
+	Clustername             string `json:"clustername,omitempty"`
+	Clustertype             string `json:"clustertype,omitempty"`
+	Cpuallocated            string `json:"cpuallocated,omitempty"`
+	Cpunumber               int    `json:"cpunumber,omitempty"`
+	Cpuspeed                int64  `json:"cpuspeed,omitempty"`
+	Cpuused                 string `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string `json:"created,omitempty"`
+	Disconnected            string `json:"disconnected,omitempty"`
+	Disksizeallocated       int64  `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64  `json:"disksizetotal,omitempty"`
+	Events                  string `json:"events,omitempty"`
+	Hahost                  bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity       bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags                string `json:"hosttags,omitempty"`
+	Hypervisor              string `json:"hypervisor,omitempty"`
+	Hypervisorversion       string `json:"hypervisorversion,omitempty"`
+	Id                      string `json:"id,omitempty"`
+	Ipaddress               string `json:"ipaddress,omitempty"`
+	Islocalstorageactive    bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged              string `json:"lastpinged,omitempty"`
+	Managementserverid      int64  `json:"managementserverid,omitempty"`
+	Memoryallocated         int64  `json:"memoryallocated,omitempty"`
+	Memorytotal             int64  `json:"memorytotal,omitempty"`
+	Memoryused              int64  `json:"memoryused,omitempty"`
+	Name                    string `json:"name,omitempty"`
+	Networkkbsread          int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite         int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid            string `json:"oscategoryid,omitempty"`
+	Oscategoryname          string `json:"oscategoryname,omitempty"`
+	Podid                   string `json:"podid,omitempty"`
+	Podname                 string `json:"podname,omitempty"`
+	Removed                 string `json:"removed,omitempty"`
+	RequiresStorageMotion   bool   `json:"requiresStorageMotion,omitempty"`
+	Resourcestate           string `json:"resourcestate,omitempty"`
+	State                   string `json:"state,omitempty"`
+	Suitableformigration    bool   `json:"suitableformigration,omitempty"`
+	Type                    string `json:"type,omitempty"`
+	Version                 string `json:"version,omitempty"`
+	Zoneid                  string `json:"zoneid,omitempty"`
+	Zonename                string `json:"zonename,omitempty"`
+}
+
+type AddSecondaryStorageParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddSecondaryStorageParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddSecondaryStorageParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddSecondaryStorageParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddSecondaryStorageParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewAddSecondaryStorageParams(url string) *AddSecondaryStorageParams {
+	p := &AddSecondaryStorageParams{}
+	p.p = make(map[string]interface{})
+	p.p["url"] = url
+	return p
+}
+
+// Adds secondary storage.
+func (s *HostService) AddSecondaryStorage(p *AddSecondaryStorageParams) (*AddSecondaryStorageResponse, error) {
+	resp, err := s.cs.newRequest("addSecondaryStorage", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddSecondaryStorageResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddSecondaryStorageResponse struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type UpdateHostPasswordParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateHostPasswordParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["update_passwd_on_host"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("update_passwd_on_host", vv)
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateHostPasswordParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *UpdateHostPasswordParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *UpdateHostPasswordParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *UpdateHostPasswordParams) SetUpdate_passwd_on_host(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["update_passwd_on_host"] = v
+	return
+}
+
+func (p *UpdateHostPasswordParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateHostPasswordParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewUpdateHostPasswordParams(password string, username string) *UpdateHostPasswordParams {
+	p := &UpdateHostPasswordParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["username"] = username
+	return p
+}
+
+// Update password of a host/pool on management server.
+func (s *HostService) UpdateHostPassword(p *UpdateHostPasswordParams) (*UpdateHostPasswordResponse, error) {
+	resp, err := s.cs.newRequest("updateHostPassword", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateHostPasswordResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateHostPasswordResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ReleaseHostReservationParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseHostReservationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseHostReservationParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseHostReservationParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewReleaseHostReservationParams(id string) *ReleaseHostReservationParams {
+	p := &ReleaseHostReservationParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Releases host reservation.
+func (s *HostService) ReleaseHostReservation(p *ReleaseHostReservationParams) (*ReleaseHostReservationResponse, error) {
+	resp, err := s.cs.newRequest("releaseHostReservation", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseHostReservationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseHostReservationResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AddBaremetalHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddBaremetalHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["clustername"]; found {
+		u.Set("clustername", v.(string))
+	}
+	if v, found := p.p["hosttags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("hosttags", vv)
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddBaremetalHostParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetClustername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clustername"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetHosttags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hosttags"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *AddBaremetalHostParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddBaremetalHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewAddBaremetalHostParams(hypervisor string, password string, podid string, url string, username string, zoneid string) *AddBaremetalHostParams {
+	p := &AddBaremetalHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["hypervisor"] = hypervisor
+	p.p["password"] = password
+	p.p["podid"] = podid
+	p.p["url"] = url
+	p.p["username"] = username
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// add a baremetal host
+func (s *HostService) AddBaremetalHost(p *AddBaremetalHostParams) (*AddBaremetalHostResponse, error) {
+	resp, err := s.cs.newRequest("addBaremetalHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddBaremetalHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddBaremetalHostResponse struct {
+	Averageload             int64             `json:"averageload,omitempty"`
+	Capabilities            string            `json:"capabilities,omitempty"`
+	Clusterid               string            `json:"clusterid,omitempty"`
+	Clustername             string            `json:"clustername,omitempty"`
+	Clustertype             string            `json:"clustertype,omitempty"`
+	Cpuallocated            string            `json:"cpuallocated,omitempty"`
+	Cpunumber               int               `json:"cpunumber,omitempty"`
+	Cpusockets              int               `json:"cpusockets,omitempty"`
+	Cpuspeed                int64             `json:"cpuspeed,omitempty"`
+	Cpuused                 string            `json:"cpuused,omitempty"`
+	Cpuwithoverprovisioning string            `json:"cpuwithoverprovisioning,omitempty"`
+	Created                 string            `json:"created,omitempty"`
+	Details                 map[string]string `json:"details,omitempty"`
+	Disconnected            string            `json:"disconnected,omitempty"`
+	Disksizeallocated       int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal           int64             `json:"disksizetotal,omitempty"`
+	Events                  string            `json:"events,omitempty"`
+	Gpugroup                []struct {
+		Gpugroupname string `json:"gpugroupname,omitempty"`
+		Vgpu         []struct {
+			Maxcapacity       int64  `json:"maxcapacity,omitempty"`
+			Maxheads          int64  `json:"maxheads,omitempty"`
+			Maxresolutionx    int64  `json:"maxresolutionx,omitempty"`
+			Maxresolutiony    int64  `json:"maxresolutiony,omitempty"`
+			Maxvgpuperpgpu    int64  `json:"maxvgpuperpgpu,omitempty"`
+			Remainingcapacity int64  `json:"remainingcapacity,omitempty"`
+			Vgputype          string `json:"vgputype,omitempty"`
+			Videoram          int64  `json:"videoram,omitempty"`
+		} `json:"vgpu,omitempty"`
+	} `json:"gpugroup,omitempty"`
+	Hahost               bool   `json:"hahost,omitempty"`
+	Hasenoughcapacity    bool   `json:"hasenoughcapacity,omitempty"`
+	Hosttags             string `json:"hosttags,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Islocalstorageactive bool   `json:"islocalstorageactive,omitempty"`
+	Lastpinged           string `json:"lastpinged,omitempty"`
+	Managementserverid   int64  `json:"managementserverid,omitempty"`
+	Memoryallocated      int64  `json:"memoryallocated,omitempty"`
+	Memorytotal          int64  `json:"memorytotal,omitempty"`
+	Memoryused           int64  `json:"memoryused,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkkbsread       int64  `json:"networkkbsread,omitempty"`
+	Networkkbswrite      int64  `json:"networkkbswrite,omitempty"`
+	Oscategoryid         string `json:"oscategoryid,omitempty"`
+	Oscategoryname       string `json:"oscategoryname,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Podname              string `json:"podname,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	Resourcestate        string `json:"resourcestate,omitempty"`
+	State                string `json:"state,omitempty"`
+	Suitableformigration bool   `json:"suitableformigration,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Version              string `json:"version,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type DedicateHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicateHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	return u
+}
+
+func (p *DedicateHostParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicateHostParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DedicateHostParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+// You should always use this function to get a new DedicateHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewDedicateHostParams(domainid string, hostid string) *DedicateHostParams {
+	p := &DedicateHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["domainid"] = domainid
+	p.p["hostid"] = hostid
+	return p
+}
+
+// Dedicates a host.
+func (s *HostService) DedicateHost(p *DedicateHostParams) (*DedicateHostResponse, error) {
+	resp, err := s.cs.newRequest("dedicateHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicateHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DedicateHostResponse struct {
+	JobID           string `json:"jobid,omitempty"`
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Hostid          string `json:"hostid,omitempty"`
+	Hostname        string `json:"hostname,omitempty"`
+	Id              string `json:"id,omitempty"`
+}
+
+type ReleaseDedicatedHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseDedicatedHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseDedicatedHostParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseDedicatedHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewReleaseDedicatedHostParams(hostid string) *ReleaseDedicatedHostParams {
+	p := &ReleaseDedicatedHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostid"] = hostid
+	return p
+}
+
+// Release the dedication for host
+func (s *HostService) ReleaseDedicatedHost(p *ReleaseDedicatedHostParams) (*ReleaseDedicatedHostResponse, error) {
+	resp, err := s.cs.newRequest("releaseDedicatedHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseDedicatedHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseDedicatedHostResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDedicatedHostsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDedicatedHostsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupid"]; found {
+		u.Set("affinitygroupid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListDedicatedHostsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetAffinitygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupid"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDedicatedHostsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListDedicatedHostsParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewListDedicatedHostsParams() *ListDedicatedHostsParams {
+	p := &ListDedicatedHostsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists dedicated hosts.
+func (s *HostService) ListDedicatedHosts(p *ListDedicatedHostsParams) (*ListDedicatedHostsResponse, error) {
+	resp, err := s.cs.newRequest("listDedicatedHosts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDedicatedHostsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDedicatedHostsResponse struct {
+	Count          int              `json:"count"`
+	DedicatedHosts []*DedicatedHost `json:"dedicatedhost"`
+}
+
+type DedicatedHost struct {
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Hostid          string `json:"hostid,omitempty"`
+	Hostname        string `json:"hostname,omitempty"`
+	Id              string `json:"id,omitempty"`
+}
+
+type AddGloboDnsHostParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddGloboDnsHostParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddGloboDnsHostParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddGloboDnsHostParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddGloboDnsHostParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddGloboDnsHostParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddGloboDnsHostParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewAddGloboDnsHostParams(password string, physicalnetworkid string, url string, username string) *AddGloboDnsHostParams {
+	p := &AddGloboDnsHostParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// Adds the GloboDNS external host
+func (s *HostService) AddGloboDnsHost(p *AddGloboDnsHostParams) (*AddGloboDnsHostResponse, error) {
+	resp, err := s.cs.newRequest("addGloboDnsHost", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddGloboDnsHostResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddGloboDnsHostResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/HypervisorService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/HypervisorService.go
@@ -1,0 +1,299 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListHypervisorsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListHypervisorsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListHypervisorsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListHypervisorsParams instance,
+// as then you are sure you have configured all required params
+func (s *HypervisorService) NewListHypervisorsParams() *ListHypervisorsParams {
+	p := &ListHypervisorsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List hypervisors
+func (s *HypervisorService) ListHypervisors(p *ListHypervisorsParams) (*ListHypervisorsResponse, error) {
+	resp, err := s.cs.newRequest("listHypervisors", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListHypervisorsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListHypervisorsResponse struct {
+	Count       int           `json:"count"`
+	Hypervisors []*Hypervisor `json:"hypervisor"`
+}
+
+type Hypervisor struct {
+	Name string `json:"name,omitempty"`
+}
+
+type UpdateHypervisorCapabilitiesParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["maxguestslimit"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("maxguestslimit", vv)
+	}
+	if v, found := p.p["securitygroupenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("securitygroupenabled", vv)
+	}
+	return u
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) SetMaxguestslimit(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxguestslimit"] = v
+	return
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) SetSecuritygroupenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupenabled"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateHypervisorCapabilitiesParams instance,
+// as then you are sure you have configured all required params
+func (s *HypervisorService) NewUpdateHypervisorCapabilitiesParams() *UpdateHypervisorCapabilitiesParams {
+	p := &UpdateHypervisorCapabilitiesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Updates a hypervisor capabilities.
+func (s *HypervisorService) UpdateHypervisorCapabilities(p *UpdateHypervisorCapabilitiesParams) (*UpdateHypervisorCapabilitiesResponse, error) {
+	resp, err := s.cs.newRequest("updateHypervisorCapabilities", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateHypervisorCapabilitiesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateHypervisorCapabilitiesResponse struct {
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Maxdatavolumeslimit  int    `json:"maxdatavolumeslimit,omitempty"`
+	Maxguestslimit       int64  `json:"maxguestslimit,omitempty"`
+	Maxhostspercluster   int    `json:"maxhostspercluster,omitempty"`
+	Securitygroupenabled bool   `json:"securitygroupenabled,omitempty"`
+	Storagemotionenabled bool   `json:"storagemotionenabled,omitempty"`
+}
+
+type ListHypervisorCapabilitiesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListHypervisorCapabilitiesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListHypervisorCapabilitiesParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListHypervisorCapabilitiesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListHypervisorCapabilitiesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListHypervisorCapabilitiesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListHypervisorCapabilitiesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListHypervisorCapabilitiesParams instance,
+// as then you are sure you have configured all required params
+func (s *HypervisorService) NewListHypervisorCapabilitiesParams() *ListHypervisorCapabilitiesParams {
+	p := &ListHypervisorCapabilitiesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *HypervisorService) GetHypervisorCapabilityByID(id string, opts ...OptionFunc) (*HypervisorCapability, int, error) {
+	p := &ListHypervisorCapabilitiesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListHypervisorCapabilities(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.HypervisorCapabilities[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for HypervisorCapability UUID: %s!", id)
+}
+
+// Lists all hypervisor capabilities.
+func (s *HypervisorService) ListHypervisorCapabilities(p *ListHypervisorCapabilitiesParams) (*ListHypervisorCapabilitiesResponse, error) {
+	resp, err := s.cs.newRequest("listHypervisorCapabilities", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListHypervisorCapabilitiesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListHypervisorCapabilitiesResponse struct {
+	Count                  int                     `json:"count"`
+	HypervisorCapabilities []*HypervisorCapability `json:"hypervisorcapability"`
+}
+
+type HypervisorCapability struct {
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Hypervisorversion    string `json:"hypervisorversion,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Maxdatavolumeslimit  int    `json:"maxdatavolumeslimit,omitempty"`
+	Maxguestslimit       int64  `json:"maxguestslimit,omitempty"`
+	Maxhostspercluster   int    `json:"maxhostspercluster,omitempty"`
+	Securitygroupenabled bool   `json:"securitygroupenabled,omitempty"`
+	Storagemotionenabled bool   `json:"storagemotionenabled,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ISOService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ISOService.go
@@ -1,0 +1,1944 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AttachIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *AttachIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *AttachIsoParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *AttachIsoParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new AttachIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewAttachIsoParams(id string, virtualmachineid string) *AttachIsoParams {
+	p := &AttachIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Attaches an ISO to a virtual machine.
+func (s *ISOService) AttachIso(p *AttachIsoParams) (*AttachIsoResponse, error) {
+	resp, err := s.cs.newRequest("attachIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AttachIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AttachIsoResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type DetachIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *DetachIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *DetachIsoParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new DetachIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewDetachIsoParams(virtualmachineid string) *DetachIsoParams {
+	p := &DetachIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Detaches any ISO file (if any) currently attached to a virtual machine.
+func (s *ISOService) DetachIso(p *DetachIsoParams) (*DetachIsoResponse, error) {
+	resp, err := s.cs.newRequest("detachIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DetachIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DetachIsoResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListIsosParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListIsosParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["bootable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("bootable", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isofilter"]; found {
+		u.Set("isofilter", v.(string))
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["isready"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isready", vv)
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["showremoved"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showremoved", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListIsosParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListIsosParams) SetBootable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bootable"] = v
+	return
+}
+
+func (p *ListIsosParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListIsosParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListIsosParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListIsosParams) SetIsofilter(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isofilter"] = v
+	return
+}
+
+func (p *ListIsosParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *ListIsosParams) SetIsready(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isready"] = v
+	return
+}
+
+func (p *ListIsosParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListIsosParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListIsosParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListIsosParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListIsosParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListIsosParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListIsosParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListIsosParams) SetShowremoved(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showremoved"] = v
+	return
+}
+
+func (p *ListIsosParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListIsosParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListIsosParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewListIsosParams() *ListIsosParams {
+	p := &ListIsosParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ISOService) GetIsoID(name string, isofilter string, zoneid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListIsosParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+	p.p["isofilter"] = isofilter
+	p.p["zoneid"] = zoneid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListIsos(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Isos[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Isos {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ISOService) GetIsoByName(name string, isofilter string, zoneid string, opts ...OptionFunc) (*Iso, int, error) {
+	id, count, err := s.GetIsoID(name, isofilter, zoneid, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetIsoByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ISOService) GetIsoByID(id string, opts ...OptionFunc) (*Iso, int, error) {
+	p := &ListIsosParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListIsos(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Isos[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Iso UUID: %s!", id)
+}
+
+// Lists all available ISO files.
+func (s *ISOService) ListIsos(p *ListIsosParams) (*ListIsosResponse, error) {
+	resp, err := s.cs.newRequest("listIsos", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListIsosResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListIsosResponse struct {
+	Count int    `json:"count"`
+	Isos  []*Iso `json:"iso"`
+}
+
+type Iso struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type RegisterIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *RegisterIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["bootable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("bootable", vv)
+	}
+	if v, found := p.p["checksum"]; found {
+		u.Set("checksum", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["imagestoreuuid"]; found {
+		u.Set("imagestoreuuid", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isextractable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isextractable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *RegisterIsoParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetBootable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bootable"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetChecksum(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["checksum"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetImagestoreuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["imagestoreuuid"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetIsextractable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isextractable"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *RegisterIsoParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new RegisterIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewRegisterIsoParams(displaytext string, name string, url string, zoneid string) *RegisterIsoParams {
+	p := &RegisterIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Registers an existing ISO into the CloudStack Cloud.
+func (s *ISOService) RegisterIso(p *RegisterIsoParams) (*RegisterIsoResponse, error) {
+	resp, err := s.cs.newRequest("registerIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RegisterIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RegisterIsoResponse struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type UpdateIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bootable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("bootable", vv)
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isrouting"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrouting", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["passwordenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passwordenabled", vv)
+	}
+	if v, found := p.p["requireshvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("requireshvm", vv)
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	return u
+}
+
+func (p *UpdateIsoParams) SetBootable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bootable"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetIsrouting(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrouting"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetPasswordenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passwordenabled"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetRequireshvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["requireshvm"] = v
+	return
+}
+
+func (p *UpdateIsoParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewUpdateIsoParams(id string) *UpdateIsoParams {
+	p := &UpdateIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an ISO file.
+func (s *ISOService) UpdateIso(p *UpdateIsoParams) (*UpdateIsoResponse, error) {
+	resp, err := s.cs.newRequest("updateIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateIsoResponse struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type DeleteIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteIsoParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DeleteIsoParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewDeleteIsoParams(id string) *DeleteIsoParams {
+	p := &DeleteIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an ISO file.
+func (s *ISOService) DeleteIso(p *DeleteIsoParams) (*DeleteIsoResponse, error) {
+	resp, err := s.cs.newRequest("deleteIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteIsoResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CopyIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *CopyIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["destzoneid"]; found {
+		u.Set("destzoneid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["sourcezoneid"]; found {
+		u.Set("sourcezoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CopyIsoParams) SetDestzoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["destzoneid"] = v
+	return
+}
+
+func (p *CopyIsoParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *CopyIsoParams) SetSourcezoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcezoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CopyIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewCopyIsoParams(destzoneid string, id string) *CopyIsoParams {
+	p := &CopyIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["destzoneid"] = destzoneid
+	p.p["id"] = id
+	return p
+}
+
+// Copies an ISO from one zone to another.
+func (s *ISOService) CopyIso(p *CopyIsoParams) (*CopyIsoResponse, error) {
+	resp, err := s.cs.newRequest("copyIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CopyIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CopyIsoResponse struct {
+	JobID                 string            `json:"jobid,omitempty"`
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type UpdateIsoPermissionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateIsoPermissionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accounts"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("accounts", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isextractable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isextractable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["op"]; found {
+		u.Set("op", v.(string))
+	}
+	if v, found := p.p["projectids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("projectids", vv)
+	}
+	return u
+}
+
+func (p *UpdateIsoPermissionsParams) SetAccounts(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounts"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetIsextractable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isextractable"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetOp(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["op"] = v
+	return
+}
+
+func (p *UpdateIsoPermissionsParams) SetProjectids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectids"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateIsoPermissionsParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewUpdateIsoPermissionsParams(id string) *UpdateIsoPermissionsParams {
+	p := &UpdateIsoPermissionsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates ISO permissions
+func (s *ISOService) UpdateIsoPermissions(p *UpdateIsoPermissionsParams) (*UpdateIsoPermissionsResponse, error) {
+	resp, err := s.cs.newRequest("updateIsoPermissions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateIsoPermissionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateIsoPermissionsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListIsoPermissionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListIsoPermissionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ListIsoPermissionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ListIsoPermissionsParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewListIsoPermissionsParams(id string) *ListIsoPermissionsParams {
+	p := &ListIsoPermissionsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ISOService) GetIsoPermissionByID(id string, opts ...OptionFunc) (*IsoPermission, int, error) {
+	p := &ListIsoPermissionsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListIsoPermissions(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.IsoPermissions[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for IsoPermission UUID: %s!", id)
+}
+
+// List iso visibility and all accounts that have permissions to view this iso.
+func (s *ISOService) ListIsoPermissions(p *ListIsoPermissionsParams) (*ListIsoPermissionsResponse, error) {
+	resp, err := s.cs.newRequest("listIsoPermissions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListIsoPermissionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListIsoPermissionsResponse struct {
+	Count          int              `json:"count"`
+	IsoPermissions []*IsoPermission `json:"isopermission"`
+}
+
+type IsoPermission struct {
+	Account    []string `json:"account,omitempty"`
+	Domainid   string   `json:"domainid,omitempty"`
+	Id         string   `json:"id,omitempty"`
+	Ispublic   bool     `json:"ispublic,omitempty"`
+	Projectids []string `json:"projectids,omitempty"`
+}
+
+type ExtractIsoParams struct {
+	p map[string]interface{}
+}
+
+func (p *ExtractIsoParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["mode"]; found {
+		u.Set("mode", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ExtractIsoParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ExtractIsoParams) SetMode(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["mode"] = v
+	return
+}
+
+func (p *ExtractIsoParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *ExtractIsoParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ExtractIsoParams instance,
+// as then you are sure you have configured all required params
+func (s *ISOService) NewExtractIsoParams(id string, mode string) *ExtractIsoParams {
+	p := &ExtractIsoParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["mode"] = mode
+	return p
+}
+
+// Extracts an ISO
+func (s *ISOService) ExtractIso(p *ExtractIsoParams) (*ExtractIsoResponse, error) {
+	resp, err := s.cs.newRequest("extractIso", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ExtractIsoResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ExtractIsoResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Accountid        string `json:"accountid,omitempty"`
+	Created          string `json:"created,omitempty"`
+	ExtractId        string `json:"extractId,omitempty"`
+	ExtractMode      string `json:"extractMode,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Resultstring     string `json:"resultstring,omitempty"`
+	State            string `json:"state,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Storagetype      string `json:"storagetype,omitempty"`
+	Uploadpercentage int    `json:"uploadpercentage,omitempty"`
+	Url              string `json:"url,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+	Zonename         string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ImageStoreService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ImageStoreService.go
@@ -1,0 +1,1062 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AddImageStoreParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddImageStoreParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddImageStoreParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *AddImageStoreParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *AddImageStoreParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *AddImageStoreParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddImageStoreParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddImageStoreParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewAddImageStoreParams(provider string) *AddImageStoreParams {
+	p := &AddImageStoreParams{}
+	p.p = make(map[string]interface{})
+	p.p["provider"] = provider
+	return p
+}
+
+// Adds backup image store.
+func (s *ImageStoreService) AddImageStore(p *AddImageStoreParams) (*AddImageStoreResponse, error) {
+	resp, err := s.cs.newRequest("addImageStore", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddImageStoreResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddImageStoreResponse struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type AddImageStoreS3Params struct {
+	p map[string]interface{}
+}
+
+func (p *AddImageStoreS3Params) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accesskey"]; found {
+		u.Set("accesskey", v.(string))
+	}
+	if v, found := p.p["bucket"]; found {
+		u.Set("bucket", v.(string))
+	}
+	if v, found := p.p["connectiontimeout"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("connectiontimeout", vv)
+	}
+	if v, found := p.p["connectionttl"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("connectionttl", vv)
+	}
+	if v, found := p.p["endpoint"]; found {
+		u.Set("endpoint", v.(string))
+	}
+	if v, found := p.p["maxerrorretry"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxerrorretry", vv)
+	}
+	if v, found := p.p["s3signer"]; found {
+		u.Set("s3signer", v.(string))
+	}
+	if v, found := p.p["secretkey"]; found {
+		u.Set("secretkey", v.(string))
+	}
+	if v, found := p.p["sockettimeout"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sockettimeout", vv)
+	}
+	if v, found := p.p["usehttps"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("usehttps", vv)
+	}
+	if v, found := p.p["usetcpkeepalive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("usetcpkeepalive", vv)
+	}
+	return u
+}
+
+func (p *AddImageStoreS3Params) SetAccesskey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accesskey"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetBucket(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bucket"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetConnectiontimeout(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["connectiontimeout"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetConnectionttl(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["connectionttl"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetEndpoint(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endpoint"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetMaxerrorretry(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxerrorretry"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetS3signer(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["s3signer"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetSecretkey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["secretkey"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetSockettimeout(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sockettimeout"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetUsehttps(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usehttps"] = v
+	return
+}
+
+func (p *AddImageStoreS3Params) SetUsetcpkeepalive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usetcpkeepalive"] = v
+	return
+}
+
+// You should always use this function to get a new AddImageStoreS3Params instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewAddImageStoreS3Params(accesskey string, bucket string, endpoint string, secretkey string) *AddImageStoreS3Params {
+	p := &AddImageStoreS3Params{}
+	p.p = make(map[string]interface{})
+	p.p["accesskey"] = accesskey
+	p.p["bucket"] = bucket
+	p.p["endpoint"] = endpoint
+	p.p["secretkey"] = secretkey
+	return p
+}
+
+// Adds S3 Image Store
+func (s *ImageStoreService) AddImageStoreS3(p *AddImageStoreS3Params) (*AddImageStoreS3Response, error) {
+	resp, err := s.cs.newRequest("addImageStoreS3", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddImageStoreS3Response
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddImageStoreS3Response struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type ListImageStoresParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListImageStoresParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListImageStoresParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *ListImageStoresParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListImageStoresParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewListImageStoresParams() *ListImageStoresParams {
+	p := &ListImageStoresParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetImageStoreID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListImageStoresParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListImageStores(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.ImageStores[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.ImageStores {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetImageStoreByName(name string, opts ...OptionFunc) (*ImageStore, int, error) {
+	id, count, err := s.GetImageStoreID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetImageStoreByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetImageStoreByID(id string, opts ...OptionFunc) (*ImageStore, int, error) {
+	p := &ListImageStoresParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListImageStores(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.ImageStores[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for ImageStore UUID: %s!", id)
+}
+
+// Lists image stores.
+func (s *ImageStoreService) ListImageStores(p *ListImageStoresParams) (*ListImageStoresResponse, error) {
+	resp, err := s.cs.newRequest("listImageStores", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListImageStoresResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListImageStoresResponse struct {
+	Count       int           `json:"count"`
+	ImageStores []*ImageStore `json:"imagestore"`
+}
+
+type ImageStore struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type DeleteImageStoreParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteImageStoreParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteImageStoreParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteImageStoreParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewDeleteImageStoreParams(id string) *DeleteImageStoreParams {
+	p := &DeleteImageStoreParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an image store or Secondary Storage.
+func (s *ImageStoreService) DeleteImageStore(p *DeleteImageStoreParams) (*DeleteImageStoreResponse, error) {
+	resp, err := s.cs.newRequest("deleteImageStore", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteImageStoreResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteImageStoreResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type CreateSecondaryStagingStoreParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateSecondaryStagingStoreParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["scope"]; found {
+		u.Set("scope", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateSecondaryStagingStoreParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *CreateSecondaryStagingStoreParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *CreateSecondaryStagingStoreParams) SetScope(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scope"] = v
+	return
+}
+
+func (p *CreateSecondaryStagingStoreParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *CreateSecondaryStagingStoreParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateSecondaryStagingStoreParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewCreateSecondaryStagingStoreParams(url string) *CreateSecondaryStagingStoreParams {
+	p := &CreateSecondaryStagingStoreParams{}
+	p.p = make(map[string]interface{})
+	p.p["url"] = url
+	return p
+}
+
+// create secondary staging store.
+func (s *ImageStoreService) CreateSecondaryStagingStore(p *CreateSecondaryStagingStoreParams) (*CreateSecondaryStagingStoreResponse, error) {
+	resp, err := s.cs.newRequest("createSecondaryStagingStore", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateSecondaryStagingStoreResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateSecondaryStagingStoreResponse struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type ListSecondaryStagingStoresParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSecondaryStagingStoresParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSecondaryStagingStoresParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *ListSecondaryStagingStoresParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSecondaryStagingStoresParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewListSecondaryStagingStoresParams() *ListSecondaryStagingStoresParams {
+	p := &ListSecondaryStagingStoresParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetSecondaryStagingStoreID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListSecondaryStagingStoresParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListSecondaryStagingStores(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.SecondaryStagingStores[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.SecondaryStagingStores {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetSecondaryStagingStoreByName(name string, opts ...OptionFunc) (*SecondaryStagingStore, int, error) {
+	id, count, err := s.GetSecondaryStagingStoreID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetSecondaryStagingStoreByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ImageStoreService) GetSecondaryStagingStoreByID(id string, opts ...OptionFunc) (*SecondaryStagingStore, int, error) {
+	p := &ListSecondaryStagingStoresParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListSecondaryStagingStores(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.SecondaryStagingStores[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for SecondaryStagingStore UUID: %s!", id)
+}
+
+// Lists secondary staging stores.
+func (s *ImageStoreService) ListSecondaryStagingStores(p *ListSecondaryStagingStoresParams) (*ListSecondaryStagingStoresResponse, error) {
+	resp, err := s.cs.newRequest("listSecondaryStagingStores", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSecondaryStagingStoresResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSecondaryStagingStoresResponse struct {
+	Count                  int                      `json:"count"`
+	SecondaryStagingStores []*SecondaryStagingStore `json:"secondarystagingstore"`
+}
+
+type SecondaryStagingStore struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type DeleteSecondaryStagingStoreParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSecondaryStagingStoreParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteSecondaryStagingStoreParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSecondaryStagingStoreParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewDeleteSecondaryStagingStoreParams(id string) *DeleteSecondaryStagingStoreParams {
+	p := &DeleteSecondaryStagingStoreParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a secondary staging store .
+func (s *ImageStoreService) DeleteSecondaryStagingStore(p *DeleteSecondaryStagingStoreParams) (*DeleteSecondaryStagingStoreResponse, error) {
+	resp, err := s.cs.newRequest("deleteSecondaryStagingStore", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSecondaryStagingStoreResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteSecondaryStagingStoreResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type UpdateCloudToUseObjectStoreParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateCloudToUseObjectStoreParams instance,
+// as then you are sure you have configured all required params
+func (s *ImageStoreService) NewUpdateCloudToUseObjectStoreParams(provider string) *UpdateCloudToUseObjectStoreParams {
+	p := &UpdateCloudToUseObjectStoreParams{}
+	p.p = make(map[string]interface{})
+	p.p["provider"] = provider
+	return p
+}
+
+// Migrate current NFS secondary storages to use object store.
+func (s *ImageStoreService) UpdateCloudToUseObjectStore(p *UpdateCloudToUseObjectStoreParams) (*UpdateCloudToUseObjectStoreResponse, error) {
+	resp, err := s.cs.newRequest("updateCloudToUseObjectStore", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateCloudToUseObjectStoreResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateCloudToUseObjectStoreResponse struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/InternalLBService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/InternalLBService.go
@@ -1,0 +1,1004 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ConfigureInternalLoadBalancerElementParams struct {
+	p map[string]interface{}
+}
+
+func (p *ConfigureInternalLoadBalancerElementParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ConfigureInternalLoadBalancerElementParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ConfigureInternalLoadBalancerElementParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ConfigureInternalLoadBalancerElementParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewConfigureInternalLoadBalancerElementParams(enabled bool, id string) *ConfigureInternalLoadBalancerElementParams {
+	p := &ConfigureInternalLoadBalancerElementParams{}
+	p.p = make(map[string]interface{})
+	p.p["enabled"] = enabled
+	p.p["id"] = id
+	return p
+}
+
+// Configures an Internal Load Balancer element.
+func (s *InternalLBService) ConfigureInternalLoadBalancerElement(p *ConfigureInternalLoadBalancerElementParams) (*ConfigureInternalLoadBalancerElementResponse, error) {
+	resp, err := s.cs.newRequest("configureInternalLoadBalancerElement", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ConfigureInternalLoadBalancerElementResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ConfigureInternalLoadBalancerElementResponse struct {
+	JobID   string `json:"jobid,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+	Id      string `json:"id,omitempty"`
+	Nspid   string `json:"nspid,omitempty"`
+}
+
+type CreateInternalLoadBalancerElementParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateInternalLoadBalancerElementParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["nspid"]; found {
+		u.Set("nspid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateInternalLoadBalancerElementParams) SetNspid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nspid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateInternalLoadBalancerElementParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewCreateInternalLoadBalancerElementParams(nspid string) *CreateInternalLoadBalancerElementParams {
+	p := &CreateInternalLoadBalancerElementParams{}
+	p.p = make(map[string]interface{})
+	p.p["nspid"] = nspid
+	return p
+}
+
+// Create an Internal Load Balancer element.
+func (s *InternalLBService) CreateInternalLoadBalancerElement(p *CreateInternalLoadBalancerElementParams) (*CreateInternalLoadBalancerElementResponse, error) {
+	resp, err := s.cs.newRequest("createInternalLoadBalancerElement", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateInternalLoadBalancerElementResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateInternalLoadBalancerElementResponse struct {
+	JobID   string `json:"jobid,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+	Id      string `json:"id,omitempty"`
+	Nspid   string `json:"nspid,omitempty"`
+}
+
+type ListInternalLoadBalancerElementsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListInternalLoadBalancerElementsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["nspid"]; found {
+		u.Set("nspid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetNspid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nspid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerElementsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListInternalLoadBalancerElementsParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewListInternalLoadBalancerElementsParams() *ListInternalLoadBalancerElementsParams {
+	p := &ListInternalLoadBalancerElementsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *InternalLBService) GetInternalLoadBalancerElementByID(id string, opts ...OptionFunc) (*InternalLoadBalancerElement, int, error) {
+	p := &ListInternalLoadBalancerElementsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListInternalLoadBalancerElements(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.InternalLoadBalancerElements[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for InternalLoadBalancerElement UUID: %s!", id)
+}
+
+// Lists all available Internal Load Balancer elements.
+func (s *InternalLBService) ListInternalLoadBalancerElements(p *ListInternalLoadBalancerElementsParams) (*ListInternalLoadBalancerElementsResponse, error) {
+	resp, err := s.cs.newRequest("listInternalLoadBalancerElements", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListInternalLoadBalancerElementsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListInternalLoadBalancerElementsResponse struct {
+	Count                        int                            `json:"count"`
+	InternalLoadBalancerElements []*InternalLoadBalancerElement `json:"internalloadbalancerelement"`
+}
+
+type InternalLoadBalancerElement struct {
+	Enabled bool   `json:"enabled,omitempty"`
+	Id      string `json:"id,omitempty"`
+	Nspid   string `json:"nspid,omitempty"`
+}
+
+type StopInternalLoadBalancerVMParams struct {
+	p map[string]interface{}
+}
+
+func (p *StopInternalLoadBalancerVMParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StopInternalLoadBalancerVMParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *StopInternalLoadBalancerVMParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StopInternalLoadBalancerVMParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewStopInternalLoadBalancerVMParams(id string) *StopInternalLoadBalancerVMParams {
+	p := &StopInternalLoadBalancerVMParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Stops an Internal LB vm.
+func (s *InternalLBService) StopInternalLoadBalancerVM(p *StopInternalLoadBalancerVMParams) (*StopInternalLoadBalancerVMResponse, error) {
+	resp, err := s.cs.newRequest("stopInternalLoadBalancerVM", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StopInternalLoadBalancerVMResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StopInternalLoadBalancerVMResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type StartInternalLoadBalancerVMParams struct {
+	p map[string]interface{}
+}
+
+func (p *StartInternalLoadBalancerVMParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StartInternalLoadBalancerVMParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StartInternalLoadBalancerVMParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewStartInternalLoadBalancerVMParams(id string) *StartInternalLoadBalancerVMParams {
+	p := &StartInternalLoadBalancerVMParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Starts an existing internal lb vm.
+func (s *InternalLBService) StartInternalLoadBalancerVM(p *StartInternalLoadBalancerVMParams) (*StartInternalLoadBalancerVMResponse, error) {
+	resp, err := s.cs.newRequest("startInternalLoadBalancerVM", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StartInternalLoadBalancerVMResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StartInternalLoadBalancerVMResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListInternalLoadBalancerVMsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListInternalLoadBalancerVMsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["forvpc"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvpc", vv)
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetForvpc(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvpc"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *ListInternalLoadBalancerVMsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListInternalLoadBalancerVMsParams instance,
+// as then you are sure you have configured all required params
+func (s *InternalLBService) NewListInternalLoadBalancerVMsParams() *ListInternalLoadBalancerVMsParams {
+	p := &ListInternalLoadBalancerVMsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *InternalLBService) GetInternalLoadBalancerVMID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListInternalLoadBalancerVMsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListInternalLoadBalancerVMs(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.InternalLoadBalancerVMs[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.InternalLoadBalancerVMs {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *InternalLBService) GetInternalLoadBalancerVMByName(name string, opts ...OptionFunc) (*InternalLoadBalancerVM, int, error) {
+	id, count, err := s.GetInternalLoadBalancerVMID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetInternalLoadBalancerVMByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *InternalLBService) GetInternalLoadBalancerVMByID(id string, opts ...OptionFunc) (*InternalLoadBalancerVM, int, error) {
+	p := &ListInternalLoadBalancerVMsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListInternalLoadBalancerVMs(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.InternalLoadBalancerVMs[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for InternalLoadBalancerVM UUID: %s!", id)
+}
+
+// List internal LB VMs.
+func (s *InternalLBService) ListInternalLoadBalancerVMs(p *ListInternalLoadBalancerVMsParams) (*ListInternalLoadBalancerVMsResponse, error) {
+	resp, err := s.cs.newRequest("listInternalLoadBalancerVMs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListInternalLoadBalancerVMsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListInternalLoadBalancerVMsResponse struct {
+	Count                   int                       `json:"count"`
+	InternalLoadBalancerVMs []*InternalLoadBalancerVM `json:"internalloadbalancervm"`
+}
+
+type InternalLoadBalancerVM struct {
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/LDAPService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/LDAPService.go
@@ -1,0 +1,239 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type LdapCreateAccountParams struct {
+	p map[string]interface{}
+}
+
+func (p *LdapCreateAccountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accountdetails"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	if v, found := p.p["userid"]; found {
+		u.Set("userid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *LdapCreateAccountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetAccountdetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountdetails"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetAccounttype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetUserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userid"] = v
+	return
+}
+
+func (p *LdapCreateAccountParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new LdapCreateAccountParams instance,
+// as then you are sure you have configured all required params
+func (s *LDAPService) NewLdapCreateAccountParams(accounttype int, username string) *LdapCreateAccountParams {
+	p := &LdapCreateAccountParams{}
+	p.p = make(map[string]interface{})
+	p.p["accounttype"] = accounttype
+	p.p["username"] = username
+	return p
+}
+
+// Creates an account from an LDAP user
+func (s *LDAPService) LdapCreateAccount(p *LdapCreateAccountParams) (*LdapCreateAccountResponse, error) {
+	resp, err := s.cs.newRequest("ldapCreateAccount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LdapCreateAccountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LdapCreateAccountResponse struct {
+	Accountdetails            map[string]string `json:"accountdetails,omitempty"`
+	Accounttype               int               `json:"accounttype,omitempty"`
+	Cpuavailable              string            `json:"cpuavailable,omitempty"`
+	Cpulimit                  string            `json:"cpulimit,omitempty"`
+	Cputotal                  int64             `json:"cputotal,omitempty"`
+	Defaultzoneid             string            `json:"defaultzoneid,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Groups                    []string          `json:"groups,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Ipavailable               string            `json:"ipavailable,omitempty"`
+	Iplimit                   string            `json:"iplimit,omitempty"`
+	Iptotal                   int64             `json:"iptotal,omitempty"`
+	Iscleanuprequired         bool              `json:"iscleanuprequired,omitempty"`
+	Isdefault                 bool              `json:"isdefault,omitempty"`
+	Memoryavailable           string            `json:"memoryavailable,omitempty"`
+	Memorylimit               string            `json:"memorylimit,omitempty"`
+	Memorytotal               int64             `json:"memorytotal,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkavailable          string            `json:"networkavailable,omitempty"`
+	Networkdomain             string            `json:"networkdomain,omitempty"`
+	Networklimit              string            `json:"networklimit,omitempty"`
+	Networktotal              int64             `json:"networktotal,omitempty"`
+	Primarystorageavailable   string            `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string            `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64             `json:"primarystoragetotal,omitempty"`
+	Projectavailable          string            `json:"projectavailable,omitempty"`
+	Projectlimit              string            `json:"projectlimit,omitempty"`
+	Projecttotal              int64             `json:"projecttotal,omitempty"`
+	Receivedbytes             int64             `json:"receivedbytes,omitempty"`
+	Secondarystorageavailable string            `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string            `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64             `json:"secondarystoragetotal,omitempty"`
+	Sentbytes                 int64             `json:"sentbytes,omitempty"`
+	Snapshotavailable         string            `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string            `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64             `json:"snapshottotal,omitempty"`
+	State                     string            `json:"state,omitempty"`
+	Templateavailable         string            `json:"templateavailable,omitempty"`
+	Templatelimit             string            `json:"templatelimit,omitempty"`
+	Templatetotal             int64             `json:"templatetotal,omitempty"`
+	User                      []struct {
+		Account             string `json:"account,omitempty"`
+		Accountid           string `json:"accountid,omitempty"`
+		Accounttype         int    `json:"accounttype,omitempty"`
+		Apikey              string `json:"apikey,omitempty"`
+		Created             string `json:"created,omitempty"`
+		Domain              string `json:"domain,omitempty"`
+		Domainid            string `json:"domainid,omitempty"`
+		Email               string `json:"email,omitempty"`
+		Firstname           string `json:"firstname,omitempty"`
+		Id                  string `json:"id,omitempty"`
+		Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+		Isdefault           bool   `json:"isdefault,omitempty"`
+		Lastname            string `json:"lastname,omitempty"`
+		Secretkey           string `json:"secretkey,omitempty"`
+		State               string `json:"state,omitempty"`
+		Timezone            string `json:"timezone,omitempty"`
+		Username            string `json:"username,omitempty"`
+	} `json:"user,omitempty"`
+	Vmavailable     string `json:"vmavailable,omitempty"`
+	Vmlimit         string `json:"vmlimit,omitempty"`
+	Vmrunning       int    `json:"vmrunning,omitempty"`
+	Vmstopped       int    `json:"vmstopped,omitempty"`
+	Vmtotal         int64  `json:"vmtotal,omitempty"`
+	Volumeavailable string `json:"volumeavailable,omitempty"`
+	Volumelimit     string `json:"volumelimit,omitempty"`
+	Volumetotal     int64  `json:"volumetotal,omitempty"`
+	Vpcavailable    string `json:"vpcavailable,omitempty"`
+	Vpclimit        string `json:"vpclimit,omitempty"`
+	Vpctotal        int64  `json:"vpctotal,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/LICENSE
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/LimitService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/LimitService.go
@@ -1,0 +1,475 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type UpdateResourceLimitParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateResourceLimitParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["max"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("max", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("resourcetype", vv)
+	}
+	return u
+}
+
+func (p *UpdateResourceLimitParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateResourceLimitParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UpdateResourceLimitParams) SetMax(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["max"] = v
+	return
+}
+
+func (p *UpdateResourceLimitParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *UpdateResourceLimitParams) SetResourcetype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateResourceLimitParams instance,
+// as then you are sure you have configured all required params
+func (s *LimitService) NewUpdateResourceLimitParams(resourcetype int) *UpdateResourceLimitParams {
+	p := &UpdateResourceLimitParams{}
+	p.p = make(map[string]interface{})
+	p.p["resourcetype"] = resourcetype
+	return p
+}
+
+// Updates resource limits for an account or domain.
+func (s *LimitService) UpdateResourceLimit(p *UpdateResourceLimitParams) (*UpdateResourceLimitResponse, error) {
+	resp, err := s.cs.newRequest("updateResourceLimit", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateResourceLimitResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateResourceLimitResponse struct {
+	Account      string `json:"account,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Max          int64  `json:"max,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Resourcetype string `json:"resourcetype,omitempty"`
+}
+
+type UpdateResourceCountParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateResourceCountParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("resourcetype", vv)
+	}
+	return u
+}
+
+func (p *UpdateResourceCountParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateResourceCountParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UpdateResourceCountParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *UpdateResourceCountParams) SetResourcetype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateResourceCountParams instance,
+// as then you are sure you have configured all required params
+func (s *LimitService) NewUpdateResourceCountParams(domainid string) *UpdateResourceCountParams {
+	p := &UpdateResourceCountParams{}
+	p.p = make(map[string]interface{})
+	p.p["domainid"] = domainid
+	return p
+}
+
+// Recalculate and update resource count for an account or domain.
+func (s *LimitService) UpdateResourceCount(p *UpdateResourceCountParams) (*UpdateResourceCountResponse, error) {
+	resp, err := s.cs.newRequest("updateResourceCount", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateResourceCountResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateResourceCountResponse struct {
+	Account       string `json:"account,omitempty"`
+	Domain        string `json:"domain,omitempty"`
+	Domainid      string `json:"domainid,omitempty"`
+	Project       string `json:"project,omitempty"`
+	Projectid     string `json:"projectid,omitempty"`
+	Resourcecount int64  `json:"resourcecount,omitempty"`
+	Resourcetype  string `json:"resourcetype,omitempty"`
+}
+
+type ListResourceLimitsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListResourceLimitsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("id", vv)
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("resourcetype", vv)
+	}
+	return u
+}
+
+func (p *ListResourceLimitsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetId(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListResourceLimitsParams) SetResourcetype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+// You should always use this function to get a new ListResourceLimitsParams instance,
+// as then you are sure you have configured all required params
+func (s *LimitService) NewListResourceLimitsParams() *ListResourceLimitsParams {
+	p := &ListResourceLimitsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists resource limits.
+func (s *LimitService) ListResourceLimits(p *ListResourceLimitsParams) (*ListResourceLimitsResponse, error) {
+	resp, err := s.cs.newRequest("listResourceLimits", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListResourceLimitsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListResourceLimitsResponse struct {
+	Count          int              `json:"count"`
+	ResourceLimits []*ResourceLimit `json:"resourcelimit"`
+}
+
+type ResourceLimit struct {
+	Account      string `json:"account,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Max          int64  `json:"max,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Resourcetype string `json:"resourcetype,omitempty"`
+}
+
+type GetApiLimitParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetApiLimitParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new GetApiLimitParams instance,
+// as then you are sure you have configured all required params
+func (s *LimitService) NewGetApiLimitParams() *GetApiLimitParams {
+	p := &GetApiLimitParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Get API limit count for the caller
+func (s *LimitService) GetApiLimit(p *GetApiLimitParams) (*GetApiLimitResponse, error) {
+	resp, err := s.cs.newRequest("getApiLimit", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetApiLimitResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetApiLimitResponse struct {
+	Account     string `json:"account,omitempty"`
+	Accountid   string `json:"accountid,omitempty"`
+	ApiAllowed  int    `json:"apiAllowed,omitempty"`
+	ApiIssued   int    `json:"apiIssued,omitempty"`
+	ExpireAfter int64  `json:"expireAfter,omitempty"`
+}
+
+type ResetApiLimitParams struct {
+	p map[string]interface{}
+}
+
+func (p *ResetApiLimitParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	return u
+}
+
+func (p *ResetApiLimitParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+// You should always use this function to get a new ResetApiLimitParams instance,
+// as then you are sure you have configured all required params
+func (s *LimitService) NewResetApiLimitParams() *ResetApiLimitParams {
+	p := &ResetApiLimitParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Reset api count
+func (s *LimitService) ResetApiLimit(p *ResetApiLimitParams) (*ResetApiLimitResponse, error) {
+	resp, err := s.cs.newRequest("resetApiLimit", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ResetApiLimitResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ResetApiLimitResponse struct {
+	Account     string `json:"account,omitempty"`
+	Accountid   string `json:"accountid,omitempty"`
+	ApiAllowed  int    `json:"apiAllowed,omitempty"`
+	ApiIssued   int    `json:"apiIssued,omitempty"`
+	ExpireAfter int64  `json:"expireAfter,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/LoadBalancerService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/LoadBalancerService.go
@@ -1,0 +1,4745 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["algorithm"]; found {
+		u.Set("algorithm", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["openfirewall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("openfirewall", vv)
+	}
+	if v, found := p.p["privateport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("privateport", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["publicipid"]; found {
+		u.Set("publicipid", v.(string))
+	}
+	if v, found := p.p["publicport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("publicport", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateLoadBalancerRuleParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetAlgorithm(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["algorithm"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetOpenfirewall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["openfirewall"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetPrivateport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privateport"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetPublicipid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicipid"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetPublicport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicport"] = v
+	return
+}
+
+func (p *CreateLoadBalancerRuleParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewCreateLoadBalancerRuleParams(algorithm string, name string, privateport int, publicport int) *CreateLoadBalancerRuleParams {
+	p := &CreateLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["algorithm"] = algorithm
+	p.p["name"] = name
+	p.p["privateport"] = privateport
+	p.p["publicport"] = publicport
+	return p
+}
+
+// Creates a load balancer rule
+func (s *LoadBalancerService) CreateLoadBalancerRule(p *CreateLoadBalancerRuleParams) (*CreateLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("createLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Account     string `json:"account,omitempty"`
+	Algorithm   string `json:"algorithm,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Privateport string `json:"privateport,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Publicip    string `json:"publicip,omitempty"`
+	Publicipid  string `json:"publicipid,omitempty"`
+	Publicport  string `json:"publicport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type DeleteLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteLoadBalancerRuleParams(id string) *DeleteLoadBalancerRuleParams {
+	p := &DeleteLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a load balancer rule.
+func (s *LoadBalancerService) DeleteLoadBalancerRule(p *DeleteLoadBalancerRuleParams) (*DeleteLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("deleteLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type RemoveFromLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveFromLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["virtualmachineids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("virtualmachineids", vv)
+	}
+	if v, found := p.p["vmidipmap"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("vmidipmap[%d].key", i), k)
+			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *RemoveFromLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *RemoveFromLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineids"] = v
+	return
+}
+
+func (p *RemoveFromLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmidipmap"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveFromLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewRemoveFromLoadBalancerRuleParams(id string) *RemoveFromLoadBalancerRuleParams {
+	p := &RemoveFromLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes a virtual machine or a list of virtual machines from a load balancer rule.
+func (s *LoadBalancerService) RemoveFromLoadBalancerRule(p *RemoveFromLoadBalancerRuleParams) (*RemoveFromLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("removeFromLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveFromLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveFromLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AssignToLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssignToLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["virtualmachineids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("virtualmachineids", vv)
+	}
+	if v, found := p.p["vmidipmap"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("vmidipmap[%d].key", i), k)
+			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *AssignToLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *AssignToLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineids"] = v
+	return
+}
+
+func (p *AssignToLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmidipmap"] = v
+	return
+}
+
+// You should always use this function to get a new AssignToLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewAssignToLoadBalancerRuleParams(id string) *AssignToLoadBalancerRuleParams {
+	p := &AssignToLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Assigns virtual machine or a list of virtual machines to a load balancer rule.
+func (s *LoadBalancerService) AssignToLoadBalancerRule(p *AssignToLoadBalancerRuleParams) (*AssignToLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("assignToLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssignToLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AssignToLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CreateLBStickinessPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateLBStickinessPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["methodname"]; found {
+		u.Set("methodname", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["param"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("param[%d].key", i), k)
+			u.Set(fmt.Sprintf("param[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *CreateLBStickinessPolicyParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateLBStickinessPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateLBStickinessPolicyParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *CreateLBStickinessPolicyParams) SetMethodname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["methodname"] = v
+	return
+}
+
+func (p *CreateLBStickinessPolicyParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateLBStickinessPolicyParams) SetParam(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["param"] = v
+	return
+}
+
+// You should always use this function to get a new CreateLBStickinessPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewCreateLBStickinessPolicyParams(lbruleid string, methodname string, name string) *CreateLBStickinessPolicyParams {
+	p := &CreateLBStickinessPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbruleid"] = lbruleid
+	p.p["methodname"] = methodname
+	p.p["name"] = name
+	return p
+}
+
+// Creates a load balancer stickiness policy
+func (s *LoadBalancerService) CreateLBStickinessPolicy(p *CreateLBStickinessPolicyParams) (*CreateLBStickinessPolicyResponse, error) {
+	resp, err := s.cs.newRequest("createLBStickinessPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateLBStickinessPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateLBStickinessPolicyResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Account          string `json:"account,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Lbruleid         string `json:"lbruleid,omitempty"`
+	Name             string `json:"name,omitempty"`
+	State            string `json:"state,omitempty"`
+	Stickinesspolicy []struct {
+		Description string            `json:"description,omitempty"`
+		Fordisplay  bool              `json:"fordisplay,omitempty"`
+		Id          string            `json:"id,omitempty"`
+		Methodname  string            `json:"methodname,omitempty"`
+		Name        string            `json:"name,omitempty"`
+		Params      map[string]string `json:"params,omitempty"`
+		State       string            `json:"state,omitempty"`
+	} `json:"stickinesspolicy,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type UpdateLBStickinessPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateLBStickinessPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateLBStickinessPolicyParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateLBStickinessPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateLBStickinessPolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateLBStickinessPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUpdateLBStickinessPolicyParams(id string) *UpdateLBStickinessPolicyParams {
+	p := &UpdateLBStickinessPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates load balancer stickiness policy
+func (s *LoadBalancerService) UpdateLBStickinessPolicy(p *UpdateLBStickinessPolicyParams) (*UpdateLBStickinessPolicyResponse, error) {
+	resp, err := s.cs.newRequest("updateLBStickinessPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateLBStickinessPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateLBStickinessPolicyResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Account          string `json:"account,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Lbruleid         string `json:"lbruleid,omitempty"`
+	Name             string `json:"name,omitempty"`
+	State            string `json:"state,omitempty"`
+	Stickinesspolicy []struct {
+		Description string            `json:"description,omitempty"`
+		Fordisplay  bool              `json:"fordisplay,omitempty"`
+		Id          string            `json:"id,omitempty"`
+		Methodname  string            `json:"methodname,omitempty"`
+		Name        string            `json:"name,omitempty"`
+		Params      map[string]string `json:"params,omitempty"`
+		State       string            `json:"state,omitempty"`
+	} `json:"stickinesspolicy,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type DeleteLBStickinessPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteLBStickinessPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteLBStickinessPolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteLBStickinessPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteLBStickinessPolicyParams(id string) *DeleteLBStickinessPolicyParams {
+	p := &DeleteLBStickinessPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a load balancer stickiness policy.
+func (s *LoadBalancerService) DeleteLBStickinessPolicy(p *DeleteLBStickinessPolicyParams) (*DeleteLBStickinessPolicyResponse, error) {
+	resp, err := s.cs.newRequest("deleteLBStickinessPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteLBStickinessPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteLBStickinessPolicyResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListLoadBalancerRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLoadBalancerRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["publicipid"]; found {
+		u.Set("publicipid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListLoadBalancerRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetPublicipid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicipid"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *ListLoadBalancerRulesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListLoadBalancerRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListLoadBalancerRulesParams() *ListLoadBalancerRulesParams {
+	p := &ListLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerRuleID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListLoadBalancerRules(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.LoadBalancerRules[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.LoadBalancerRules {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerRuleByName(name string, opts ...OptionFunc) (*LoadBalancerRule, int, error) {
+	id, count, err := s.GetLoadBalancerRuleID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetLoadBalancerRuleByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerRuleByID(id string, opts ...OptionFunc) (*LoadBalancerRule, int, error) {
+	p := &ListLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListLoadBalancerRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.LoadBalancerRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for LoadBalancerRule UUID: %s!", id)
+}
+
+// Lists load balancer rules.
+func (s *LoadBalancerService) ListLoadBalancerRules(p *ListLoadBalancerRulesParams) (*ListLoadBalancerRulesResponse, error) {
+	resp, err := s.cs.newRequest("listLoadBalancerRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLoadBalancerRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLoadBalancerRulesResponse struct {
+	Count             int                 `json:"count"`
+	LoadBalancerRules []*LoadBalancerRule `json:"loadbalancerrule"`
+}
+
+type LoadBalancerRule struct {
+	Account     string `json:"account,omitempty"`
+	Algorithm   string `json:"algorithm,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Privateport string `json:"privateport,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Publicip    string `json:"publicip,omitempty"`
+	Publicipid  string `json:"publicipid,omitempty"`
+	Publicport  string `json:"publicport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type ListLBStickinessPoliciesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLBStickinessPoliciesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListLBStickinessPoliciesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListLBStickinessPoliciesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListLBStickinessPoliciesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLBStickinessPoliciesParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *ListLBStickinessPoliciesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLBStickinessPoliciesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListLBStickinessPoliciesParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListLBStickinessPoliciesParams() *ListLBStickinessPoliciesParams {
+	p := &ListLBStickinessPoliciesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLBStickinessPolicyByID(id string, opts ...OptionFunc) (*LBStickinessPolicy, int, error) {
+	p := &ListLBStickinessPoliciesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListLBStickinessPolicies(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.LBStickinessPolicies[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for LBStickinessPolicy UUID: %s!", id)
+}
+
+// Lists load balancer stickiness policies.
+func (s *LoadBalancerService) ListLBStickinessPolicies(p *ListLBStickinessPoliciesParams) (*ListLBStickinessPoliciesResponse, error) {
+	resp, err := s.cs.newRequest("listLBStickinessPolicies", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLBStickinessPoliciesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLBStickinessPoliciesResponse struct {
+	Count                int                   `json:"count"`
+	LBStickinessPolicies []*LBStickinessPolicy `json:"lbstickinesspolicy"`
+}
+
+type LBStickinessPolicy struct {
+	Account          string `json:"account,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Lbruleid         string `json:"lbruleid,omitempty"`
+	Name             string `json:"name,omitempty"`
+	State            string `json:"state,omitempty"`
+	Stickinesspolicy []struct {
+		Description string            `json:"description,omitempty"`
+		Fordisplay  bool              `json:"fordisplay,omitempty"`
+		Id          string            `json:"id,omitempty"`
+		Methodname  string            `json:"methodname,omitempty"`
+		Name        string            `json:"name,omitempty"`
+		Params      map[string]string `json:"params,omitempty"`
+		State       string            `json:"state,omitempty"`
+	} `json:"stickinesspolicy,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type ListLBHealthCheckPoliciesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLBHealthCheckPoliciesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLBHealthCheckPoliciesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListLBHealthCheckPoliciesParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListLBHealthCheckPoliciesParams() *ListLBHealthCheckPoliciesParams {
+	p := &ListLBHealthCheckPoliciesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLBHealthCheckPolicyByID(id string, opts ...OptionFunc) (*LBHealthCheckPolicy, int, error) {
+	p := &ListLBHealthCheckPoliciesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListLBHealthCheckPolicies(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.LBHealthCheckPolicies[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for LBHealthCheckPolicy UUID: %s!", id)
+}
+
+// Lists load balancer health check policies.
+func (s *LoadBalancerService) ListLBHealthCheckPolicies(p *ListLBHealthCheckPoliciesParams) (*ListLBHealthCheckPoliciesResponse, error) {
+	resp, err := s.cs.newRequest("listLBHealthCheckPolicies", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLBHealthCheckPoliciesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLBHealthCheckPoliciesResponse struct {
+	Count                 int                    `json:"count"`
+	LBHealthCheckPolicies []*LBHealthCheckPolicy `json:"lbhealthcheckpolicy"`
+}
+
+type LBHealthCheckPolicy struct {
+	Account           string `json:"account,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Healthcheckpolicy []struct {
+		Description             string `json:"description,omitempty"`
+		Fordisplay              bool   `json:"fordisplay,omitempty"`
+		Healthcheckinterval     int    `json:"healthcheckinterval,omitempty"`
+		Healthcheckthresshold   int    `json:"healthcheckthresshold,omitempty"`
+		Id                      string `json:"id,omitempty"`
+		Pingpath                string `json:"pingpath,omitempty"`
+		Responsetime            int    `json:"responsetime,omitempty"`
+		State                   string `json:"state,omitempty"`
+		Unhealthcheckthresshold int    `json:"unhealthcheckthresshold,omitempty"`
+	} `json:"healthcheckpolicy,omitempty"`
+	Lbruleid string `json:"lbruleid,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+}
+
+type CreateLBHealthCheckPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateLBHealthCheckPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["healthythreshold"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("healthythreshold", vv)
+	}
+	if v, found := p.p["intervaltime"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("intervaltime", vv)
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["pingpath"]; found {
+		u.Set("pingpath", v.(string))
+	}
+	if v, found := p.p["responsetimeout"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("responsetimeout", vv)
+	}
+	if v, found := p.p["unhealthythreshold"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("unhealthythreshold", vv)
+	}
+	return u
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetHealthythreshold(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["healthythreshold"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetIntervaltime(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["intervaltime"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetPingpath(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pingpath"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetResponsetimeout(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["responsetimeout"] = v
+	return
+}
+
+func (p *CreateLBHealthCheckPolicyParams) SetUnhealthythreshold(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["unhealthythreshold"] = v
+	return
+}
+
+// You should always use this function to get a new CreateLBHealthCheckPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewCreateLBHealthCheckPolicyParams(lbruleid string) *CreateLBHealthCheckPolicyParams {
+	p := &CreateLBHealthCheckPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbruleid"] = lbruleid
+	return p
+}
+
+// Creates a load balancer health check policy
+func (s *LoadBalancerService) CreateLBHealthCheckPolicy(p *CreateLBHealthCheckPolicyParams) (*CreateLBHealthCheckPolicyResponse, error) {
+	resp, err := s.cs.newRequest("createLBHealthCheckPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateLBHealthCheckPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateLBHealthCheckPolicyResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Healthcheckpolicy []struct {
+		Description             string `json:"description,omitempty"`
+		Fordisplay              bool   `json:"fordisplay,omitempty"`
+		Healthcheckinterval     int    `json:"healthcheckinterval,omitempty"`
+		Healthcheckthresshold   int    `json:"healthcheckthresshold,omitempty"`
+		Id                      string `json:"id,omitempty"`
+		Pingpath                string `json:"pingpath,omitempty"`
+		Responsetime            int    `json:"responsetime,omitempty"`
+		State                   string `json:"state,omitempty"`
+		Unhealthcheckthresshold int    `json:"unhealthcheckthresshold,omitempty"`
+	} `json:"healthcheckpolicy,omitempty"`
+	Lbruleid string `json:"lbruleid,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+}
+
+type UpdateLBHealthCheckPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateLBHealthCheckPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateLBHealthCheckPolicyParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateLBHealthCheckPolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateLBHealthCheckPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUpdateLBHealthCheckPolicyParams(id string) *UpdateLBHealthCheckPolicyParams {
+	p := &UpdateLBHealthCheckPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates load balancer health check policy
+func (s *LoadBalancerService) UpdateLBHealthCheckPolicy(p *UpdateLBHealthCheckPolicyParams) (*UpdateLBHealthCheckPolicyResponse, error) {
+	resp, err := s.cs.newRequest("updateLBHealthCheckPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateLBHealthCheckPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateLBHealthCheckPolicyResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Healthcheckpolicy []struct {
+		Description             string `json:"description,omitempty"`
+		Fordisplay              bool   `json:"fordisplay,omitempty"`
+		Healthcheckinterval     int    `json:"healthcheckinterval,omitempty"`
+		Healthcheckthresshold   int    `json:"healthcheckthresshold,omitempty"`
+		Id                      string `json:"id,omitempty"`
+		Pingpath                string `json:"pingpath,omitempty"`
+		Responsetime            int    `json:"responsetime,omitempty"`
+		State                   string `json:"state,omitempty"`
+		Unhealthcheckthresshold int    `json:"unhealthcheckthresshold,omitempty"`
+	} `json:"healthcheckpolicy,omitempty"`
+	Lbruleid string `json:"lbruleid,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+}
+
+type DeleteLBHealthCheckPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteLBHealthCheckPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteLBHealthCheckPolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteLBHealthCheckPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteLBHealthCheckPolicyParams(id string) *DeleteLBHealthCheckPolicyParams {
+	p := &DeleteLBHealthCheckPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a load balancer health check policy.
+func (s *LoadBalancerService) DeleteLBHealthCheckPolicy(p *DeleteLBHealthCheckPolicyParams) (*DeleteLBHealthCheckPolicyResponse, error) {
+	resp, err := s.cs.newRequest("deleteLBHealthCheckPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteLBHealthCheckPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteLBHealthCheckPolicyResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListLoadBalancerRuleInstancesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["applied"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("applied", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbvmips"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("lbvmips", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetApplied(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["applied"] = v
+	return
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetLbvmips(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbvmips"] = v
+	return
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListLoadBalancerRuleInstancesParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListLoadBalancerRuleInstancesParams(id string) *ListLoadBalancerRuleInstancesParams {
+	p := &ListLoadBalancerRuleInstancesParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerRuleInstanceByID(id string, opts ...OptionFunc) (*VirtualMachine, int, error) {
+	p := &ListLoadBalancerRuleInstancesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListLoadBalancerRuleInstances(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.LoadBalancerRuleInstances[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for LoadBalancerRuleInstance UUID: %s!", id)
+}
+
+// List all virtual machine instances that are assigned to a load balancer rule.
+func (s *LoadBalancerService) ListLoadBalancerRuleInstances(p *ListLoadBalancerRuleInstancesParams) (*ListLoadBalancerRuleInstancesResponse, error) {
+	resp, err := s.cs.newRequest("listLoadBalancerRuleInstances", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLoadBalancerRuleInstancesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLoadBalancerRuleInstancesResponse struct {
+	Count                     int                         `json:"count"`
+	LBRuleVMIDIPs             []*LoadBalancerRuleInstance `json:"lbrulevmidip,omitempty"`
+	LoadBalancerRuleInstances []*VirtualMachine           `json:"loadbalancerruleinstance,omitempty"`
+}
+
+type LoadBalancerRuleInstance struct {
+	Lbvmipaddresses          []string        `json:"lbvmipaddresses,omitempty"`
+	Loadbalancerruleinstance *VirtualMachine `json:"loadbalancerruleinstance,omitempty"`
+}
+
+type UpdateLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["algorithm"]; found {
+		u.Set("algorithm", v.(string))
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetAlgorithm(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["algorithm"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerRuleParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUpdateLoadBalancerRuleParams(id string) *UpdateLoadBalancerRuleParams {
+	p := &UpdateLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates load balancer
+func (s *LoadBalancerService) UpdateLoadBalancerRule(p *UpdateLoadBalancerRuleParams) (*UpdateLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("updateLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Account     string `json:"account,omitempty"`
+	Algorithm   string `json:"algorithm,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Networkid   string `json:"networkid,omitempty"`
+	Privateport string `json:"privateport,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Publicip    string `json:"publicip,omitempty"`
+	Publicipid  string `json:"publicipid,omitempty"`
+	Publicport  string `json:"publicport,omitempty"`
+	State       string `json:"state,omitempty"`
+	Tags        []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type UploadSslCertParams struct {
+	p map[string]interface{}
+}
+
+func (p *UploadSslCertParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["certchain"]; found {
+		u.Set("certchain", v.(string))
+	}
+	if v, found := p.p["certificate"]; found {
+		u.Set("certificate", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["privatekey"]; found {
+		u.Set("privatekey", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *UploadSslCertParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetCertchain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["certchain"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetCertificate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["certificate"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetPrivatekey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["privatekey"] = v
+	return
+}
+
+func (p *UploadSslCertParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new UploadSslCertParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUploadSslCertParams(certificate string, privatekey string) *UploadSslCertParams {
+	p := &UploadSslCertParams{}
+	p.p = make(map[string]interface{})
+	p.p["certificate"] = certificate
+	p.p["privatekey"] = privatekey
+	return p
+}
+
+// Upload a certificate to CloudStack
+func (s *LoadBalancerService) UploadSslCert(p *UploadSslCertParams) (*UploadSslCertResponse, error) {
+	resp, err := s.cs.newRequest("uploadSslCert", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UploadSslCertResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UploadSslCertResponse struct {
+	Account              string   `json:"account,omitempty"`
+	Certchain            string   `json:"certchain,omitempty"`
+	Certificate          string   `json:"certificate,omitempty"`
+	Domain               string   `json:"domain,omitempty"`
+	Domainid             string   `json:"domainid,omitempty"`
+	Fingerprint          string   `json:"fingerprint,omitempty"`
+	Id                   string   `json:"id,omitempty"`
+	Loadbalancerrulelist []string `json:"loadbalancerrulelist,omitempty"`
+	Project              string   `json:"project,omitempty"`
+	Projectid            string   `json:"projectid,omitempty"`
+}
+
+type DeleteSslCertParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSslCertParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteSslCertParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSslCertParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteSslCertParams(id string) *DeleteSslCertParams {
+	p := &DeleteSslCertParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Delete a certificate to CloudStack
+func (s *LoadBalancerService) DeleteSslCert(p *DeleteSslCertParams) (*DeleteSslCertResponse, error) {
+	resp, err := s.cs.newRequest("deleteSslCert", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSslCertResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteSslCertResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListSslCertsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSslCertsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["certid"]; found {
+		u.Set("certid", v.(string))
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSslCertsParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *ListSslCertsParams) SetCertid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["certid"] = v
+	return
+}
+
+func (p *ListSslCertsParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+func (p *ListSslCertsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSslCertsParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListSslCertsParams() *ListSslCertsParams {
+	p := &ListSslCertsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists SSL certificates
+func (s *LoadBalancerService) ListSslCerts(p *ListSslCertsParams) (*ListSslCertsResponse, error) {
+	resp, err := s.cs.newRequest("listSslCerts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSslCertsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSslCertsResponse struct {
+	Count    int        `json:"count"`
+	SslCerts []*SslCert `json:"sslcert"`
+}
+
+type SslCert struct {
+	Account              string   `json:"account,omitempty"`
+	Certchain            string   `json:"certchain,omitempty"`
+	Certificate          string   `json:"certificate,omitempty"`
+	Domain               string   `json:"domain,omitempty"`
+	Domainid             string   `json:"domainid,omitempty"`
+	Fingerprint          string   `json:"fingerprint,omitempty"`
+	Id                   string   `json:"id,omitempty"`
+	Loadbalancerrulelist []string `json:"loadbalancerrulelist,omitempty"`
+	Project              string   `json:"project,omitempty"`
+	Projectid            string   `json:"projectid,omitempty"`
+}
+
+type AssignCertToLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssignCertToLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["certid"]; found {
+		u.Set("certid", v.(string))
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	return u
+}
+
+func (p *AssignCertToLoadBalancerParams) SetCertid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["certid"] = v
+	return
+}
+
+func (p *AssignCertToLoadBalancerParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+// You should always use this function to get a new AssignCertToLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewAssignCertToLoadBalancerParams(certid string, lbruleid string) *AssignCertToLoadBalancerParams {
+	p := &AssignCertToLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["certid"] = certid
+	p.p["lbruleid"] = lbruleid
+	return p
+}
+
+// Assigns a certificate to a load balancer rule
+func (s *LoadBalancerService) AssignCertToLoadBalancer(p *AssignCertToLoadBalancerParams) (*AssignCertToLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("assignCertToLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssignCertToLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AssignCertToLoadBalancerResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type RemoveCertFromLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveCertFromLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["lbruleid"]; found {
+		u.Set("lbruleid", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveCertFromLoadBalancerParams) SetLbruleid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbruleid"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveCertFromLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewRemoveCertFromLoadBalancerParams(lbruleid string) *RemoveCertFromLoadBalancerParams {
+	p := &RemoveCertFromLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbruleid"] = lbruleid
+	return p
+}
+
+// Removes a certificate from a load balancer rule
+func (s *LoadBalancerService) RemoveCertFromLoadBalancer(p *RemoveCertFromLoadBalancerParams) (*RemoveCertFromLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("removeCertFromLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveCertFromLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveCertFromLoadBalancerResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AddNetscalerLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddNetscalerLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["gslbprovider"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("gslbprovider", vv)
+	}
+	if v, found := p.p["gslbproviderprivateip"]; found {
+		u.Set("gslbproviderprivateip", v.(string))
+	}
+	if v, found := p.p["gslbproviderpublicip"]; found {
+		u.Set("gslbproviderpublicip", v.(string))
+	}
+	if v, found := p.p["isexclusivegslbprovider"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isexclusivegslbprovider", vv)
+	}
+	if v, found := p.p["networkdevicetype"]; found {
+		u.Set("networkdevicetype", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetGslbprovider(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbprovider"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetGslbproviderprivateip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbproviderprivateip"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetGslbproviderpublicip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbproviderpublicip"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetIsexclusivegslbprovider(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isexclusivegslbprovider"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetNetworkdevicetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdevicetype"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddNetscalerLoadBalancerParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddNetscalerLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewAddNetscalerLoadBalancerParams(networkdevicetype string, password string, physicalnetworkid string, url string, username string) *AddNetscalerLoadBalancerParams {
+	p := &AddNetscalerLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["networkdevicetype"] = networkdevicetype
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// Adds a netscaler load balancer device
+func (s *LoadBalancerService) AddNetscalerLoadBalancer(p *AddNetscalerLoadBalancerParams) (*AddNetscalerLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("addNetscalerLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddNetscalerLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddNetscalerLoadBalancerResponse struct {
+	JobID                   string   `json:"jobid,omitempty"`
+	Gslbprovider            bool     `json:"gslbprovider,omitempty"`
+	Gslbproviderprivateip   string   `json:"gslbproviderprivateip,omitempty"`
+	Gslbproviderpublicip    string   `json:"gslbproviderpublicip,omitempty"`
+	Ipaddress               string   `json:"ipaddress,omitempty"`
+	Isexclusivegslbprovider bool     `json:"isexclusivegslbprovider,omitempty"`
+	Lbdevicecapacity        int64    `json:"lbdevicecapacity,omitempty"`
+	Lbdevicededicated       bool     `json:"lbdevicededicated,omitempty"`
+	Lbdeviceid              string   `json:"lbdeviceid,omitempty"`
+	Lbdevicename            string   `json:"lbdevicename,omitempty"`
+	Lbdevicestate           string   `json:"lbdevicestate,omitempty"`
+	Physicalnetworkid       string   `json:"physicalnetworkid,omitempty"`
+	Podids                  []string `json:"podids,omitempty"`
+	Privateinterface        string   `json:"privateinterface,omitempty"`
+	Provider                string   `json:"provider,omitempty"`
+	Publicinterface         string   `json:"publicinterface,omitempty"`
+}
+
+type DeleteNetscalerLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetscalerLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["lbdeviceid"]; found {
+		u.Set("lbdeviceid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdeviceid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetscalerLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteNetscalerLoadBalancerParams(lbdeviceid string) *DeleteNetscalerLoadBalancerParams {
+	p := &DeleteNetscalerLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbdeviceid"] = lbdeviceid
+	return p
+}
+
+//  delete a netscaler load balancer device
+func (s *LoadBalancerService) DeleteNetscalerLoadBalancer(p *DeleteNetscalerLoadBalancerParams) (*DeleteNetscalerLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetscalerLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetscalerLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNetscalerLoadBalancerResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ConfigureNetscalerLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["inline"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("inline", vv)
+	}
+	if v, found := p.p["lbdevicecapacity"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("lbdevicecapacity", vv)
+	}
+	if v, found := p.p["lbdevicededicated"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("lbdevicededicated", vv)
+	}
+	if v, found := p.p["lbdeviceid"]; found {
+		u.Set("lbdeviceid", v.(string))
+	}
+	if v, found := p.p["podids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("podids", vv)
+	}
+	return u
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) SetInline(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["inline"] = v
+	return
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicecapacity(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdevicecapacity"] = v
+	return
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicededicated(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdevicededicated"] = v
+	return
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdeviceid"] = v
+	return
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) SetPodids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podids"] = v
+	return
+}
+
+// You should always use this function to get a new ConfigureNetscalerLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewConfigureNetscalerLoadBalancerParams(lbdeviceid string) *ConfigureNetscalerLoadBalancerParams {
+	p := &ConfigureNetscalerLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbdeviceid"] = lbdeviceid
+	return p
+}
+
+// configures a netscaler load balancer device
+func (s *LoadBalancerService) ConfigureNetscalerLoadBalancer(p *ConfigureNetscalerLoadBalancerParams) (*ConfigureNetscalerLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("configureNetscalerLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ConfigureNetscalerLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ConfigureNetscalerLoadBalancerResponse struct {
+	JobID                   string   `json:"jobid,omitempty"`
+	Gslbprovider            bool     `json:"gslbprovider,omitempty"`
+	Gslbproviderprivateip   string   `json:"gslbproviderprivateip,omitempty"`
+	Gslbproviderpublicip    string   `json:"gslbproviderpublicip,omitempty"`
+	Ipaddress               string   `json:"ipaddress,omitempty"`
+	Isexclusivegslbprovider bool     `json:"isexclusivegslbprovider,omitempty"`
+	Lbdevicecapacity        int64    `json:"lbdevicecapacity,omitempty"`
+	Lbdevicededicated       bool     `json:"lbdevicededicated,omitempty"`
+	Lbdeviceid              string   `json:"lbdeviceid,omitempty"`
+	Lbdevicename            string   `json:"lbdevicename,omitempty"`
+	Lbdevicestate           string   `json:"lbdevicestate,omitempty"`
+	Physicalnetworkid       string   `json:"physicalnetworkid,omitempty"`
+	Podids                  []string `json:"podids,omitempty"`
+	Privateinterface        string   `json:"privateinterface,omitempty"`
+	Provider                string   `json:"provider,omitempty"`
+	Publicinterface         string   `json:"publicinterface,omitempty"`
+}
+
+type ListNetscalerLoadBalancersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetscalerLoadBalancersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbdeviceid"]; found {
+		u.Set("lbdeviceid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetscalerLoadBalancersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancersParams) SetLbdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdeviceid"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancersParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetscalerLoadBalancersParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListNetscalerLoadBalancersParams() *ListNetscalerLoadBalancersParams {
+	p := &ListNetscalerLoadBalancersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// lists netscaler load balancer devices
+func (s *LoadBalancerService) ListNetscalerLoadBalancers(p *ListNetscalerLoadBalancersParams) (*ListNetscalerLoadBalancersResponse, error) {
+	resp, err := s.cs.newRequest("listNetscalerLoadBalancers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetscalerLoadBalancersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetscalerLoadBalancersResponse struct {
+	Count                  int                      `json:"count"`
+	NetscalerLoadBalancers []*NetscalerLoadBalancer `json:"netscalerloadbalancer"`
+}
+
+type NetscalerLoadBalancer struct {
+	Gslbprovider            bool     `json:"gslbprovider,omitempty"`
+	Gslbproviderprivateip   string   `json:"gslbproviderprivateip,omitempty"`
+	Gslbproviderpublicip    string   `json:"gslbproviderpublicip,omitempty"`
+	Ipaddress               string   `json:"ipaddress,omitempty"`
+	Isexclusivegslbprovider bool     `json:"isexclusivegslbprovider,omitempty"`
+	Lbdevicecapacity        int64    `json:"lbdevicecapacity,omitempty"`
+	Lbdevicededicated       bool     `json:"lbdevicededicated,omitempty"`
+	Lbdeviceid              string   `json:"lbdeviceid,omitempty"`
+	Lbdevicename            string   `json:"lbdevicename,omitempty"`
+	Lbdevicestate           string   `json:"lbdevicestate,omitempty"`
+	Physicalnetworkid       string   `json:"physicalnetworkid,omitempty"`
+	Podids                  []string `json:"podids,omitempty"`
+	Privateinterface        string   `json:"privateinterface,omitempty"`
+	Provider                string   `json:"provider,omitempty"`
+	Publicinterface         string   `json:"publicinterface,omitempty"`
+}
+
+type CreateGlobalLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["gslbdomainname"]; found {
+		u.Set("gslbdomainname", v.(string))
+	}
+	if v, found := p.p["gslblbmethod"]; found {
+		u.Set("gslblbmethod", v.(string))
+	}
+	if v, found := p.p["gslbservicetype"]; found {
+		u.Set("gslbservicetype", v.(string))
+	}
+	if v, found := p.p["gslbstickysessionmethodname"]; found {
+		u.Set("gslbstickysessionmethodname", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["regionid"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("regionid", vv)
+	}
+	return u
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetGslbdomainname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbdomainname"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslblbmethod"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetGslbservicetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbservicetype"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbstickysessionmethodname"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) SetRegionid(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["regionid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateGlobalLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewCreateGlobalLoadBalancerRuleParams(gslbdomainname string, gslbservicetype string, name string, regionid int) *CreateGlobalLoadBalancerRuleParams {
+	p := &CreateGlobalLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["gslbdomainname"] = gslbdomainname
+	p.p["gslbservicetype"] = gslbservicetype
+	p.p["name"] = name
+	p.p["regionid"] = regionid
+	return p
+}
+
+// Creates a global load balancer rule
+func (s *LoadBalancerService) CreateGlobalLoadBalancerRule(p *CreateGlobalLoadBalancerRuleParams) (*CreateGlobalLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("createGlobalLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateGlobalLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateGlobalLoadBalancerRuleResponse struct {
+	JobID                       string `json:"jobid,omitempty"`
+	Account                     string `json:"account,omitempty"`
+	Description                 string `json:"description,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gslbdomainname              string `json:"gslbdomainname,omitempty"`
+	Gslblbmethod                string `json:"gslblbmethod,omitempty"`
+	Gslbservicetype             string `json:"gslbservicetype,omitempty"`
+	Gslbstickysessionmethodname string `json:"gslbstickysessionmethodname,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Loadbalancerrule            []struct {
+		Account     string `json:"account,omitempty"`
+		Algorithm   string `json:"algorithm,omitempty"`
+		Cidrlist    string `json:"cidrlist,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Fordisplay  bool   `json:"fordisplay,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Networkid   string `json:"networkid,omitempty"`
+		Privateport string `json:"privateport,omitempty"`
+		Project     string `json:"project,omitempty"`
+		Projectid   string `json:"projectid,omitempty"`
+		Protocol    string `json:"protocol,omitempty"`
+		Publicip    string `json:"publicip,omitempty"`
+		Publicipid  string `json:"publicipid,omitempty"`
+		Publicport  string `json:"publicport,omitempty"`
+		State       string `json:"state,omitempty"`
+		Tags        []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Zoneid string `json:"zoneid,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	Regionid  int    `json:"regionid,omitempty"`
+}
+
+type DeleteGlobalLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteGlobalLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteGlobalLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteGlobalLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteGlobalLoadBalancerRuleParams(id string) *DeleteGlobalLoadBalancerRuleParams {
+	p := &DeleteGlobalLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a global load balancer rule.
+func (s *LoadBalancerService) DeleteGlobalLoadBalancerRule(p *DeleteGlobalLoadBalancerRuleParams) (*DeleteGlobalLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("deleteGlobalLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteGlobalLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteGlobalLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateGlobalLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["gslblbmethod"]; found {
+		u.Set("gslblbmethod", v.(string))
+	}
+	if v, found := p.p["gslbstickysessionmethodname"]; found {
+		u.Set("gslbstickysessionmethodname", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslblbmethod"] = v
+	return
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslbstickysessionmethodname"] = v
+	return
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateGlobalLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUpdateGlobalLoadBalancerRuleParams(id string) *UpdateGlobalLoadBalancerRuleParams {
+	p := &UpdateGlobalLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// update global load balancer rules.
+func (s *LoadBalancerService) UpdateGlobalLoadBalancerRule(p *UpdateGlobalLoadBalancerRuleParams) (*UpdateGlobalLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("updateGlobalLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateGlobalLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateGlobalLoadBalancerRuleResponse struct {
+	JobID                       string `json:"jobid,omitempty"`
+	Account                     string `json:"account,omitempty"`
+	Description                 string `json:"description,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gslbdomainname              string `json:"gslbdomainname,omitempty"`
+	Gslblbmethod                string `json:"gslblbmethod,omitempty"`
+	Gslbservicetype             string `json:"gslbservicetype,omitempty"`
+	Gslbstickysessionmethodname string `json:"gslbstickysessionmethodname,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Loadbalancerrule            []struct {
+		Account     string `json:"account,omitempty"`
+		Algorithm   string `json:"algorithm,omitempty"`
+		Cidrlist    string `json:"cidrlist,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Fordisplay  bool   `json:"fordisplay,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Networkid   string `json:"networkid,omitempty"`
+		Privateport string `json:"privateport,omitempty"`
+		Project     string `json:"project,omitempty"`
+		Projectid   string `json:"projectid,omitempty"`
+		Protocol    string `json:"protocol,omitempty"`
+		Publicip    string `json:"publicip,omitempty"`
+		Publicipid  string `json:"publicipid,omitempty"`
+		Publicport  string `json:"publicport,omitempty"`
+		State       string `json:"state,omitempty"`
+		Tags        []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Zoneid string `json:"zoneid,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	Regionid  int    `json:"regionid,omitempty"`
+}
+
+type ListGlobalLoadBalancerRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["regionid"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("regionid", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetRegionid(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["regionid"] = v
+	return
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListGlobalLoadBalancerRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListGlobalLoadBalancerRulesParams() *ListGlobalLoadBalancerRulesParams {
+	p := &ListGlobalLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetGlobalLoadBalancerRuleID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListGlobalLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListGlobalLoadBalancerRules(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.GlobalLoadBalancerRules[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.GlobalLoadBalancerRules {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetGlobalLoadBalancerRuleByName(name string, opts ...OptionFunc) (*GlobalLoadBalancerRule, int, error) {
+	id, count, err := s.GetGlobalLoadBalancerRuleID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetGlobalLoadBalancerRuleByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetGlobalLoadBalancerRuleByID(id string, opts ...OptionFunc) (*GlobalLoadBalancerRule, int, error) {
+	p := &ListGlobalLoadBalancerRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListGlobalLoadBalancerRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.GlobalLoadBalancerRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for GlobalLoadBalancerRule UUID: %s!", id)
+}
+
+// Lists load balancer rules.
+func (s *LoadBalancerService) ListGlobalLoadBalancerRules(p *ListGlobalLoadBalancerRulesParams) (*ListGlobalLoadBalancerRulesResponse, error) {
+	resp, err := s.cs.newRequest("listGlobalLoadBalancerRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListGlobalLoadBalancerRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListGlobalLoadBalancerRulesResponse struct {
+	Count                   int                       `json:"count"`
+	GlobalLoadBalancerRules []*GlobalLoadBalancerRule `json:"globalloadbalancerrule"`
+}
+
+type GlobalLoadBalancerRule struct {
+	Account                     string `json:"account,omitempty"`
+	Description                 string `json:"description,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gslbdomainname              string `json:"gslbdomainname,omitempty"`
+	Gslblbmethod                string `json:"gslblbmethod,omitempty"`
+	Gslbservicetype             string `json:"gslbservicetype,omitempty"`
+	Gslbstickysessionmethodname string `json:"gslbstickysessionmethodname,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Loadbalancerrule            []struct {
+		Account     string `json:"account,omitempty"`
+		Algorithm   string `json:"algorithm,omitempty"`
+		Cidrlist    string `json:"cidrlist,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Fordisplay  bool   `json:"fordisplay,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Networkid   string `json:"networkid,omitempty"`
+		Privateport string `json:"privateport,omitempty"`
+		Project     string `json:"project,omitempty"`
+		Projectid   string `json:"projectid,omitempty"`
+		Protocol    string `json:"protocol,omitempty"`
+		Publicip    string `json:"publicip,omitempty"`
+		Publicipid  string `json:"publicipid,omitempty"`
+		Publicport  string `json:"publicport,omitempty"`
+		State       string `json:"state,omitempty"`
+		Tags        []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Zoneid string `json:"zoneid,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	Regionid  int    `json:"regionid,omitempty"`
+}
+
+type AssignToGlobalLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssignToGlobalLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["gslblbruleweightsmap"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("gslblbruleweightsmap[%d].key", i), k)
+			u.Set(fmt.Sprintf("gslblbruleweightsmap[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["loadbalancerrulelist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("loadbalancerrulelist", vv)
+	}
+	return u
+}
+
+func (p *AssignToGlobalLoadBalancerRuleParams) SetGslblbruleweightsmap(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gslblbruleweightsmap"] = v
+	return
+}
+
+func (p *AssignToGlobalLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *AssignToGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["loadbalancerrulelist"] = v
+	return
+}
+
+// You should always use this function to get a new AssignToGlobalLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewAssignToGlobalLoadBalancerRuleParams(id string, loadbalancerrulelist []string) *AssignToGlobalLoadBalancerRuleParams {
+	p := &AssignToGlobalLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["loadbalancerrulelist"] = loadbalancerrulelist
+	return p
+}
+
+// Assign load balancer rule or list of load balancer rules to a global load balancer rules.
+func (s *LoadBalancerService) AssignToGlobalLoadBalancerRule(p *AssignToGlobalLoadBalancerRuleParams) (*AssignToGlobalLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("assignToGlobalLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssignToGlobalLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AssignToGlobalLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type RemoveFromGlobalLoadBalancerRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveFromGlobalLoadBalancerRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["loadbalancerrulelist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("loadbalancerrulelist", vv)
+	}
+	return u
+}
+
+func (p *RemoveFromGlobalLoadBalancerRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *RemoveFromGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["loadbalancerrulelist"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveFromGlobalLoadBalancerRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewRemoveFromGlobalLoadBalancerRuleParams(id string, loadbalancerrulelist []string) *RemoveFromGlobalLoadBalancerRuleParams {
+	p := &RemoveFromGlobalLoadBalancerRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["loadbalancerrulelist"] = loadbalancerrulelist
+	return p
+}
+
+// Removes a load balancer rule association with global load balancer rule
+func (s *LoadBalancerService) RemoveFromGlobalLoadBalancerRule(p *RemoveFromGlobalLoadBalancerRuleParams) (*RemoveFromGlobalLoadBalancerRuleResponse, error) {
+	resp, err := s.cs.newRequest("removeFromGlobalLoadBalancerRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveFromGlobalLoadBalancerRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveFromGlobalLoadBalancerRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CreateLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["algorithm"]; found {
+		u.Set("algorithm", v.(string))
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["instanceport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("instanceport", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["scheme"]; found {
+		u.Set("scheme", v.(string))
+	}
+	if v, found := p.p["sourceipaddress"]; found {
+		u.Set("sourceipaddress", v.(string))
+	}
+	if v, found := p.p["sourceipaddressnetworkid"]; found {
+		u.Set("sourceipaddressnetworkid", v.(string))
+	}
+	if v, found := p.p["sourceport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sourceport", vv)
+	}
+	return u
+}
+
+func (p *CreateLoadBalancerParams) SetAlgorithm(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["algorithm"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetInstanceport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["instanceport"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetScheme(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scheme"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetSourceipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourceipaddress"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetSourceipaddressnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourceipaddressnetworkid"] = v
+	return
+}
+
+func (p *CreateLoadBalancerParams) SetSourceport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourceport"] = v
+	return
+}
+
+// You should always use this function to get a new CreateLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewCreateLoadBalancerParams(algorithm string, instanceport int, name string, networkid string, scheme string, sourceipaddressnetworkid string, sourceport int) *CreateLoadBalancerParams {
+	p := &CreateLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["algorithm"] = algorithm
+	p.p["instanceport"] = instanceport
+	p.p["name"] = name
+	p.p["networkid"] = networkid
+	p.p["scheme"] = scheme
+	p.p["sourceipaddressnetworkid"] = sourceipaddressnetworkid
+	p.p["sourceport"] = sourceport
+	return p
+}
+
+// Creates a load balancer
+func (s *LoadBalancerService) CreateLoadBalancer(p *CreateLoadBalancerParams) (*CreateLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("createLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateLoadBalancerResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Algorithm            string `json:"algorithm,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Loadbalancerinstance []struct {
+		Id        string `json:"id,omitempty"`
+		Ipaddress string `json:"ipaddress,omitempty"`
+		Name      string `json:"name,omitempty"`
+		State     string `json:"state,omitempty"`
+	} `json:"loadbalancerinstance,omitempty"`
+	Loadbalancerrule []struct {
+		Instanceport int    `json:"instanceport,omitempty"`
+		Sourceport   int    `json:"sourceport,omitempty"`
+		State        string `json:"state,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Networkid                string `json:"networkid,omitempty"`
+	Project                  string `json:"project,omitempty"`
+	Projectid                string `json:"projectid,omitempty"`
+	Sourceipaddress          string `json:"sourceipaddress,omitempty"`
+	Sourceipaddressnetworkid string `json:"sourceipaddressnetworkid,omitempty"`
+	Tags                     []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type ListLoadBalancersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLoadBalancersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["scheme"]; found {
+		u.Set("scheme", v.(string))
+	}
+	if v, found := p.p["sourceipaddress"]; found {
+		u.Set("sourceipaddress", v.(string))
+	}
+	if v, found := p.p["sourceipaddressnetworkid"]; found {
+		u.Set("sourceipaddressnetworkid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListLoadBalancersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetScheme(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scheme"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetSourceipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourceipaddress"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetSourceipaddressnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourceipaddressnetworkid"] = v
+	return
+}
+
+func (p *ListLoadBalancersParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListLoadBalancersParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewListLoadBalancersParams() *ListLoadBalancersParams {
+	p := &ListLoadBalancersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListLoadBalancersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListLoadBalancers(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.LoadBalancers[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.LoadBalancers {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerByName(name string, opts ...OptionFunc) (*LoadBalancer, int, error) {
+	id, count, err := s.GetLoadBalancerID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetLoadBalancerByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *LoadBalancerService) GetLoadBalancerByID(id string, opts ...OptionFunc) (*LoadBalancer, int, error) {
+	p := &ListLoadBalancersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListLoadBalancers(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.LoadBalancers[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for LoadBalancer UUID: %s!", id)
+}
+
+// Lists load balancers
+func (s *LoadBalancerService) ListLoadBalancers(p *ListLoadBalancersParams) (*ListLoadBalancersResponse, error) {
+	resp, err := s.cs.newRequest("listLoadBalancers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLoadBalancersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLoadBalancersResponse struct {
+	Count         int             `json:"count"`
+	LoadBalancers []*LoadBalancer `json:"loadbalancer"`
+}
+
+type LoadBalancer struct {
+	Account              string `json:"account,omitempty"`
+	Algorithm            string `json:"algorithm,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Loadbalancerinstance []struct {
+		Id        string `json:"id,omitempty"`
+		Ipaddress string `json:"ipaddress,omitempty"`
+		Name      string `json:"name,omitempty"`
+		State     string `json:"state,omitempty"`
+	} `json:"loadbalancerinstance,omitempty"`
+	Loadbalancerrule []struct {
+		Instanceport int    `json:"instanceport,omitempty"`
+		Sourceport   int    `json:"sourceport,omitempty"`
+		State        string `json:"state,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Networkid                string `json:"networkid,omitempty"`
+	Project                  string `json:"project,omitempty"`
+	Projectid                string `json:"projectid,omitempty"`
+	Sourceipaddress          string `json:"sourceipaddress,omitempty"`
+	Sourceipaddressnetworkid string `json:"sourceipaddressnetworkid,omitempty"`
+	Tags                     []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type DeleteLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteLoadBalancerParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewDeleteLoadBalancerParams(id string) *DeleteLoadBalancerParams {
+	p := &DeleteLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a load balancer
+func (s *LoadBalancerService) DeleteLoadBalancer(p *DeleteLoadBalancerParams) (*DeleteLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("deleteLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteLoadBalancerResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateLoadBalancerParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateLoadBalancerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateLoadBalancerParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateLoadBalancerParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateLoadBalancerParams instance,
+// as then you are sure you have configured all required params
+func (s *LoadBalancerService) NewUpdateLoadBalancerParams(id string) *UpdateLoadBalancerParams {
+	p := &UpdateLoadBalancerParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a load balancer
+func (s *LoadBalancerService) UpdateLoadBalancer(p *UpdateLoadBalancerParams) (*UpdateLoadBalancerResponse, error) {
+	resp, err := s.cs.newRequest("updateLoadBalancer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateLoadBalancerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateLoadBalancerResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Algorithm            string `json:"algorithm,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Loadbalancerinstance []struct {
+		Id        string `json:"id,omitempty"`
+		Ipaddress string `json:"ipaddress,omitempty"`
+		Name      string `json:"name,omitempty"`
+		State     string `json:"state,omitempty"`
+	} `json:"loadbalancerinstance,omitempty"`
+	Loadbalancerrule []struct {
+		Instanceport int    `json:"instanceport,omitempty"`
+		Sourceport   int    `json:"sourceport,omitempty"`
+		State        string `json:"state,omitempty"`
+	} `json:"loadbalancerrule,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Networkid                string `json:"networkid,omitempty"`
+	Project                  string `json:"project,omitempty"`
+	Projectid                string `json:"projectid,omitempty"`
+	Sourceipaddress          string `json:"sourceipaddress,omitempty"`
+	Sourceipaddressnetworkid string `json:"sourceipaddressnetworkid,omitempty"`
+	Tags                     []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NATService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NATService.go
@@ -1,0 +1,631 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type EnableStaticNatParams struct {
+	p map[string]interface{}
+}
+
+func (p *EnableStaticNatParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["vmguestip"]; found {
+		u.Set("vmguestip", v.(string))
+	}
+	return u
+}
+
+func (p *EnableStaticNatParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *EnableStaticNatParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *EnableStaticNatParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *EnableStaticNatParams) SetVmguestip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmguestip"] = v
+	return
+}
+
+// You should always use this function to get a new EnableStaticNatParams instance,
+// as then you are sure you have configured all required params
+func (s *NATService) NewEnableStaticNatParams(ipaddressid string, virtualmachineid string) *EnableStaticNatParams {
+	p := &EnableStaticNatParams{}
+	p.p = make(map[string]interface{})
+	p.p["ipaddressid"] = ipaddressid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Enables static NAT for given IP address
+func (s *NATService) EnableStaticNat(p *EnableStaticNatParams) (*EnableStaticNatResponse, error) {
+	resp, err := s.cs.newRequest("enableStaticNat", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r EnableStaticNatResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type EnableStaticNatResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type CreateIpForwardingRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateIpForwardingRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["openfirewall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("openfirewall", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	return u
+}
+
+func (p *CreateIpForwardingRuleParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateIpForwardingRuleParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *CreateIpForwardingRuleParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *CreateIpForwardingRuleParams) SetOpenfirewall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["openfirewall"] = v
+	return
+}
+
+func (p *CreateIpForwardingRuleParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreateIpForwardingRuleParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+// You should always use this function to get a new CreateIpForwardingRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *NATService) NewCreateIpForwardingRuleParams(ipaddressid string, protocol string, startport int) *CreateIpForwardingRuleParams {
+	p := &CreateIpForwardingRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["ipaddressid"] = ipaddressid
+	p.p["protocol"] = protocol
+	p.p["startport"] = startport
+	return p
+}
+
+// Creates an IP forwarding rule
+func (s *NATService) CreateIpForwardingRule(p *CreateIpForwardingRuleParams) (*CreateIpForwardingRuleResponse, error) {
+	resp, err := s.cs.newRequest("createIpForwardingRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateIpForwardingRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateIpForwardingRuleResponse struct {
+	JobID          string `json:"jobid,omitempty"`
+	Cidrlist       string `json:"cidrlist,omitempty"`
+	Fordisplay     bool   `json:"fordisplay,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Ipaddress      string `json:"ipaddress,omitempty"`
+	Ipaddressid    string `json:"ipaddressid,omitempty"`
+	Networkid      string `json:"networkid,omitempty"`
+	Privateendport string `json:"privateendport,omitempty"`
+	Privateport    string `json:"privateport,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	Publicendport  string `json:"publicendport,omitempty"`
+	Publicport     string `json:"publicport,omitempty"`
+	State          string `json:"state,omitempty"`
+	Tags           []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vmguestip                 string `json:"vmguestip,omitempty"`
+}
+
+type DeleteIpForwardingRuleParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteIpForwardingRuleParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteIpForwardingRuleParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteIpForwardingRuleParams instance,
+// as then you are sure you have configured all required params
+func (s *NATService) NewDeleteIpForwardingRuleParams(id string) *DeleteIpForwardingRuleParams {
+	p := &DeleteIpForwardingRuleParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an IP forwarding rule
+func (s *NATService) DeleteIpForwardingRule(p *DeleteIpForwardingRuleParams) (*DeleteIpForwardingRuleResponse, error) {
+	resp, err := s.cs.newRequest("deleteIpForwardingRule", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteIpForwardingRuleResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteIpForwardingRuleResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListIpForwardingRulesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListIpForwardingRulesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *ListIpForwardingRulesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListIpForwardingRulesParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new ListIpForwardingRulesParams instance,
+// as then you are sure you have configured all required params
+func (s *NATService) NewListIpForwardingRulesParams() *ListIpForwardingRulesParams {
+	p := &ListIpForwardingRulesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NATService) GetIpForwardingRuleByID(id string, opts ...OptionFunc) (*IpForwardingRule, int, error) {
+	p := &ListIpForwardingRulesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListIpForwardingRules(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.IpForwardingRules[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for IpForwardingRule UUID: %s!", id)
+}
+
+// List the IP forwarding rules
+func (s *NATService) ListIpForwardingRules(p *ListIpForwardingRulesParams) (*ListIpForwardingRulesResponse, error) {
+	resp, err := s.cs.newRequest("listIpForwardingRules", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListIpForwardingRulesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListIpForwardingRulesResponse struct {
+	Count             int                 `json:"count"`
+	IpForwardingRules []*IpForwardingRule `json:"ipforwardingrule"`
+}
+
+type IpForwardingRule struct {
+	Cidrlist       string `json:"cidrlist,omitempty"`
+	Fordisplay     bool   `json:"fordisplay,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Ipaddress      string `json:"ipaddress,omitempty"`
+	Ipaddressid    string `json:"ipaddressid,omitempty"`
+	Networkid      string `json:"networkid,omitempty"`
+	Privateendport string `json:"privateendport,omitempty"`
+	Privateport    string `json:"privateport,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	Publicendport  string `json:"publicendport,omitempty"`
+	Publicport     string `json:"publicport,omitempty"`
+	State          string `json:"state,omitempty"`
+	Tags           []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vmguestip                 string `json:"vmguestip,omitempty"`
+}
+
+type DisableStaticNatParams struct {
+	p map[string]interface{}
+}
+
+func (p *DisableStaticNatParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["ipaddressid"]; found {
+		u.Set("ipaddressid", v.(string))
+	}
+	return u
+}
+
+func (p *DisableStaticNatParams) SetIpaddressid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddressid"] = v
+	return
+}
+
+// You should always use this function to get a new DisableStaticNatParams instance,
+// as then you are sure you have configured all required params
+func (s *NATService) NewDisableStaticNatParams(ipaddressid string) *DisableStaticNatParams {
+	p := &DisableStaticNatParams{}
+	p.p = make(map[string]interface{})
+	p.p["ipaddressid"] = ipaddressid
+	return p
+}
+
+// Disables static rule for given IP address
+func (s *NATService) DisableStaticNat(p *DisableStaticNatParams) (*DisableStaticNatResponse, error) {
+	resp, err := s.cs.newRequest("disableStaticNat", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DisableStaticNatResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DisableStaticNatResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkACLService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkACLService.go
@@ -1,0 +1,1458 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateNetworkACLParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateNetworkACLParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["aclid"]; found {
+		u.Set("aclid", v.(string))
+	}
+	if v, found := p.p["action"]; found {
+		u.Set("action", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["number"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("number", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	return u
+}
+
+func (p *CreateNetworkACLParams) SetAclid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["aclid"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetAction(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["action"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetNumber(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["number"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *CreateNetworkACLParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+// You should always use this function to get a new CreateNetworkACLParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewCreateNetworkACLParams(protocol string) *CreateNetworkACLParams {
+	p := &CreateNetworkACLParams{}
+	p.p = make(map[string]interface{})
+	p.p["protocol"] = protocol
+	return p
+}
+
+// Creates a ACL rule in the given network (the network has to belong to VPC)
+func (s *NetworkACLService) CreateNetworkACL(p *CreateNetworkACLParams) (*CreateNetworkACLResponse, error) {
+	resp, err := s.cs.newRequest("createNetworkACL", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateNetworkACLResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateNetworkACLResponse struct {
+	JobID      string `json:"jobid,omitempty"`
+	Aclid      string `json:"aclid,omitempty"`
+	Action     string `json:"action,omitempty"`
+	Cidrlist   string `json:"cidrlist,omitempty"`
+	Endport    string `json:"endport,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Icmpcode   int    `json:"icmpcode,omitempty"`
+	Icmptype   int    `json:"icmptype,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Number     int    `json:"number,omitempty"`
+	Protocol   string `json:"protocol,omitempty"`
+	Startport  string `json:"startport,omitempty"`
+	State      string `json:"state,omitempty"`
+	Tags       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype string `json:"traffictype,omitempty"`
+}
+
+type UpdateNetworkACLItemParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateNetworkACLItemParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["action"]; found {
+		u.Set("action", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["number"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("number", vv)
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateNetworkACLItemParams) SetAction(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["action"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetNumber(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["number"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *UpdateNetworkACLItemParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateNetworkACLItemParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewUpdateNetworkACLItemParams(id string) *UpdateNetworkACLItemParams {
+	p := &UpdateNetworkACLItemParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates ACL item with specified ID
+func (s *NetworkACLService) UpdateNetworkACLItem(p *UpdateNetworkACLItemParams) (*UpdateNetworkACLItemResponse, error) {
+	resp, err := s.cs.newRequest("updateNetworkACLItem", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateNetworkACLItemResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateNetworkACLItemResponse struct {
+	JobID      string `json:"jobid,omitempty"`
+	Aclid      string `json:"aclid,omitempty"`
+	Action     string `json:"action,omitempty"`
+	Cidrlist   string `json:"cidrlist,omitempty"`
+	Endport    string `json:"endport,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Icmpcode   int    `json:"icmpcode,omitempty"`
+	Icmptype   int    `json:"icmptype,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Number     int    `json:"number,omitempty"`
+	Protocol   string `json:"protocol,omitempty"`
+	Startport  string `json:"startport,omitempty"`
+	State      string `json:"state,omitempty"`
+	Tags       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype string `json:"traffictype,omitempty"`
+}
+
+type DeleteNetworkACLParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkACLParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkACLParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkACLParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewDeleteNetworkACLParams(id string) *DeleteNetworkACLParams {
+	p := &DeleteNetworkACLParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a network ACL
+func (s *NetworkACLService) DeleteNetworkACL(p *DeleteNetworkACLParams) (*DeleteNetworkACLResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetworkACL", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkACLResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNetworkACLResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListNetworkACLsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkACLsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["aclid"]; found {
+		u.Set("aclid", v.(string))
+	}
+	if v, found := p.p["action"]; found {
+		u.Set("action", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetworkACLsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetAclid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["aclid"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetAction(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["action"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListNetworkACLsParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkACLsParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewListNetworkACLsParams() *ListNetworkACLsParams {
+	p := &ListNetworkACLsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkACLService) GetNetworkACLByID(id string, opts ...OptionFunc) (*NetworkACL, int, error) {
+	p := &ListNetworkACLsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListNetworkACLs(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkACLs[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for NetworkACL UUID: %s!", id)
+}
+
+// Lists all network ACL items
+func (s *NetworkACLService) ListNetworkACLs(p *ListNetworkACLsParams) (*ListNetworkACLsResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkACLs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkACLsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkACLsResponse struct {
+	Count       int           `json:"count"`
+	NetworkACLs []*NetworkACL `json:"networkacl"`
+}
+
+type NetworkACL struct {
+	Aclid      string `json:"aclid,omitempty"`
+	Action     string `json:"action,omitempty"`
+	Cidrlist   string `json:"cidrlist,omitempty"`
+	Endport    string `json:"endport,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Icmpcode   int    `json:"icmpcode,omitempty"`
+	Icmptype   int    `json:"icmptype,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Number     int    `json:"number,omitempty"`
+	Protocol   string `json:"protocol,omitempty"`
+	Startport  string `json:"startport,omitempty"`
+	State      string `json:"state,omitempty"`
+	Tags       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype string `json:"traffictype,omitempty"`
+}
+
+type CreateNetworkACLListParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateNetworkACLListParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateNetworkACLListParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateNetworkACLListParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateNetworkACLListParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateNetworkACLListParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateNetworkACLListParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewCreateNetworkACLListParams(name string, vpcid string) *CreateNetworkACLListParams {
+	p := &CreateNetworkACLListParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["vpcid"] = vpcid
+	return p
+}
+
+// Creates a network ACL for the given VPC
+func (s *NetworkACLService) CreateNetworkACLList(p *CreateNetworkACLListParams) (*CreateNetworkACLListResponse, error) {
+	resp, err := s.cs.newRequest("createNetworkACLList", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateNetworkACLListResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateNetworkACLListResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Description string `json:"description,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Vpcid       string `json:"vpcid,omitempty"`
+}
+
+type DeleteNetworkACLListParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkACLListParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkACLListParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkACLListParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewDeleteNetworkACLListParams(id string) *DeleteNetworkACLListParams {
+	p := &DeleteNetworkACLListParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a network ACL
+func (s *NetworkACLService) DeleteNetworkACLList(p *DeleteNetworkACLListParams) (*DeleteNetworkACLListResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetworkACLList", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkACLListResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNetworkACLListResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ReplaceNetworkACLListParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReplaceNetworkACLListParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["aclid"]; found {
+		u.Set("aclid", v.(string))
+	}
+	if v, found := p.p["gatewayid"]; found {
+		u.Set("gatewayid", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	return u
+}
+
+func (p *ReplaceNetworkACLListParams) SetAclid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["aclid"] = v
+	return
+}
+
+func (p *ReplaceNetworkACLListParams) SetGatewayid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gatewayid"] = v
+	return
+}
+
+func (p *ReplaceNetworkACLListParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+// You should always use this function to get a new ReplaceNetworkACLListParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewReplaceNetworkACLListParams(aclid string) *ReplaceNetworkACLListParams {
+	p := &ReplaceNetworkACLListParams{}
+	p.p = make(map[string]interface{})
+	p.p["aclid"] = aclid
+	return p
+}
+
+// Replaces ACL associated with a network or private gateway
+func (s *NetworkACLService) ReplaceNetworkACLList(p *ReplaceNetworkACLListParams) (*ReplaceNetworkACLListResponse, error) {
+	resp, err := s.cs.newRequest("replaceNetworkACLList", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReplaceNetworkACLListResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReplaceNetworkACLListResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListNetworkACLListsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkACLListsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetworkACLListsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListNetworkACLListsParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkACLListsParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewListNetworkACLListsParams() *ListNetworkACLListsParams {
+	p := &ListNetworkACLListsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkACLService) GetNetworkACLListID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNetworkACLListsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNetworkACLLists(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkACLLists[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.NetworkACLLists {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkACLService) GetNetworkACLListByName(name string, opts ...OptionFunc) (*NetworkACLList, int, error) {
+	id, count, err := s.GetNetworkACLListID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetNetworkACLListByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkACLService) GetNetworkACLListByID(id string, opts ...OptionFunc) (*NetworkACLList, int, error) {
+	p := &ListNetworkACLListsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListNetworkACLLists(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkACLLists[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for NetworkACLList UUID: %s!", id)
+}
+
+// Lists all network ACLs
+func (s *NetworkACLService) ListNetworkACLLists(p *ListNetworkACLListsParams) (*ListNetworkACLListsResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkACLLists", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkACLListsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkACLListsResponse struct {
+	Count           int               `json:"count"`
+	NetworkACLLists []*NetworkACLList `json:"networkacllist"`
+}
+
+type NetworkACLList struct {
+	Description string `json:"description,omitempty"`
+	Fordisplay  bool   `json:"fordisplay,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Vpcid       string `json:"vpcid,omitempty"`
+}
+
+type UpdateNetworkACLListParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateNetworkACLListParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateNetworkACLListParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateNetworkACLListParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateNetworkACLListParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateNetworkACLListParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkACLService) NewUpdateNetworkACLListParams(id string) *UpdateNetworkACLListParams {
+	p := &UpdateNetworkACLListParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates network ACL list
+func (s *NetworkACLService) UpdateNetworkACLList(p *UpdateNetworkACLListParams) (*UpdateNetworkACLListResponse, error) {
+	resp, err := s.cs.newRequest("updateNetworkACLList", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateNetworkACLListResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateNetworkACLListResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkDeviceService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkDeviceService.go
@@ -1,0 +1,245 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type AddNetworkDeviceParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddNetworkDeviceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["networkdeviceparameterlist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].key", i), k)
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["networkdevicetype"]; found {
+		u.Set("networkdevicetype", v.(string))
+	}
+	return u
+}
+
+func (p *AddNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdeviceparameterlist"] = v
+	return
+}
+
+func (p *AddNetworkDeviceParams) SetNetworkdevicetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdevicetype"] = v
+	return
+}
+
+// You should always use this function to get a new AddNetworkDeviceParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkDeviceService) NewAddNetworkDeviceParams() *AddNetworkDeviceParams {
+	p := &AddNetworkDeviceParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Adds a network device of one of the following types: ExternalDhcp, ExternalFirewall, ExternalLoadBalancer, PxeServer
+func (s *NetworkDeviceService) AddNetworkDevice(p *AddNetworkDeviceParams) (*AddNetworkDeviceResponse, error) {
+	resp, err := s.cs.newRequest("addNetworkDevice", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddNetworkDeviceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddNetworkDeviceResponse struct {
+	Id string `json:"id,omitempty"`
+}
+
+type ListNetworkDeviceParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkDeviceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["networkdeviceparameterlist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].key", i), k)
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["networkdevicetype"]; found {
+		u.Set("networkdevicetype", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListNetworkDeviceParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdeviceparameterlist"] = v
+	return
+}
+
+func (p *ListNetworkDeviceParams) SetNetworkdevicetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdevicetype"] = v
+	return
+}
+
+func (p *ListNetworkDeviceParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkDeviceParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkDeviceParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkDeviceService) NewListNetworkDeviceParams() *ListNetworkDeviceParams {
+	p := &ListNetworkDeviceParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List network devices
+func (s *NetworkDeviceService) ListNetworkDevice(p *ListNetworkDeviceParams) (*ListNetworkDeviceResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkDevice", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkDeviceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkDeviceResponse struct {
+	Count         int              `json:"count"`
+	NetworkDevice []*NetworkDevice `json:"networkdevice"`
+}
+
+type NetworkDevice struct {
+	Id string `json:"id,omitempty"`
+}
+
+type DeleteNetworkDeviceParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkDeviceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkDeviceParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkDeviceParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkDeviceService) NewDeleteNetworkDeviceParams(id string) *DeleteNetworkDeviceParams {
+	p := &DeleteNetworkDeviceParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes network device.
+func (s *NetworkDeviceService) DeleteNetworkDevice(p *DeleteNetworkDeviceParams) (*DeleteNetworkDeviceResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetworkDevice", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkDeviceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteNetworkDeviceResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkOfferingService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkOfferingService.go
@@ -1,0 +1,951 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateNetworkOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["availability"]; found {
+		u.Set("availability", v.(string))
+	}
+	if v, found := p.p["conservemode"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("conservemode", vv)
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["egressdefaultpolicy"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("egressdefaultpolicy", vv)
+	}
+	if v, found := p.p["guestiptype"]; found {
+		u.Set("guestiptype", v.(string))
+	}
+	if v, found := p.p["ispersistent"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispersistent", vv)
+	}
+	if v, found := p.p["keepaliveenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("keepaliveenabled", vv)
+	}
+	if v, found := p.p["maxconnections"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxconnections", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkrate"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("networkrate", vv)
+	}
+	if v, found := p.p["servicecapabilitylist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].key", i), k)
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["serviceproviderlist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["specifyipranges"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("specifyipranges", vv)
+	}
+	if v, found := p.p["specifyvlan"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("specifyvlan", vv)
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		u.Set("tags", v.(string))
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	return u
+}
+
+func (p *CreateNetworkOfferingParams) SetAvailability(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["availability"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetConservemode(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["conservemode"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetEgressdefaultpolicy(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["egressdefaultpolicy"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetGuestiptype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestiptype"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetIspersistent(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispersistent"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keepaliveenabled"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetMaxconnections(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxconnections"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetNetworkrate(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkrate"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetServicecapabilitylist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["servicecapabilitylist"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetServiceproviderlist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceproviderlist"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetSpecifyipranges(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["specifyipranges"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetSpecifyvlan(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["specifyvlan"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetTags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *CreateNetworkOfferingParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+// You should always use this function to get a new CreateNetworkOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkOfferingService) NewCreateNetworkOfferingParams(displaytext string, guestiptype string, name string, supportedservices []string, traffictype string) *CreateNetworkOfferingParams {
+	p := &CreateNetworkOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["guestiptype"] = guestiptype
+	p.p["name"] = name
+	p.p["supportedservices"] = supportedservices
+	p.p["traffictype"] = traffictype
+	return p
+}
+
+// Creates a network offering.
+func (s *NetworkOfferingService) CreateNetworkOffering(p *CreateNetworkOfferingParams) (*CreateNetworkOfferingResponse, error) {
+	resp, err := s.cs.newRequest("createNetworkOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
+	var r CreateNetworkOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateNetworkOfferingResponse struct {
+	Availability        string            `json:"availability,omitempty"`
+	Conservemode        bool              `json:"conservemode,omitempty"`
+	Created             string            `json:"created,omitempty"`
+	Details             map[string]string `json:"details,omitempty"`
+	Displaytext         string            `json:"displaytext,omitempty"`
+	Egressdefaultpolicy bool              `json:"egressdefaultpolicy,omitempty"`
+	Forvpc              bool              `json:"forvpc,omitempty"`
+	Guestiptype         string            `json:"guestiptype,omitempty"`
+	Id                  string            `json:"id,omitempty"`
+	Isdefault           bool              `json:"isdefault,omitempty"`
+	Ispersistent        bool              `json:"ispersistent,omitempty"`
+	Maxconnections      int               `json:"maxconnections,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	Networkrate         int               `json:"networkrate,omitempty"`
+	Service             []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Serviceofferingid        string `json:"serviceofferingid,omitempty"`
+	Specifyipranges          bool   `json:"specifyipranges,omitempty"`
+	Specifyvlan              bool   `json:"specifyvlan,omitempty"`
+	State                    string `json:"state,omitempty"`
+	Supportsstrechedl2subnet bool   `json:"supportsstrechedl2subnet,omitempty"`
+	Tags                     string `json:"tags,omitempty"`
+	Traffictype              string `json:"traffictype,omitempty"`
+}
+
+type UpdateNetworkOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateNetworkOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["availability"]; found {
+		u.Set("availability", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keepaliveenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("keepaliveenabled", vv)
+	}
+	if v, found := p.p["maxconnections"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxconnections", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateNetworkOfferingParams) SetAvailability(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["availability"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keepaliveenabled"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetMaxconnections(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxconnections"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+	return
+}
+
+func (p *UpdateNetworkOfferingParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateNetworkOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkOfferingService) NewUpdateNetworkOfferingParams() *UpdateNetworkOfferingParams {
+	p := &UpdateNetworkOfferingParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Updates a network offering.
+func (s *NetworkOfferingService) UpdateNetworkOffering(p *UpdateNetworkOfferingParams) (*UpdateNetworkOfferingResponse, error) {
+	resp, err := s.cs.newRequest("updateNetworkOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateNetworkOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateNetworkOfferingResponse struct {
+	Availability        string            `json:"availability,omitempty"`
+	Conservemode        bool              `json:"conservemode,omitempty"`
+	Created             string            `json:"created,omitempty"`
+	Details             map[string]string `json:"details,omitempty"`
+	Displaytext         string            `json:"displaytext,omitempty"`
+	Egressdefaultpolicy bool              `json:"egressdefaultpolicy,omitempty"`
+	Forvpc              bool              `json:"forvpc,omitempty"`
+	Guestiptype         string            `json:"guestiptype,omitempty"`
+	Id                  string            `json:"id,omitempty"`
+	Isdefault           bool              `json:"isdefault,omitempty"`
+	Ispersistent        bool              `json:"ispersistent,omitempty"`
+	Maxconnections      int               `json:"maxconnections,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	Networkrate         int               `json:"networkrate,omitempty"`
+	Service             []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Serviceofferingid        string `json:"serviceofferingid,omitempty"`
+	Specifyipranges          bool   `json:"specifyipranges,omitempty"`
+	Specifyvlan              bool   `json:"specifyvlan,omitempty"`
+	State                    string `json:"state,omitempty"`
+	Supportsstrechedl2subnet bool   `json:"supportsstrechedl2subnet,omitempty"`
+	Tags                     string `json:"tags,omitempty"`
+	Traffictype              string `json:"traffictype,omitempty"`
+}
+
+type DeleteNetworkOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkOfferingService) NewDeleteNetworkOfferingParams(id string) *DeleteNetworkOfferingParams {
+	p := &DeleteNetworkOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a network offering.
+func (s *NetworkOfferingService) DeleteNetworkOffering(p *DeleteNetworkOfferingParams) (*DeleteNetworkOfferingResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetworkOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteNetworkOfferingResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListNetworkOfferingsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkOfferingsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["availability"]; found {
+		u.Set("availability", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["forvpc"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvpc", vv)
+	}
+	if v, found := p.p["guestiptype"]; found {
+		u.Set("guestiptype", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isdefault"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdefault", vv)
+	}
+	if v, found := p.p["istagged"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("istagged", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["sourcenatsupported"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("sourcenatsupported", vv)
+	}
+	if v, found := p.p["specifyipranges"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("specifyipranges", vv)
+	}
+	if v, found := p.p["specifyvlan"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("specifyvlan", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		u.Set("tags", v.(string))
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetworkOfferingsParams) SetAvailability(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["availability"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetForvpc(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvpc"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetGuestiptype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestiptype"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetIsdefault(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdefault"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetIstagged(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["istagged"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetSourcenatsupported(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatsupported"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetSpecifyipranges(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["specifyipranges"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetSpecifyvlan(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["specifyvlan"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetTags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+func (p *ListNetworkOfferingsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkOfferingsParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkOfferingService) NewListNetworkOfferingsParams() *ListNetworkOfferingsParams {
+	p := &ListNetworkOfferingsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkOfferingService) GetNetworkOfferingID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNetworkOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNetworkOfferings(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkOfferings[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.NetworkOfferings {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkOfferingService) GetNetworkOfferingByName(name string, opts ...OptionFunc) (*NetworkOffering, int, error) {
+	id, count, err := s.GetNetworkOfferingID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetNetworkOfferingByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkOfferingService) GetNetworkOfferingByID(id string, opts ...OptionFunc) (*NetworkOffering, int, error) {
+	p := &ListNetworkOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListNetworkOfferings(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkOfferings[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for NetworkOffering UUID: %s!", id)
+}
+
+// Lists all available network offerings.
+func (s *NetworkOfferingService) ListNetworkOfferings(p *ListNetworkOfferingsParams) (*ListNetworkOfferingsResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkOfferings", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkOfferingsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkOfferingsResponse struct {
+	Count            int                `json:"count"`
+	NetworkOfferings []*NetworkOffering `json:"networkoffering"`
+}
+
+type NetworkOffering struct {
+	Availability        string            `json:"availability,omitempty"`
+	Conservemode        bool              `json:"conservemode,omitempty"`
+	Created             string            `json:"created,omitempty"`
+	Details             map[string]string `json:"details,omitempty"`
+	Displaytext         string            `json:"displaytext,omitempty"`
+	Egressdefaultpolicy bool              `json:"egressdefaultpolicy,omitempty"`
+	Forvpc              bool              `json:"forvpc,omitempty"`
+	Guestiptype         string            `json:"guestiptype,omitempty"`
+	Id                  string            `json:"id,omitempty"`
+	Isdefault           bool              `json:"isdefault,omitempty"`
+	Ispersistent        bool              `json:"ispersistent,omitempty"`
+	Maxconnections      int               `json:"maxconnections,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	Networkrate         int               `json:"networkrate,omitempty"`
+	Service             []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Serviceofferingid        string `json:"serviceofferingid,omitempty"`
+	Specifyipranges          bool   `json:"specifyipranges,omitempty"`
+	Specifyvlan              bool   `json:"specifyvlan,omitempty"`
+	State                    string `json:"state,omitempty"`
+	Supportsstrechedl2subnet bool   `json:"supportsstrechedl2subnet,omitempty"`
+	Tags                     string `json:"tags,omitempty"`
+	Traffictype              string `json:"traffictype,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NetworkService.go
@@ -1,0 +1,4024 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type DedicatePublicIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicatePublicIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *DedicatePublicIpRangeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicatePublicIpRangeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DedicatePublicIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DedicatePublicIpRangeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new DedicatePublicIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDedicatePublicIpRangeParams(domainid string, id string) *DedicatePublicIpRangeParams {
+	p := &DedicatePublicIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["domainid"] = domainid
+	p.p["id"] = id
+	return p
+}
+
+// Dedicates a Public IP range to an account
+func (s *NetworkService) DedicatePublicIpRange(p *DedicatePublicIpRangeParams) (*DedicatePublicIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("dedicatePublicIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicatePublicIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DedicatePublicIpRangeResponse struct {
+	Account           string `json:"account,omitempty"`
+	Description       string `json:"description,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Endip             string `json:"endip,omitempty"`
+	Endipv6           string `json:"endipv6,omitempty"`
+	Forvirtualnetwork bool   `json:"forvirtualnetwork,omitempty"`
+	Gateway           string `json:"gateway,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Ip6cidr           string `json:"ip6cidr,omitempty"`
+	Ip6gateway        string `json:"ip6gateway,omitempty"`
+	Netmask           string `json:"netmask,omitempty"`
+	Networkid         string `json:"networkid,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Podid             string `json:"podid,omitempty"`
+	Podname           string `json:"podname,omitempty"`
+	Project           string `json:"project,omitempty"`
+	Projectid         string `json:"projectid,omitempty"`
+	Startip           string `json:"startip,omitempty"`
+	Startipv6         string `json:"startipv6,omitempty"`
+	Vlan              string `json:"vlan,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}
+
+type ReleasePublicIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleasePublicIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ReleasePublicIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ReleasePublicIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewReleasePublicIpRangeParams(id string) *ReleasePublicIpRangeParams {
+	p := &ReleasePublicIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Releases a Public IP range back to the system pool
+func (s *NetworkService) ReleasePublicIpRange(p *ReleasePublicIpRangeParams) (*ReleasePublicIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("releasePublicIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleasePublicIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ReleasePublicIpRangeResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type CreateNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["aclid"]; found {
+		u.Set("aclid", v.(string))
+	}
+	if v, found := p.p["acltype"]; found {
+		u.Set("acltype", v.(string))
+	}
+	if v, found := p.p["displaynetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displaynetwork", vv)
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["endipv6"]; found {
+		u.Set("endipv6", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["ip6cidr"]; found {
+		u.Set("ip6cidr", v.(string))
+	}
+	if v, found := p.p["ip6gateway"]; found {
+		u.Set("ip6gateway", v.(string))
+	}
+	if v, found := p.p["isolatedpvlan"]; found {
+		u.Set("isolatedpvlan", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["networkofferingid"]; found {
+		u.Set("networkofferingid", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["startipv6"]; found {
+		u.Set("startipv6", v.(string))
+	}
+	if v, found := p.p["subdomainaccess"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("subdomainaccess", vv)
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateNetworkParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetAclid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["aclid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetAcltype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["acltype"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetDisplaynetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaynetwork"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetEndipv6(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endipv6"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetIp6cidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6cidr"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetIp6gateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6gateway"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetIsolatedpvlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isolatedpvlan"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetNetworkofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkofferingid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetStartipv6(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startipv6"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetSubdomainaccess(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["subdomainaccess"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *CreateNetworkParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewCreateNetworkParams(displaytext string, name string, networkofferingid string, zoneid string) *CreateNetworkParams {
+	p := &CreateNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	p.p["networkofferingid"] = networkofferingid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a network
+func (s *NetworkService) CreateNetwork(p *CreateNetworkParams) (*CreateNetworkResponse, error) {
+	resp, err := s.cs.newRequest("createNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
+	var r CreateNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateNetworkResponse struct {
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type DeleteNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *DeleteNetworkParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDeleteNetworkParams(id string) *DeleteNetworkParams {
+	p := &DeleteNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a network
+func (s *NetworkService) DeleteNetwork(p *DeleteNetworkParams) (*DeleteNetworkResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNetworkResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListNetworksParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworksParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["acltype"]; found {
+		u.Set("acltype", v.(string))
+	}
+	if v, found := p.p["canusefordeploy"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("canusefordeploy", vv)
+	}
+	if v, found := p.p["displaynetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displaynetwork", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["forvpc"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvpc", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["issystem"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("issystem", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["restartrequired"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("restartrequired", vv)
+	}
+	if v, found := p.p["specifyipranges"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("specifyipranges", vv)
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetworksParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetAcltype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["acltype"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetCanusefordeploy(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["canusefordeploy"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetDisplaynetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaynetwork"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetForvpc(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvpc"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetIssystem(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["issystem"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetRestartrequired(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["restartrequired"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetSpecifyipranges(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["specifyipranges"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkType"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *ListNetworksParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworksParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListNetworksParams() *ListNetworksParams {
+	p := &ListNetworksParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNetworkID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNetworks(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.Networks[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Networks {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNetworkByName(name string, opts ...OptionFunc) (*Network, int, error) {
+	id, count, err := s.GetNetworkID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetNetworkByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNetworkByID(id string, opts ...OptionFunc) (*Network, int, error) {
+	p := &ListNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListNetworks(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Networks[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Network UUID: %s!", id)
+}
+
+// Lists all available networks.
+func (s *NetworkService) ListNetworks(p *ListNetworksParams) (*ListNetworksResponse, error) {
+	resp, err := s.cs.newRequest("listNetworks", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworksResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworksResponse struct {
+	Count    int        `json:"count"`
+	Networks []*Network `json:"network"`
+}
+
+type Network struct {
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type RestartNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *RestartNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cleanup"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("cleanup", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RestartNetworkParams) SetCleanup(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cleanup"] = v
+	return
+}
+
+func (p *RestartNetworkParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RestartNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewRestartNetworkParams(id string) *RestartNetworkParams {
+	p := &RestartNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Restarts the network; includes 1) restarting network elements - virtual routers, DHCP servers 2) reapplying all public IPs 3) reapplying loadBalancing/portForwarding rules
+func (s *NetworkService) RestartNetwork(p *RestartNetworkParams) (*RestartNetworkResponse, error) {
+	resp, err := s.cs.newRequest("restartNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RestartNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RestartNetworkResponse struct {
+	JobID                 string `json:"jobid,omitempty"`
+	Account               string `json:"account,omitempty"`
+	Allocated             string `json:"allocated,omitempty"`
+	Associatednetworkid   string `json:"associatednetworkid,omitempty"`
+	Associatednetworkname string `json:"associatednetworkname,omitempty"`
+	Domain                string `json:"domain,omitempty"`
+	Domainid              string `json:"domainid,omitempty"`
+	Fordisplay            bool   `json:"fordisplay,omitempty"`
+	Forvirtualnetwork     bool   `json:"forvirtualnetwork,omitempty"`
+	Id                    string `json:"id,omitempty"`
+	Ipaddress             string `json:"ipaddress,omitempty"`
+	Isportable            bool   `json:"isportable,omitempty"`
+	Issourcenat           bool   `json:"issourcenat,omitempty"`
+	Isstaticnat           bool   `json:"isstaticnat,omitempty"`
+	Issystem              bool   `json:"issystem,omitempty"`
+	Networkid             string `json:"networkid,omitempty"`
+	Physicalnetworkid     string `json:"physicalnetworkid,omitempty"`
+	Project               string `json:"project,omitempty"`
+	Projectid             string `json:"projectid,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	State                 string `json:"state,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinedisplayname string `json:"virtualmachinedisplayname,omitempty"`
+	Virtualmachineid          string `json:"virtualmachineid,omitempty"`
+	Virtualmachinename        string `json:"virtualmachinename,omitempty"`
+	Vlanid                    string `json:"vlanid,omitempty"`
+	Vlanname                  string `json:"vlanname,omitempty"`
+	Vmipaddress               string `json:"vmipaddress,omitempty"`
+	Vpcid                     string `json:"vpcid,omitempty"`
+	Zoneid                    string `json:"zoneid,omitempty"`
+	Zonename                  string `json:"zonename,omitempty"`
+}
+
+type UpdateNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["changecidr"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("changecidr", vv)
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["displaynetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displaynetwork", vv)
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["guestvmcidr"]; found {
+		u.Set("guestvmcidr", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["networkofferingid"]; found {
+		u.Set("networkofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateNetworkParams) SetChangecidr(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["changecidr"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetDisplaynetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaynetwork"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetGuestvmcidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestvmcidr"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetNetworkofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewUpdateNetworkParams(id string) *UpdateNetworkParams {
+	p := &UpdateNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a network
+func (s *NetworkService) UpdateNetwork(p *UpdateNetworkParams) (*UpdateNetworkResponse, error) {
+	resp, err := s.cs.newRequest("updateNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateNetworkResponse struct {
+	JobID                       string `json:"jobid,omitempty"`
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type CreatePhysicalNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreatePhysicalNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["broadcastdomainrange"]; found {
+		u.Set("broadcastdomainrange", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["isolationmethods"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("isolationmethods", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkspeed"]; found {
+		u.Set("networkspeed", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("tags", vv)
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreatePhysicalNetworkParams) SetBroadcastdomainrange(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["broadcastdomainrange"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetIsolationmethods(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isolationmethods"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetNetworkspeed(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkspeed"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetTags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *CreatePhysicalNetworkParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreatePhysicalNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewCreatePhysicalNetworkParams(name string, zoneid string) *CreatePhysicalNetworkParams {
+	p := &CreatePhysicalNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a physical network
+func (s *NetworkService) CreatePhysicalNetwork(p *CreatePhysicalNetworkParams) (*CreatePhysicalNetworkResponse, error) {
+	resp, err := s.cs.newRequest("createPhysicalNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreatePhysicalNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreatePhysicalNetworkResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Broadcastdomainrange string `json:"broadcastdomainrange,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isolationmethods     string `json:"isolationmethods,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkspeed         string `json:"networkspeed,omitempty"`
+	State                string `json:"state,omitempty"`
+	Tags                 string `json:"tags,omitempty"`
+	Vlan                 string `json:"vlan,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type DeletePhysicalNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePhysicalNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePhysicalNetworkParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePhysicalNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDeletePhysicalNetworkParams(id string) *DeletePhysicalNetworkParams {
+	p := &DeletePhysicalNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a Physical Network.
+func (s *NetworkService) DeletePhysicalNetwork(p *DeletePhysicalNetworkParams) (*DeletePhysicalNetworkResponse, error) {
+	resp, err := s.cs.newRequest("deletePhysicalNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePhysicalNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeletePhysicalNetworkResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListPhysicalNetworksParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPhysicalNetworksParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListPhysicalNetworksParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPhysicalNetworksParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPhysicalNetworksParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListPhysicalNetworksParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPhysicalNetworksParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPhysicalNetworksParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPhysicalNetworksParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListPhysicalNetworksParams() *ListPhysicalNetworksParams {
+	p := &ListPhysicalNetworksParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetPhysicalNetworkID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListPhysicalNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListPhysicalNetworks(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.PhysicalNetworks[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.PhysicalNetworks {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetPhysicalNetworkByName(name string, opts ...OptionFunc) (*PhysicalNetwork, int, error) {
+	id, count, err := s.GetPhysicalNetworkID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetPhysicalNetworkByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetPhysicalNetworkByID(id string, opts ...OptionFunc) (*PhysicalNetwork, int, error) {
+	p := &ListPhysicalNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPhysicalNetworks(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.PhysicalNetworks[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for PhysicalNetwork UUID: %s!", id)
+}
+
+// Lists physical networks
+func (s *NetworkService) ListPhysicalNetworks(p *ListPhysicalNetworksParams) (*ListPhysicalNetworksResponse, error) {
+	resp, err := s.cs.newRequest("listPhysicalNetworks", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPhysicalNetworksResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPhysicalNetworksResponse struct {
+	Count            int                `json:"count"`
+	PhysicalNetworks []*PhysicalNetwork `json:"physicalnetwork"`
+}
+
+type PhysicalNetwork struct {
+	Broadcastdomainrange string `json:"broadcastdomainrange,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isolationmethods     string `json:"isolationmethods,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkspeed         string `json:"networkspeed,omitempty"`
+	State                string `json:"state,omitempty"`
+	Tags                 string `json:"tags,omitempty"`
+	Vlan                 string `json:"vlan,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type UpdatePhysicalNetworkParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdatePhysicalNetworkParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["networkspeed"]; found {
+		u.Set("networkspeed", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("tags", vv)
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	return u
+}
+
+func (p *UpdatePhysicalNetworkParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdatePhysicalNetworkParams) SetNetworkspeed(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkspeed"] = v
+	return
+}
+
+func (p *UpdatePhysicalNetworkParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *UpdatePhysicalNetworkParams) SetTags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *UpdatePhysicalNetworkParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+// You should always use this function to get a new UpdatePhysicalNetworkParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewUpdatePhysicalNetworkParams(id string) *UpdatePhysicalNetworkParams {
+	p := &UpdatePhysicalNetworkParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a physical network
+func (s *NetworkService) UpdatePhysicalNetwork(p *UpdatePhysicalNetworkParams) (*UpdatePhysicalNetworkResponse, error) {
+	resp, err := s.cs.newRequest("updatePhysicalNetwork", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdatePhysicalNetworkResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdatePhysicalNetworkResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Broadcastdomainrange string `json:"broadcastdomainrange,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isolationmethods     string `json:"isolationmethods,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkspeed         string `json:"networkspeed,omitempty"`
+	State                string `json:"state,omitempty"`
+	Tags                 string `json:"tags,omitempty"`
+	Vlan                 string `json:"vlan,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+}
+
+type ListSupportedNetworkServicesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSupportedNetworkServicesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["service"]; found {
+		u.Set("service", v.(string))
+	}
+	return u
+}
+
+func (p *ListSupportedNetworkServicesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSupportedNetworkServicesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSupportedNetworkServicesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSupportedNetworkServicesParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *ListSupportedNetworkServicesParams) SetService(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["service"] = v
+	return
+}
+
+// You should always use this function to get a new ListSupportedNetworkServicesParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListSupportedNetworkServicesParams() *ListSupportedNetworkServicesParams {
+	p := &ListSupportedNetworkServicesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all network services provided by CloudStack or for the given Provider.
+func (s *NetworkService) ListSupportedNetworkServices(p *ListSupportedNetworkServicesParams) (*ListSupportedNetworkServicesResponse, error) {
+	resp, err := s.cs.newRequest("listSupportedNetworkServices", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSupportedNetworkServicesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSupportedNetworkServicesResponse struct {
+	Count                    int                        `json:"count"`
+	SupportedNetworkServices []*SupportedNetworkService `json:"supportednetworkservice"`
+}
+
+type SupportedNetworkService struct {
+	Capability []struct {
+		Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+		Name                       string `json:"name,omitempty"`
+		Value                      string `json:"value,omitempty"`
+	} `json:"capability,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Provider []struct {
+		Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+		Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+		Id                           string   `json:"id,omitempty"`
+		Name                         string   `json:"name,omitempty"`
+		Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+		Servicelist                  []string `json:"servicelist,omitempty"`
+		State                        string   `json:"state,omitempty"`
+	} `json:"provider,omitempty"`
+}
+
+type AddNetworkServiceProviderParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddNetworkServiceProviderParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["destinationphysicalnetworkid"]; found {
+		u.Set("destinationphysicalnetworkid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["servicelist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("servicelist", vv)
+	}
+	return u
+}
+
+func (p *AddNetworkServiceProviderParams) SetDestinationphysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["destinationphysicalnetworkid"] = v
+	return
+}
+
+func (p *AddNetworkServiceProviderParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *AddNetworkServiceProviderParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddNetworkServiceProviderParams) SetServicelist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["servicelist"] = v
+	return
+}
+
+// You should always use this function to get a new AddNetworkServiceProviderParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewAddNetworkServiceProviderParams(name string, physicalnetworkid string) *AddNetworkServiceProviderParams {
+	p := &AddNetworkServiceProviderParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["physicalnetworkid"] = physicalnetworkid
+	return p
+}
+
+// Adds a network serviceProvider to a physical network
+func (s *NetworkService) AddNetworkServiceProvider(p *AddNetworkServiceProviderParams) (*AddNetworkServiceProviderResponse, error) {
+	resp, err := s.cs.newRequest("addNetworkServiceProvider", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddNetworkServiceProviderResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddNetworkServiceProviderResponse struct {
+	JobID                        string   `json:"jobid,omitempty"`
+	Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+	Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+	Id                           string   `json:"id,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+	Servicelist                  []string `json:"servicelist,omitempty"`
+	State                        string   `json:"state,omitempty"`
+}
+
+type DeleteNetworkServiceProviderParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNetworkServiceProviderParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNetworkServiceProviderParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNetworkServiceProviderParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDeleteNetworkServiceProviderParams(id string) *DeleteNetworkServiceProviderParams {
+	p := &DeleteNetworkServiceProviderParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a Network Service Provider.
+func (s *NetworkService) DeleteNetworkServiceProvider(p *DeleteNetworkServiceProviderParams) (*DeleteNetworkServiceProviderResponse, error) {
+	resp, err := s.cs.newRequest("deleteNetworkServiceProvider", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNetworkServiceProviderResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNetworkServiceProviderResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListNetworkServiceProvidersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkServiceProvidersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *ListNetworkServiceProvidersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkServiceProvidersParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListNetworkServiceProvidersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkServiceProvidersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNetworkServiceProvidersParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *ListNetworkServiceProvidersParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkServiceProvidersParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListNetworkServiceProvidersParams() *ListNetworkServiceProvidersParams {
+	p := &ListNetworkServiceProvidersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNetworkServiceProviderID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNetworkServiceProvidersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNetworkServiceProviders(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetworkServiceProviders[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.NetworkServiceProviders {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// Lists network serviceproviders for a given physical network.
+func (s *NetworkService) ListNetworkServiceProviders(p *ListNetworkServiceProvidersParams) (*ListNetworkServiceProvidersResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkServiceProviders", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkServiceProvidersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkServiceProvidersResponse struct {
+	Count                   int                       `json:"count"`
+	NetworkServiceProviders []*NetworkServiceProvider `json:"networkserviceprovider"`
+}
+
+type NetworkServiceProvider struct {
+	Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+	Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+	Id                           string   `json:"id,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+	Servicelist                  []string `json:"servicelist,omitempty"`
+	State                        string   `json:"state,omitempty"`
+}
+
+type UpdateNetworkServiceProviderParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateNetworkServiceProviderParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["servicelist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("servicelist", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateNetworkServiceProviderParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateNetworkServiceProviderParams) SetServicelist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["servicelist"] = v
+	return
+}
+
+func (p *UpdateNetworkServiceProviderParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateNetworkServiceProviderParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewUpdateNetworkServiceProviderParams(id string) *UpdateNetworkServiceProviderParams {
+	p := &UpdateNetworkServiceProviderParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a network serviceProvider of a physical network
+func (s *NetworkService) UpdateNetworkServiceProvider(p *UpdateNetworkServiceProviderParams) (*UpdateNetworkServiceProviderResponse, error) {
+	resp, err := s.cs.newRequest("updateNetworkServiceProvider", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateNetworkServiceProviderResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateNetworkServiceProviderResponse struct {
+	JobID                        string   `json:"jobid,omitempty"`
+	Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+	Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+	Id                           string   `json:"id,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+	Servicelist                  []string `json:"servicelist,omitempty"`
+	State                        string   `json:"state,omitempty"`
+}
+
+type CreateStorageNetworkIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateStorageNetworkIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("vlan", vv)
+	}
+	return u
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *CreateStorageNetworkIpRangeParams) SetVlan(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+// You should always use this function to get a new CreateStorageNetworkIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewCreateStorageNetworkIpRangeParams(gateway string, netmask string, podid string, startip string) *CreateStorageNetworkIpRangeParams {
+	p := &CreateStorageNetworkIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["gateway"] = gateway
+	p.p["netmask"] = netmask
+	p.p["podid"] = podid
+	p.p["startip"] = startip
+	return p
+}
+
+// Creates a Storage network IP range.
+func (s *NetworkService) CreateStorageNetworkIpRange(p *CreateStorageNetworkIpRangeParams) (*CreateStorageNetworkIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("createStorageNetworkIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateStorageNetworkIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateStorageNetworkIpRangeResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Endip     string `json:"endip,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Netmask   string `json:"netmask,omitempty"`
+	Networkid string `json:"networkid,omitempty"`
+	Podid     string `json:"podid,omitempty"`
+	Startip   string `json:"startip,omitempty"`
+	Vlan      int    `json:"vlan,omitempty"`
+	Zoneid    string `json:"zoneid,omitempty"`
+}
+
+type DeleteStorageNetworkIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteStorageNetworkIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteStorageNetworkIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteStorageNetworkIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDeleteStorageNetworkIpRangeParams(id string) *DeleteStorageNetworkIpRangeParams {
+	p := &DeleteStorageNetworkIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a storage network IP Range.
+func (s *NetworkService) DeleteStorageNetworkIpRange(p *DeleteStorageNetworkIpRangeParams) (*DeleteStorageNetworkIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("deleteStorageNetworkIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteStorageNetworkIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteStorageNetworkIpRangeResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListStorageNetworkIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListStorageNetworkIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListStorageNetworkIpRangeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListStorageNetworkIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListStorageNetworkIpRangeParams() *ListStorageNetworkIpRangeParams {
+	p := &ListStorageNetworkIpRangeParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetStorageNetworkIpRangeByID(id string, opts ...OptionFunc) (*StorageNetworkIpRange, int, error) {
+	p := &ListStorageNetworkIpRangeParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListStorageNetworkIpRange(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.StorageNetworkIpRange[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for StorageNetworkIpRange UUID: %s!", id)
+}
+
+// List a storage network IP range.
+func (s *NetworkService) ListStorageNetworkIpRange(p *ListStorageNetworkIpRangeParams) (*ListStorageNetworkIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("listStorageNetworkIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListStorageNetworkIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListStorageNetworkIpRangeResponse struct {
+	Count                 int                      `json:"count"`
+	StorageNetworkIpRange []*StorageNetworkIpRange `json:"storagenetworkiprange"`
+}
+
+type StorageNetworkIpRange struct {
+	Endip     string `json:"endip,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Netmask   string `json:"netmask,omitempty"`
+	Networkid string `json:"networkid,omitempty"`
+	Podid     string `json:"podid,omitempty"`
+	Startip   string `json:"startip,omitempty"`
+	Vlan      int    `json:"vlan,omitempty"`
+	Zoneid    string `json:"zoneid,omitempty"`
+}
+
+type UpdateStorageNetworkIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("vlan", vv)
+	}
+	return u
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) SetVlan(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateStorageNetworkIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewUpdateStorageNetworkIpRangeParams(id string) *UpdateStorageNetworkIpRangeParams {
+	p := &UpdateStorageNetworkIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Update a Storage network IP range, only allowed when no IPs in this range have been allocated.
+func (s *NetworkService) UpdateStorageNetworkIpRange(p *UpdateStorageNetworkIpRangeParams) (*UpdateStorageNetworkIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("updateStorageNetworkIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateStorageNetworkIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateStorageNetworkIpRangeResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Endip     string `json:"endip,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Netmask   string `json:"netmask,omitempty"`
+	Networkid string `json:"networkid,omitempty"`
+	Podid     string `json:"podid,omitempty"`
+	Startip   string `json:"startip,omitempty"`
+	Vlan      int    `json:"vlan,omitempty"`
+	Zoneid    string `json:"zoneid,omitempty"`
+}
+
+type ListPaloAltoFirewallNetworksParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbdeviceid"]; found {
+		u.Set("lbdeviceid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) SetLbdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdeviceid"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListPaloAltoFirewallNetworksParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListPaloAltoFirewallNetworksParams(lbdeviceid string) *ListPaloAltoFirewallNetworksParams {
+	p := &ListPaloAltoFirewallNetworksParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbdeviceid"] = lbdeviceid
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetPaloAltoFirewallNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListPaloAltoFirewallNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+	p.p["lbdeviceid"] = lbdeviceid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListPaloAltoFirewallNetworks(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.PaloAltoFirewallNetworks[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.PaloAltoFirewallNetworks {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// lists network that are using Palo Alto firewall device
+func (s *NetworkService) ListPaloAltoFirewallNetworks(p *ListPaloAltoFirewallNetworksParams) (*ListPaloAltoFirewallNetworksResponse, error) {
+	resp, err := s.cs.newRequest("listPaloAltoFirewallNetworks", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPaloAltoFirewallNetworksResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPaloAltoFirewallNetworksResponse struct {
+	Count                    int                        `json:"count"`
+	PaloAltoFirewallNetworks []*PaloAltoFirewallNetwork `json:"paloaltofirewallnetwork"`
+}
+
+type PaloAltoFirewallNetwork struct {
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type ListNetscalerLoadBalancerNetworksParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["lbdeviceid"]; found {
+		u.Set("lbdeviceid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) SetLbdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lbdeviceid"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetscalerLoadBalancerNetworksParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListNetscalerLoadBalancerNetworksParams(lbdeviceid string) *ListNetscalerLoadBalancerNetworksParams {
+	p := &ListNetscalerLoadBalancerNetworksParams{}
+	p.p = make(map[string]interface{})
+	p.p["lbdeviceid"] = lbdeviceid
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNetscalerLoadBalancerNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNetscalerLoadBalancerNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+	p.p["lbdeviceid"] = lbdeviceid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNetscalerLoadBalancerNetworks(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.NetscalerLoadBalancerNetworks[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.NetscalerLoadBalancerNetworks {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// lists network that are using a netscaler load balancer device
+func (s *NetworkService) ListNetscalerLoadBalancerNetworks(p *ListNetscalerLoadBalancerNetworksParams) (*ListNetscalerLoadBalancerNetworksResponse, error) {
+	resp, err := s.cs.newRequest("listNetscalerLoadBalancerNetworks", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetscalerLoadBalancerNetworksResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetscalerLoadBalancerNetworksResponse struct {
+	Count                         int                             `json:"count"`
+	NetscalerLoadBalancerNetworks []*NetscalerLoadBalancerNetwork `json:"netscalerloadbalancernetwork"`
+}
+
+type NetscalerLoadBalancerNetwork struct {
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type ListNiciraNvpDeviceNetworksParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["nvpdeviceid"]; found {
+		u.Set("nvpdeviceid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) SetNvpdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nvpdeviceid"] = v
+	return
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListNiciraNvpDeviceNetworksParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListNiciraNvpDeviceNetworksParams(nvpdeviceid string) *ListNiciraNvpDeviceNetworksParams {
+	p := &ListNiciraNvpDeviceNetworksParams{}
+	p.p = make(map[string]interface{})
+	p.p["nvpdeviceid"] = nvpdeviceid
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetNiciraNvpDeviceNetworkID(keyword string, nvpdeviceid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListNiciraNvpDeviceNetworksParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+	p.p["nvpdeviceid"] = nvpdeviceid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListNiciraNvpDeviceNetworks(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.NiciraNvpDeviceNetworks[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.NiciraNvpDeviceNetworks {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// lists network that are using a nicira nvp device
+func (s *NetworkService) ListNiciraNvpDeviceNetworks(p *ListNiciraNvpDeviceNetworksParams) (*ListNiciraNvpDeviceNetworksResponse, error) {
+	resp, err := s.cs.newRequest("listNiciraNvpDeviceNetworks", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNiciraNvpDeviceNetworksResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNiciraNvpDeviceNetworksResponse struct {
+	Count                   int                       `json:"count"`
+	NiciraNvpDeviceNetworks []*NiciraNvpDeviceNetwork `json:"niciranvpdevicenetwork"`
+}
+
+type NiciraNvpDeviceNetwork struct {
+	Account                     string `json:"account,omitempty"`
+	Aclid                       string `json:"aclid,omitempty"`
+	Acltype                     string `json:"acltype,omitempty"`
+	Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+	Broadcasturi                string `json:"broadcasturi,omitempty"`
+	Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+	Cidr                        string `json:"cidr,omitempty"`
+	Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+	Displaytext                 string `json:"displaytext,omitempty"`
+	Dns1                        string `json:"dns1,omitempty"`
+	Dns2                        string `json:"dns2,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	Domainid                    string `json:"domainid,omitempty"`
+	Gateway                     string `json:"gateway,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	Ip6cidr                     string `json:"ip6cidr,omitempty"`
+	Ip6gateway                  string `json:"ip6gateway,omitempty"`
+	Isdefault                   bool   `json:"isdefault,omitempty"`
+	Ispersistent                bool   `json:"ispersistent,omitempty"`
+	Issystem                    bool   `json:"issystem,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Netmask                     string `json:"netmask,omitempty"`
+	Networkcidr                 string `json:"networkcidr,omitempty"`
+	Networkdomain               string `json:"networkdomain,omitempty"`
+	Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+	Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+	Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+	Networkofferingid           string `json:"networkofferingid,omitempty"`
+	Networkofferingname         string `json:"networkofferingname,omitempty"`
+	Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+	Project                     string `json:"project,omitempty"`
+	Projectid                   string `json:"projectid,omitempty"`
+	Related                     string `json:"related,omitempty"`
+	Reservediprange             string `json:"reservediprange,omitempty"`
+	Restartrequired             bool   `json:"restartrequired,omitempty"`
+	Service                     []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+	State            string `json:"state,omitempty"`
+	Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+	Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+	Tags             []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Traffictype       string   `json:"traffictype,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Vlan              string   `json:"vlan,omitempty"`
+	Vpcid             string   `json:"vpcid,omitempty"`
+	Zoneid            string   `json:"zoneid,omitempty"`
+	Zonename          string   `json:"zonename,omitempty"`
+	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+}
+
+type ListNetworkIsolationMethodsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNetworkIsolationMethodsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListNetworkIsolationMethodsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNetworkIsolationMethodsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNetworkIsolationMethodsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListNetworkIsolationMethodsParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListNetworkIsolationMethodsParams() *ListNetworkIsolationMethodsParams {
+	p := &ListNetworkIsolationMethodsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists supported methods of network isolation
+func (s *NetworkService) ListNetworkIsolationMethods(p *ListNetworkIsolationMethodsParams) (*ListNetworkIsolationMethodsResponse, error) {
+	resp, err := s.cs.newRequest("listNetworkIsolationMethods", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNetworkIsolationMethodsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNetworkIsolationMethodsResponse struct {
+	Count                   int                       `json:"count"`
+	NetworkIsolationMethods []*NetworkIsolationMethod `json:"networkisolationmethod"`
+}
+
+type NetworkIsolationMethod struct {
+	Name string `json:"name,omitempty"`
+}
+
+type AddOpenDaylightControllerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddOpenDaylightControllerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddOpenDaylightControllerParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddOpenDaylightControllerParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddOpenDaylightControllerParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddOpenDaylightControllerParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddOpenDaylightControllerParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewAddOpenDaylightControllerParams(password string, physicalnetworkid string, url string, username string) *AddOpenDaylightControllerParams {
+	p := &AddOpenDaylightControllerParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["url"] = url
+	p.p["username"] = username
+	return p
+}
+
+// Adds an OpenDyalight controler
+func (s *NetworkService) AddOpenDaylightController(p *AddOpenDaylightControllerParams) (*AddOpenDaylightControllerResponse, error) {
+	resp, err := s.cs.newRequest("addOpenDaylightController", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddOpenDaylightControllerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddOpenDaylightControllerResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Url               string `json:"url,omitempty"`
+	Username          string `json:"username,omitempty"`
+}
+
+type DeleteOpenDaylightControllerParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteOpenDaylightControllerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteOpenDaylightControllerParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteOpenDaylightControllerParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewDeleteOpenDaylightControllerParams(id string) *DeleteOpenDaylightControllerParams {
+	p := &DeleteOpenDaylightControllerParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes an OpenDyalight controler
+func (s *NetworkService) DeleteOpenDaylightController(p *DeleteOpenDaylightControllerParams) (*DeleteOpenDaylightControllerResponse, error) {
+	resp, err := s.cs.newRequest("deleteOpenDaylightController", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteOpenDaylightControllerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteOpenDaylightControllerResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Url               string `json:"url,omitempty"`
+	Username          string `json:"username,omitempty"`
+}
+
+type ListOpenDaylightControllersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListOpenDaylightControllersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListOpenDaylightControllersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListOpenDaylightControllersParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListOpenDaylightControllersParams instance,
+// as then you are sure you have configured all required params
+func (s *NetworkService) NewListOpenDaylightControllersParams() *ListOpenDaylightControllersParams {
+	p := &ListOpenDaylightControllersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *NetworkService) GetOpenDaylightControllerByID(id string, opts ...OptionFunc) (*OpenDaylightController, int, error) {
+	p := &ListOpenDaylightControllersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListOpenDaylightControllers(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.OpenDaylightControllers[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for OpenDaylightController UUID: %s!", id)
+}
+
+// Lists OpenDyalight controllers
+func (s *NetworkService) ListOpenDaylightControllers(p *ListOpenDaylightControllersParams) (*ListOpenDaylightControllersResponse, error) {
+	resp, err := s.cs.newRequest("listOpenDaylightControllers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListOpenDaylightControllersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListOpenDaylightControllersResponse struct {
+	Count                   int                       `json:"count"`
+	OpenDaylightControllers []*OpenDaylightController `json:"opendaylightcontroller"`
+}
+
+type OpenDaylightController struct {
+	Id                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Url               string `json:"url,omitempty"`
+	Username          string `json:"username,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NicService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NicService.go
@@ -1,0 +1,574 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type AddIpToNicParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddIpToNicParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["nicid"]; found {
+		u.Set("nicid", v.(string))
+	}
+	return u
+}
+
+func (p *AddIpToNicParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *AddIpToNicParams) SetNicid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicid"] = v
+	return
+}
+
+// You should always use this function to get a new AddIpToNicParams instance,
+// as then you are sure you have configured all required params
+func (s *NicService) NewAddIpToNicParams(nicid string) *AddIpToNicParams {
+	p := &AddIpToNicParams{}
+	p.p = make(map[string]interface{})
+	p.p["nicid"] = nicid
+	return p
+}
+
+// Assigns secondary IP to NIC
+func (s *NicService) AddIpToNic(p *AddIpToNicParams) (*AddIpToNicResponse, error) {
+	resp, err := s.cs.newRequest("addIpToNic", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddIpToNicResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddIpToNicResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Ipaddress        string `json:"ipaddress,omitempty"`
+	Networkid        string `json:"networkid,omitempty"`
+	Nicid            string `json:"nicid,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+}
+
+type RemoveIpFromNicParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveIpFromNicParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveIpFromNicParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveIpFromNicParams instance,
+// as then you are sure you have configured all required params
+func (s *NicService) NewRemoveIpFromNicParams(id string) *RemoveIpFromNicParams {
+	p := &RemoveIpFromNicParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes secondary IP from the NIC.
+func (s *NicService) RemoveIpFromNic(p *RemoveIpFromNicParams) (*RemoveIpFromNicResponse, error) {
+	resp, err := s.cs.newRequest("removeIpFromNic", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveIpFromNicResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveIpFromNicResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateVmNicIpParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVmNicIpParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["nicid"]; found {
+		u.Set("nicid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVmNicIpParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *UpdateVmNicIpParams) SetNicid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVmNicIpParams instance,
+// as then you are sure you have configured all required params
+func (s *NicService) NewUpdateVmNicIpParams(nicid string) *UpdateVmNicIpParams {
+	p := &UpdateVmNicIpParams{}
+	p.p = make(map[string]interface{})
+	p.p["nicid"] = nicid
+	return p
+}
+
+// Update the default Ip of a VM Nic
+func (s *NicService) UpdateVmNicIp(p *UpdateVmNicIpParams) (*UpdateVmNicIpResponse, error) {
+	resp, err := s.cs.newRequest("updateVmNicIp", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVmNicIpResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVmNicIpResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListNicsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNicsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["nicid"]; found {
+		u.Set("nicid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNicsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListNicsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNicsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListNicsParams) SetNicid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicid"] = v
+	return
+}
+
+func (p *ListNicsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNicsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNicsParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNicsParams instance,
+// as then you are sure you have configured all required params
+func (s *NicService) NewListNicsParams(virtualmachineid string) *ListNicsParams {
+	p := &ListNicsParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// list the vm nics  IP to NIC
+func (s *NicService) ListNics(p *ListNicsParams) (*ListNicsResponse, error) {
+	resp, err := s.cs.newRequest("listNics", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNicsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNicsResponse struct {
+	Count int    `json:"count"`
+	Nics  []*Nic `json:"nic"`
+}
+
+type Nic struct {
+	Broadcasturi string `json:"broadcasturi,omitempty"`
+	Deviceid     string `json:"deviceid,omitempty"`
+	Gateway      string `json:"gateway,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Ip6address   string `json:"ip6address,omitempty"`
+	Ip6cidr      string `json:"ip6cidr,omitempty"`
+	Ip6gateway   string `json:"ip6gateway,omitempty"`
+	Ipaddress    string `json:"ipaddress,omitempty"`
+	Isdefault    bool   `json:"isdefault,omitempty"`
+	Isolationuri string `json:"isolationuri,omitempty"`
+	Macaddress   string `json:"macaddress,omitempty"`
+	Netmask      string `json:"netmask,omitempty"`
+	Networkid    string `json:"networkid,omitempty"`
+	Networkname  string `json:"networkname,omitempty"`
+	Secondaryip  []struct {
+		Id        string `json:"id,omitempty"`
+		Ipaddress string `json:"ipaddress,omitempty"`
+	} `json:"secondaryip,omitempty"`
+	Traffictype      string `json:"traffictype,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/NiciraNVPService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/NiciraNVPService.go
@@ -1,0 +1,332 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type AddNiciraNvpDeviceParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddNiciraNvpDeviceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostname"]; found {
+		u.Set("hostname", v.(string))
+	}
+	if v, found := p.p["l3gatewayserviceuuid"]; found {
+		u.Set("l3gatewayserviceuuid", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["transportzoneuuid"]; found {
+		u.Set("transportzoneuuid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddNiciraNvpDeviceParams) SetHostname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostname"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetL3gatewayserviceuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["l3gatewayserviceuuid"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetTransportzoneuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["transportzoneuuid"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddNiciraNvpDeviceParams instance,
+// as then you are sure you have configured all required params
+func (s *NiciraNVPService) NewAddNiciraNvpDeviceParams(hostname string, password string, physicalnetworkid string, transportzoneuuid string, username string) *AddNiciraNvpDeviceParams {
+	p := &AddNiciraNvpDeviceParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostname"] = hostname
+	p.p["password"] = password
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["transportzoneuuid"] = transportzoneuuid
+	p.p["username"] = username
+	return p
+}
+
+// Adds a Nicira NVP device
+func (s *NiciraNVPService) AddNiciraNvpDevice(p *AddNiciraNvpDeviceParams) (*AddNiciraNvpDeviceResponse, error) {
+	resp, err := s.cs.newRequest("addNiciraNvpDevice", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddNiciraNvpDeviceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddNiciraNvpDeviceResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	L3gatewayserviceuuid string `json:"l3gatewayserviceuuid,omitempty"`
+	Niciradevicename     string `json:"niciradevicename,omitempty"`
+	Nvpdeviceid          string `json:"nvpdeviceid,omitempty"`
+	Physicalnetworkid    string `json:"physicalnetworkid,omitempty"`
+	Provider             string `json:"provider,omitempty"`
+	Transportzoneuuid    string `json:"transportzoneuuid,omitempty"`
+}
+
+type DeleteNiciraNvpDeviceParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteNiciraNvpDeviceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["nvpdeviceid"]; found {
+		u.Set("nvpdeviceid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteNiciraNvpDeviceParams) SetNvpdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nvpdeviceid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteNiciraNvpDeviceParams instance,
+// as then you are sure you have configured all required params
+func (s *NiciraNVPService) NewDeleteNiciraNvpDeviceParams(nvpdeviceid string) *DeleteNiciraNvpDeviceParams {
+	p := &DeleteNiciraNvpDeviceParams{}
+	p.p = make(map[string]interface{})
+	p.p["nvpdeviceid"] = nvpdeviceid
+	return p
+}
+
+//  delete a nicira nvp device
+func (s *NiciraNVPService) DeleteNiciraNvpDevice(p *DeleteNiciraNvpDeviceParams) (*DeleteNiciraNvpDeviceResponse, error) {
+	resp, err := s.cs.newRequest("deleteNiciraNvpDevice", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteNiciraNvpDeviceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteNiciraNvpDeviceResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListNiciraNvpDevicesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListNiciraNvpDevicesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["nvpdeviceid"]; found {
+		u.Set("nvpdeviceid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListNiciraNvpDevicesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListNiciraNvpDevicesParams) SetNvpdeviceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nvpdeviceid"] = v
+	return
+}
+
+func (p *ListNiciraNvpDevicesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListNiciraNvpDevicesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListNiciraNvpDevicesParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListNiciraNvpDevicesParams instance,
+// as then you are sure you have configured all required params
+func (s *NiciraNVPService) NewListNiciraNvpDevicesParams() *ListNiciraNvpDevicesParams {
+	p := &ListNiciraNvpDevicesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists Nicira NVP devices
+func (s *NiciraNVPService) ListNiciraNvpDevices(p *ListNiciraNvpDevicesParams) (*ListNiciraNvpDevicesResponse, error) {
+	resp, err := s.cs.newRequest("listNiciraNvpDevices", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListNiciraNvpDevicesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListNiciraNvpDevicesResponse struct {
+	Count            int                `json:"count"`
+	NiciraNvpDevices []*NiciraNvpDevice `json:"niciranvpdevice"`
+}
+
+type NiciraNvpDevice struct {
+	Hostname             string `json:"hostname,omitempty"`
+	L3gatewayserviceuuid string `json:"l3gatewayserviceuuid,omitempty"`
+	Niciradevicename     string `json:"niciradevicename,omitempty"`
+	Nvpdeviceid          string `json:"nvpdeviceid,omitempty"`
+	Physicalnetworkid    string `json:"physicalnetworkid,omitempty"`
+	Provider             string `json:"provider,omitempty"`
+	Transportzoneuuid    string `json:"transportzoneuuid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/OvsElementService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/OvsElementService.go
@@ -1,0 +1,268 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ConfigureOvsElementParams struct {
+	p map[string]interface{}
+}
+
+func (p *ConfigureOvsElementParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ConfigureOvsElementParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ConfigureOvsElementParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ConfigureOvsElementParams instance,
+// as then you are sure you have configured all required params
+func (s *OvsElementService) NewConfigureOvsElementParams(enabled bool, id string) *ConfigureOvsElementParams {
+	p := &ConfigureOvsElementParams{}
+	p.p = make(map[string]interface{})
+	p.p["enabled"] = enabled
+	p.p["id"] = id
+	return p
+}
+
+// Configures an ovs element.
+func (s *OvsElementService) ConfigureOvsElement(p *ConfigureOvsElementParams) (*ConfigureOvsElementResponse, error) {
+	resp, err := s.cs.newRequest("configureOvsElement", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ConfigureOvsElementResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ConfigureOvsElementResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Nspid     string `json:"nspid,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}
+
+type ListOvsElementsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListOvsElementsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["nspid"]; found {
+		u.Set("nspid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListOvsElementsParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ListOvsElementsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListOvsElementsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListOvsElementsParams) SetNspid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nspid"] = v
+	return
+}
+
+func (p *ListOvsElementsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListOvsElementsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListOvsElementsParams instance,
+// as then you are sure you have configured all required params
+func (s *OvsElementService) NewListOvsElementsParams() *ListOvsElementsParams {
+	p := &ListOvsElementsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *OvsElementService) GetOvsElementByID(id string, opts ...OptionFunc) (*OvsElement, int, error) {
+	p := &ListOvsElementsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListOvsElements(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.OvsElements[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for OvsElement UUID: %s!", id)
+}
+
+// Lists all available ovs elements.
+func (s *OvsElementService) ListOvsElements(p *ListOvsElementsParams) (*ListOvsElementsResponse, error) {
+	resp, err := s.cs.newRequest("listOvsElements", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListOvsElementsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListOvsElementsResponse struct {
+	Count       int           `json:"count"`
+	OvsElements []*OvsElement `json:"ovselement"`
+}
+
+type OvsElement struct {
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Nspid     string `json:"nspid,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/PodService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/PodService.go
@@ -1,0 +1,882 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreatePodParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreatePodParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreatePodParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *CreatePodParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *CreatePodParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreatePodParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreatePodParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreatePodParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *CreatePodParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreatePodParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewCreatePodParams(gateway string, name string, netmask string, startip string, zoneid string) *CreatePodParams {
+	p := &CreatePodParams{}
+	p.p = make(map[string]interface{})
+	p.p["gateway"] = gateway
+	p.p["name"] = name
+	p.p["netmask"] = netmask
+	p.p["startip"] = startip
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a new Pod.
+func (s *PodService) CreatePod(p *CreatePodParams) (*CreatePodResponse, error) {
+	resp, err := s.cs.newRequest("createPod", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreatePodResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreatePodResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Endip    string `json:"endip,omitempty"`
+	Gateway  string `json:"gateway,omitempty"`
+	Id       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Netmask  string `json:"netmask,omitempty"`
+	Startip  string `json:"startip,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+	Zonename string `json:"zonename,omitempty"`
+}
+
+type UpdatePodParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdatePodParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	return u
+}
+
+func (p *UpdatePodParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *UpdatePodParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+// You should always use this function to get a new UpdatePodParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewUpdatePodParams(id string) *UpdatePodParams {
+	p := &UpdatePodParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a Pod.
+func (s *PodService) UpdatePod(p *UpdatePodParams) (*UpdatePodResponse, error) {
+	resp, err := s.cs.newRequest("updatePod", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdatePodResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdatePodResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Endip    string `json:"endip,omitempty"`
+	Gateway  string `json:"gateway,omitempty"`
+	Id       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Netmask  string `json:"netmask,omitempty"`
+	Startip  string `json:"startip,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+	Zonename string `json:"zonename,omitempty"`
+}
+
+type DeletePodParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePodParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePodParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePodParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewDeletePodParams(id string) *DeletePodParams {
+	p := &DeletePodParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a Pod.
+func (s *PodService) DeletePod(p *DeletePodParams) (*DeletePodResponse, error) {
+	resp, err := s.cs.newRequest("deletePod", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePodResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeletePodResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListPodsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPodsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["showcapacities"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showcapacities", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListPodsParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *ListPodsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPodsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPodsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListPodsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPodsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPodsParams) SetShowcapacities(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showcapacities"] = v
+	return
+}
+
+func (p *ListPodsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPodsParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewListPodsParams() *ListPodsParams {
+	p := &ListPodsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PodService) GetPodID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListPodsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListPods(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Pods[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Pods {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PodService) GetPodByName(name string, opts ...OptionFunc) (*Pod, int, error) {
+	id, count, err := s.GetPodID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetPodByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PodService) GetPodByID(id string, opts ...OptionFunc) (*Pod, int, error) {
+	p := &ListPodsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPods(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Pods[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Pod UUID: %s!", id)
+}
+
+// Lists all Pods.
+func (s *PodService) ListPods(p *ListPodsParams) (*ListPodsResponse, error) {
+	resp, err := s.cs.newRequest("listPods", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPodsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPodsResponse struct {
+	Count int    `json:"count"`
+	Pods  []*Pod `json:"pod"`
+}
+
+type Pod struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Endip    string `json:"endip,omitempty"`
+	Gateway  string `json:"gateway,omitempty"`
+	Id       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Netmask  string `json:"netmask,omitempty"`
+	Startip  string `json:"startip,omitempty"`
+	Zoneid   string `json:"zoneid,omitempty"`
+	Zonename string `json:"zonename,omitempty"`
+}
+
+type DedicatePodParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicatePodParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	return u
+}
+
+func (p *DedicatePodParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicatePodParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DedicatePodParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+// You should always use this function to get a new DedicatePodParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewDedicatePodParams(domainid string, podid string) *DedicatePodParams {
+	p := &DedicatePodParams{}
+	p.p = make(map[string]interface{})
+	p.p["domainid"] = domainid
+	p.p["podid"] = podid
+	return p
+}
+
+// Dedicates a Pod.
+func (s *PodService) DedicatePod(p *DedicatePodParams) (*DedicatePodResponse, error) {
+	resp, err := s.cs.newRequest("dedicatePod", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicatePodResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DedicatePodResponse struct {
+	JobID           string `json:"jobid,omitempty"`
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+	Podid           string `json:"podid,omitempty"`
+	Podname         string `json:"podname,omitempty"`
+}
+
+type ReleaseDedicatedPodParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseDedicatedPodParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseDedicatedPodParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseDedicatedPodParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewReleaseDedicatedPodParams(podid string) *ReleaseDedicatedPodParams {
+	p := &ReleaseDedicatedPodParams{}
+	p.p = make(map[string]interface{})
+	p.p["podid"] = podid
+	return p
+}
+
+// Release the dedication for the pod
+func (s *PodService) ReleaseDedicatedPod(p *ReleaseDedicatedPodParams) (*ReleaseDedicatedPodResponse, error) {
+	resp, err := s.cs.newRequest("releaseDedicatedPod", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseDedicatedPodResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseDedicatedPodResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDedicatedPodsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDedicatedPodsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupid"]; found {
+		u.Set("affinitygroupid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	return u
+}
+
+func (p *ListDedicatedPodsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetAffinitygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupid"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListDedicatedPodsParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+// You should always use this function to get a new ListDedicatedPodsParams instance,
+// as then you are sure you have configured all required params
+func (s *PodService) NewListDedicatedPodsParams() *ListDedicatedPodsParams {
+	p := &ListDedicatedPodsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists dedicated pods.
+func (s *PodService) ListDedicatedPods(p *ListDedicatedPodsParams) (*ListDedicatedPodsResponse, error) {
+	resp, err := s.cs.newRequest("listDedicatedPods", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDedicatedPodsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDedicatedPodsResponse struct {
+	Count         int             `json:"count"`
+	DedicatedPods []*DedicatedPod `json:"dedicatedpod"`
+}
+
+type DedicatedPod struct {
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+	Podid           string `json:"podid,omitempty"`
+	Podname         string `json:"podname,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/PoolService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/PoolService.go
@@ -1,0 +1,800 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListStoragePoolsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListStoragePoolsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["path"]; found {
+		u.Set("path", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["scope"]; found {
+		u.Set("scope", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListStoragePoolsParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetPath(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["path"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetScope(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scope"] = v
+	return
+}
+
+func (p *ListStoragePoolsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListStoragePoolsParams instance,
+// as then you are sure you have configured all required params
+func (s *PoolService) NewListStoragePoolsParams() *ListStoragePoolsParams {
+	p := &ListStoragePoolsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PoolService) GetStoragePoolID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListStoragePoolsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListStoragePools(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.StoragePools[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.StoragePools {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PoolService) GetStoragePoolByName(name string, opts ...OptionFunc) (*StoragePool, int, error) {
+	id, count, err := s.GetStoragePoolID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetStoragePoolByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PoolService) GetStoragePoolByID(id string, opts ...OptionFunc) (*StoragePool, int, error) {
+	p := &ListStoragePoolsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListStoragePools(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.StoragePools[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for StoragePool UUID: %s!", id)
+}
+
+// Lists storage pools.
+func (s *PoolService) ListStoragePools(p *ListStoragePoolsParams) (*ListStoragePoolsResponse, error) {
+	resp, err := s.cs.newRequest("listStoragePools", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListStoragePoolsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListStoragePoolsResponse struct {
+	Count        int            `json:"count"`
+	StoragePools []*StoragePool `json:"storagepool"`
+}
+
+type StoragePool struct {
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}
+
+type CreateStoragePoolParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateStoragePoolParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["capacitybytes"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("capacitybytes", vv)
+	}
+	if v, found := p.p["capacityiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("capacityiops", vv)
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["managed"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("managed", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["provider"]; found {
+		u.Set("provider", v.(string))
+	}
+	if v, found := p.p["scope"]; found {
+		u.Set("scope", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		u.Set("tags", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateStoragePoolParams) SetCapacitybytes(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["capacitybytes"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetCapacityiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["capacityiops"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetManaged(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managed"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetProvider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provider"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetScope(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["scope"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetTags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *CreateStoragePoolParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateStoragePoolParams instance,
+// as then you are sure you have configured all required params
+func (s *PoolService) NewCreateStoragePoolParams(name string, url string, zoneid string) *CreateStoragePoolParams {
+	p := &CreateStoragePoolParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a storage pool.
+func (s *PoolService) CreateStoragePool(p *CreateStoragePoolParams) (*CreateStoragePoolResponse, error) {
+	resp, err := s.cs.newRequest("createStoragePool", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateStoragePoolResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateStoragePoolResponse struct {
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}
+
+type UpdateStoragePoolParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateStoragePoolParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["capacitybytes"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("capacitybytes", vv)
+	}
+	if v, found := p.p["capacityiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("capacityiops", vv)
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("tags", vv)
+	}
+	return u
+}
+
+func (p *UpdateStoragePoolParams) SetCapacitybytes(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["capacitybytes"] = v
+	return
+}
+
+func (p *UpdateStoragePoolParams) SetCapacityiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["capacityiops"] = v
+	return
+}
+
+func (p *UpdateStoragePoolParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *UpdateStoragePoolParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateStoragePoolParams) SetTags(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateStoragePoolParams instance,
+// as then you are sure you have configured all required params
+func (s *PoolService) NewUpdateStoragePoolParams(id string) *UpdateStoragePoolParams {
+	p := &UpdateStoragePoolParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a storage pool.
+func (s *PoolService) UpdateStoragePool(p *UpdateStoragePoolParams) (*UpdateStoragePoolResponse, error) {
+	resp, err := s.cs.newRequest("updateStoragePool", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateStoragePoolResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateStoragePoolResponse struct {
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}
+
+type DeleteStoragePoolParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteStoragePoolParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteStoragePoolParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *DeleteStoragePoolParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteStoragePoolParams instance,
+// as then you are sure you have configured all required params
+func (s *PoolService) NewDeleteStoragePoolParams(id string) *DeleteStoragePoolParams {
+	p := &DeleteStoragePoolParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a storage pool.
+func (s *PoolService) DeleteStoragePool(p *DeleteStoragePoolParams) (*DeleteStoragePoolResponse, error) {
+	resp, err := s.cs.newRequest("deleteStoragePool", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteStoragePoolResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteStoragePoolResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type FindStoragePoolsForMigrationParams struct {
+	p map[string]interface{}
+}
+
+func (p *FindStoragePoolsForMigrationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *FindStoragePoolsForMigrationParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *FindStoragePoolsForMigrationParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *FindStoragePoolsForMigrationParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *FindStoragePoolsForMigrationParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new FindStoragePoolsForMigrationParams instance,
+// as then you are sure you have configured all required params
+func (s *PoolService) NewFindStoragePoolsForMigrationParams(id string) *FindStoragePoolsForMigrationParams {
+	p := &FindStoragePoolsForMigrationParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Lists storage pools available for migration of a volume.
+func (s *PoolService) FindStoragePoolsForMigration(p *FindStoragePoolsForMigrationParams) (*FindStoragePoolsForMigrationResponse, error) {
+	resp, err := s.cs.newRequest("findStoragePoolsForMigration", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r FindStoragePoolsForMigrationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type FindStoragePoolsForMigrationResponse struct {
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/PortableIPService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/PortableIPService.go
@@ -1,0 +1,393 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreatePortableIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreatePortableIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["regionid"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("regionid", vv)
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	return u
+}
+
+func (p *CreatePortableIpRangeParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *CreatePortableIpRangeParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreatePortableIpRangeParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreatePortableIpRangeParams) SetRegionid(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["regionid"] = v
+	return
+}
+
+func (p *CreatePortableIpRangeParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *CreatePortableIpRangeParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+// You should always use this function to get a new CreatePortableIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *PortableIPService) NewCreatePortableIpRangeParams(endip string, gateway string, netmask string, regionid int, startip string) *CreatePortableIpRangeParams {
+	p := &CreatePortableIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["endip"] = endip
+	p.p["gateway"] = gateway
+	p.p["netmask"] = netmask
+	p.p["regionid"] = regionid
+	p.p["startip"] = startip
+	return p
+}
+
+// adds a range of portable public IP's to a region
+func (s *PortableIPService) CreatePortableIpRange(p *CreatePortableIpRangeParams) (*CreatePortableIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("createPortableIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreatePortableIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreatePortableIpRangeResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Endip             string `json:"endip,omitempty"`
+	Gateway           string `json:"gateway,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Netmask           string `json:"netmask,omitempty"`
+	Portableipaddress []struct {
+		Accountid         string `json:"accountid,omitempty"`
+		Allocated         string `json:"allocated,omitempty"`
+		Domainid          string `json:"domainid,omitempty"`
+		Ipaddress         string `json:"ipaddress,omitempty"`
+		Networkid         string `json:"networkid,omitempty"`
+		Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+		Regionid          int    `json:"regionid,omitempty"`
+		State             string `json:"state,omitempty"`
+		Vpcid             string `json:"vpcid,omitempty"`
+		Zoneid            string `json:"zoneid,omitempty"`
+	} `json:"portableipaddress,omitempty"`
+	Regionid int    `json:"regionid,omitempty"`
+	Startip  string `json:"startip,omitempty"`
+	Vlan     string `json:"vlan,omitempty"`
+}
+
+type DeletePortableIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePortableIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePortableIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePortableIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *PortableIPService) NewDeletePortableIpRangeParams(id string) *DeletePortableIpRangeParams {
+	p := &DeletePortableIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// deletes a range of portable public IP's associated with a region
+func (s *PortableIPService) DeletePortableIpRange(p *DeletePortableIpRangeParams) (*DeletePortableIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("deletePortableIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePortableIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeletePortableIpRangeResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListPortableIpRangesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPortableIpRangesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["regionid"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("regionid", vv)
+	}
+	return u
+}
+
+func (p *ListPortableIpRangesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPortableIpRangesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPortableIpRangesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPortableIpRangesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPortableIpRangesParams) SetRegionid(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["regionid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPortableIpRangesParams instance,
+// as then you are sure you have configured all required params
+func (s *PortableIPService) NewListPortableIpRangesParams() *ListPortableIpRangesParams {
+	p := &ListPortableIpRangesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *PortableIPService) GetPortableIpRangeByID(id string, opts ...OptionFunc) (*PortableIpRange, int, error) {
+	p := &ListPortableIpRangesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPortableIpRanges(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.PortableIpRanges[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for PortableIpRange UUID: %s!", id)
+}
+
+// list portable IP ranges
+func (s *PortableIPService) ListPortableIpRanges(p *ListPortableIpRangesParams) (*ListPortableIpRangesResponse, error) {
+	resp, err := s.cs.newRequest("listPortableIpRanges", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPortableIpRangesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPortableIpRangesResponse struct {
+	Count            int                `json:"count"`
+	PortableIpRanges []*PortableIpRange `json:"portableiprange"`
+}
+
+type PortableIpRange struct {
+	Endip             string `json:"endip,omitempty"`
+	Gateway           string `json:"gateway,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Netmask           string `json:"netmask,omitempty"`
+	Portableipaddress []struct {
+		Accountid         string `json:"accountid,omitempty"`
+		Allocated         string `json:"allocated,omitempty"`
+		Domainid          string `json:"domainid,omitempty"`
+		Ipaddress         string `json:"ipaddress,omitempty"`
+		Networkid         string `json:"networkid,omitempty"`
+		Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+		Regionid          int    `json:"regionid,omitempty"`
+		State             string `json:"state,omitempty"`
+		Vpcid             string `json:"vpcid,omitempty"`
+		Zoneid            string `json:"zoneid,omitempty"`
+	} `json:"portableipaddress,omitempty"`
+	Regionid int    `json:"regionid,omitempty"`
+	Startip  string `json:"startip,omitempty"`
+	Vlan     string `json:"vlan,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ProjectService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ProjectService.go
@@ -1,0 +1,1341 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *CreateProjectParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateProjectParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateProjectParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateProjectParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new CreateProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewCreateProjectParams(displaytext string, name string) *CreateProjectParams {
+	p := &CreateProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	return p
+}
+
+// Creates a project
+func (s *ProjectService) CreateProject(p *CreateProjectParams) (*CreateProjectResponse, error) {
+	resp, err := s.cs.newRequest("createProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateProjectResponse struct {
+	JobID                     string `json:"jobid,omitempty"`
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type DeleteProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteProjectParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewDeleteProjectParams(id string) *DeleteProjectParams {
+	p := &DeleteProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a project
+func (s *ProjectService) DeleteProject(p *DeleteProjectParams) (*DeleteProjectResponse, error) {
+	resp, err := s.cs.newRequest("deleteProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteProjectResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateProjectParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateProjectParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateProjectParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewUpdateProjectParams(id string) *UpdateProjectParams {
+	p := &UpdateProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a project
+func (s *ProjectService) UpdateProject(p *UpdateProjectParams) (*UpdateProjectResponse, error) {
+	resp, err := s.cs.newRequest("updateProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateProjectResponse struct {
+	JobID                     string `json:"jobid,omitempty"`
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type ActivateProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *ActivateProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ActivateProjectParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ActivateProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewActivateProjectParams(id string) *ActivateProjectParams {
+	p := &ActivateProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Activates a project
+func (s *ProjectService) ActivateProject(p *ActivateProjectParams) (*ActivateProjectResponse, error) {
+	resp, err := s.cs.newRequest("activateProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ActivateProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ActivateProjectResponse struct {
+	JobID                     string `json:"jobid,omitempty"`
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type SuspendProjectParams struct {
+	p map[string]interface{}
+}
+
+func (p *SuspendProjectParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *SuspendProjectParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new SuspendProjectParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewSuspendProjectParams(id string) *SuspendProjectParams {
+	p := &SuspendProjectParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Suspends a project
+func (s *ProjectService) SuspendProject(p *SuspendProjectParams) (*SuspendProjectResponse, error) {
+	resp, err := s.cs.newRequest("suspendProject", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r SuspendProjectResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type SuspendProjectResponse struct {
+	JobID                     string `json:"jobid,omitempty"`
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type ListProjectsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListProjectsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListProjectsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListProjectsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListProjectsParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewListProjectsParams() *ListProjectsParams {
+	p := &ListProjectsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ProjectService) GetProjectID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListProjectsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListProjects(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Projects[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Projects {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ProjectService) GetProjectByName(name string, opts ...OptionFunc) (*Project, int, error) {
+	id, count, err := s.GetProjectID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetProjectByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ProjectService) GetProjectByID(id string, opts ...OptionFunc) (*Project, int, error) {
+	p := &ListProjectsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListProjects(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Projects[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Project UUID: %s!", id)
+}
+
+// Lists projects and provides detailed information for listed projects
+func (s *ProjectService) ListProjects(p *ListProjectsParams) (*ListProjectsResponse, error) {
+	resp, err := s.cs.newRequest("listProjects", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListProjectsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListProjectsResponse struct {
+	Count    int        `json:"count"`
+	Projects []*Project `json:"project"`
+}
+
+type Project struct {
+	Account                   string `json:"account,omitempty"`
+	Cpuavailable              string `json:"cpuavailable,omitempty"`
+	Cpulimit                  string `json:"cpulimit,omitempty"`
+	Cputotal                  int64  `json:"cputotal,omitempty"`
+	Displaytext               string `json:"displaytext,omitempty"`
+	Domain                    string `json:"domain,omitempty"`
+	Domainid                  string `json:"domainid,omitempty"`
+	Id                        string `json:"id,omitempty"`
+	Ipavailable               string `json:"ipavailable,omitempty"`
+	Iplimit                   string `json:"iplimit,omitempty"`
+	Iptotal                   int64  `json:"iptotal,omitempty"`
+	Memoryavailable           string `json:"memoryavailable,omitempty"`
+	Memorylimit               string `json:"memorylimit,omitempty"`
+	Memorytotal               int64  `json:"memorytotal,omitempty"`
+	Name                      string `json:"name,omitempty"`
+	Networkavailable          string `json:"networkavailable,omitempty"`
+	Networklimit              string `json:"networklimit,omitempty"`
+	Networktotal              int64  `json:"networktotal,omitempty"`
+	Primarystorageavailable   string `json:"primarystorageavailable,omitempty"`
+	Primarystoragelimit       string `json:"primarystoragelimit,omitempty"`
+	Primarystoragetotal       int64  `json:"primarystoragetotal,omitempty"`
+	Secondarystorageavailable string `json:"secondarystorageavailable,omitempty"`
+	Secondarystoragelimit     string `json:"secondarystoragelimit,omitempty"`
+	Secondarystoragetotal     int64  `json:"secondarystoragetotal,omitempty"`
+	Snapshotavailable         string `json:"snapshotavailable,omitempty"`
+	Snapshotlimit             string `json:"snapshotlimit,omitempty"`
+	Snapshottotal             int64  `json:"snapshottotal,omitempty"`
+	State                     string `json:"state,omitempty"`
+	Tags                      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templateavailable string `json:"templateavailable,omitempty"`
+	Templatelimit     string `json:"templatelimit,omitempty"`
+	Templatetotal     int64  `json:"templatetotal,omitempty"`
+	Vmavailable       string `json:"vmavailable,omitempty"`
+	Vmlimit           string `json:"vmlimit,omitempty"`
+	Vmrunning         int    `json:"vmrunning,omitempty"`
+	Vmstopped         int    `json:"vmstopped,omitempty"`
+	Vmtotal           int64  `json:"vmtotal,omitempty"`
+	Volumeavailable   string `json:"volumeavailable,omitempty"`
+	Volumelimit       string `json:"volumelimit,omitempty"`
+	Volumetotal       int64  `json:"volumetotal,omitempty"`
+	Vpcavailable      string `json:"vpcavailable,omitempty"`
+	Vpclimit          string `json:"vpclimit,omitempty"`
+	Vpctotal          int64  `json:"vpctotal,omitempty"`
+}
+
+type ListProjectInvitationsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListProjectInvitationsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["activeonly"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("activeonly", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *ListProjectInvitationsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetActiveonly(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["activeonly"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListProjectInvitationsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new ListProjectInvitationsParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewListProjectInvitationsParams() *ListProjectInvitationsParams {
+	p := &ListProjectInvitationsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ProjectService) GetProjectInvitationByID(id string, opts ...OptionFunc) (*ProjectInvitation, int, error) {
+	p := &ListProjectInvitationsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListProjectInvitations(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.ProjectInvitations[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for ProjectInvitation UUID: %s!", id)
+}
+
+// Lists project invitations and provides detailed information for listed invitations
+func (s *ProjectService) ListProjectInvitations(p *ListProjectInvitationsParams) (*ListProjectInvitationsResponse, error) {
+	resp, err := s.cs.newRequest("listProjectInvitations", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListProjectInvitationsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListProjectInvitationsResponse struct {
+	Count              int                  `json:"count"`
+	ProjectInvitations []*ProjectInvitation `json:"projectinvitation"`
+}
+
+type ProjectInvitation struct {
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Email     string `json:"email,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	State     string `json:"state,omitempty"`
+}
+
+type UpdateProjectInvitationParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateProjectInvitationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accept"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("accept", vv)
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["token"]; found {
+		u.Set("token", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateProjectInvitationParams) SetAccept(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accept"] = v
+	return
+}
+
+func (p *UpdateProjectInvitationParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateProjectInvitationParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *UpdateProjectInvitationParams) SetToken(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["token"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateProjectInvitationParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewUpdateProjectInvitationParams(projectid string) *UpdateProjectInvitationParams {
+	p := &UpdateProjectInvitationParams{}
+	p.p = make(map[string]interface{})
+	p.p["projectid"] = projectid
+	return p
+}
+
+// Accepts or declines project invitation
+func (s *ProjectService) UpdateProjectInvitation(p *UpdateProjectInvitationParams) (*UpdateProjectInvitationResponse, error) {
+	resp, err := s.cs.newRequest("updateProjectInvitation", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateProjectInvitationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateProjectInvitationResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteProjectInvitationParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteProjectInvitationParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteProjectInvitationParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteProjectInvitationParams instance,
+// as then you are sure you have configured all required params
+func (s *ProjectService) NewDeleteProjectInvitationParams(id string) *DeleteProjectInvitationParams {
+	p := &DeleteProjectInvitationParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes project invitation
+func (s *ProjectService) DeleteProjectInvitation(p *DeleteProjectInvitationParams) (*DeleteProjectInvitationResponse, error) {
+	resp, err := s.cs.newRequest("deleteProjectInvitation", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteProjectInvitationResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteProjectInvitationResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/QuotaService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/QuotaService.go
@@ -1,0 +1,60 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type QuotaIsEnabledParams struct {
+	p map[string]interface{}
+}
+
+func (p *QuotaIsEnabledParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new QuotaIsEnabledParams instance,
+// as then you are sure you have configured all required params
+func (s *QuotaService) NewQuotaIsEnabledParams() *QuotaIsEnabledParams {
+	p := &QuotaIsEnabledParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Return true if the plugin is enabled
+func (s *QuotaService) QuotaIsEnabled(p *QuotaIsEnabledParams) (*QuotaIsEnabledResponse, error) {
+	resp, err := s.cs.newRequest("quotaIsEnabled", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r QuotaIsEnabledResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type QuotaIsEnabledResponse struct {
+	Isenabled bool `json:"isenabled,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/RegionService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/RegionService.go
@@ -1,0 +1,336 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type AddRegionParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddRegionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["endpoint"]; found {
+		u.Set("endpoint", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("id", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *AddRegionParams) SetEndpoint(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endpoint"] = v
+	return
+}
+
+func (p *AddRegionParams) SetId(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *AddRegionParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new AddRegionParams instance,
+// as then you are sure you have configured all required params
+func (s *RegionService) NewAddRegionParams(endpoint string, id int, name string) *AddRegionParams {
+	p := &AddRegionParams{}
+	p.p = make(map[string]interface{})
+	p.p["endpoint"] = endpoint
+	p.p["id"] = id
+	p.p["name"] = name
+	return p
+}
+
+// Adds a Region
+func (s *RegionService) AddRegion(p *AddRegionParams) (*AddRegionResponse, error) {
+	resp, err := s.cs.newRequest("addRegion", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddRegionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddRegionResponse struct {
+	Endpoint                 string `json:"endpoint,omitempty"`
+	Gslbserviceenabled       bool   `json:"gslbserviceenabled,omitempty"`
+	Id                       int    `json:"id,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Portableipserviceenabled bool   `json:"portableipserviceenabled,omitempty"`
+}
+
+type UpdateRegionParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateRegionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["endpoint"]; found {
+		u.Set("endpoint", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("id", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateRegionParams) SetEndpoint(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endpoint"] = v
+	return
+}
+
+func (p *UpdateRegionParams) SetId(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateRegionParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateRegionParams instance,
+// as then you are sure you have configured all required params
+func (s *RegionService) NewUpdateRegionParams(id int) *UpdateRegionParams {
+	p := &UpdateRegionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a region
+func (s *RegionService) UpdateRegion(p *UpdateRegionParams) (*UpdateRegionResponse, error) {
+	resp, err := s.cs.newRequest("updateRegion", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateRegionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateRegionResponse struct {
+	Endpoint                 string `json:"endpoint,omitempty"`
+	Gslbserviceenabled       bool   `json:"gslbserviceenabled,omitempty"`
+	Id                       int    `json:"id,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Portableipserviceenabled bool   `json:"portableipserviceenabled,omitempty"`
+}
+
+type RemoveRegionParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveRegionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("id", vv)
+	}
+	return u
+}
+
+func (p *RemoveRegionParams) SetId(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveRegionParams instance,
+// as then you are sure you have configured all required params
+func (s *RegionService) NewRemoveRegionParams(id int) *RemoveRegionParams {
+	p := &RemoveRegionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes specified region
+func (s *RegionService) RemoveRegion(p *RemoveRegionParams) (*RemoveRegionResponse, error) {
+	resp, err := s.cs.newRequest("removeRegion", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveRegionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RemoveRegionResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListRegionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListRegionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("id", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListRegionsParams) SetId(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListRegionsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListRegionsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListRegionsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListRegionsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListRegionsParams instance,
+// as then you are sure you have configured all required params
+func (s *RegionService) NewListRegionsParams() *ListRegionsParams {
+	p := &ListRegionsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists Regions
+func (s *RegionService) ListRegions(p *ListRegionsParams) (*ListRegionsResponse, error) {
+	resp, err := s.cs.newRequest("listRegions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListRegionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListRegionsResponse struct {
+	Count   int       `json:"count"`
+	Regions []*Region `json:"region"`
+}
+
+type Region struct {
+	Endpoint                 string `json:"endpoint,omitempty"`
+	Gslbserviceenabled       bool   `json:"gslbserviceenabled,omitempty"`
+	Id                       int    `json:"id,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Portableipserviceenabled bool   `json:"portableipserviceenabled,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcemetadataService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcemetadataService.go
@@ -1,0 +1,423 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type AddResourceDetailParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddResourceDetailParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["resourceid"]; found {
+		u.Set("resourceid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	return u
+}
+
+func (p *AddResourceDetailParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *AddResourceDetailParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *AddResourceDetailParams) SetResourceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceid"] = v
+	return
+}
+
+func (p *AddResourceDetailParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+// You should always use this function to get a new AddResourceDetailParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcemetadataService) NewAddResourceDetailParams(details map[string]string, resourceid string, resourcetype string) *AddResourceDetailParams {
+	p := &AddResourceDetailParams{}
+	p.p = make(map[string]interface{})
+	p.p["details"] = details
+	p.p["resourceid"] = resourceid
+	p.p["resourcetype"] = resourcetype
+	return p
+}
+
+// Adds detail for the Resource.
+func (s *ResourcemetadataService) AddResourceDetail(p *AddResourceDetailParams) (*AddResourceDetailResponse, error) {
+	resp, err := s.cs.newRequest("addResourceDetail", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddResourceDetailResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddResourceDetailResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type RemoveResourceDetailParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveResourceDetailParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["key"]; found {
+		u.Set("key", v.(string))
+	}
+	if v, found := p.p["resourceid"]; found {
+		u.Set("resourceid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveResourceDetailParams) SetKey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["key"] = v
+	return
+}
+
+func (p *RemoveResourceDetailParams) SetResourceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceid"] = v
+	return
+}
+
+func (p *RemoveResourceDetailParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveResourceDetailParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcemetadataService) NewRemoveResourceDetailParams(resourceid string, resourcetype string) *RemoveResourceDetailParams {
+	p := &RemoveResourceDetailParams{}
+	p.p = make(map[string]interface{})
+	p.p["resourceid"] = resourceid
+	p.p["resourcetype"] = resourcetype
+	return p
+}
+
+// Removes detail for the Resource.
+func (s *ResourcemetadataService) RemoveResourceDetail(p *RemoveResourceDetailParams) (*RemoveResourceDetailResponse, error) {
+	resp, err := s.cs.newRequest("removeResourceDetail", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveResourceDetailResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveResourceDetailResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListResourceDetailsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListResourceDetailsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["key"]; found {
+		u.Set("key", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["resourceid"]; found {
+		u.Set("resourceid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	if v, found := p.p["value"]; found {
+		u.Set("value", v.(string))
+	}
+	return u
+}
+
+func (p *ListResourceDetailsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetKey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["key"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetResourceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceid"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+func (p *ListResourceDetailsParams) SetValue(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["value"] = v
+	return
+}
+
+// You should always use this function to get a new ListResourceDetailsParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcemetadataService) NewListResourceDetailsParams(resourcetype string) *ListResourceDetailsParams {
+	p := &ListResourceDetailsParams{}
+	p.p = make(map[string]interface{})
+	p.p["resourcetype"] = resourcetype
+	return p
+}
+
+// List resource detail(s)
+func (s *ResourcemetadataService) ListResourceDetails(p *ListResourceDetailsParams) (*ListResourceDetailsResponse, error) {
+	resp, err := s.cs.newRequest("listResourceDetails", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListResourceDetailsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListResourceDetailsResponse struct {
+	Count           int               `json:"count"`
+	ResourceDetails []*ResourceDetail `json:"resourcedetail"`
+}
+
+type ResourceDetail struct {
+	Account      string `json:"account,omitempty"`
+	Customer     string `json:"customer,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Key          string `json:"key,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Resourceid   string `json:"resourceid,omitempty"`
+	Resourcetype string `json:"resourcetype,omitempty"`
+	Value        string `json:"value,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcetagsService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcetagsService.go
@@ -1,0 +1,544 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ListStorageTagsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListStorageTagsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListStorageTagsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListStorageTagsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListStorageTagsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListStorageTagsParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcetagsService) NewListStorageTagsParams() *ListStorageTagsParams {
+	p := &ListStorageTagsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ResourcetagsService) GetStorageTagID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListStorageTagsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListStorageTags(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.StorageTags[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.StorageTags {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// Lists storage tags
+func (s *ResourcetagsService) ListStorageTags(p *ListStorageTagsParams) (*ListStorageTagsResponse, error) {
+	resp, err := s.cs.newRequest("listStorageTags", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListStorageTagsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListStorageTagsResponse struct {
+	Count       int           `json:"count"`
+	StorageTags []*StorageTag `json:"storagetag"`
+}
+
+type StorageTag struct {
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Poolid int64  `json:"poolid,omitempty"`
+}
+
+type CreateTagsParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateTagsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customer"]; found {
+		u.Set("customer", v.(string))
+	}
+	if v, found := p.p["resourceids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("resourceids", vv)
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *CreateTagsParams) SetCustomer(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customer"] = v
+	return
+}
+
+func (p *CreateTagsParams) SetResourceids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceids"] = v
+	return
+}
+
+func (p *CreateTagsParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+func (p *CreateTagsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new CreateTagsParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcetagsService) NewCreateTagsParams(resourceids []string, resourcetype string, tags map[string]string) *CreateTagsParams {
+	p := &CreateTagsParams{}
+	p.p = make(map[string]interface{})
+	p.p["resourceids"] = resourceids
+	p.p["resourcetype"] = resourcetype
+	p.p["tags"] = tags
+	return p
+}
+
+// Creates resource tag(s)
+func (s *ResourcetagsService) CreateTags(p *CreateTagsParams) (*CreateTagsResponse, error) {
+	resp, err := s.cs.newRequest("createTags", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateTagsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateTagsResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteTagsParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteTagsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["resourceids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("resourceids", vv)
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *DeleteTagsParams) SetResourceids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceids"] = v
+	return
+}
+
+func (p *DeleteTagsParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+func (p *DeleteTagsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteTagsParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcetagsService) NewDeleteTagsParams(resourceids []string, resourcetype string) *DeleteTagsParams {
+	p := &DeleteTagsParams{}
+	p.p = make(map[string]interface{})
+	p.p["resourceids"] = resourceids
+	p.p["resourcetype"] = resourcetype
+	return p
+}
+
+// Deleting resource tag(s)
+func (s *ResourcetagsService) DeleteTags(p *DeleteTagsParams) (*DeleteTagsResponse, error) {
+	resp, err := s.cs.newRequest("deleteTags", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteTagsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteTagsResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListTagsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTagsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["customer"]; found {
+		u.Set("customer", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["key"]; found {
+		u.Set("key", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["resourceid"]; found {
+		u.Set("resourceid", v.(string))
+	}
+	if v, found := p.p["resourcetype"]; found {
+		u.Set("resourcetype", v.(string))
+	}
+	if v, found := p.p["value"]; found {
+		u.Set("value", v.(string))
+	}
+	return u
+}
+
+func (p *ListTagsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListTagsParams) SetCustomer(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customer"] = v
+	return
+}
+
+func (p *ListTagsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListTagsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListTagsParams) SetKey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["key"] = v
+	return
+}
+
+func (p *ListTagsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListTagsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListTagsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListTagsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListTagsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListTagsParams) SetResourceid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourceid"] = v
+	return
+}
+
+func (p *ListTagsParams) SetResourcetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["resourcetype"] = v
+	return
+}
+
+func (p *ListTagsParams) SetValue(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["value"] = v
+	return
+}
+
+// You should always use this function to get a new ListTagsParams instance,
+// as then you are sure you have configured all required params
+func (s *ResourcetagsService) NewListTagsParams() *ListTagsParams {
+	p := &ListTagsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List resource tag(s)
+func (s *ResourcetagsService) ListTags(p *ListTagsParams) (*ListTagsResponse, error) {
+	resp, err := s.cs.newRequest("listTags", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTagsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTagsResponse struct {
+	Count int    `json:"count"`
+	Tags  []*Tag `json:"tag"`
+}
+
+type Tag struct {
+	Account      string `json:"account,omitempty"`
+	Customer     string `json:"customer,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Key          string `json:"key,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Resourceid   string `json:"resourceid,omitempty"`
+	Resourcetype string `json:"resourcetype,omitempty"`
+	Value        string `json:"value,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/RouterService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/RouterService.go
@@ -1,0 +1,1457 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type StartRouterParams struct {
+	p map[string]interface{}
+}
+
+func (p *StartRouterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StartRouterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StartRouterParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewStartRouterParams(id string) *StartRouterParams {
+	p := &StartRouterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Starts a router.
+func (s *RouterService) StartRouter(p *StartRouterParams) (*StartRouterResponse, error) {
+	resp, err := s.cs.newRequest("startRouter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StartRouterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StartRouterResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type RebootRouterParams struct {
+	p map[string]interface{}
+}
+
+func (p *RebootRouterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RebootRouterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RebootRouterParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewRebootRouterParams(id string) *RebootRouterParams {
+	p := &RebootRouterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Starts a router.
+func (s *RouterService) RebootRouter(p *RebootRouterParams) (*RebootRouterResponse, error) {
+	resp, err := s.cs.newRequest("rebootRouter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RebootRouterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RebootRouterResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type StopRouterParams struct {
+	p map[string]interface{}
+}
+
+func (p *StopRouterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StopRouterParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *StopRouterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StopRouterParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewStopRouterParams(id string) *StopRouterParams {
+	p := &StopRouterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Stops a router.
+func (s *RouterService) StopRouter(p *StopRouterParams) (*StopRouterResponse, error) {
+	resp, err := s.cs.newRequest("stopRouter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StopRouterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StopRouterResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type DestroyRouterParams struct {
+	p map[string]interface{}
+}
+
+func (p *DestroyRouterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DestroyRouterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DestroyRouterParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewDestroyRouterParams(id string) *DestroyRouterParams {
+	p := &DestroyRouterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Destroys a router.
+func (s *RouterService) DestroyRouter(p *DestroyRouterParams) (*DestroyRouterResponse, error) {
+	resp, err := s.cs.newRequest("destroyRouter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DestroyRouterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DestroyRouterResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ChangeServiceForRouterParams struct {
+	p map[string]interface{}
+}
+
+func (p *ChangeServiceForRouterParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *ChangeServiceForRouterParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ChangeServiceForRouterParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new ChangeServiceForRouterParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewChangeServiceForRouterParams(id string, serviceofferingid string) *ChangeServiceForRouterParams {
+	p := &ChangeServiceForRouterParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["serviceofferingid"] = serviceofferingid
+	return p
+}
+
+// Upgrades domain router to a new service offering
+func (s *RouterService) ChangeServiceForRouter(p *ChangeServiceForRouterParams) (*ChangeServiceForRouterResponse, error) {
+	resp, err := s.cs.newRequest("changeServiceForRouter", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ChangeServiceForRouterResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ChangeServiceForRouterResponse struct {
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListRoutersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListRoutersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["forvpc"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvpc", vv)
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["version"]; found {
+		u.Set("version", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListRoutersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetForvpc(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvpc"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetVersion(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["version"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *ListRoutersParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListRoutersParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewListRoutersParams() *ListRoutersParams {
+	p := &ListRoutersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *RouterService) GetRouterID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListRoutersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListRouters(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Routers[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Routers {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *RouterService) GetRouterByName(name string, opts ...OptionFunc) (*Router, int, error) {
+	id, count, err := s.GetRouterID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetRouterByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *RouterService) GetRouterByID(id string, opts ...OptionFunc) (*Router, int, error) {
+	p := &ListRoutersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListRouters(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Routers[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Router UUID: %s!", id)
+}
+
+// List routers.
+func (s *RouterService) ListRouters(p *ListRoutersParams) (*ListRoutersResponse, error) {
+	resp, err := s.cs.newRequest("listRouters", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListRoutersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListRoutersResponse struct {
+	Count   int       `json:"count"`
+	Routers []*Router `json:"router"`
+}
+
+type Router struct {
+	Account             string `json:"account,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Dns1                string `json:"dns1,omitempty"`
+	Dns2                string `json:"dns2,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Gateway             string `json:"gateway,omitempty"`
+	Guestipaddress      string `json:"guestipaddress,omitempty"`
+	Guestmacaddress     string `json:"guestmacaddress,omitempty"`
+	Guestnetmask        string `json:"guestnetmask,omitempty"`
+	Guestnetworkid      string `json:"guestnetworkid,omitempty"`
+	Guestnetworkname    string `json:"guestnetworkname,omitempty"`
+	Hostid              string `json:"hostid,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	Hypervisor          string `json:"hypervisor,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Ip6dns1             string `json:"ip6dns1,omitempty"`
+	Ip6dns2             string `json:"ip6dns2,omitempty"`
+	Isredundantrouter   bool   `json:"isredundantrouter,omitempty"`
+	Linklocalip         string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask    string `json:"linklocalnetmask,omitempty"`
+	Linklocalnetworkid  string `json:"linklocalnetworkid,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Networkdomain       string `json:"networkdomain,omitempty"`
+	Nic                 []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Podid               string `json:"podid,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicmacaddress    string `json:"publicmacaddress,omitempty"`
+	Publicnetmask       string `json:"publicnetmask,omitempty"`
+	Publicnetworkid     string `json:"publicnetworkid,omitempty"`
+	Redundantstate      string `json:"redundantstate,omitempty"`
+	Requiresupgrade     bool   `json:"requiresupgrade,omitempty"`
+	Role                string `json:"role,omitempty"`
+	Scriptsversion      string `json:"scriptsversion,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	State               string `json:"state,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Vpcid               string `json:"vpcid,omitempty"`
+	Vpcname             string `json:"vpcname,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListVirtualRouterElementsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVirtualRouterElementsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["nspid"]; found {
+		u.Set("nspid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListVirtualRouterElementsParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ListVirtualRouterElementsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVirtualRouterElementsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVirtualRouterElementsParams) SetNspid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nspid"] = v
+	return
+}
+
+func (p *ListVirtualRouterElementsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVirtualRouterElementsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListVirtualRouterElementsParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewListVirtualRouterElementsParams() *ListVirtualRouterElementsParams {
+	p := &ListVirtualRouterElementsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *RouterService) GetVirtualRouterElementByID(id string, opts ...OptionFunc) (*VirtualRouterElement, int, error) {
+	p := &ListVirtualRouterElementsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVirtualRouterElements(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VirtualRouterElements[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VirtualRouterElement UUID: %s!", id)
+}
+
+// Lists all available virtual router elements.
+func (s *RouterService) ListVirtualRouterElements(p *ListVirtualRouterElementsParams) (*ListVirtualRouterElementsResponse, error) {
+	resp, err := s.cs.newRequest("listVirtualRouterElements", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVirtualRouterElementsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVirtualRouterElementsResponse struct {
+	Count                 int                     `json:"count"`
+	VirtualRouterElements []*VirtualRouterElement `json:"virtualrouterelement"`
+}
+
+type VirtualRouterElement struct {
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Nspid     string `json:"nspid,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}
+
+type ConfigureVirtualRouterElementParams struct {
+	p map[string]interface{}
+}
+
+func (p *ConfigureVirtualRouterElementParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["enabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("enabled", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ConfigureVirtualRouterElementParams) SetEnabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enabled"] = v
+	return
+}
+
+func (p *ConfigureVirtualRouterElementParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ConfigureVirtualRouterElementParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewConfigureVirtualRouterElementParams(enabled bool, id string) *ConfigureVirtualRouterElementParams {
+	p := &ConfigureVirtualRouterElementParams{}
+	p.p = make(map[string]interface{})
+	p.p["enabled"] = enabled
+	p.p["id"] = id
+	return p
+}
+
+// Configures a virtual router element.
+func (s *RouterService) ConfigureVirtualRouterElement(p *ConfigureVirtualRouterElementParams) (*ConfigureVirtualRouterElementResponse, error) {
+	resp, err := s.cs.newRequest("configureVirtualRouterElement", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ConfigureVirtualRouterElementResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ConfigureVirtualRouterElementResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Nspid     string `json:"nspid,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}
+
+type CreateVirtualRouterElementParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVirtualRouterElementParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["nspid"]; found {
+		u.Set("nspid", v.(string))
+	}
+	if v, found := p.p["providertype"]; found {
+		u.Set("providertype", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVirtualRouterElementParams) SetNspid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nspid"] = v
+	return
+}
+
+func (p *CreateVirtualRouterElementParams) SetProvidertype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["providertype"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVirtualRouterElementParams instance,
+// as then you are sure you have configured all required params
+func (s *RouterService) NewCreateVirtualRouterElementParams(nspid string) *CreateVirtualRouterElementParams {
+	p := &CreateVirtualRouterElementParams{}
+	p.p = make(map[string]interface{})
+	p.p["nspid"] = nspid
+	return p
+}
+
+// Create a virtual router element.
+func (s *RouterService) CreateVirtualRouterElement(p *CreateVirtualRouterElementParams) (*CreateVirtualRouterElementResponse, error) {
+	resp, err := s.cs.newRequest("createVirtualRouterElement", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVirtualRouterElementResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVirtualRouterElementResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Nspid     string `json:"nspid,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SSHService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SSHService.go
@@ -1,0 +1,746 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type ResetSSHKeyForVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keypair"]; found {
+		u.Set("keypair", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) SetKeypair(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keypair"] = v
+	return
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new ResetSSHKeyForVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *SSHService) NewResetSSHKeyForVirtualMachineParams(id string, keypair string) *ResetSSHKeyForVirtualMachineParams {
+	p := &ResetSSHKeyForVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["keypair"] = keypair
+	return p
+}
+
+// Resets the SSH Key for virtual machine. The virtual machine must be in a "Stopped" state. [async]
+func (s *SSHService) ResetSSHKeyForVirtualMachine(p *ResetSSHKeyForVirtualMachineParams) (*ResetSSHKeyForVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("resetSSHKeyForVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ResetSSHKeyForVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ResetSSHKeyForVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type RegisterSSHKeyPairParams struct {
+	p map[string]interface{}
+}
+
+func (p *RegisterSSHKeyPairParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["publickey"]; found {
+		u.Set("publickey", v.(string))
+	}
+	return u
+}
+
+func (p *RegisterSSHKeyPairParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *RegisterSSHKeyPairParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *RegisterSSHKeyPairParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *RegisterSSHKeyPairParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *RegisterSSHKeyPairParams) SetPublickey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publickey"] = v
+	return
+}
+
+// You should always use this function to get a new RegisterSSHKeyPairParams instance,
+// as then you are sure you have configured all required params
+func (s *SSHService) NewRegisterSSHKeyPairParams(name string, publickey string) *RegisterSSHKeyPairParams {
+	p := &RegisterSSHKeyPairParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["publickey"] = publickey
+	return p
+}
+
+// Register a public key in a keypair under a certain name
+func (s *SSHService) RegisterSSHKeyPair(p *RegisterSSHKeyPairParams) (*RegisterSSHKeyPairResponse, error) {
+	resp, err := s.cs.newRequest("registerSSHKeyPair", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
+	var r RegisterSSHKeyPairResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RegisterSSHKeyPairResponse struct {
+	Account     string `json:"account,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
+type CreateSSHKeyPairParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateSSHKeyPairParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateSSHKeyPairParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateSSHKeyPairParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateSSHKeyPairParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateSSHKeyPairParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateSSHKeyPairParams instance,
+// as then you are sure you have configured all required params
+func (s *SSHService) NewCreateSSHKeyPairParams(name string) *CreateSSHKeyPairParams {
+	p := &CreateSSHKeyPairParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Create a new keypair and returns the private key
+func (s *SSHService) CreateSSHKeyPair(p *CreateSSHKeyPairParams) (*CreateSSHKeyPairResponse, error) {
+	resp, err := s.cs.newRequest("createSSHKeyPair", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
+	var r CreateSSHKeyPairResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateSSHKeyPairResponse struct {
+	Privatekey string `json:"privatekey,omitempty"`
+}
+
+type DeleteSSHKeyPairParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSSHKeyPairParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteSSHKeyPairParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DeleteSSHKeyPairParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DeleteSSHKeyPairParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *DeleteSSHKeyPairParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSSHKeyPairParams instance,
+// as then you are sure you have configured all required params
+func (s *SSHService) NewDeleteSSHKeyPairParams(name string) *DeleteSSHKeyPairParams {
+	p := &DeleteSSHKeyPairParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Deletes a keypair by name
+func (s *SSHService) DeleteSSHKeyPair(p *DeleteSSHKeyPairParams) (*DeleteSSHKeyPairResponse, error) {
+	resp, err := s.cs.newRequest("deleteSSHKeyPair", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSSHKeyPairResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteSSHKeyPairResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListSSHKeyPairsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSSHKeyPairsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fingerprint"]; found {
+		u.Set("fingerprint", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSSHKeyPairsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetFingerprint(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fingerprint"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSSHKeyPairsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSSHKeyPairsParams instance,
+// as then you are sure you have configured all required params
+func (s *SSHService) NewListSSHKeyPairsParams() *ListSSHKeyPairsParams {
+	p := &ListSSHKeyPairsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List registered keypairs
+func (s *SSHService) ListSSHKeyPairs(p *ListSSHKeyPairsParams) (*ListSSHKeyPairsResponse, error) {
+	resp, err := s.cs.newRequest("listSSHKeyPairs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSSHKeyPairsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSSHKeyPairsResponse struct {
+	Count       int           `json:"count"`
+	SSHKeyPairs []*SSHKeyPair `json:"sshkeypair"`
+}
+
+type SSHKeyPair struct {
+	Account     string `json:"account,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Name        string `json:"name,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SecurityGroupService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SecurityGroupService.go
@@ -1,0 +1,1190 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateSecurityGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateSecurityGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateSecurityGroupParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateSecurityGroupParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateSecurityGroupParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateSecurityGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateSecurityGroupParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateSecurityGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewCreateSecurityGroupParams(name string) *CreateSecurityGroupParams {
+	p := &CreateSecurityGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Creates a security group
+func (s *SecurityGroupService) CreateSecurityGroup(p *CreateSecurityGroupParams) (*CreateSecurityGroupResponse, error) {
+	resp, err := s.cs.newRequest("createSecurityGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateSecurityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateSecurityGroupResponse struct {
+	Account     string `json:"account,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Egressrule  []struct {
+		Account           string `json:"account,omitempty"`
+		Cidr              string `json:"cidr,omitempty"`
+		Endport           int    `json:"endport,omitempty"`
+		Icmpcode          int    `json:"icmpcode,omitempty"`
+		Icmptype          int    `json:"icmptype,omitempty"`
+		Protocol          string `json:"protocol,omitempty"`
+		Ruleid            string `json:"ruleid,omitempty"`
+		Securitygroupname string `json:"securitygroupname,omitempty"`
+		Startport         int    `json:"startport,omitempty"`
+		Tags              []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+	} `json:"egressrule,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ingressrule []struct {
+		Account           string `json:"account,omitempty"`
+		Cidr              string `json:"cidr,omitempty"`
+		Endport           int    `json:"endport,omitempty"`
+		Icmpcode          int    `json:"icmpcode,omitempty"`
+		Icmptype          int    `json:"icmptype,omitempty"`
+		Protocol          string `json:"protocol,omitempty"`
+		Ruleid            string `json:"ruleid,omitempty"`
+		Securitygroupname string `json:"securitygroupname,omitempty"`
+		Startport         int    `json:"startport,omitempty"`
+		Tags              []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+	} `json:"ingressrule,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	Tags      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+	Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+}
+
+type DeleteSecurityGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSecurityGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteSecurityGroupParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DeleteSecurityGroupParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DeleteSecurityGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DeleteSecurityGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *DeleteSecurityGroupParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSecurityGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewDeleteSecurityGroupParams() *DeleteSecurityGroupParams {
+	p := &DeleteSecurityGroupParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Deletes security group
+func (s *SecurityGroupService) DeleteSecurityGroup(p *DeleteSecurityGroupParams) (*DeleteSecurityGroupResponse, error) {
+	resp, err := s.cs.newRequest("deleteSecurityGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSecurityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteSecurityGroupResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type AuthorizeSecurityGroupIngressParams struct {
+	p map[string]interface{}
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["securitygroupid"]; found {
+		u.Set("securitygroupid", v.(string))
+	}
+	if v, found := p.p["securitygroupname"]; found {
+		u.Set("securitygroupname", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["usersecuritygrouplist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].key", i), k)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupname"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) SetUsersecuritygrouplist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usersecuritygrouplist"] = v
+	return
+}
+
+// You should always use this function to get a new AuthorizeSecurityGroupIngressParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewAuthorizeSecurityGroupIngressParams() *AuthorizeSecurityGroupIngressParams {
+	p := &AuthorizeSecurityGroupIngressParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Authorizes a particular ingress rule for this security group
+func (s *SecurityGroupService) AuthorizeSecurityGroupIngress(p *AuthorizeSecurityGroupIngressParams) (*AuthorizeSecurityGroupIngressResponse, error) {
+	resp, err := s.cs.newRequest("authorizeSecurityGroupIngress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AuthorizeSecurityGroupIngressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AuthorizeSecurityGroupIngressResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Cidr              string `json:"cidr,omitempty"`
+	Endport           int    `json:"endport,omitempty"`
+	Icmpcode          int    `json:"icmpcode,omitempty"`
+	Icmptype          int    `json:"icmptype,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Ruleid            string `json:"ruleid,omitempty"`
+	Securitygroupname string `json:"securitygroupname,omitempty"`
+	Startport         int    `json:"startport,omitempty"`
+	Tags              []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type RevokeSecurityGroupIngressParams struct {
+	p map[string]interface{}
+}
+
+func (p *RevokeSecurityGroupIngressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RevokeSecurityGroupIngressParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RevokeSecurityGroupIngressParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewRevokeSecurityGroupIngressParams(id string) *RevokeSecurityGroupIngressParams {
+	p := &RevokeSecurityGroupIngressParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a particular ingress rule from this security group
+func (s *SecurityGroupService) RevokeSecurityGroupIngress(p *RevokeSecurityGroupIngressParams) (*RevokeSecurityGroupIngressResponse, error) {
+	resp, err := s.cs.newRequest("revokeSecurityGroupIngress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RevokeSecurityGroupIngressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RevokeSecurityGroupIngressResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AuthorizeSecurityGroupEgressParams struct {
+	p map[string]interface{}
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("cidrlist", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["endport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("endport", vv)
+	}
+	if v, found := p.p["icmpcode"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmpcode", vv)
+	}
+	if v, found := p.p["icmptype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("icmptype", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["protocol"]; found {
+		u.Set("protocol", v.(string))
+	}
+	if v, found := p.p["securitygroupid"]; found {
+		u.Set("securitygroupid", v.(string))
+	}
+	if v, found := p.p["securitygroupname"]; found {
+		u.Set("securitygroupname", v.(string))
+	}
+	if v, found := p.p["startport"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("startport", vv)
+	}
+	if v, found := p.p["usersecuritygrouplist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].key", i), k)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetCidrlist(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetEndport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endport"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetIcmpcode(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmpcode"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetIcmptype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["icmptype"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetProtocol(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["protocol"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupid"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupname"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetStartport(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startport"] = v
+	return
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) SetUsersecuritygrouplist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usersecuritygrouplist"] = v
+	return
+}
+
+// You should always use this function to get a new AuthorizeSecurityGroupEgressParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewAuthorizeSecurityGroupEgressParams() *AuthorizeSecurityGroupEgressParams {
+	p := &AuthorizeSecurityGroupEgressParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Authorizes a particular egress rule for this security group
+func (s *SecurityGroupService) AuthorizeSecurityGroupEgress(p *AuthorizeSecurityGroupEgressParams) (*AuthorizeSecurityGroupEgressResponse, error) {
+	resp, err := s.cs.newRequest("authorizeSecurityGroupEgress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AuthorizeSecurityGroupEgressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AuthorizeSecurityGroupEgressResponse struct {
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Cidr              string `json:"cidr,omitempty"`
+	Endport           int    `json:"endport,omitempty"`
+	Icmpcode          int    `json:"icmpcode,omitempty"`
+	Icmptype          int    `json:"icmptype,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Ruleid            string `json:"ruleid,omitempty"`
+	Securitygroupname string `json:"securitygroupname,omitempty"`
+	Startport         int    `json:"startport,omitempty"`
+	Tags              []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+}
+
+type RevokeSecurityGroupEgressParams struct {
+	p map[string]interface{}
+}
+
+func (p *RevokeSecurityGroupEgressParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RevokeSecurityGroupEgressParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RevokeSecurityGroupEgressParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewRevokeSecurityGroupEgressParams(id string) *RevokeSecurityGroupEgressParams {
+	p := &RevokeSecurityGroupEgressParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a particular egress rule from this security group
+func (s *SecurityGroupService) RevokeSecurityGroupEgress(p *RevokeSecurityGroupEgressParams) (*RevokeSecurityGroupEgressResponse, error) {
+	resp, err := s.cs.newRequest("revokeSecurityGroupEgress", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RevokeSecurityGroupEgressResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RevokeSecurityGroupEgressResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListSecurityGroupsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSecurityGroupsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["securitygroupname"]; found {
+		u.Set("securitygroupname", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSecurityGroupsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetSecuritygroupname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupname"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListSecurityGroupsParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSecurityGroupsParams instance,
+// as then you are sure you have configured all required params
+func (s *SecurityGroupService) NewListSecurityGroupsParams() *ListSecurityGroupsParams {
+	p := &ListSecurityGroupsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SecurityGroupService) GetSecurityGroupID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListSecurityGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListSecurityGroups(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.SecurityGroups[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.SecurityGroups {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SecurityGroupService) GetSecurityGroupByName(name string, opts ...OptionFunc) (*SecurityGroup, int, error) {
+	id, count, err := s.GetSecurityGroupID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetSecurityGroupByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SecurityGroupService) GetSecurityGroupByID(id string, opts ...OptionFunc) (*SecurityGroup, int, error) {
+	p := &ListSecurityGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListSecurityGroups(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.SecurityGroups[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for SecurityGroup UUID: %s!", id)
+}
+
+// Lists security groups
+func (s *SecurityGroupService) ListSecurityGroups(p *ListSecurityGroupsParams) (*ListSecurityGroupsResponse, error) {
+	resp, err := s.cs.newRequest("listSecurityGroups", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSecurityGroupsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSecurityGroupsResponse struct {
+	Count          int              `json:"count"`
+	SecurityGroups []*SecurityGroup `json:"securitygroup"`
+}
+
+type SecurityGroup struct {
+	Account     string `json:"account,omitempty"`
+	Description string `json:"description,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Egressrule  []struct {
+		Account           string `json:"account,omitempty"`
+		Cidr              string `json:"cidr,omitempty"`
+		Endport           int    `json:"endport,omitempty"`
+		Icmpcode          int    `json:"icmpcode,omitempty"`
+		Icmptype          int    `json:"icmptype,omitempty"`
+		Protocol          string `json:"protocol,omitempty"`
+		Ruleid            string `json:"ruleid,omitempty"`
+		Securitygroupname string `json:"securitygroupname,omitempty"`
+		Startport         int    `json:"startport,omitempty"`
+		Tags              []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+	} `json:"egressrule,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ingressrule []struct {
+		Account           string `json:"account,omitempty"`
+		Cidr              string `json:"cidr,omitempty"`
+		Endport           int    `json:"endport,omitempty"`
+		Icmpcode          int    `json:"icmpcode,omitempty"`
+		Icmptype          int    `json:"icmptype,omitempty"`
+		Protocol          string `json:"protocol,omitempty"`
+		Ruleid            string `json:"ruleid,omitempty"`
+		Securitygroupname string `json:"securitygroupname,omitempty"`
+		Startport         int    `json:"startport,omitempty"`
+		Tags              []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+	} `json:"ingressrule,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	Tags      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+	Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ServiceOfferingService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ServiceOfferingService.go
@@ -1,0 +1,853 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateServiceOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateServiceOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bytesreadrate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("bytesreadrate", vv)
+	}
+	if v, found := p.p["byteswriterate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("byteswriterate", vv)
+	}
+	if v, found := p.p["cpunumber"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("cpunumber", vv)
+	}
+	if v, found := p.p["cpuspeed"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("cpuspeed", vv)
+	}
+	if v, found := p.p["customizediops"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("customizediops", vv)
+	}
+	if v, found := p.p["deploymentplanner"]; found {
+		u.Set("deploymentplanner", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hosttags"]; found {
+		u.Set("hosttags", v.(string))
+	}
+	if v, found := p.p["hypervisorsnapshotreserve"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("hypervisorsnapshotreserve", vv)
+	}
+	if v, found := p.p["iopsreadrate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("iopsreadrate", vv)
+	}
+	if v, found := p.p["iopswriterate"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("iopswriterate", vv)
+	}
+	if v, found := p.p["issystem"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("issystem", vv)
+	}
+	if v, found := p.p["isvolatile"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isvolatile", vv)
+	}
+	if v, found := p.p["limitcpuuse"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("limitcpuuse", vv)
+	}
+	if v, found := p.p["maxiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("maxiops", vv)
+	}
+	if v, found := p.p["memory"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("memory", vv)
+	}
+	if v, found := p.p["miniops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("miniops", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkrate"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("networkrate", vv)
+	}
+	if v, found := p.p["offerha"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("offerha", vv)
+	}
+	if v, found := p.p["provisioningtype"]; found {
+		u.Set("provisioningtype", v.(string))
+	}
+	if v, found := p.p["serviceofferingdetails"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("serviceofferingdetails[%d].key", i), k)
+			u.Set(fmt.Sprintf("serviceofferingdetails[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["storagetype"]; found {
+		u.Set("storagetype", v.(string))
+	}
+	if v, found := p.p["systemvmtype"]; found {
+		u.Set("systemvmtype", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		u.Set("tags", v.(string))
+	}
+	return u
+}
+
+func (p *CreateServiceOfferingParams) SetBytesreadrate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bytesreadrate"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetByteswriterate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["byteswriterate"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetCpunumber(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cpunumber"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetCpuspeed(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cpuspeed"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetCustomizediops(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customizediops"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetDeploymentplanner(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["deploymentplanner"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetHosttags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hosttags"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetHypervisorsnapshotreserve(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisorsnapshotreserve"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetIopsreadrate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iopsreadrate"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetIopswriterate(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iopswriterate"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetIssystem(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["issystem"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetIsvolatile(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isvolatile"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetLimitcpuuse(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["limitcpuuse"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetMaxiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxiops"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetMemory(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["memory"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetMiniops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["miniops"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetNetworkrate(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkrate"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetOfferha(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["offerha"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetProvisioningtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["provisioningtype"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetServiceofferingdetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingdetails"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetStoragetype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storagetype"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetSystemvmtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["systemvmtype"] = v
+	return
+}
+
+func (p *CreateServiceOfferingParams) SetTags(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new CreateServiceOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *ServiceOfferingService) NewCreateServiceOfferingParams(displaytext string, name string) *CreateServiceOfferingParams {
+	p := &CreateServiceOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	return p
+}
+
+// Creates a service offering.
+func (s *ServiceOfferingService) CreateServiceOffering(p *CreateServiceOfferingParams) (*CreateServiceOfferingResponse, error) {
+	resp, err := s.cs.newRequest("createServiceOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
+	var r CreateServiceOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateServiceOfferingResponse struct {
+	Cpunumber                 int               `json:"cpunumber,omitempty"`
+	Cpuspeed                  int               `json:"cpuspeed,omitempty"`
+	Created                   string            `json:"created,omitempty"`
+	Defaultuse                bool              `json:"defaultuse,omitempty"`
+	Deploymentplanner         string            `json:"deploymentplanner,omitempty"`
+	DiskBytesReadRate         int64             `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64             `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64             `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64             `json:"diskIopsWriteRate,omitempty"`
+	Displaytext               string            `json:"displaytext,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Hosttags                  string            `json:"hosttags,omitempty"`
+	Hypervisorsnapshotreserve int               `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Iscustomized              bool              `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool              `json:"iscustomizediops,omitempty"`
+	Issystem                  bool              `json:"issystem,omitempty"`
+	Isvolatile                bool              `json:"isvolatile,omitempty"`
+	Limitcpuuse               bool              `json:"limitcpuuse,omitempty"`
+	Maxiops                   int64             `json:"maxiops,omitempty"`
+	Memory                    int               `json:"memory,omitempty"`
+	Miniops                   int64             `json:"miniops,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkrate               int               `json:"networkrate,omitempty"`
+	Offerha                   bool              `json:"offerha,omitempty"`
+	Provisioningtype          string            `json:"provisioningtype,omitempty"`
+	Serviceofferingdetails    map[string]string `json:"serviceofferingdetails,omitempty"`
+	Storagetype               string            `json:"storagetype,omitempty"`
+	Systemvmtype              string            `json:"systemvmtype,omitempty"`
+	Tags                      string            `json:"tags,omitempty"`
+}
+
+type DeleteServiceOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteServiceOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteServiceOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteServiceOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *ServiceOfferingService) NewDeleteServiceOfferingParams(id string) *DeleteServiceOfferingParams {
+	p := &DeleteServiceOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a service offering.
+func (s *ServiceOfferingService) DeleteServiceOffering(p *DeleteServiceOfferingParams) (*DeleteServiceOfferingResponse, error) {
+	resp, err := s.cs.newRequest("deleteServiceOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteServiceOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteServiceOfferingResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type UpdateServiceOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateServiceOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	return u
+}
+
+func (p *UpdateServiceOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateServiceOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateServiceOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateServiceOfferingParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateServiceOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *ServiceOfferingService) NewUpdateServiceOfferingParams(id string) *UpdateServiceOfferingParams {
+	p := &UpdateServiceOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a service offering.
+func (s *ServiceOfferingService) UpdateServiceOffering(p *UpdateServiceOfferingParams) (*UpdateServiceOfferingResponse, error) {
+	resp, err := s.cs.newRequest("updateServiceOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateServiceOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateServiceOfferingResponse struct {
+	Cpunumber                 int               `json:"cpunumber,omitempty"`
+	Cpuspeed                  int               `json:"cpuspeed,omitempty"`
+	Created                   string            `json:"created,omitempty"`
+	Defaultuse                bool              `json:"defaultuse,omitempty"`
+	Deploymentplanner         string            `json:"deploymentplanner,omitempty"`
+	DiskBytesReadRate         int64             `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64             `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64             `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64             `json:"diskIopsWriteRate,omitempty"`
+	Displaytext               string            `json:"displaytext,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Hosttags                  string            `json:"hosttags,omitempty"`
+	Hypervisorsnapshotreserve int               `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Iscustomized              bool              `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool              `json:"iscustomizediops,omitempty"`
+	Issystem                  bool              `json:"issystem,omitempty"`
+	Isvolatile                bool              `json:"isvolatile,omitempty"`
+	Limitcpuuse               bool              `json:"limitcpuuse,omitempty"`
+	Maxiops                   int64             `json:"maxiops,omitempty"`
+	Memory                    int               `json:"memory,omitempty"`
+	Miniops                   int64             `json:"miniops,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkrate               int               `json:"networkrate,omitempty"`
+	Offerha                   bool              `json:"offerha,omitempty"`
+	Provisioningtype          string            `json:"provisioningtype,omitempty"`
+	Serviceofferingdetails    map[string]string `json:"serviceofferingdetails,omitempty"`
+	Storagetype               string            `json:"storagetype,omitempty"`
+	Systemvmtype              string            `json:"systemvmtype,omitempty"`
+	Tags                      string            `json:"tags,omitempty"`
+}
+
+type ListServiceOfferingsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListServiceOfferingsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["issystem"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("issystem", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["systemvmtype"]; found {
+		u.Set("systemvmtype", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *ListServiceOfferingsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetIssystem(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["issystem"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetSystemvmtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["systemvmtype"] = v
+	return
+}
+
+func (p *ListServiceOfferingsParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new ListServiceOfferingsParams instance,
+// as then you are sure you have configured all required params
+func (s *ServiceOfferingService) NewListServiceOfferingsParams() *ListServiceOfferingsParams {
+	p := &ListServiceOfferingsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ServiceOfferingService) GetServiceOfferingID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListServiceOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListServiceOfferings(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.ServiceOfferings[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.ServiceOfferings {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ServiceOfferingService) GetServiceOfferingByName(name string, opts ...OptionFunc) (*ServiceOffering, int, error) {
+	id, count, err := s.GetServiceOfferingID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetServiceOfferingByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ServiceOfferingService) GetServiceOfferingByID(id string, opts ...OptionFunc) (*ServiceOffering, int, error) {
+	p := &ListServiceOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListServiceOfferings(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.ServiceOfferings[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for ServiceOffering UUID: %s!", id)
+}
+
+// Lists all available service offerings.
+func (s *ServiceOfferingService) ListServiceOfferings(p *ListServiceOfferingsParams) (*ListServiceOfferingsResponse, error) {
+	resp, err := s.cs.newRequest("listServiceOfferings", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListServiceOfferingsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListServiceOfferingsResponse struct {
+	Count            int                `json:"count"`
+	ServiceOfferings []*ServiceOffering `json:"serviceoffering"`
+}
+
+type ServiceOffering struct {
+	Cpunumber                 int               `json:"cpunumber,omitempty"`
+	Cpuspeed                  int               `json:"cpuspeed,omitempty"`
+	Created                   string            `json:"created,omitempty"`
+	Defaultuse                bool              `json:"defaultuse,omitempty"`
+	Deploymentplanner         string            `json:"deploymentplanner,omitempty"`
+	DiskBytesReadRate         int64             `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate        int64             `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate          int64             `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate         int64             `json:"diskIopsWriteRate,omitempty"`
+	Displaytext               string            `json:"displaytext,omitempty"`
+	Domain                    string            `json:"domain,omitempty"`
+	Domainid                  string            `json:"domainid,omitempty"`
+	Hosttags                  string            `json:"hosttags,omitempty"`
+	Hypervisorsnapshotreserve int               `json:"hypervisorsnapshotreserve,omitempty"`
+	Id                        string            `json:"id,omitempty"`
+	Iscustomized              bool              `json:"iscustomized,omitempty"`
+	Iscustomizediops          bool              `json:"iscustomizediops,omitempty"`
+	Issystem                  bool              `json:"issystem,omitempty"`
+	Isvolatile                bool              `json:"isvolatile,omitempty"`
+	Limitcpuuse               bool              `json:"limitcpuuse,omitempty"`
+	Maxiops                   int64             `json:"maxiops,omitempty"`
+	Memory                    int               `json:"memory,omitempty"`
+	Miniops                   int64             `json:"miniops,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Networkrate               int               `json:"networkrate,omitempty"`
+	Offerha                   bool              `json:"offerha,omitempty"`
+	Provisioningtype          string            `json:"provisioningtype,omitempty"`
+	Serviceofferingdetails    map[string]string `json:"serviceofferingdetails,omitempty"`
+	Storagetype               string            `json:"storagetype,omitempty"`
+	Systemvmtype              string            `json:"systemvmtype,omitempty"`
+	Tags                      string            `json:"tags,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SnapshotService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SnapshotService.go
@@ -1,0 +1,1793 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["policyid"]; found {
+		u.Set("policyid", v.(string))
+	}
+	if v, found := p.p["quiescevm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("quiescevm", vv)
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateSnapshotParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateSnapshotParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateSnapshotParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateSnapshotParams) SetPolicyid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["policyid"] = v
+	return
+}
+
+func (p *CreateSnapshotParams) SetQuiescevm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["quiescevm"] = v
+	return
+}
+
+func (p *CreateSnapshotParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewCreateSnapshotParams(volumeid string) *CreateSnapshotParams {
+	p := &CreateSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["volumeid"] = volumeid
+	return p
+}
+
+// Creates an instant snapshot of a volume.
+func (s *SnapshotService) CreateSnapshot(p *CreateSnapshotParams) (*CreateSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("createSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateSnapshotResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Account      string `json:"account,omitempty"`
+	Created      string `json:"created,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype string `json:"intervaltype,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Physicalsize int64  `json:"physicalsize,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Revertable   bool   `json:"revertable,omitempty"`
+	Snapshottype string `json:"snapshottype,omitempty"`
+	State        string `json:"state,omitempty"`
+	Tags         []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Volumeid   string `json:"volumeid,omitempty"`
+	Volumename string `json:"volumename,omitempty"`
+	Volumetype string `json:"volumetype,omitempty"`
+	Zoneid     string `json:"zoneid,omitempty"`
+}
+
+type ListSnapshotsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSnapshotsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["intervaltype"]; found {
+		u.Set("intervaltype", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["snapshottype"]; found {
+		u.Set("snapshottype", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSnapshotsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetIntervaltype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["intervaltype"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetSnapshottype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["snapshottype"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+func (p *ListSnapshotsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSnapshotsParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewListSnapshotsParams() *ListSnapshotsParams {
+	p := &ListSnapshotsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SnapshotService) GetSnapshotID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListSnapshotsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListSnapshots(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Snapshots[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Snapshots {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SnapshotService) GetSnapshotByName(name string, opts ...OptionFunc) (*Snapshot, int, error) {
+	id, count, err := s.GetSnapshotID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetSnapshotByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SnapshotService) GetSnapshotByID(id string, opts ...OptionFunc) (*Snapshot, int, error) {
+	p := &ListSnapshotsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListSnapshots(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Snapshots[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Snapshot UUID: %s!", id)
+}
+
+// Lists all available snapshots for the account.
+func (s *SnapshotService) ListSnapshots(p *ListSnapshotsParams) (*ListSnapshotsResponse, error) {
+	resp, err := s.cs.newRequest("listSnapshots", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSnapshotsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSnapshotsResponse struct {
+	Count     int         `json:"count"`
+	Snapshots []*Snapshot `json:"snapshot"`
+}
+
+type Snapshot struct {
+	Account      string `json:"account,omitempty"`
+	Created      string `json:"created,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype string `json:"intervaltype,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Physicalsize int64  `json:"physicalsize,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Revertable   bool   `json:"revertable,omitempty"`
+	Snapshottype string `json:"snapshottype,omitempty"`
+	State        string `json:"state,omitempty"`
+	Tags         []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Volumeid   string `json:"volumeid,omitempty"`
+	Volumename string `json:"volumename,omitempty"`
+	Volumetype string `json:"volumetype,omitempty"`
+	Zoneid     string `json:"zoneid,omitempty"`
+}
+
+type DeleteSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteSnapshotParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewDeleteSnapshotParams(id string) *DeleteSnapshotParams {
+	p := &DeleteSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a snapshot of a disk volume.
+func (s *SnapshotService) DeleteSnapshot(p *DeleteSnapshotParams) (*DeleteSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("deleteSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteSnapshotResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CreateSnapshotPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateSnapshotPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["intervaltype"]; found {
+		u.Set("intervaltype", v.(string))
+	}
+	if v, found := p.p["maxsnaps"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("maxsnaps", vv)
+	}
+	if v, found := p.p["schedule"]; found {
+		u.Set("schedule", v.(string))
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateSnapshotPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateSnapshotPolicyParams) SetIntervaltype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["intervaltype"] = v
+	return
+}
+
+func (p *CreateSnapshotPolicyParams) SetMaxsnaps(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxsnaps"] = v
+	return
+}
+
+func (p *CreateSnapshotPolicyParams) SetSchedule(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["schedule"] = v
+	return
+}
+
+func (p *CreateSnapshotPolicyParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+func (p *CreateSnapshotPolicyParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateSnapshotPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewCreateSnapshotPolicyParams(intervaltype string, maxsnaps int, schedule string, timezone string, volumeid string) *CreateSnapshotPolicyParams {
+	p := &CreateSnapshotPolicyParams{}
+	p.p = make(map[string]interface{})
+	p.p["intervaltype"] = intervaltype
+	p.p["maxsnaps"] = maxsnaps
+	p.p["schedule"] = schedule
+	p.p["timezone"] = timezone
+	p.p["volumeid"] = volumeid
+	return p
+}
+
+// Creates a snapshot policy for the account.
+func (s *SnapshotService) CreateSnapshotPolicy(p *CreateSnapshotPolicyParams) (*CreateSnapshotPolicyResponse, error) {
+	resp, err := s.cs.newRequest("createSnapshotPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateSnapshotPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateSnapshotPolicyResponse struct {
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype int    `json:"intervaltype,omitempty"`
+	Maxsnaps     int    `json:"maxsnaps,omitempty"`
+	Schedule     string `json:"schedule,omitempty"`
+	Timezone     string `json:"timezone,omitempty"`
+	Volumeid     string `json:"volumeid,omitempty"`
+}
+
+type UpdateSnapshotPolicyParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateSnapshotPolicyParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateSnapshotPolicyParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateSnapshotPolicyParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateSnapshotPolicyParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateSnapshotPolicyParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewUpdateSnapshotPolicyParams() *UpdateSnapshotPolicyParams {
+	p := &UpdateSnapshotPolicyParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Updates the snapshot policy.
+func (s *SnapshotService) UpdateSnapshotPolicy(p *UpdateSnapshotPolicyParams) (*UpdateSnapshotPolicyResponse, error) {
+	resp, err := s.cs.newRequest("updateSnapshotPolicy", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateSnapshotPolicyResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateSnapshotPolicyResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype int    `json:"intervaltype,omitempty"`
+	Maxsnaps     int    `json:"maxsnaps,omitempty"`
+	Schedule     string `json:"schedule,omitempty"`
+	Timezone     string `json:"timezone,omitempty"`
+	Volumeid     string `json:"volumeid,omitempty"`
+}
+
+type DeleteSnapshotPoliciesParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteSnapshotPoliciesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	return u
+}
+
+func (p *DeleteSnapshotPoliciesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DeleteSnapshotPoliciesParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteSnapshotPoliciesParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewDeleteSnapshotPoliciesParams() *DeleteSnapshotPoliciesParams {
+	p := &DeleteSnapshotPoliciesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Deletes snapshot policies for the account.
+func (s *SnapshotService) DeleteSnapshotPolicies(p *DeleteSnapshotPoliciesParams) (*DeleteSnapshotPoliciesResponse, error) {
+	resp, err := s.cs.newRequest("deleteSnapshotPolicies", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteSnapshotPoliciesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteSnapshotPoliciesResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListSnapshotPoliciesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSnapshotPoliciesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSnapshotPoliciesParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListSnapshotPoliciesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSnapshotPoliciesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSnapshotPoliciesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSnapshotPoliciesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSnapshotPoliciesParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSnapshotPoliciesParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewListSnapshotPoliciesParams() *ListSnapshotPoliciesParams {
+	p := &ListSnapshotPoliciesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SnapshotService) GetSnapshotPolicyByID(id string, opts ...OptionFunc) (*SnapshotPolicy, int, error) {
+	p := &ListSnapshotPoliciesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListSnapshotPolicies(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.SnapshotPolicies[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for SnapshotPolicy UUID: %s!", id)
+}
+
+// Lists snapshot policies.
+func (s *SnapshotService) ListSnapshotPolicies(p *ListSnapshotPoliciesParams) (*ListSnapshotPoliciesResponse, error) {
+	resp, err := s.cs.newRequest("listSnapshotPolicies", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSnapshotPoliciesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSnapshotPoliciesResponse struct {
+	Count            int               `json:"count"`
+	SnapshotPolicies []*SnapshotPolicy `json:"snapshotpolicy"`
+}
+
+type SnapshotPolicy struct {
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype int    `json:"intervaltype,omitempty"`
+	Maxsnaps     int    `json:"maxsnaps,omitempty"`
+	Schedule     string `json:"schedule,omitempty"`
+	Timezone     string `json:"timezone,omitempty"`
+	Volumeid     string `json:"volumeid,omitempty"`
+}
+
+type RevertSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *RevertSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RevertSnapshotParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RevertSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewRevertSnapshotParams(id string) *RevertSnapshotParams {
+	p := &RevertSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// revert a volume snapshot.
+func (s *SnapshotService) RevertSnapshot(p *RevertSnapshotParams) (*RevertSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("revertSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RevertSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RevertSnapshotResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Account      string `json:"account,omitempty"`
+	Created      string `json:"created,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Intervaltype string `json:"intervaltype,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Physicalsize int64  `json:"physicalsize,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Revertable   bool   `json:"revertable,omitempty"`
+	Snapshottype string `json:"snapshottype,omitempty"`
+	State        string `json:"state,omitempty"`
+	Tags         []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Volumeid   string `json:"volumeid,omitempty"`
+	Volumename string `json:"volumename,omitempty"`
+	Volumetype string `json:"volumetype,omitempty"`
+	Zoneid     string `json:"zoneid,omitempty"`
+}
+
+type ListVMSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVMSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["vmsnapshotid"]; found {
+		u.Set("vmsnapshotid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVMSnapshotParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *ListVMSnapshotParams) SetVmsnapshotid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmsnapshotid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVMSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewListVMSnapshotParams() *ListVMSnapshotParams {
+	p := &ListVMSnapshotParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SnapshotService) GetVMSnapshotID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVMSnapshotParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVMSnapshot(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.VMSnapshot[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.VMSnapshot {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// List virtual machine snapshot by conditions
+func (s *SnapshotService) ListVMSnapshot(p *ListVMSnapshotParams) (*ListVMSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("listVMSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVMSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVMSnapshotResponse struct {
+	Count      int           `json:"count"`
+	VMSnapshot []*VMSnapshot `json:"vmsnapshot"`
+}
+
+type VMSnapshot struct {
+	Account          string `json:"account,omitempty"`
+	Created          string `json:"created,omitempty"`
+	Current          bool   `json:"current,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Displayname      string `json:"displayname,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Parent           string `json:"parent,omitempty"`
+	ParentName       string `json:"parentName,omitempty"`
+	Project          string `json:"project,omitempty"`
+	Projectid        string `json:"projectid,omitempty"`
+	State            string `json:"state,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+}
+
+type CreateVMSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVMSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["description"]; found {
+		u.Set("description", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["quiescevm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("quiescevm", vv)
+	}
+	if v, found := p.p["snapshotmemory"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("snapshotmemory", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVMSnapshotParams) SetDescription(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["description"] = v
+	return
+}
+
+func (p *CreateVMSnapshotParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateVMSnapshotParams) SetQuiescevm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["quiescevm"] = v
+	return
+}
+
+func (p *CreateVMSnapshotParams) SetSnapshotmemory(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["snapshotmemory"] = v
+	return
+}
+
+func (p *CreateVMSnapshotParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVMSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewCreateVMSnapshotParams(virtualmachineid string) *CreateVMSnapshotParams {
+	p := &CreateVMSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Creates snapshot for a vm.
+func (s *SnapshotService) CreateVMSnapshot(p *CreateVMSnapshotParams) (*CreateVMSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("createVMSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVMSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVMSnapshotResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Account          string `json:"account,omitempty"`
+	Created          string `json:"created,omitempty"`
+	Current          bool   `json:"current,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Displayname      string `json:"displayname,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Parent           string `json:"parent,omitempty"`
+	ParentName       string `json:"parentName,omitempty"`
+	Project          string `json:"project,omitempty"`
+	Projectid        string `json:"projectid,omitempty"`
+	State            string `json:"state,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+}
+
+type DeleteVMSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVMSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["vmsnapshotid"]; found {
+		u.Set("vmsnapshotid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVMSnapshotParams) SetVmsnapshotid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmsnapshotid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVMSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewDeleteVMSnapshotParams(vmsnapshotid string) *DeleteVMSnapshotParams {
+	p := &DeleteVMSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["vmsnapshotid"] = vmsnapshotid
+	return p
+}
+
+// Deletes a vmsnapshot.
+func (s *SnapshotService) DeleteVMSnapshot(p *DeleteVMSnapshotParams) (*DeleteVMSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("deleteVMSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVMSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVMSnapshotResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type RevertToVMSnapshotParams struct {
+	p map[string]interface{}
+}
+
+func (p *RevertToVMSnapshotParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["vmsnapshotid"]; found {
+		u.Set("vmsnapshotid", v.(string))
+	}
+	return u
+}
+
+func (p *RevertToVMSnapshotParams) SetVmsnapshotid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmsnapshotid"] = v
+	return
+}
+
+// You should always use this function to get a new RevertToVMSnapshotParams instance,
+// as then you are sure you have configured all required params
+func (s *SnapshotService) NewRevertToVMSnapshotParams(vmsnapshotid string) *RevertToVMSnapshotParams {
+	p := &RevertToVMSnapshotParams{}
+	p.p = make(map[string]interface{})
+	p.p["vmsnapshotid"] = vmsnapshotid
+	return p
+}
+
+// Revert VM from a vmsnapshot.
+func (s *SnapshotService) RevertToVMSnapshot(p *RevertToVMSnapshotParams) (*RevertToVMSnapshotResponse, error) {
+	resp, err := s.cs.newRequest("revertToVMSnapshot", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RevertToVMSnapshotResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RevertToVMSnapshotResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/StoragePoolService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/StoragePoolService.go
@@ -1,0 +1,300 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type ListStorageProvidersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListStorageProvidersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	return u
+}
+
+func (p *ListStorageProvidersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListStorageProvidersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListStorageProvidersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListStorageProvidersParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storagePoolType"] = v
+	return
+}
+
+// You should always use this function to get a new ListStorageProvidersParams instance,
+// as then you are sure you have configured all required params
+func (s *StoragePoolService) NewListStorageProvidersParams(storagePoolType string) *ListStorageProvidersParams {
+	p := &ListStorageProvidersParams{}
+	p.p = make(map[string]interface{})
+	p.p["storagePoolType"] = storagePoolType
+	return p
+}
+
+// Lists storage providers.
+func (s *StoragePoolService) ListStorageProviders(p *ListStorageProvidersParams) (*ListStorageProvidersResponse, error) {
+	resp, err := s.cs.newRequest("listStorageProviders", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListStorageProvidersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListStorageProvidersResponse struct {
+	Count            int                `json:"count"`
+	StorageProviders []*StorageProvider `json:"storageprovider"`
+}
+
+type StorageProvider struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+type EnableStorageMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *EnableStorageMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *EnableStorageMaintenanceParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new EnableStorageMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *StoragePoolService) NewEnableStorageMaintenanceParams(id string) *EnableStorageMaintenanceParams {
+	p := &EnableStorageMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Puts storage pool into maintenance state
+func (s *StoragePoolService) EnableStorageMaintenance(p *EnableStorageMaintenanceParams) (*EnableStorageMaintenanceResponse, error) {
+	resp, err := s.cs.newRequest("enableStorageMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r EnableStorageMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type EnableStorageMaintenanceResponse struct {
+	JobID                string            `json:"jobid,omitempty"`
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}
+
+type CancelStorageMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *CancelStorageMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *CancelStorageMaintenanceParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new CancelStorageMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *StoragePoolService) NewCancelStorageMaintenanceParams(id string) *CancelStorageMaintenanceParams {
+	p := &CancelStorageMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Cancels maintenance for primary storage
+func (s *StoragePoolService) CancelStorageMaintenance(p *CancelStorageMaintenanceParams) (*CancelStorageMaintenanceResponse, error) {
+	resp, err := s.cs.newRequest("cancelStorageMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CancelStorageMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CancelStorageMaintenanceResponse struct {
+	JobID                string            `json:"jobid,omitempty"`
+	Capacityiops         int64             `json:"capacityiops,omitempty"`
+	Clusterid            string            `json:"clusterid,omitempty"`
+	Clustername          string            `json:"clustername,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	Disksizeallocated    int64             `json:"disksizeallocated,omitempty"`
+	Disksizetotal        int64             `json:"disksizetotal,omitempty"`
+	Disksizeused         int64             `json:"disksizeused,omitempty"`
+	Hypervisor           string            `json:"hypervisor,omitempty"`
+	Id                   string            `json:"id,omitempty"`
+	Ipaddress            string            `json:"ipaddress,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Overprovisionfactor  string            `json:"overprovisionfactor,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	Podid                string            `json:"podid,omitempty"`
+	Podname              string            `json:"podname,omitempty"`
+	Scope                string            `json:"scope,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Storagecapabilities  map[string]string `json:"storagecapabilities,omitempty"`
+	Suitableformigration bool              `json:"suitableformigration,omitempty"`
+	Tags                 string            `json:"tags,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Zoneid               string            `json:"zoneid,omitempty"`
+	Zonename             string            `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/StratosphereSSPService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/StratosphereSSPService.go
@@ -1,0 +1,132 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type AddStratosphereSspParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddStratosphereSspParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["tenantuuid"]; found {
+		u.Set("tenantuuid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddStratosphereSspParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *AddStratosphereSspParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddStratosphereSspParams) SetTenantuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tenantuuid"] = v
+	return
+}
+
+func (p *AddStratosphereSspParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddStratosphereSspParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *AddStratosphereSspParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddStratosphereSspParams instance,
+// as then you are sure you have configured all required params
+func (s *StratosphereSSPService) NewAddStratosphereSspParams(name string, url string, zoneid string) *AddStratosphereSspParams {
+	p := &AddStratosphereSspParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Adds stratosphere ssp server
+func (s *StratosphereSSPService) AddStratosphereSsp(p *AddStratosphereSspParams) (*AddStratosphereSspResponse, error) {
+	resp, err := s.cs.newRequest("addStratosphereSsp", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddStratosphereSspResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddStratosphereSspResponse struct {
+	Hostid string `json:"hostid,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Url    string `json:"url,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SwiftService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SwiftService.go
@@ -1,0 +1,249 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type AddSwiftParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddSwiftParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["key"]; found {
+		u.Set("key", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddSwiftParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AddSwiftParams) SetKey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["key"] = v
+	return
+}
+
+func (p *AddSwiftParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddSwiftParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddSwiftParams instance,
+// as then you are sure you have configured all required params
+func (s *SwiftService) NewAddSwiftParams(url string) *AddSwiftParams {
+	p := &AddSwiftParams{}
+	p.p = make(map[string]interface{})
+	p.p["url"] = url
+	return p
+}
+
+// Adds Swift.
+func (s *SwiftService) AddSwift(p *AddSwiftParams) (*AddSwiftResponse, error) {
+	resp, err := s.cs.newRequest("addSwift", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddSwiftResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddSwiftResponse struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}
+
+type ListSwiftsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSwiftsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("id", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListSwiftsParams) SetId(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSwiftsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSwiftsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSwiftsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListSwiftsParams instance,
+// as then you are sure you have configured all required params
+func (s *SwiftService) NewListSwiftsParams() *ListSwiftsParams {
+	p := &ListSwiftsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SwiftService) GetSwiftID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListSwiftsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListSwifts(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.Swifts[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Swifts {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// List Swift.
+func (s *SwiftService) ListSwifts(p *ListSwiftsParams) (*ListSwiftsResponse, error) {
+	resp, err := s.cs.newRequest("listSwifts", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSwiftsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSwiftsResponse struct {
+	Count  int      `json:"count"`
+	Swifts []*Swift `json:"swift"`
+}
+
+type Swift struct {
+	Details      []string `json:"details,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Providername string   `json:"providername,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	Url          string   `json:"url,omitempty"`
+	Zoneid       string   `json:"zoneid,omitempty"`
+	Zonename     string   `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SystemCapacityService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SystemCapacityService.go
@@ -1,0 +1,178 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type ListCapacityParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListCapacityParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["fetchlatest"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fetchlatest", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["sortby"]; found {
+		u.Set("sortby", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("type", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListCapacityParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetFetchlatest(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fetchlatest"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetSortby(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortby"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetType(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["systemCapacityType"] = v
+	return
+}
+
+func (p *ListCapacityParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListCapacityParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemCapacityService) NewListCapacityParams() *ListCapacityParams {
+	p := &ListCapacityParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all the system wide capacities.
+func (s *SystemCapacityService) ListCapacity(p *ListCapacityParams) (*ListCapacityResponse, error) {
+	resp, err := s.cs.newRequest("listCapacity", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListCapacityResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListCapacityResponse struct {
+	Count    int         `json:"count"`
+	Capacity []*Capacity `json:"capacity"`
+}
+
+type Capacity struct {
+	Capacitytotal int64  `json:"capacitytotal,omitempty"`
+	Capacityused  int64  `json:"capacityused,omitempty"`
+	Clusterid     string `json:"clusterid,omitempty"`
+	Clustername   string `json:"clustername,omitempty"`
+	Percentused   string `json:"percentused,omitempty"`
+	Podid         string `json:"podid,omitempty"`
+	Podname       string `json:"podname,omitempty"`
+	Type          int    `json:"type,omitempty"`
+	Zoneid        string `json:"zoneid,omitempty"`
+	Zonename      string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/SystemVMService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/SystemVMService.go
@@ -1,0 +1,1046 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type StartSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *StartSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StartSystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StartSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewStartSystemVmParams(id string) *StartSystemVmParams {
+	p := &StartSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Starts a system virtual machine.
+func (s *SystemVMService) StartSystemVm(p *StartSystemVmParams) (*StartSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("startSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StartSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StartSystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type RebootSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *RebootSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RebootSystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RebootSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewRebootSystemVmParams(id string) *RebootSystemVmParams {
+	p := &RebootSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Reboots a system VM.
+func (s *SystemVMService) RebootSystemVm(p *RebootSystemVmParams) (*RebootSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("rebootSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RebootSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RebootSystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type StopSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *StopSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StopSystemVmParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *StopSystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StopSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewStopSystemVmParams(id string) *StopSystemVmParams {
+	p := &StopSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Stops a system VM.
+func (s *SystemVMService) StopSystemVm(p *StopSystemVmParams) (*StopSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("stopSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StopSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StopSystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type DestroySystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *DestroySystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DestroySystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DestroySystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewDestroySystemVmParams(id string) *DestroySystemVmParams {
+	p := &DestroySystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Destroyes a system virtual machine.
+func (s *SystemVMService) DestroySystemVm(p *DestroySystemVmParams) (*DestroySystemVmResponse, error) {
+	resp, err := s.cs.newRequest("destroySystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DestroySystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DestroySystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ListSystemVmsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListSystemVmsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["systemvmtype"]; found {
+		u.Set("systemvmtype", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListSystemVmsParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetSystemvmtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["systemvmtype"] = v
+	return
+}
+
+func (p *ListSystemVmsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListSystemVmsParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewListSystemVmsParams() *ListSystemVmsParams {
+	p := &ListSystemVmsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SystemVMService) GetSystemVmID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListSystemVmsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListSystemVms(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.SystemVms[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.SystemVms {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SystemVMService) GetSystemVmByName(name string, opts ...OptionFunc) (*SystemVm, int, error) {
+	id, count, err := s.GetSystemVmID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetSystemVmByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *SystemVMService) GetSystemVmByID(id string, opts ...OptionFunc) (*SystemVm, int, error) {
+	p := &ListSystemVmsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListSystemVms(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.SystemVms[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for SystemVm UUID: %s!", id)
+}
+
+// List system virtual machines.
+func (s *SystemVMService) ListSystemVms(p *ListSystemVmsParams) (*ListSystemVmsResponse, error) {
+	resp, err := s.cs.newRequest("listSystemVms", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListSystemVmsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListSystemVmsResponse struct {
+	Count     int         `json:"count"`
+	SystemVms []*SystemVm `json:"systemvm"`
+}
+
+type SystemVm struct {
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type MigrateSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *MigrateSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *MigrateSystemVmParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *MigrateSystemVmParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new MigrateSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewMigrateSystemVmParams(hostid string, virtualmachineid string) *MigrateSystemVmParams {
+	p := &MigrateSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostid"] = hostid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Attempts Migration of a system virtual machine to the host specified.
+func (s *SystemVMService) MigrateSystemVm(p *MigrateSystemVmParams) (*MigrateSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("migrateSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r MigrateSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type MigrateSystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ChangeServiceForSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *ChangeServiceForSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *ChangeServiceForSystemVmParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ChangeServiceForSystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ChangeServiceForSystemVmParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new ChangeServiceForSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewChangeServiceForSystemVmParams(id string, serviceofferingid string) *ChangeServiceForSystemVmParams {
+	p := &ChangeServiceForSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["serviceofferingid"] = serviceofferingid
+	return p
+}
+
+// Changes the service offering for a system vm (console proxy or secondary storage). The system vm must be in a "Stopped" state for this command to take effect.
+func (s *SystemVMService) ChangeServiceForSystemVm(p *ChangeServiceForSystemVmParams) (*ChangeServiceForSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("changeServiceForSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ChangeServiceForSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ChangeServiceForSystemVmResponse struct {
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}
+
+type ScaleSystemVmParams struct {
+	p map[string]interface{}
+}
+
+func (p *ScaleSystemVmParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *ScaleSystemVmParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ScaleSystemVmParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ScaleSystemVmParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new ScaleSystemVmParams instance,
+// as then you are sure you have configured all required params
+func (s *SystemVMService) NewScaleSystemVmParams(id string, serviceofferingid string) *ScaleSystemVmParams {
+	p := &ScaleSystemVmParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["serviceofferingid"] = serviceofferingid
+	return p
+}
+
+// Scale the service offering for a system vm (console proxy or secondary storage). The system vm must be in a "Stopped" state for this command to take effect.
+func (s *SystemVMService) ScaleSystemVm(p *ScaleSystemVmParams) (*ScaleSystemVmResponse, error) {
+	resp, err := s.cs.newRequest("scaleSystemVm", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ScaleSystemVmResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ScaleSystemVmResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Activeviewersessions int    `json:"activeviewersessions,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Dns1                 string `json:"dns1,omitempty"`
+	Dns2                 string `json:"dns2,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Hostid               string `json:"hostid,omitempty"`
+	Hostname             string `json:"hostname,omitempty"`
+	Hypervisor           string `json:"hypervisor,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Jobid                string `json:"jobid,omitempty"`
+	Jobstatus            int    `json:"jobstatus,omitempty"`
+	Linklocalip          string `json:"linklocalip,omitempty"`
+	Linklocalmacaddress  string `json:"linklocalmacaddress,omitempty"`
+	Linklocalnetmask     string `json:"linklocalnetmask,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Networkdomain        string `json:"networkdomain,omitempty"`
+	Podid                string `json:"podid,omitempty"`
+	Privateip            string `json:"privateip,omitempty"`
+	Privatemacaddress    string `json:"privatemacaddress,omitempty"`
+	Privatenetmask       string `json:"privatenetmask,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Publicmacaddress     string `json:"publicmacaddress,omitempty"`
+	Publicnetmask        string `json:"publicnetmask,omitempty"`
+	State                string `json:"state,omitempty"`
+	Systemvmtype         string `json:"systemvmtype,omitempty"`
+	Templateid           string `json:"templateid,omitempty"`
+	Zoneid               string `json:"zoneid,omitempty"`
+	Zonename             string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/TemplateService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/TemplateService.go
@@ -1,0 +1,2318 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bits"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("bits", vv)
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["passwordenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passwordenabled", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["requireshvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("requireshvm", vv)
+	}
+	if v, found := p.p["snapshotid"]; found {
+		u.Set("snapshotid", v.(string))
+	}
+	if v, found := p.p["templatetag"]; found {
+		u.Set("templatetag", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateTemplateParams) SetBits(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bits"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetPasswordenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passwordenabled"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetRequireshvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["requireshvm"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetSnapshotid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["snapshotid"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetTemplatetag(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templatetag"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *CreateTemplateParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewCreateTemplateParams(displaytext string, name string, ostypeid string) *CreateTemplateParams {
+	p := &CreateTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	p.p["ostypeid"] = ostypeid
+	return p
+}
+
+// Creates a template of a virtual machine. The virtual machine must be in a STOPPED state. A template created from this command is automatically designated as a private template visible to the account that created it.
+func (s *TemplateService) CreateTemplate(p *CreateTemplateParams) (*CreateTemplateResponse, error) {
+	resp, err := s.cs.newRequest("createTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateTemplateResponse struct {
+	JobID                 string            `json:"jobid,omitempty"`
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type RegisterTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *RegisterTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["bits"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("bits", vv)
+	}
+	if v, found := p.p["checksum"]; found {
+		u.Set("checksum", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isextractable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isextractable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["isrouting"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrouting", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["passwordenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passwordenabled", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["requireshvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("requireshvm", vv)
+	}
+	if v, found := p.p["sshkeyenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("sshkeyenabled", vv)
+	}
+	if v, found := p.p["templatetag"]; found {
+		u.Set("templatetag", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *RegisterTemplateParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetBits(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bits"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetChecksum(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["checksum"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetIsextractable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isextractable"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetIsrouting(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrouting"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetPasswordenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passwordenabled"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetRequireshvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["requireshvm"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetSshkeyenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sshkeyenabled"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetTemplatetag(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templatetag"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *RegisterTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new RegisterTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewRegisterTemplateParams(displaytext string, format string, hypervisor string, name string, ostypeid string, url string, zoneid string) *RegisterTemplateParams {
+	p := &RegisterTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["format"] = format
+	p.p["hypervisor"] = hypervisor
+	p.p["name"] = name
+	p.p["ostypeid"] = ostypeid
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Registers an existing template into the CloudStack cloud.
+func (s *TemplateService) RegisterTemplate(p *RegisterTemplateParams) (*RegisterTemplateResponse, error) {
+	resp, err := s.cs.newRequest("registerTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RegisterTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RegisterTemplateResponse struct {
+	Count            int                 `json:"count"`
+	RegisterTemplate []*RegisterTemplate `json:"template"`
+}
+
+type RegisterTemplate struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type UpdateTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bootable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("bootable", vv)
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isrouting"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrouting", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["passwordenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passwordenabled", vv)
+	}
+	if v, found := p.p["requireshvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("requireshvm", vv)
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	return u
+}
+
+func (p *UpdateTemplateParams) SetBootable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bootable"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetIsrouting(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrouting"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetPasswordenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passwordenabled"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetRequireshvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["requireshvm"] = v
+	return
+}
+
+func (p *UpdateTemplateParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewUpdateTemplateParams(id string) *UpdateTemplateParams {
+	p := &UpdateTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates attributes of a template.
+func (s *TemplateService) UpdateTemplate(p *UpdateTemplateParams) (*UpdateTemplateResponse, error) {
+	resp, err := s.cs.newRequest("updateTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateTemplateResponse struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type CopyTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *CopyTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["destzoneid"]; found {
+		u.Set("destzoneid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["sourcezoneid"]; found {
+		u.Set("sourcezoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CopyTemplateParams) SetDestzoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["destzoneid"] = v
+	return
+}
+
+func (p *CopyTemplateParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *CopyTemplateParams) SetSourcezoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcezoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CopyTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewCopyTemplateParams(destzoneid string, id string) *CopyTemplateParams {
+	p := &CopyTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["destzoneid"] = destzoneid
+	p.p["id"] = id
+	return p
+}
+
+// Copies a template from one zone to another.
+func (s *TemplateService) CopyTemplate(p *CopyTemplateParams) (*CopyTemplateResponse, error) {
+	resp, err := s.cs.newRequest("copyTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CopyTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CopyTemplateResponse struct {
+	JobID                 string            `json:"jobid,omitempty"`
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type DeleteTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteTemplateParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DeleteTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewDeleteTemplateParams(id string) *DeleteTemplateParams {
+	p := &DeleteTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a template from the system. All virtual machines using the deleted template will not be affected.
+func (s *TemplateService) DeleteTemplate(p *DeleteTemplateParams) (*DeleteTemplateResponse, error) {
+	resp, err := s.cs.newRequest("deleteTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteTemplateResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListTemplatesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTemplatesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["showremoved"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showremoved", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["templatefilter"]; found {
+		u.Set("templatefilter", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListTemplatesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetShowremoved(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showremoved"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetTemplatefilter(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templatefilter"] = v
+	return
+}
+
+func (p *ListTemplatesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListTemplatesParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewListTemplatesParams(templatefilter string) *ListTemplatesParams {
+	p := &ListTemplatesParams{}
+	p.p = make(map[string]interface{})
+	p.p["templatefilter"] = templatefilter
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListTemplatesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+	p.p["templatefilter"] = templatefilter
+	p.p["zoneid"] = zoneid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListTemplates(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Templates[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Templates {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *TemplateService) GetTemplateByName(name string, templatefilter string, zoneid string, opts ...OptionFunc) (*Template, int, error) {
+	id, count, err := s.GetTemplateID(name, templatefilter, zoneid, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetTemplateByID(id, templatefilter, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *TemplateService) GetTemplateByID(id string, templatefilter string, opts ...OptionFunc) (*Template, int, error) {
+	p := &ListTemplatesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+	p.p["templatefilter"] = templatefilter
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListTemplates(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Templates[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Template UUID: %s!", id)
+}
+
+// List all public, private, and privileged templates.
+func (s *TemplateService) ListTemplates(p *ListTemplatesParams) (*ListTemplatesResponse, error) {
+	resp, err := s.cs.newRequest("listTemplates", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTemplatesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTemplatesResponse struct {
+	Count     int         `json:"count"`
+	Templates []*Template `json:"template"`
+}
+
+type Template struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type UpdateTemplatePermissionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateTemplatePermissionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["accounts"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("accounts", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isextractable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isextractable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["op"]; found {
+		u.Set("op", v.(string))
+	}
+	if v, found := p.p["projectids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("projectids", vv)
+	}
+	return u
+}
+
+func (p *UpdateTemplatePermissionsParams) SetAccounts(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounts"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetIsextractable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isextractable"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetOp(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["op"] = v
+	return
+}
+
+func (p *UpdateTemplatePermissionsParams) SetProjectids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectids"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateTemplatePermissionsParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewUpdateTemplatePermissionsParams(id string) *UpdateTemplatePermissionsParams {
+	p := &UpdateTemplatePermissionsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a template visibility permissions. A public template is visible to all accounts within the same domain. A private template is visible only to the owner of the template. A priviledged template is a private template with account permissions added. Only accounts specified under the template permissions are visible to them.
+func (s *TemplateService) UpdateTemplatePermissions(p *UpdateTemplatePermissionsParams) (*UpdateTemplatePermissionsResponse, error) {
+	resp, err := s.cs.newRequest("updateTemplatePermissions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateTemplatePermissionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateTemplatePermissionsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListTemplatePermissionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTemplatePermissionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ListTemplatePermissionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ListTemplatePermissionsParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewListTemplatePermissionsParams(id string) *ListTemplatePermissionsParams {
+	p := &ListTemplatePermissionsParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *TemplateService) GetTemplatePermissionByID(id string, opts ...OptionFunc) (*TemplatePermission, int, error) {
+	p := &ListTemplatePermissionsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListTemplatePermissions(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.TemplatePermissions[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for TemplatePermission UUID: %s!", id)
+}
+
+// List template visibility and all accounts that have permissions to view this template.
+func (s *TemplateService) ListTemplatePermissions(p *ListTemplatePermissionsParams) (*ListTemplatePermissionsResponse, error) {
+	resp, err := s.cs.newRequest("listTemplatePermissions", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTemplatePermissionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTemplatePermissionsResponse struct {
+	Count               int                   `json:"count"`
+	TemplatePermissions []*TemplatePermission `json:"templatepermission"`
+}
+
+type TemplatePermission struct {
+	Account    []string `json:"account,omitempty"`
+	Domainid   string   `json:"domainid,omitempty"`
+	Id         string   `json:"id,omitempty"`
+	Ispublic   bool     `json:"ispublic,omitempty"`
+	Projectids []string `json:"projectids,omitempty"`
+}
+
+type ExtractTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *ExtractTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["mode"]; found {
+		u.Set("mode", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ExtractTemplateParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ExtractTemplateParams) SetMode(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["mode"] = v
+	return
+}
+
+func (p *ExtractTemplateParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *ExtractTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ExtractTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewExtractTemplateParams(id string, mode string) *ExtractTemplateParams {
+	p := &ExtractTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["mode"] = mode
+	return p
+}
+
+// Extracts a template
+func (s *TemplateService) ExtractTemplate(p *ExtractTemplateParams) (*ExtractTemplateResponse, error) {
+	resp, err := s.cs.newRequest("extractTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ExtractTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ExtractTemplateResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Accountid        string `json:"accountid,omitempty"`
+	Created          string `json:"created,omitempty"`
+	ExtractId        string `json:"extractId,omitempty"`
+	ExtractMode      string `json:"extractMode,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Resultstring     string `json:"resultstring,omitempty"`
+	State            string `json:"state,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Storagetype      string `json:"storagetype,omitempty"`
+	Uploadpercentage int    `json:"uploadpercentage,omitempty"`
+	Url              string `json:"url,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+	Zonename         string `json:"zonename,omitempty"`
+}
+
+type PrepareTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *PrepareTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *PrepareTemplateParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *PrepareTemplateParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *PrepareTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new PrepareTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewPrepareTemplateParams(templateid string, zoneid string) *PrepareTemplateParams {
+	p := &PrepareTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["templateid"] = templateid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// load template into primary storage
+func (s *TemplateService) PrepareTemplate(p *PrepareTemplateParams) (*PrepareTemplateResponse, error) {
+	resp, err := s.cs.newRequest("prepareTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r PrepareTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type PrepareTemplateResponse struct {
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatetag  string `json:"templatetag,omitempty"`
+	Templatetype string `json:"templatetype,omitempty"`
+	Zoneid       string `json:"zoneid,omitempty"`
+	Zonename     string `json:"zonename,omitempty"`
+}
+
+type UpgradeRouterTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpgradeRouterTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *UpgradeRouterTemplateParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpgradeRouterTemplateParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *UpgradeRouterTemplateParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UpgradeRouterTemplateParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpgradeRouterTemplateParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *UpgradeRouterTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new UpgradeRouterTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewUpgradeRouterTemplateParams() *UpgradeRouterTemplateParams {
+	p := &UpgradeRouterTemplateParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Upgrades router to use newer template
+func (s *TemplateService) UpgradeRouterTemplate(p *UpgradeRouterTemplateParams) (*UpgradeRouterTemplateResponse, error) {
+	resp, err := s.cs.newRequest("upgradeRouterTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpgradeRouterTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpgradeRouterTemplateResponse struct {
+	Jobid     string `json:"jobid,omitempty"`
+	Jobstatus int    `json:"jobstatus,omitempty"`
+}
+
+type GetUploadParamsForTemplateParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetUploadParamsForTemplateParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["bits"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("bits", vv)
+	}
+	if v, found := p.p["checksum"]; found {
+		u.Set("checksum", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["isextractable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isextractable", vv)
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["isrouting"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrouting", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["passwordenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passwordenabled", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["requireshvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("requireshvm", vv)
+	}
+	if v, found := p.p["sshkeyenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("sshkeyenabled", vv)
+	}
+	if v, found := p.p["templatetag"]; found {
+		u.Set("templatetag", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *GetUploadParamsForTemplateParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetBits(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bits"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetChecksum(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["checksum"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetIsextractable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isextractable"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetIsrouting(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrouting"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetPasswordenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passwordenabled"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetRequireshvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["requireshvm"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetSshkeyenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sshkeyenabled"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetTemplatetag(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templatetag"] = v
+	return
+}
+
+func (p *GetUploadParamsForTemplateParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new GetUploadParamsForTemplateParams instance,
+// as then you are sure you have configured all required params
+func (s *TemplateService) NewGetUploadParamsForTemplateParams(displaytext string, format string, hypervisor string, name string, ostypeid string, zoneid string) *GetUploadParamsForTemplateParams {
+	p := &GetUploadParamsForTemplateParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["format"] = format
+	p.p["hypervisor"] = hypervisor
+	p.p["name"] = name
+	p.p["ostypeid"] = ostypeid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// upload an existing template into the CloudStack cloud.
+func (s *TemplateService) GetUploadParamsForTemplate(p *GetUploadParamsForTemplateParams) (*GetUploadParamsForTemplateResponse, error) {
+	resp, err := s.cs.newRequest("getUploadParamsForTemplate", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetUploadParamsForTemplateResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetUploadParamsForTemplateResponse struct {
+	Expires   string `json:"expires,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Metadata  string `json:"metadata,omitempty"`
+	PostURL   string `json:"postURL,omitempty"`
+	Signature string `json:"signature,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/UCSService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/UCSService.go
@@ -1,0 +1,594 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AddUcsManagerParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddUcsManagerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddUcsManagerParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *AddUcsManagerParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddUcsManagerParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddUcsManagerParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *AddUcsManagerParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddUcsManagerParams instance,
+// as then you are sure you have configured all required params
+func (s *UCSService) NewAddUcsManagerParams(password string, url string, username string, zoneid string) *AddUcsManagerParams {
+	p := &AddUcsManagerParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["url"] = url
+	p.p["username"] = username
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Adds a Ucs manager
+func (s *UCSService) AddUcsManager(p *AddUcsManagerParams) (*AddUcsManagerResponse, error) {
+	resp, err := s.cs.newRequest("addUcsManager", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddUcsManagerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddUcsManagerResponse struct {
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Url    string `json:"url,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type ListUcsManagersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUcsManagersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListUcsManagersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListUcsManagersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListUcsManagersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListUcsManagersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListUcsManagersParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListUcsManagersParams instance,
+// as then you are sure you have configured all required params
+func (s *UCSService) NewListUcsManagersParams() *ListUcsManagersParams {
+	p := &ListUcsManagersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *UCSService) GetUcsManagerID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListUcsManagersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListUcsManagers(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.UcsManagers[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.UcsManagers {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *UCSService) GetUcsManagerByName(name string, opts ...OptionFunc) (*UcsManager, int, error) {
+	id, count, err := s.GetUcsManagerID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetUcsManagerByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *UCSService) GetUcsManagerByID(id string, opts ...OptionFunc) (*UcsManager, int, error) {
+	p := &ListUcsManagersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListUcsManagers(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.UcsManagers[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for UcsManager UUID: %s!", id)
+}
+
+// List ucs manager
+func (s *UCSService) ListUcsManagers(p *ListUcsManagersParams) (*ListUcsManagersResponse, error) {
+	resp, err := s.cs.newRequest("listUcsManagers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUcsManagersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUcsManagersResponse struct {
+	Count       int           `json:"count"`
+	UcsManagers []*UcsManager `json:"ucsmanager"`
+}
+
+type UcsManager struct {
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Url    string `json:"url,omitempty"`
+	Zoneid string `json:"zoneid,omitempty"`
+}
+
+type ListUcsProfilesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUcsProfilesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["ucsmanagerid"]; found {
+		u.Set("ucsmanagerid", v.(string))
+	}
+	return u
+}
+
+func (p *ListUcsProfilesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListUcsProfilesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListUcsProfilesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListUcsProfilesParams) SetUcsmanagerid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ucsmanagerid"] = v
+	return
+}
+
+// You should always use this function to get a new ListUcsProfilesParams instance,
+// as then you are sure you have configured all required params
+func (s *UCSService) NewListUcsProfilesParams(ucsmanagerid string) *ListUcsProfilesParams {
+	p := &ListUcsProfilesParams{}
+	p.p = make(map[string]interface{})
+	p.p["ucsmanagerid"] = ucsmanagerid
+	return p
+}
+
+// List profile in ucs manager
+func (s *UCSService) ListUcsProfiles(p *ListUcsProfilesParams) (*ListUcsProfilesResponse, error) {
+	resp, err := s.cs.newRequest("listUcsProfiles", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUcsProfilesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUcsProfilesResponse struct {
+	Count       int           `json:"count"`
+	UcsProfiles []*UcsProfile `json:"ucsprofile"`
+}
+
+type UcsProfile struct {
+	Ucsdn string `json:"ucsdn,omitempty"`
+}
+
+type ListUcsBladesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUcsBladesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["ucsmanagerid"]; found {
+		u.Set("ucsmanagerid", v.(string))
+	}
+	return u
+}
+
+func (p *ListUcsBladesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListUcsBladesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListUcsBladesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListUcsBladesParams) SetUcsmanagerid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ucsmanagerid"] = v
+	return
+}
+
+// You should always use this function to get a new ListUcsBladesParams instance,
+// as then you are sure you have configured all required params
+func (s *UCSService) NewListUcsBladesParams(ucsmanagerid string) *ListUcsBladesParams {
+	p := &ListUcsBladesParams{}
+	p.p = make(map[string]interface{})
+	p.p["ucsmanagerid"] = ucsmanagerid
+	return p
+}
+
+// List ucs blades
+func (s *UCSService) ListUcsBlades(p *ListUcsBladesParams) (*ListUcsBladesResponse, error) {
+	resp, err := s.cs.newRequest("listUcsBlades", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUcsBladesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUcsBladesResponse struct {
+	Count     int         `json:"count"`
+	UcsBlades []*UcsBlade `json:"ucsblade"`
+}
+
+type UcsBlade struct {
+	Bladedn      string `json:"bladedn,omitempty"`
+	Hostid       string `json:"hostid,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Profiledn    string `json:"profiledn,omitempty"`
+	Ucsmanagerid string `json:"ucsmanagerid,omitempty"`
+}
+
+type AssociateUcsProfileToBladeParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssociateUcsProfileToBladeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["bladeid"]; found {
+		u.Set("bladeid", v.(string))
+	}
+	if v, found := p.p["profiledn"]; found {
+		u.Set("profiledn", v.(string))
+	}
+	if v, found := p.p["ucsmanagerid"]; found {
+		u.Set("ucsmanagerid", v.(string))
+	}
+	return u
+}
+
+func (p *AssociateUcsProfileToBladeParams) SetBladeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["bladeid"] = v
+	return
+}
+
+func (p *AssociateUcsProfileToBladeParams) SetProfiledn(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["profiledn"] = v
+	return
+}
+
+func (p *AssociateUcsProfileToBladeParams) SetUcsmanagerid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ucsmanagerid"] = v
+	return
+}
+
+// You should always use this function to get a new AssociateUcsProfileToBladeParams instance,
+// as then you are sure you have configured all required params
+func (s *UCSService) NewAssociateUcsProfileToBladeParams(bladeid string, profiledn string, ucsmanagerid string) *AssociateUcsProfileToBladeParams {
+	p := &AssociateUcsProfileToBladeParams{}
+	p.p = make(map[string]interface{})
+	p.p["bladeid"] = bladeid
+	p.p["profiledn"] = profiledn
+	p.p["ucsmanagerid"] = ucsmanagerid
+	return p
+}
+
+// associate a profile to a blade
+func (s *UCSService) AssociateUcsProfileToBlade(p *AssociateUcsProfileToBladeParams) (*AssociateUcsProfileToBladeResponse, error) {
+	resp, err := s.cs.newRequest("associateUcsProfileToBlade", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateUcsProfileToBladeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AssociateUcsProfileToBladeResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Bladedn      string `json:"bladedn,omitempty"`
+	Hostid       string `json:"hostid,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Profiledn    string `json:"profiledn,omitempty"`
+	Ucsmanagerid string `json:"ucsmanagerid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/UsageService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/UsageService.go
@@ -1,0 +1,1213 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type AddTrafficTypeParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddTrafficTypeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hypervnetworklabel"]; found {
+		u.Set("hypervnetworklabel", v.(string))
+	}
+	if v, found := p.p["isolationmethod"]; found {
+		u.Set("isolationmethod", v.(string))
+	}
+	if v, found := p.p["kvmnetworklabel"]; found {
+		u.Set("kvmnetworklabel", v.(string))
+	}
+	if v, found := p.p["ovm3networklabel"]; found {
+		u.Set("ovm3networklabel", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["vmwarenetworklabel"]; found {
+		u.Set("vmwarenetworklabel", v.(string))
+	}
+	if v, found := p.p["xennetworklabel"]; found {
+		u.Set("xennetworklabel", v.(string))
+	}
+	return u
+}
+
+func (p *AddTrafficTypeParams) SetHypervnetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervnetworklabel"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetIsolationmethod(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isolationmethod"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetKvmnetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["kvmnetworklabel"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetOvm3networklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ovm3networklabel"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetVmwarenetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmwarenetworklabel"] = v
+	return
+}
+
+func (p *AddTrafficTypeParams) SetXennetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["xennetworklabel"] = v
+	return
+}
+
+// You should always use this function to get a new AddTrafficTypeParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewAddTrafficTypeParams(physicalnetworkid string, traffictype string) *AddTrafficTypeParams {
+	p := &AddTrafficTypeParams{}
+	p.p = make(map[string]interface{})
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["traffictype"] = traffictype
+	return p
+}
+
+// Adds traffic type to a physical network
+func (s *UsageService) AddTrafficType(p *AddTrafficTypeParams) (*AddTrafficTypeResponse, error) {
+	resp, err := s.cs.newRequest("addTrafficType", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddTrafficTypeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddTrafficTypeResponse struct {
+	JobID              string `json:"jobid,omitempty"`
+	Hypervnetworklabel string `json:"hypervnetworklabel,omitempty"`
+	Id                 string `json:"id,omitempty"`
+	Kvmnetworklabel    string `json:"kvmnetworklabel,omitempty"`
+	Ovm3networklabel   string `json:"ovm3networklabel,omitempty"`
+	Physicalnetworkid  string `json:"physicalnetworkid,omitempty"`
+	Traffictype        string `json:"traffictype,omitempty"`
+	Vmwarenetworklabel string `json:"vmwarenetworklabel,omitempty"`
+	Xennetworklabel    string `json:"xennetworklabel,omitempty"`
+}
+
+type DeleteTrafficTypeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteTrafficTypeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteTrafficTypeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteTrafficTypeParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewDeleteTrafficTypeParams(id string) *DeleteTrafficTypeParams {
+	p := &DeleteTrafficTypeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes traffic type of a physical network
+func (s *UsageService) DeleteTrafficType(p *DeleteTrafficTypeParams) (*DeleteTrafficTypeResponse, error) {
+	resp, err := s.cs.newRequest("deleteTrafficType", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteTrafficTypeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteTrafficTypeResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListTrafficTypesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTrafficTypesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	return u
+}
+
+func (p *ListTrafficTypesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListTrafficTypesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListTrafficTypesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListTrafficTypesParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+// You should always use this function to get a new ListTrafficTypesParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewListTrafficTypesParams(physicalnetworkid string) *ListTrafficTypesParams {
+	p := &ListTrafficTypesParams{}
+	p.p = make(map[string]interface{})
+	p.p["physicalnetworkid"] = physicalnetworkid
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *UsageService) GetTrafficTypeID(keyword string, physicalnetworkid string, opts ...OptionFunc) (string, int, error) {
+	p := &ListTrafficTypesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+	p.p["physicalnetworkid"] = physicalnetworkid
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListTrafficTypes(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.TrafficTypes[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.TrafficTypes {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// Lists traffic types of a given physical network.
+func (s *UsageService) ListTrafficTypes(p *ListTrafficTypesParams) (*ListTrafficTypesResponse, error) {
+	resp, err := s.cs.newRequest("listTrafficTypes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTrafficTypesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTrafficTypesResponse struct {
+	Count        int            `json:"count"`
+	TrafficTypes []*TrafficType `json:"traffictype"`
+}
+
+type TrafficType struct {
+	Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+	Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+	Id                           string   `json:"id,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+	Servicelist                  []string `json:"servicelist,omitempty"`
+	State                        string   `json:"state,omitempty"`
+}
+
+type UpdateTrafficTypeParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateTrafficTypeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hypervnetworklabel"]; found {
+		u.Set("hypervnetworklabel", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["kvmnetworklabel"]; found {
+		u.Set("kvmnetworklabel", v.(string))
+	}
+	if v, found := p.p["ovm3networklabel"]; found {
+		u.Set("ovm3networklabel", v.(string))
+	}
+	if v, found := p.p["vmwarenetworklabel"]; found {
+		u.Set("vmwarenetworklabel", v.(string))
+	}
+	if v, found := p.p["xennetworklabel"]; found {
+		u.Set("xennetworklabel", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateTrafficTypeParams) SetHypervnetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervnetworklabel"] = v
+	return
+}
+
+func (p *UpdateTrafficTypeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateTrafficTypeParams) SetKvmnetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["kvmnetworklabel"] = v
+	return
+}
+
+func (p *UpdateTrafficTypeParams) SetOvm3networklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ovm3networklabel"] = v
+	return
+}
+
+func (p *UpdateTrafficTypeParams) SetVmwarenetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vmwarenetworklabel"] = v
+	return
+}
+
+func (p *UpdateTrafficTypeParams) SetXennetworklabel(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["xennetworklabel"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateTrafficTypeParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewUpdateTrafficTypeParams(id string) *UpdateTrafficTypeParams {
+	p := &UpdateTrafficTypeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates traffic type of a physical network
+func (s *UsageService) UpdateTrafficType(p *UpdateTrafficTypeParams) (*UpdateTrafficTypeResponse, error) {
+	resp, err := s.cs.newRequest("updateTrafficType", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateTrafficTypeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateTrafficTypeResponse struct {
+	JobID              string `json:"jobid,omitempty"`
+	Hypervnetworklabel string `json:"hypervnetworklabel,omitempty"`
+	Id                 string `json:"id,omitempty"`
+	Kvmnetworklabel    string `json:"kvmnetworklabel,omitempty"`
+	Ovm3networklabel   string `json:"ovm3networklabel,omitempty"`
+	Physicalnetworkid  string `json:"physicalnetworkid,omitempty"`
+	Traffictype        string `json:"traffictype,omitempty"`
+	Vmwarenetworklabel string `json:"vmwarenetworklabel,omitempty"`
+	Xennetworklabel    string `json:"xennetworklabel,omitempty"`
+}
+
+type ListTrafficTypeImplementorsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTrafficTypeImplementorsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["traffictype"]; found {
+		u.Set("traffictype", v.(string))
+	}
+	return u
+}
+
+func (p *ListTrafficTypeImplementorsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListTrafficTypeImplementorsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListTrafficTypeImplementorsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListTrafficTypeImplementorsParams) SetTraffictype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["traffictype"] = v
+	return
+}
+
+// You should always use this function to get a new ListTrafficTypeImplementorsParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewListTrafficTypeImplementorsParams() *ListTrafficTypeImplementorsParams {
+	p := &ListTrafficTypeImplementorsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists implementors of implementor of a network traffic type or implementors of all network traffic types
+func (s *UsageService) ListTrafficTypeImplementors(p *ListTrafficTypeImplementorsParams) (*ListTrafficTypeImplementorsResponse, error) {
+	resp, err := s.cs.newRequest("listTrafficTypeImplementors", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTrafficTypeImplementorsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTrafficTypeImplementorsResponse struct {
+	Count                   int                       `json:"count"`
+	TrafficTypeImplementors []*TrafficTypeImplementor `json:"traffictypeimplementor"`
+}
+
+type TrafficTypeImplementor struct {
+	Traffictype            string `json:"traffictype,omitempty"`
+	Traffictypeimplementor string `json:"traffictypeimplementor,omitempty"`
+}
+
+type GenerateUsageRecordsParams struct {
+	p map[string]interface{}
+}
+
+func (p *GenerateUsageRecordsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	return u
+}
+
+func (p *GenerateUsageRecordsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *GenerateUsageRecordsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *GenerateUsageRecordsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+// You should always use this function to get a new GenerateUsageRecordsParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewGenerateUsageRecordsParams(enddate string, startdate string) *GenerateUsageRecordsParams {
+	p := &GenerateUsageRecordsParams{}
+	p.p = make(map[string]interface{})
+	p.p["enddate"] = enddate
+	p.p["startdate"] = startdate
+	return p
+}
+
+// Generates usage records. This will generate records only if there any records to be generated, i.e if the scheduled usage job was not run or failed
+func (s *UsageService) GenerateUsageRecords(p *GenerateUsageRecordsParams) (*GenerateUsageRecordsResponse, error) {
+	resp, err := s.cs.newRequest("generateUsageRecords", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GenerateUsageRecordsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GenerateUsageRecordsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListUsageRecordsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUsageRecordsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accountid"]; found {
+		u.Set("accountid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["enddate"]; found {
+		u.Set("enddate", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["startdate"]; found {
+		u.Set("startdate", v.(string))
+	}
+	if v, found := p.p["type"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("type", vv)
+	}
+	if v, found := p.p["usageid"]; found {
+		u.Set("usageid", v.(string))
+	}
+	return u
+}
+
+func (p *ListUsageRecordsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetAccountid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountid"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetEnddate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["enddate"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetStartdate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startdate"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetType(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usageType"] = v
+	return
+}
+
+func (p *ListUsageRecordsParams) SetUsageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usageid"] = v
+	return
+}
+
+// You should always use this function to get a new ListUsageRecordsParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewListUsageRecordsParams(enddate string, startdate string) *ListUsageRecordsParams {
+	p := &ListUsageRecordsParams{}
+	p.p = make(map[string]interface{})
+	p.p["enddate"] = enddate
+	p.p["startdate"] = startdate
+	return p
+}
+
+// Lists usage records for accounts
+func (s *UsageService) ListUsageRecords(p *ListUsageRecordsParams) (*ListUsageRecordsResponse, error) {
+	resp, err := s.cs.newRequest("listUsageRecords", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUsageRecordsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUsageRecordsResponse struct {
+	Count        int            `json:"count"`
+	UsageRecords []*UsageRecord `json:"usagerecord"`
+}
+
+type UsageRecord struct {
+	Account          string `json:"account,omitempty"`
+	Accountid        string `json:"accountid,omitempty"`
+	Cpunumber        int64  `json:"cpunumber,omitempty"`
+	Cpuspeed         int64  `json:"cpuspeed,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Domain           string `json:"domain,omitempty"`
+	Domainid         string `json:"domainid,omitempty"`
+	Enddate          string `json:"enddate,omitempty"`
+	Isdefault        bool   `json:"isdefault,omitempty"`
+	Issourcenat      bool   `json:"issourcenat,omitempty"`
+	Issystem         bool   `json:"issystem,omitempty"`
+	Memory           int64  `json:"memory,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Networkid        string `json:"networkid,omitempty"`
+	Offeringid       string `json:"offeringid,omitempty"`
+	Project          string `json:"project,omitempty"`
+	Projectid        string `json:"projectid,omitempty"`
+	Rawusage         string `json:"rawusage,omitempty"`
+	Size             int64  `json:"size,omitempty"`
+	Startdate        string `json:"startdate,omitempty"`
+	Templateid       string `json:"templateid,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Usage            string `json:"usage,omitempty"`
+	Usageid          string `json:"usageid,omitempty"`
+	Usagetype        int    `json:"usagetype,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	Virtualsize      int64  `json:"virtualsize,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+}
+
+type ListUsageTypesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUsageTypesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new ListUsageTypesParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewListUsageTypesParams() *ListUsageTypesParams {
+	p := &ListUsageTypesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List Usage Types
+func (s *UsageService) ListUsageTypes(p *ListUsageTypesParams) (*ListUsageTypesResponse, error) {
+	resp, err := s.cs.newRequest("listUsageTypes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUsageTypesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUsageTypesResponse struct {
+	Count      int          `json:"count"`
+	UsageTypes []*UsageType `json:"usagetype"`
+}
+
+type UsageType struct {
+	Description string `json:"description,omitempty"`
+	Usagetypeid int    `json:"usagetypeid,omitempty"`
+}
+
+type RemoveRawUsageRecordsParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveRawUsageRecordsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["interval"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("interval", vv)
+	}
+	return u
+}
+
+func (p *RemoveRawUsageRecordsParams) SetInterval(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["interval"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveRawUsageRecordsParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewRemoveRawUsageRecordsParams(interval int) *RemoveRawUsageRecordsParams {
+	p := &RemoveRawUsageRecordsParams{}
+	p.p = make(map[string]interface{})
+	p.p["interval"] = interval
+	return p
+}
+
+// Safely removes raw records from cloud_usage table
+func (s *UsageService) RemoveRawUsageRecords(p *RemoveRawUsageRecordsParams) (*RemoveRawUsageRecordsResponse, error) {
+	resp, err := s.cs.newRequest("removeRawUsageRecords", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveRawUsageRecordsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RemoveRawUsageRecordsResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type AddTrafficMonitorParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddTrafficMonitorParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["excludezones"]; found {
+		u.Set("excludezones", v.(string))
+	}
+	if v, found := p.p["includezones"]; found {
+		u.Set("includezones", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *AddTrafficMonitorParams) SetExcludezones(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["excludezones"] = v
+	return
+}
+
+func (p *AddTrafficMonitorParams) SetIncludezones(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["includezones"] = v
+	return
+}
+
+func (p *AddTrafficMonitorParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *AddTrafficMonitorParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new AddTrafficMonitorParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewAddTrafficMonitorParams(url string, zoneid string) *AddTrafficMonitorParams {
+	p := &AddTrafficMonitorParams{}
+	p.p = make(map[string]interface{})
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Adds Traffic Monitor Host for Direct Network Usage
+func (s *UsageService) AddTrafficMonitor(p *AddTrafficMonitorParams) (*AddTrafficMonitorResponse, error) {
+	resp, err := s.cs.newRequest("addTrafficMonitor", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddTrafficMonitorResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AddTrafficMonitorResponse struct {
+	Id         string `json:"id,omitempty"`
+	Ipaddress  string `json:"ipaddress,omitempty"`
+	Numretries string `json:"numretries,omitempty"`
+	Timeout    string `json:"timeout,omitempty"`
+	Zoneid     string `json:"zoneid,omitempty"`
+}
+
+type DeleteTrafficMonitorParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteTrafficMonitorParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteTrafficMonitorParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteTrafficMonitorParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewDeleteTrafficMonitorParams(id string) *DeleteTrafficMonitorParams {
+	p := &DeleteTrafficMonitorParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an traffic monitor host.
+func (s *UsageService) DeleteTrafficMonitor(p *DeleteTrafficMonitorParams) (*DeleteTrafficMonitorResponse, error) {
+	resp, err := s.cs.newRequest("deleteTrafficMonitor", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteTrafficMonitorResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteTrafficMonitorResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListTrafficMonitorsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListTrafficMonitorsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListTrafficMonitorsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListTrafficMonitorsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListTrafficMonitorsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListTrafficMonitorsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListTrafficMonitorsParams instance,
+// as then you are sure you have configured all required params
+func (s *UsageService) NewListTrafficMonitorsParams(zoneid string) *ListTrafficMonitorsParams {
+	p := &ListTrafficMonitorsParams{}
+	p.p = make(map[string]interface{})
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// List traffic monitor Hosts.
+func (s *UsageService) ListTrafficMonitors(p *ListTrafficMonitorsParams) (*ListTrafficMonitorsResponse, error) {
+	resp, err := s.cs.newRequest("listTrafficMonitors", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListTrafficMonitorsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListTrafficMonitorsResponse struct {
+	Count           int               `json:"count"`
+	TrafficMonitors []*TrafficMonitor `json:"trafficmonitor"`
+}
+
+type TrafficMonitor struct {
+	Id         string `json:"id,omitempty"`
+	Ipaddress  string `json:"ipaddress,omitempty"`
+	Numretries string `json:"numretries,omitempty"`
+	Timeout    string `json:"timeout,omitempty"`
+	Zoneid     string `json:"zoneid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/UserService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/UserService.go
@@ -1,0 +1,1239 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["email"]; found {
+		u.Set("email", v.(string))
+	}
+	if v, found := p.p["firstname"]; found {
+		u.Set("firstname", v.(string))
+	}
+	if v, found := p.p["lastname"]; found {
+		u.Set("lastname", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	if v, found := p.p["userid"]; found {
+		u.Set("userid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *CreateUserParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateUserParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateUserParams) SetEmail(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["email"] = v
+	return
+}
+
+func (p *CreateUserParams) SetFirstname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["firstname"] = v
+	return
+}
+
+func (p *CreateUserParams) SetLastname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lastname"] = v
+	return
+}
+
+func (p *CreateUserParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *CreateUserParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+func (p *CreateUserParams) SetUserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userid"] = v
+	return
+}
+
+func (p *CreateUserParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new CreateUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewCreateUserParams(account string, email string, firstname string, lastname string, password string, username string) *CreateUserParams {
+	p := &CreateUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["email"] = email
+	p.p["firstname"] = firstname
+	p.p["lastname"] = lastname
+	p.p["password"] = password
+	p.p["username"] = username
+	return p
+}
+
+// Creates a user for an account that already exists
+func (s *UserService) CreateUser(p *CreateUserParams) (*CreateUserResponse, error) {
+	resp, err := s.cs.newRequest("createUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateUserResponse struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type DeleteUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteUserParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewDeleteUserParams(id string) *DeleteUserParams {
+	p := &DeleteUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a user for an account
+func (s *UserService) DeleteUser(p *DeleteUserParams) (*DeleteUserResponse, error) {
+	resp, err := s.cs.newRequest("deleteUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteUserResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type UpdateUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["email"]; found {
+		u.Set("email", v.(string))
+	}
+	if v, found := p.p["firstname"]; found {
+		u.Set("firstname", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["lastname"]; found {
+		u.Set("lastname", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	if v, found := p.p["userapikey"]; found {
+		u.Set("userapikey", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	if v, found := p.p["usersecretkey"]; found {
+		u.Set("usersecretkey", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateUserParams) SetEmail(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["email"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetFirstname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["firstname"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetLastname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["lastname"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetUserapikey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userapikey"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+func (p *UpdateUserParams) SetUsersecretkey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["usersecretkey"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewUpdateUserParams(id string) *UpdateUserParams {
+	p := &UpdateUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a user account
+func (s *UserService) UpdateUser(p *UpdateUserParams) (*UpdateUserResponse, error) {
+	resp, err := s.cs.newRequest("updateUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateUserResponse struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type ListUsersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListUsersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *ListUsersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListUsersParams) SetAccounttype(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *ListUsersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListUsersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListUsersParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListUsersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListUsersParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListUsersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListUsersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListUsersParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListUsersParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new ListUsersParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewListUsersParams() *ListUsersParams {
+	p := &ListUsersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *UserService) GetUserByID(id string, opts ...OptionFunc) (*User, int, error) {
+	p := &ListUsersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListUsers(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Users[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for User UUID: %s!", id)
+}
+
+// Lists user accounts
+func (s *UserService) ListUsers(p *ListUsersParams) (*ListUsersResponse, error) {
+	resp, err := s.cs.newRequest("listUsers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListUsersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListUsersResponse struct {
+	Count int     `json:"count"`
+	Users []*User `json:"user"`
+}
+
+type User struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type LockUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *LockUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *LockUserParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new LockUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewLockUserParams(id string) *LockUserParams {
+	p := &LockUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Locks a user account
+func (s *UserService) LockUser(p *LockUserParams) (*LockUserResponse, error) {
+	resp, err := s.cs.newRequest("lockUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r LockUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type LockUserResponse struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type DisableUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *DisableUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DisableUserParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DisableUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewDisableUserParams(id string) *DisableUserParams {
+	p := &DisableUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Disables a user account
+func (s *UserService) DisableUser(p *DisableUserParams) (*DisableUserResponse, error) {
+	resp, err := s.cs.newRequest("disableUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DisableUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DisableUserResponse struct {
+	JobID               string `json:"jobid,omitempty"`
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type EnableUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *EnableUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *EnableUserParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new EnableUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewEnableUserParams(id string) *EnableUserParams {
+	p := &EnableUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Enables a user account
+func (s *UserService) EnableUser(p *EnableUserParams) (*EnableUserResponse, error) {
+	resp, err := s.cs.newRequest("enableUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r EnableUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type EnableUserResponse struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type GetUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["userapikey"]; found {
+		u.Set("userapikey", v.(string))
+	}
+	return u
+}
+
+func (p *GetUserParams) SetUserapikey(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userapikey"] = v
+	return
+}
+
+// You should always use this function to get a new GetUserParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewGetUserParams(userapikey string) *GetUserParams {
+	p := &GetUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["userapikey"] = userapikey
+	return p
+}
+
+// Find user account by API key
+func (s *UserService) GetUser(p *GetUserParams) (*GetUserResponse, error) {
+	resp, err := s.cs.newRequest("getUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetUserResponse struct {
+	Account             string `json:"account,omitempty"`
+	Accountid           string `json:"accountid,omitempty"`
+	Accounttype         int    `json:"accounttype,omitempty"`
+	Apikey              string `json:"apikey,omitempty"`
+	Created             string `json:"created,omitempty"`
+	Domain              string `json:"domain,omitempty"`
+	Domainid            string `json:"domainid,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Firstname           string `json:"firstname,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Iscallerchilddomain bool   `json:"iscallerchilddomain,omitempty"`
+	Isdefault           bool   `json:"isdefault,omitempty"`
+	Lastname            string `json:"lastname,omitempty"`
+	Secretkey           string `json:"secretkey,omitempty"`
+	State               string `json:"state,omitempty"`
+	Timezone            string `json:"timezone,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+type GetVirtualMachineUserDataParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetVirtualMachineUserDataParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *GetVirtualMachineUserDataParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new GetVirtualMachineUserDataParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewGetVirtualMachineUserDataParams(virtualmachineid string) *GetVirtualMachineUserDataParams {
+	p := &GetVirtualMachineUserDataParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Returns user data associated with the VM
+func (s *UserService) GetVirtualMachineUserData(p *GetVirtualMachineUserDataParams) (*GetVirtualMachineUserDataResponse, error) {
+	resp, err := s.cs.newRequest("getVirtualMachineUserData", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetVirtualMachineUserDataResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetVirtualMachineUserDataResponse struct {
+	Userdata         string `json:"userdata,omitempty"`
+	Virtualmachineid string `json:"virtualmachineid,omitempty"`
+}
+
+type RegisterUserKeysParams struct {
+	p map[string]interface{}
+}
+
+func (p *RegisterUserKeysParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RegisterUserKeysParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RegisterUserKeysParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewRegisterUserKeysParams(id string) *RegisterUserKeysParams {
+	p := &RegisterUserKeysParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// This command allows a user to register for the developer API, returning a secret key and an API key. This request is made through the integration API port, so it is a privileged command and must be made on behalf of a user. It is up to the implementer just how the username and password are entered, and then how that translates to an integration API request. Both secret key and API key should be returned to the user
+func (s *UserService) RegisterUserKeys(p *RegisterUserKeysParams) (*RegisterUserKeysResponse, error) {
+	resp, err := s.cs.newRequest("registerUserKeys", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RegisterUserKeysResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RegisterUserKeysResponse struct {
+	Apikey    string `json:"apikey,omitempty"`
+	Secretkey string `json:"secretkey,omitempty"`
+}
+
+type ListLdapUsersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListLdapUsersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listtype"]; found {
+		u.Set("listtype", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	return u
+}
+
+func (p *ListLdapUsersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListLdapUsersParams) SetListtype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listtype"] = v
+	return
+}
+
+func (p *ListLdapUsersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListLdapUsersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+// You should always use this function to get a new ListLdapUsersParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewListLdapUsersParams() *ListLdapUsersParams {
+	p := &ListLdapUsersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Lists all LDAP Users
+func (s *UserService) ListLdapUsers(p *ListLdapUsersParams) (*ListLdapUsersResponse, error) {
+	resp, err := s.cs.newRequest("listLdapUsers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListLdapUsersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListLdapUsersResponse struct {
+	Count     int         `json:"count"`
+	LdapUsers []*LdapUser `json:"ldapuser"`
+}
+
+type LdapUser struct {
+	Domain    string `json:"domain,omitempty"`
+	Email     string `json:"email,omitempty"`
+	Firstname string `json:"firstname,omitempty"`
+	Lastname  string `json:"lastname,omitempty"`
+	Principal string `json:"principal,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+type ImportLdapUsersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ImportLdapUsersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["accountdetails"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["accounttype"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("accounttype", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["group"]; found {
+		u.Set("group", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["timezone"]; found {
+		u.Set("timezone", v.(string))
+	}
+	return u
+}
+
+func (p *ImportLdapUsersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetAccountdetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accountdetails"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetAccounttype(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["accounttype"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetGroup(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["group"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ImportLdapUsersParams) SetTimezone(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["timezone"] = v
+	return
+}
+
+// You should always use this function to get a new ImportLdapUsersParams instance,
+// as then you are sure you have configured all required params
+func (s *UserService) NewImportLdapUsersParams(accounttype int) *ImportLdapUsersParams {
+	p := &ImportLdapUsersParams{}
+	p.p = make(map[string]interface{})
+	p.p["accounttype"] = accounttype
+	return p
+}
+
+// Import LDAP users
+func (s *UserService) ImportLdapUsers(p *ImportLdapUsersParams) (*ImportLdapUsersResponse, error) {
+	resp, err := s.cs.newRequest("importLdapUsers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ImportLdapUsersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ImportLdapUsersResponse struct {
+	Domain    string `json:"domain,omitempty"`
+	Email     string `json:"email,omitempty"`
+	Firstname string `json:"firstname,omitempty"`
+	Lastname  string `json:"lastname,omitempty"`
+	Principal string `json:"principal,omitempty"`
+	Username  string `json:"username,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VLANService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VLANService.go
@@ -1,0 +1,934 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateVlanIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVlanIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["endip"]; found {
+		u.Set("endip", v.(string))
+	}
+	if v, found := p.p["endipv6"]; found {
+		u.Set("endipv6", v.(string))
+	}
+	if v, found := p.p["forvirtualnetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvirtualnetwork", vv)
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["ip6cidr"]; found {
+		u.Set("ip6cidr", v.(string))
+	}
+	if v, found := p.p["ip6gateway"]; found {
+		u.Set("ip6gateway", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["startip"]; found {
+		u.Set("startip", v.(string))
+	}
+	if v, found := p.p["startipv6"]; found {
+		u.Set("startipv6", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVlanIpRangeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetEndip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endip"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetEndipv6(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["endipv6"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetForvirtualnetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvirtualnetwork"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetIp6cidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6cidr"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetIp6gateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6gateway"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetStartip(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startip"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetStartipv6(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startipv6"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *CreateVlanIpRangeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVlanIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewCreateVlanIpRangeParams() *CreateVlanIpRangeParams {
+	p := &CreateVlanIpRangeParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Creates a VLAN IP range.
+func (s *VLANService) CreateVlanIpRange(p *CreateVlanIpRangeParams) (*CreateVlanIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("createVlanIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVlanIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateVlanIpRangeResponse struct {
+	Account           string `json:"account,omitempty"`
+	Description       string `json:"description,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Endip             string `json:"endip,omitempty"`
+	Endipv6           string `json:"endipv6,omitempty"`
+	Forvirtualnetwork bool   `json:"forvirtualnetwork,omitempty"`
+	Gateway           string `json:"gateway,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Ip6cidr           string `json:"ip6cidr,omitempty"`
+	Ip6gateway        string `json:"ip6gateway,omitempty"`
+	Netmask           string `json:"netmask,omitempty"`
+	Networkid         string `json:"networkid,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Podid             string `json:"podid,omitempty"`
+	Podname           string `json:"podname,omitempty"`
+	Project           string `json:"project,omitempty"`
+	Projectid         string `json:"projectid,omitempty"`
+	Startip           string `json:"startip,omitempty"`
+	Startipv6         string `json:"startipv6,omitempty"`
+	Vlan              string `json:"vlan,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}
+
+type DeleteVlanIpRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVlanIpRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVlanIpRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVlanIpRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewDeleteVlanIpRangeParams(id string) *DeleteVlanIpRangeParams {
+	p := &DeleteVlanIpRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Creates a VLAN IP range.
+func (s *VLANService) DeleteVlanIpRange(p *DeleteVlanIpRangeParams) (*DeleteVlanIpRangeResponse, error) {
+	resp, err := s.cs.newRequest("deleteVlanIpRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVlanIpRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteVlanIpRangeResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListVlanIpRangesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVlanIpRangesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["forvirtualnetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvirtualnetwork", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVlanIpRangesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetForvirtualnetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvirtualnetwork"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *ListVlanIpRangesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVlanIpRangesParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewListVlanIpRangesParams() *ListVlanIpRangesParams {
+	p := &ListVlanIpRangesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VLANService) GetVlanIpRangeByID(id string, opts ...OptionFunc) (*VlanIpRange, int, error) {
+	p := &ListVlanIpRangesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVlanIpRanges(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VlanIpRanges[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VlanIpRange UUID: %s!", id)
+}
+
+// Lists all VLAN IP ranges.
+func (s *VLANService) ListVlanIpRanges(p *ListVlanIpRangesParams) (*ListVlanIpRangesResponse, error) {
+	resp, err := s.cs.newRequest("listVlanIpRanges", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVlanIpRangesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVlanIpRangesResponse struct {
+	Count        int            `json:"count"`
+	VlanIpRanges []*VlanIpRange `json:"vlaniprange"`
+}
+
+type VlanIpRange struct {
+	Account           string `json:"account,omitempty"`
+	Description       string `json:"description,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Endip             string `json:"endip,omitempty"`
+	Endipv6           string `json:"endipv6,omitempty"`
+	Forvirtualnetwork bool   `json:"forvirtualnetwork,omitempty"`
+	Gateway           string `json:"gateway,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Ip6cidr           string `json:"ip6cidr,omitempty"`
+	Ip6gateway        string `json:"ip6gateway,omitempty"`
+	Netmask           string `json:"netmask,omitempty"`
+	Networkid         string `json:"networkid,omitempty"`
+	Physicalnetworkid string `json:"physicalnetworkid,omitempty"`
+	Podid             string `json:"podid,omitempty"`
+	Podname           string `json:"podname,omitempty"`
+	Project           string `json:"project,omitempty"`
+	Projectid         string `json:"projectid,omitempty"`
+	Startip           string `json:"startip,omitempty"`
+	Startipv6         string `json:"startipv6,omitempty"`
+	Vlan              string `json:"vlan,omitempty"`
+	Zoneid            string `json:"zoneid,omitempty"`
+}
+
+type DedicateGuestVlanRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicateGuestVlanRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vlanrange"]; found {
+		u.Set("vlanrange", v.(string))
+	}
+	return u
+}
+
+func (p *DedicateGuestVlanRangeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicateGuestVlanRangeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DedicateGuestVlanRangeParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *DedicateGuestVlanRangeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *DedicateGuestVlanRangeParams) SetVlanrange(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlanrange"] = v
+	return
+}
+
+// You should always use this function to get a new DedicateGuestVlanRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewDedicateGuestVlanRangeParams(account string, domainid string, physicalnetworkid string, vlanrange string) *DedicateGuestVlanRangeParams {
+	p := &DedicateGuestVlanRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["domainid"] = domainid
+	p.p["physicalnetworkid"] = physicalnetworkid
+	p.p["vlanrange"] = vlanrange
+	return p
+}
+
+// Dedicates a guest vlan range to an account
+func (s *VLANService) DedicateGuestVlanRange(p *DedicateGuestVlanRangeParams) (*DedicateGuestVlanRangeResponse, error) {
+	resp, err := s.cs.newRequest("dedicateGuestVlanRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicateGuestVlanRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DedicateGuestVlanRangeResponse struct {
+	Account           string `json:"account,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Guestvlanrange    string `json:"guestvlanrange,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Physicalnetworkid int64  `json:"physicalnetworkid,omitempty"`
+	Project           string `json:"project,omitempty"`
+	Projectid         string `json:"projectid,omitempty"`
+	Zoneid            int64  `json:"zoneid,omitempty"`
+}
+
+type ReleaseDedicatedGuestVlanRangeParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseDedicatedGuestVlanRangeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseDedicatedGuestVlanRangeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseDedicatedGuestVlanRangeParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewReleaseDedicatedGuestVlanRangeParams(id string) *ReleaseDedicatedGuestVlanRangeParams {
+	p := &ReleaseDedicatedGuestVlanRangeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Releases a dedicated guest vlan range to the system
+func (s *VLANService) ReleaseDedicatedGuestVlanRange(p *ReleaseDedicatedGuestVlanRangeParams) (*ReleaseDedicatedGuestVlanRangeResponse, error) {
+	resp, err := s.cs.newRequest("releaseDedicatedGuestVlanRange", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseDedicatedGuestVlanRangeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseDedicatedGuestVlanRangeResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDedicatedGuestVlanRangesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["guestvlanrange"]; found {
+		u.Set("guestvlanrange", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetGuestvlanrange(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestvlanrange"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListDedicatedGuestVlanRangesParams instance,
+// as then you are sure you have configured all required params
+func (s *VLANService) NewListDedicatedGuestVlanRangesParams() *ListDedicatedGuestVlanRangesParams {
+	p := &ListDedicatedGuestVlanRangesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VLANService) GetDedicatedGuestVlanRangeByID(id string, opts ...OptionFunc) (*DedicatedGuestVlanRange, int, error) {
+	p := &ListDedicatedGuestVlanRangesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListDedicatedGuestVlanRanges(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.DedicatedGuestVlanRanges[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for DedicatedGuestVlanRange UUID: %s!", id)
+}
+
+// Lists dedicated guest vlan ranges
+func (s *VLANService) ListDedicatedGuestVlanRanges(p *ListDedicatedGuestVlanRangesParams) (*ListDedicatedGuestVlanRangesResponse, error) {
+	resp, err := s.cs.newRequest("listDedicatedGuestVlanRanges", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDedicatedGuestVlanRangesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDedicatedGuestVlanRangesResponse struct {
+	Count                    int                        `json:"count"`
+	DedicatedGuestVlanRanges []*DedicatedGuestVlanRange `json:"dedicatedguestvlanrange"`
+}
+
+type DedicatedGuestVlanRange struct {
+	Account           string `json:"account,omitempty"`
+	Domain            string `json:"domain,omitempty"`
+	Domainid          string `json:"domainid,omitempty"`
+	Guestvlanrange    string `json:"guestvlanrange,omitempty"`
+	Id                string `json:"id,omitempty"`
+	Physicalnetworkid int64  `json:"physicalnetworkid,omitempty"`
+	Project           string `json:"project,omitempty"`
+	Projectid         string `json:"projectid,omitempty"`
+	Zoneid            int64  `json:"zoneid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VMGroupService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VMGroupService.go
@@ -1,0 +1,481 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateInstanceGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateInstanceGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateInstanceGroupParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateInstanceGroupParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateInstanceGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateInstanceGroupParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateInstanceGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *VMGroupService) NewCreateInstanceGroupParams(name string) *CreateInstanceGroupParams {
+	p := &CreateInstanceGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Creates a vm group
+func (s *VMGroupService) CreateInstanceGroup(p *CreateInstanceGroupParams) (*CreateInstanceGroupResponse, error) {
+	resp, err := s.cs.newRequest("createInstanceGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateInstanceGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateInstanceGroupResponse struct {
+	Account   string `json:"account,omitempty"`
+	Created   string `json:"created,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}
+
+type DeleteInstanceGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteInstanceGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteInstanceGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteInstanceGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *VMGroupService) NewDeleteInstanceGroupParams(id string) *DeleteInstanceGroupParams {
+	p := &DeleteInstanceGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a vm group
+func (s *VMGroupService) DeleteInstanceGroup(p *DeleteInstanceGroupParams) (*DeleteInstanceGroupResponse, error) {
+	resp, err := s.cs.newRequest("deleteInstanceGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteInstanceGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteInstanceGroupResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type UpdateInstanceGroupParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateInstanceGroupParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateInstanceGroupParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateInstanceGroupParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateInstanceGroupParams instance,
+// as then you are sure you have configured all required params
+func (s *VMGroupService) NewUpdateInstanceGroupParams(id string) *UpdateInstanceGroupParams {
+	p := &UpdateInstanceGroupParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a vm group
+func (s *VMGroupService) UpdateInstanceGroup(p *UpdateInstanceGroupParams) (*UpdateInstanceGroupResponse, error) {
+	resp, err := s.cs.newRequest("updateInstanceGroup", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateInstanceGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateInstanceGroupResponse struct {
+	Account   string `json:"account,omitempty"`
+	Created   string `json:"created,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}
+
+type ListInstanceGroupsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListInstanceGroupsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *ListInstanceGroupsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListInstanceGroupsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new ListInstanceGroupsParams instance,
+// as then you are sure you have configured all required params
+func (s *VMGroupService) NewListInstanceGroupsParams() *ListInstanceGroupsParams {
+	p := &ListInstanceGroupsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VMGroupService) GetInstanceGroupID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListInstanceGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListInstanceGroups(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.InstanceGroups[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.InstanceGroups {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VMGroupService) GetInstanceGroupByName(name string, opts ...OptionFunc) (*InstanceGroup, int, error) {
+	id, count, err := s.GetInstanceGroupID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetInstanceGroupByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VMGroupService) GetInstanceGroupByID(id string, opts ...OptionFunc) (*InstanceGroup, int, error) {
+	p := &ListInstanceGroupsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListInstanceGroups(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.InstanceGroups[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for InstanceGroup UUID: %s!", id)
+}
+
+// Lists vm groups
+func (s *VMGroupService) ListInstanceGroups(p *ListInstanceGroupsParams) (*ListInstanceGroupsResponse, error) {
+	resp, err := s.cs.newRequest("listInstanceGroups", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListInstanceGroupsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListInstanceGroupsResponse struct {
+	Count          int              `json:"count"`
+	InstanceGroups []*InstanceGroup `json:"instancegroup"`
+}
+
+type InstanceGroup struct {
+	Account   string `json:"account,omitempty"`
+	Created   string `json:"created,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VPCService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VPCService.go
@@ -1,0 +1,2843 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateVPCParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVPCParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidr"]; found {
+		u.Set("cidr", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkdomain"]; found {
+		u.Set("networkdomain", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["start"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("start", vv)
+	}
+	if v, found := p.p["vpcofferingid"]; found {
+		u.Set("vpcofferingid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVPCParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetCidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidr"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetNetworkdomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkdomain"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetStart(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["start"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetVpcofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcofferingid"] = v
+	return
+}
+
+func (p *CreateVPCParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVPCParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewCreateVPCParams(cidr string, displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams {
+	p := &CreateVPCParams{}
+	p.p = make(map[string]interface{})
+	p.p["cidr"] = cidr
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	p.p["vpcofferingid"] = vpcofferingid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates a VPC
+func (s *VPCService) CreateVPC(p *CreateVPCParams) (*CreateVPCResponse, error) {
+	resp, err := s.cs.newRequest("createVPC", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVPCResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVPCResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidr                 string `json:"cidr,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Network              []struct {
+		Account                     string `json:"account,omitempty"`
+		Aclid                       string `json:"aclid,omitempty"`
+		Acltype                     string `json:"acltype,omitempty"`
+		Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+		Broadcasturi                string `json:"broadcasturi,omitempty"`
+		Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+		Cidr                        string `json:"cidr,omitempty"`
+		Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+		Displaytext                 string `json:"displaytext,omitempty"`
+		Dns1                        string `json:"dns1,omitempty"`
+		Dns2                        string `json:"dns2,omitempty"`
+		Domain                      string `json:"domain,omitempty"`
+		Domainid                    string `json:"domainid,omitempty"`
+		Gateway                     string `json:"gateway,omitempty"`
+		Id                          string `json:"id,omitempty"`
+		Ip6cidr                     string `json:"ip6cidr,omitempty"`
+		Ip6gateway                  string `json:"ip6gateway,omitempty"`
+		Isdefault                   bool   `json:"isdefault,omitempty"`
+		Ispersistent                bool   `json:"ispersistent,omitempty"`
+		Issystem                    bool   `json:"issystem,omitempty"`
+		Name                        string `json:"name,omitempty"`
+		Netmask                     string `json:"netmask,omitempty"`
+		Networkcidr                 string `json:"networkcidr,omitempty"`
+		Networkdomain               string `json:"networkdomain,omitempty"`
+		Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+		Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+		Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+		Networkofferingid           string `json:"networkofferingid,omitempty"`
+		Networkofferingname         string `json:"networkofferingname,omitempty"`
+		Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+		Project                     string `json:"project,omitempty"`
+		Projectid                   string `json:"projectid,omitempty"`
+		Related                     string `json:"related,omitempty"`
+		Reservediprange             string `json:"reservediprange,omitempty"`
+		Restartrequired             bool   `json:"restartrequired,omitempty"`
+		Service                     []struct {
+			Capability []struct {
+				Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+				Name                       string `json:"name,omitempty"`
+				Value                      string `json:"value,omitempty"`
+			} `json:"capability,omitempty"`
+			Name     string `json:"name,omitempty"`
+			Provider []struct {
+				Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+				Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+				Id                           string   `json:"id,omitempty"`
+				Name                         string   `json:"name,omitempty"`
+				Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+				Servicelist                  []string `json:"servicelist,omitempty"`
+				State                        string   `json:"state,omitempty"`
+			} `json:"provider,omitempty"`
+		} `json:"service,omitempty"`
+		Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+		State            string `json:"state,omitempty"`
+		Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+		Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+		Tags             []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Traffictype       string   `json:"traffictype,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		Vlan              string   `json:"vlan,omitempty"`
+		Vpcid             string   `json:"vpcid,omitempty"`
+		Zoneid            string   `json:"zoneid,omitempty"`
+		Zonename          string   `json:"zonename,omitempty"`
+		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	} `json:"network,omitempty"`
+	Networkdomain      string `json:"networkdomain,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Redundantvpcrouter bool   `json:"redundantvpcrouter,omitempty"`
+	Regionlevelvpc     bool   `json:"regionlevelvpc,omitempty"`
+	Restartrequired    bool   `json:"restartrequired,omitempty"`
+	Service            []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State string `json:"state,omitempty"`
+	Tags  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcofferingid string `json:"vpcofferingid,omitempty"`
+	Zoneid        string `json:"zoneid,omitempty"`
+	Zonename      string `json:"zonename,omitempty"`
+}
+
+type ListVPCsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVPCsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidr"]; found {
+		u.Set("cidr", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["restartrequired"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("restartrequired", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["vpcofferingid"]; found {
+		u.Set("vpcofferingid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVPCsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetCidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidr"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetRestartrequired(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["restartrequired"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetVpcofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcofferingid"] = v
+	return
+}
+
+func (p *ListVPCsParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVPCsParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewListVPCsParams() *ListVPCsParams {
+	p := &ListVPCsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVPCsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVPCs(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.VPCs[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.VPCs {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCByName(name string, opts ...OptionFunc) (*VPC, int, error) {
+	id, count, err := s.GetVPCID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetVPCByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCByID(id string, opts ...OptionFunc) (*VPC, int, error) {
+	p := &ListVPCsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVPCs(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VPCs[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VPC UUID: %s!", id)
+}
+
+// Lists VPCs
+func (s *VPCService) ListVPCs(p *ListVPCsParams) (*ListVPCsResponse, error) {
+	resp, err := s.cs.newRequest("listVPCs", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVPCsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVPCsResponse struct {
+	Count int    `json:"count"`
+	VPCs  []*VPC `json:"vpc"`
+}
+
+type VPC struct {
+	Account              string `json:"account,omitempty"`
+	Cidr                 string `json:"cidr,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Network              []struct {
+		Account                     string `json:"account,omitempty"`
+		Aclid                       string `json:"aclid,omitempty"`
+		Acltype                     string `json:"acltype,omitempty"`
+		Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+		Broadcasturi                string `json:"broadcasturi,omitempty"`
+		Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+		Cidr                        string `json:"cidr,omitempty"`
+		Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+		Displaytext                 string `json:"displaytext,omitempty"`
+		Dns1                        string `json:"dns1,omitempty"`
+		Dns2                        string `json:"dns2,omitempty"`
+		Domain                      string `json:"domain,omitempty"`
+		Domainid                    string `json:"domainid,omitempty"`
+		Gateway                     string `json:"gateway,omitempty"`
+		Id                          string `json:"id,omitempty"`
+		Ip6cidr                     string `json:"ip6cidr,omitempty"`
+		Ip6gateway                  string `json:"ip6gateway,omitempty"`
+		Isdefault                   bool   `json:"isdefault,omitempty"`
+		Ispersistent                bool   `json:"ispersistent,omitempty"`
+		Issystem                    bool   `json:"issystem,omitempty"`
+		Name                        string `json:"name,omitempty"`
+		Netmask                     string `json:"netmask,omitempty"`
+		Networkcidr                 string `json:"networkcidr,omitempty"`
+		Networkdomain               string `json:"networkdomain,omitempty"`
+		Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+		Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+		Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+		Networkofferingid           string `json:"networkofferingid,omitempty"`
+		Networkofferingname         string `json:"networkofferingname,omitempty"`
+		Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+		Project                     string `json:"project,omitempty"`
+		Projectid                   string `json:"projectid,omitempty"`
+		Related                     string `json:"related,omitempty"`
+		Reservediprange             string `json:"reservediprange,omitempty"`
+		Restartrequired             bool   `json:"restartrequired,omitempty"`
+		Service                     []struct {
+			Capability []struct {
+				Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+				Name                       string `json:"name,omitempty"`
+				Value                      string `json:"value,omitempty"`
+			} `json:"capability,omitempty"`
+			Name     string `json:"name,omitempty"`
+			Provider []struct {
+				Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+				Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+				Id                           string   `json:"id,omitempty"`
+				Name                         string   `json:"name,omitempty"`
+				Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+				Servicelist                  []string `json:"servicelist,omitempty"`
+				State                        string   `json:"state,omitempty"`
+			} `json:"provider,omitempty"`
+		} `json:"service,omitempty"`
+		Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+		State            string `json:"state,omitempty"`
+		Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+		Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+		Tags             []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Traffictype       string   `json:"traffictype,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		Vlan              string   `json:"vlan,omitempty"`
+		Vpcid             string   `json:"vpcid,omitempty"`
+		Zoneid            string   `json:"zoneid,omitempty"`
+		Zonename          string   `json:"zonename,omitempty"`
+		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	} `json:"network,omitempty"`
+	Networkdomain      string `json:"networkdomain,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Redundantvpcrouter bool   `json:"redundantvpcrouter,omitempty"`
+	Regionlevelvpc     bool   `json:"regionlevelvpc,omitempty"`
+	Restartrequired    bool   `json:"restartrequired,omitempty"`
+	Service            []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State string `json:"state,omitempty"`
+	Tags  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcofferingid string `json:"vpcofferingid,omitempty"`
+	Zoneid        string `json:"zoneid,omitempty"`
+	Zonename      string `json:"zonename,omitempty"`
+}
+
+type DeleteVPCParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVPCParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVPCParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVPCParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewDeleteVPCParams(id string) *DeleteVPCParams {
+	p := &DeleteVPCParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a VPC
+func (s *VPCService) DeleteVPC(p *DeleteVPCParams) (*DeleteVPCResponse, error) {
+	resp, err := s.cs.newRequest("deleteVPC", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVPCResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVPCResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateVPCParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVPCParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVPCParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateVPCParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateVPCParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateVPCParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateVPCParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVPCParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewUpdateVPCParams(id string) *UpdateVPCParams {
+	p := &UpdateVPCParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a VPC
+func (s *VPCService) UpdateVPC(p *UpdateVPCParams) (*UpdateVPCResponse, error) {
+	resp, err := s.cs.newRequest("updateVPC", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVPCResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVPCResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidr                 string `json:"cidr,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Network              []struct {
+		Account                     string `json:"account,omitempty"`
+		Aclid                       string `json:"aclid,omitempty"`
+		Acltype                     string `json:"acltype,omitempty"`
+		Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+		Broadcasturi                string `json:"broadcasturi,omitempty"`
+		Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+		Cidr                        string `json:"cidr,omitempty"`
+		Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+		Displaytext                 string `json:"displaytext,omitempty"`
+		Dns1                        string `json:"dns1,omitempty"`
+		Dns2                        string `json:"dns2,omitempty"`
+		Domain                      string `json:"domain,omitempty"`
+		Domainid                    string `json:"domainid,omitempty"`
+		Gateway                     string `json:"gateway,omitempty"`
+		Id                          string `json:"id,omitempty"`
+		Ip6cidr                     string `json:"ip6cidr,omitempty"`
+		Ip6gateway                  string `json:"ip6gateway,omitempty"`
+		Isdefault                   bool   `json:"isdefault,omitempty"`
+		Ispersistent                bool   `json:"ispersistent,omitempty"`
+		Issystem                    bool   `json:"issystem,omitempty"`
+		Name                        string `json:"name,omitempty"`
+		Netmask                     string `json:"netmask,omitempty"`
+		Networkcidr                 string `json:"networkcidr,omitempty"`
+		Networkdomain               string `json:"networkdomain,omitempty"`
+		Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+		Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+		Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+		Networkofferingid           string `json:"networkofferingid,omitempty"`
+		Networkofferingname         string `json:"networkofferingname,omitempty"`
+		Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+		Project                     string `json:"project,omitempty"`
+		Projectid                   string `json:"projectid,omitempty"`
+		Related                     string `json:"related,omitempty"`
+		Reservediprange             string `json:"reservediprange,omitempty"`
+		Restartrequired             bool   `json:"restartrequired,omitempty"`
+		Service                     []struct {
+			Capability []struct {
+				Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+				Name                       string `json:"name,omitempty"`
+				Value                      string `json:"value,omitempty"`
+			} `json:"capability,omitempty"`
+			Name     string `json:"name,omitempty"`
+			Provider []struct {
+				Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+				Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+				Id                           string   `json:"id,omitempty"`
+				Name                         string   `json:"name,omitempty"`
+				Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+				Servicelist                  []string `json:"servicelist,omitempty"`
+				State                        string   `json:"state,omitempty"`
+			} `json:"provider,omitempty"`
+		} `json:"service,omitempty"`
+		Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+		State            string `json:"state,omitempty"`
+		Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+		Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+		Tags             []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Traffictype       string   `json:"traffictype,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		Vlan              string   `json:"vlan,omitempty"`
+		Vpcid             string   `json:"vpcid,omitempty"`
+		Zoneid            string   `json:"zoneid,omitempty"`
+		Zonename          string   `json:"zonename,omitempty"`
+		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	} `json:"network,omitempty"`
+	Networkdomain      string `json:"networkdomain,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Redundantvpcrouter bool   `json:"redundantvpcrouter,omitempty"`
+	Regionlevelvpc     bool   `json:"regionlevelvpc,omitempty"`
+	Restartrequired    bool   `json:"restartrequired,omitempty"`
+	Service            []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State string `json:"state,omitempty"`
+	Tags  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcofferingid string `json:"vpcofferingid,omitempty"`
+	Zoneid        string `json:"zoneid,omitempty"`
+	Zonename      string `json:"zonename,omitempty"`
+}
+
+type RestartVPCParams struct {
+	p map[string]interface{}
+}
+
+func (p *RestartVPCParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cleanup"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("cleanup", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["makeredundant"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("makeredundant", vv)
+	}
+	return u
+}
+
+func (p *RestartVPCParams) SetCleanup(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cleanup"] = v
+	return
+}
+
+func (p *RestartVPCParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *RestartVPCParams) SetMakeredundant(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["makeredundant"] = v
+	return
+}
+
+// You should always use this function to get a new RestartVPCParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewRestartVPCParams(id string) *RestartVPCParams {
+	p := &RestartVPCParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Restarts a VPC
+func (s *VPCService) RestartVPC(p *RestartVPCParams) (*RestartVPCResponse, error) {
+	resp, err := s.cs.newRequest("restartVPC", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RestartVPCResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RestartVPCResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidr                 string `json:"cidr,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Network              []struct {
+		Account                     string `json:"account,omitempty"`
+		Aclid                       string `json:"aclid,omitempty"`
+		Acltype                     string `json:"acltype,omitempty"`
+		Broadcastdomaintype         string `json:"broadcastdomaintype,omitempty"`
+		Broadcasturi                string `json:"broadcasturi,omitempty"`
+		Canusefordeploy             bool   `json:"canusefordeploy,omitempty"`
+		Cidr                        string `json:"cidr,omitempty"`
+		Displaynetwork              bool   `json:"displaynetwork,omitempty"`
+		Displaytext                 string `json:"displaytext,omitempty"`
+		Dns1                        string `json:"dns1,omitempty"`
+		Dns2                        string `json:"dns2,omitempty"`
+		Domain                      string `json:"domain,omitempty"`
+		Domainid                    string `json:"domainid,omitempty"`
+		Gateway                     string `json:"gateway,omitempty"`
+		Id                          string `json:"id,omitempty"`
+		Ip6cidr                     string `json:"ip6cidr,omitempty"`
+		Ip6gateway                  string `json:"ip6gateway,omitempty"`
+		Isdefault                   bool   `json:"isdefault,omitempty"`
+		Ispersistent                bool   `json:"ispersistent,omitempty"`
+		Issystem                    bool   `json:"issystem,omitempty"`
+		Name                        string `json:"name,omitempty"`
+		Netmask                     string `json:"netmask,omitempty"`
+		Networkcidr                 string `json:"networkcidr,omitempty"`
+		Networkdomain               string `json:"networkdomain,omitempty"`
+		Networkofferingavailability string `json:"networkofferingavailability,omitempty"`
+		Networkofferingconservemode bool   `json:"networkofferingconservemode,omitempty"`
+		Networkofferingdisplaytext  string `json:"networkofferingdisplaytext,omitempty"`
+		Networkofferingid           string `json:"networkofferingid,omitempty"`
+		Networkofferingname         string `json:"networkofferingname,omitempty"`
+		Physicalnetworkid           string `json:"physicalnetworkid,omitempty"`
+		Project                     string `json:"project,omitempty"`
+		Projectid                   string `json:"projectid,omitempty"`
+		Related                     string `json:"related,omitempty"`
+		Reservediprange             string `json:"reservediprange,omitempty"`
+		Restartrequired             bool   `json:"restartrequired,omitempty"`
+		Service                     []struct {
+			Capability []struct {
+				Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+				Name                       string `json:"name,omitempty"`
+				Value                      string `json:"value,omitempty"`
+			} `json:"capability,omitempty"`
+			Name     string `json:"name,omitempty"`
+			Provider []struct {
+				Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+				Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+				Id                           string   `json:"id,omitempty"`
+				Name                         string   `json:"name,omitempty"`
+				Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+				Servicelist                  []string `json:"servicelist,omitempty"`
+				State                        string   `json:"state,omitempty"`
+			} `json:"provider,omitempty"`
+		} `json:"service,omitempty"`
+		Specifyipranges  bool   `json:"specifyipranges,omitempty"`
+		State            string `json:"state,omitempty"`
+		Strechedl2subnet bool   `json:"strechedl2subnet,omitempty"`
+		Subdomainaccess  bool   `json:"subdomainaccess,omitempty"`
+		Tags             []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Traffictype       string   `json:"traffictype,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		Vlan              string   `json:"vlan,omitempty"`
+		Vpcid             string   `json:"vpcid,omitempty"`
+		Zoneid            string   `json:"zoneid,omitempty"`
+		Zonename          string   `json:"zonename,omitempty"`
+		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	} `json:"network,omitempty"`
+	Networkdomain      string `json:"networkdomain,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Redundantvpcrouter bool   `json:"redundantvpcrouter,omitempty"`
+	Regionlevelvpc     bool   `json:"regionlevelvpc,omitempty"`
+	Restartrequired    bool   `json:"restartrequired,omitempty"`
+	Service            []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State string `json:"state,omitempty"`
+	Tags  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcofferingid string `json:"vpcofferingid,omitempty"`
+	Zoneid        string `json:"zoneid,omitempty"`
+	Zonename      string `json:"zonename,omitempty"`
+}
+
+type CreateVPCOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVPCOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["servicecapabilitylist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].key", i), k)
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["serviceproviderlist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	return u
+}
+
+func (p *CreateVPCOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *CreateVPCOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateVPCOfferingParams) SetServicecapabilitylist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["servicecapabilitylist"] = v
+	return
+}
+
+func (p *CreateVPCOfferingParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *CreateVPCOfferingParams) SetServiceproviderlist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceproviderlist"] = v
+	return
+}
+
+func (p *CreateVPCOfferingParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVPCOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewCreateVPCOfferingParams(displaytext string, name string, supportedservices []string) *CreateVPCOfferingParams {
+	p := &CreateVPCOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
+	p.p["name"] = name
+	p.p["supportedservices"] = supportedservices
+	return p
+}
+
+// Creates VPC offering
+func (s *VPCService) CreateVPCOffering(p *CreateVPCOfferingParams) (*CreateVPCOfferingResponse, error) {
+	resp, err := s.cs.newRequest("createVPCOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVPCOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVPCOfferingResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isdefault            bool   `json:"isdefault,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Service              []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State                  string `json:"state,omitempty"`
+	SupportsregionLevelvpc bool   `json:"supportsregionLevelvpc,omitempty"`
+}
+
+type UpdateVPCOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVPCOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVPCOfferingParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateVPCOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateVPCOfferingParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateVPCOfferingParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVPCOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewUpdateVPCOfferingParams(id string) *UpdateVPCOfferingParams {
+	p := &UpdateVPCOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates VPC offering
+func (s *VPCService) UpdateVPCOffering(p *UpdateVPCOfferingParams) (*UpdateVPCOfferingResponse, error) {
+	resp, err := s.cs.newRequest("updateVPCOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVPCOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVPCOfferingResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isdefault            bool   `json:"isdefault,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Service              []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State                  string `json:"state,omitempty"`
+	SupportsregionLevelvpc bool   `json:"supportsregionLevelvpc,omitempty"`
+}
+
+type DeleteVPCOfferingParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVPCOfferingParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVPCOfferingParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVPCOfferingParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewDeleteVPCOfferingParams(id string) *DeleteVPCOfferingParams {
+	p := &DeleteVPCOfferingParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes VPC offering
+func (s *VPCService) DeleteVPCOffering(p *DeleteVPCOfferingParams) (*DeleteVPCOfferingResponse, error) {
+	resp, err := s.cs.newRequest("deleteVPCOffering", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVPCOfferingResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVPCOfferingResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListVPCOfferingsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVPCOfferingsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["displaytext"]; found {
+		u.Set("displaytext", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isdefault"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdefault", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["supportedservices"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("supportedservices", vv)
+	}
+	return u
+}
+
+func (p *ListVPCOfferingsParams) SetDisplaytext(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displaytext"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetIsdefault(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdefault"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListVPCOfferingsParams) SetSupportedservices(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["supportedservices"] = v
+	return
+}
+
+// You should always use this function to get a new ListVPCOfferingsParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewListVPCOfferingsParams() *ListVPCOfferingsParams {
+	p := &ListVPCOfferingsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCOfferingID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVPCOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVPCOfferings(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.VPCOfferings[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.VPCOfferings {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCOfferingByName(name string, opts ...OptionFunc) (*VPCOffering, int, error) {
+	id, count, err := s.GetVPCOfferingID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetVPCOfferingByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetVPCOfferingByID(id string, opts ...OptionFunc) (*VPCOffering, int, error) {
+	p := &ListVPCOfferingsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVPCOfferings(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VPCOfferings[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VPCOffering UUID: %s!", id)
+}
+
+// Lists VPC offerings
+func (s *VPCService) ListVPCOfferings(p *ListVPCOfferingsParams) (*ListVPCOfferingsResponse, error) {
+	resp, err := s.cs.newRequest("listVPCOfferings", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVPCOfferingsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVPCOfferingsResponse struct {
+	Count        int            `json:"count"`
+	VPCOfferings []*VPCOffering `json:"vpcoffering"`
+}
+
+type VPCOffering struct {
+	Created              string `json:"created,omitempty"`
+	Displaytext          string `json:"displaytext,omitempty"`
+	Distributedvpcrouter bool   `json:"distributedvpcrouter,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Isdefault            bool   `json:"isdefault,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Service              []struct {
+		Capability []struct {
+			Canchooseservicecapability bool   `json:"canchooseservicecapability,omitempty"`
+			Name                       string `json:"name,omitempty"`
+			Value                      string `json:"value,omitempty"`
+		} `json:"capability,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Provider []struct {
+			Canenableindividualservice   bool     `json:"canenableindividualservice,omitempty"`
+			Destinationphysicalnetworkid string   `json:"destinationphysicalnetworkid,omitempty"`
+			Id                           string   `json:"id,omitempty"`
+			Name                         string   `json:"name,omitempty"`
+			Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
+			Servicelist                  []string `json:"servicelist,omitempty"`
+			State                        string   `json:"state,omitempty"`
+		} `json:"provider,omitempty"`
+	} `json:"service,omitempty"`
+	State                  string `json:"state,omitempty"`
+	SupportsregionLevelvpc bool   `json:"supportsregionLevelvpc,omitempty"`
+}
+
+type CreatePrivateGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreatePrivateGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["aclid"]; found {
+		u.Set("aclid", v.(string))
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["netmask"]; found {
+		u.Set("netmask", v.(string))
+	}
+	if v, found := p.p["networkofferingid"]; found {
+		u.Set("networkofferingid", v.(string))
+	}
+	if v, found := p.p["physicalnetworkid"]; found {
+		u.Set("physicalnetworkid", v.(string))
+	}
+	if v, found := p.p["sourcenatsupported"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("sourcenatsupported", vv)
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *CreatePrivateGatewayParams) SetAclid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["aclid"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetNetmask(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["netmask"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetNetworkofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkofferingid"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetPhysicalnetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["physicalnetworkid"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetSourcenatsupported(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatsupported"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *CreatePrivateGatewayParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new CreatePrivateGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewCreatePrivateGatewayParams(gateway string, ipaddress string, netmask string, vlan string, vpcid string) *CreatePrivateGatewayParams {
+	p := &CreatePrivateGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["gateway"] = gateway
+	p.p["ipaddress"] = ipaddress
+	p.p["netmask"] = netmask
+	p.p["vlan"] = vlan
+	p.p["vpcid"] = vpcid
+	return p
+}
+
+// Creates a private gateway
+func (s *VPCService) CreatePrivateGateway(p *CreatePrivateGatewayParams) (*CreatePrivateGatewayResponse, error) {
+	resp, err := s.cs.newRequest("createPrivateGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreatePrivateGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreatePrivateGatewayResponse struct {
+	JobID              string `json:"jobid,omitempty"`
+	Account            string `json:"account,omitempty"`
+	Aclid              string `json:"aclid,omitempty"`
+	Domain             string `json:"domain,omitempty"`
+	Domainid           string `json:"domainid,omitempty"`
+	Gateway            string `json:"gateway,omitempty"`
+	Id                 string `json:"id,omitempty"`
+	Ipaddress          string `json:"ipaddress,omitempty"`
+	Netmask            string `json:"netmask,omitempty"`
+	Physicalnetworkid  string `json:"physicalnetworkid,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Sourcenatsupported bool   `json:"sourcenatsupported,omitempty"`
+	State              string `json:"state,omitempty"`
+	Vlan               string `json:"vlan,omitempty"`
+	Vpcid              string `json:"vpcid,omitempty"`
+	Zoneid             string `json:"zoneid,omitempty"`
+	Zonename           string `json:"zonename,omitempty"`
+}
+
+type ListPrivateGatewaysParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListPrivateGatewaysParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["vlan"]; found {
+		u.Set("vlan", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *ListPrivateGatewaysParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetVlan(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vlan"] = v
+	return
+}
+
+func (p *ListPrivateGatewaysParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new ListPrivateGatewaysParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewListPrivateGatewaysParams() *ListPrivateGatewaysParams {
+	p := &ListPrivateGatewaysParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetPrivateGatewayByID(id string, opts ...OptionFunc) (*PrivateGateway, int, error) {
+	p := &ListPrivateGatewaysParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListPrivateGateways(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.PrivateGateways[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for PrivateGateway UUID: %s!", id)
+}
+
+// List private gateways
+func (s *VPCService) ListPrivateGateways(p *ListPrivateGatewaysParams) (*ListPrivateGatewaysResponse, error) {
+	resp, err := s.cs.newRequest("listPrivateGateways", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListPrivateGatewaysResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListPrivateGatewaysResponse struct {
+	Count           int               `json:"count"`
+	PrivateGateways []*PrivateGateway `json:"privategateway"`
+}
+
+type PrivateGateway struct {
+	Account            string `json:"account,omitempty"`
+	Aclid              string `json:"aclid,omitempty"`
+	Domain             string `json:"domain,omitempty"`
+	Domainid           string `json:"domainid,omitempty"`
+	Gateway            string `json:"gateway,omitempty"`
+	Id                 string `json:"id,omitempty"`
+	Ipaddress          string `json:"ipaddress,omitempty"`
+	Netmask            string `json:"netmask,omitempty"`
+	Physicalnetworkid  string `json:"physicalnetworkid,omitempty"`
+	Project            string `json:"project,omitempty"`
+	Projectid          string `json:"projectid,omitempty"`
+	Sourcenatsupported bool   `json:"sourcenatsupported,omitempty"`
+	State              string `json:"state,omitempty"`
+	Vlan               string `json:"vlan,omitempty"`
+	Vpcid              string `json:"vpcid,omitempty"`
+	Zoneid             string `json:"zoneid,omitempty"`
+	Zonename           string `json:"zonename,omitempty"`
+}
+
+type DeletePrivateGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeletePrivateGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeletePrivateGatewayParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeletePrivateGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewDeletePrivateGatewayParams(id string) *DeletePrivateGatewayParams {
+	p := &DeletePrivateGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a Private gateway
+func (s *VPCService) DeletePrivateGateway(p *DeletePrivateGatewayParams) (*DeletePrivateGatewayResponse, error) {
+	resp, err := s.cs.newRequest("deletePrivateGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeletePrivateGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeletePrivateGatewayResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CreateStaticRouteParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateStaticRouteParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["cidr"]; found {
+		u.Set("cidr", v.(string))
+	}
+	if v, found := p.p["gatewayid"]; found {
+		u.Set("gatewayid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateStaticRouteParams) SetCidr(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidr"] = v
+	return
+}
+
+func (p *CreateStaticRouteParams) SetGatewayid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gatewayid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateStaticRouteParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewCreateStaticRouteParams(cidr string, gatewayid string) *CreateStaticRouteParams {
+	p := &CreateStaticRouteParams{}
+	p.p = make(map[string]interface{})
+	p.p["cidr"] = cidr
+	p.p["gatewayid"] = gatewayid
+	return p
+}
+
+// Creates a static route
+func (s *VPCService) CreateStaticRoute(p *CreateStaticRouteParams) (*CreateStaticRouteResponse, error) {
+	resp, err := s.cs.newRequest("createStaticRoute", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateStaticRouteResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateStaticRouteResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Account   string `json:"account,omitempty"`
+	Cidr      string `json:"cidr,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Gatewayid string `json:"gatewayid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	State     string `json:"state,omitempty"`
+	Tags      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcid string `json:"vpcid,omitempty"`
+}
+
+type DeleteStaticRouteParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteStaticRouteParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteStaticRouteParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteStaticRouteParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewDeleteStaticRouteParams(id string) *DeleteStaticRouteParams {
+	p := &DeleteStaticRouteParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a static route
+func (s *VPCService) DeleteStaticRoute(p *DeleteStaticRouteParams) (*DeleteStaticRouteResponse, error) {
+	resp, err := s.cs.newRequest("deleteStaticRoute", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteStaticRouteResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteStaticRouteResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListStaticRoutesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListStaticRoutesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["gatewayid"]; found {
+		u.Set("gatewayid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *ListStaticRoutesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetGatewayid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gatewayid"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListStaticRoutesParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new ListStaticRoutesParams instance,
+// as then you are sure you have configured all required params
+func (s *VPCService) NewListStaticRoutesParams() *ListStaticRoutesParams {
+	p := &ListStaticRoutesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPCService) GetStaticRouteByID(id string, opts ...OptionFunc) (*StaticRoute, int, error) {
+	p := &ListStaticRoutesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListStaticRoutes(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.StaticRoutes[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for StaticRoute UUID: %s!", id)
+}
+
+// Lists all static routes
+func (s *VPCService) ListStaticRoutes(p *ListStaticRoutesParams) (*ListStaticRoutesResponse, error) {
+	resp, err := s.cs.newRequest("listStaticRoutes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListStaticRoutesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListStaticRoutesResponse struct {
+	Count        int            `json:"count"`
+	StaticRoutes []*StaticRoute `json:"staticroute"`
+}
+
+type StaticRoute struct {
+	Account   string `json:"account,omitempty"`
+	Cidr      string `json:"cidr,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Gatewayid string `json:"gatewayid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	State     string `json:"state,omitempty"`
+	Tags      []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Vpcid string `json:"vpcid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VPNService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VPNService.go
@@ -1,0 +1,2874 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateRemoteAccessVpnParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateRemoteAccessVpnParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["iprange"]; found {
+		u.Set("iprange", v.(string))
+	}
+	if v, found := p.p["openfirewall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("openfirewall", vv)
+	}
+	if v, found := p.p["publicipid"]; found {
+		u.Set("publicipid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateRemoteAccessVpnParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateRemoteAccessVpnParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateRemoteAccessVpnParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateRemoteAccessVpnParams) SetIprange(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iprange"] = v
+	return
+}
+
+func (p *CreateRemoteAccessVpnParams) SetOpenfirewall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["openfirewall"] = v
+	return
+}
+
+func (p *CreateRemoteAccessVpnParams) SetPublicipid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicipid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateRemoteAccessVpnParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewCreateRemoteAccessVpnParams(publicipid string) *CreateRemoteAccessVpnParams {
+	p := &CreateRemoteAccessVpnParams{}
+	p.p = make(map[string]interface{})
+	p.p["publicipid"] = publicipid
+	return p
+}
+
+// Creates a l2tp/ipsec remote access vpn
+func (s *VPNService) CreateRemoteAccessVpn(p *CreateRemoteAccessVpnParams) (*CreateRemoteAccessVpnResponse, error) {
+	resp, err := s.cs.newRequest("createRemoteAccessVpn", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateRemoteAccessVpnResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateRemoteAccessVpnResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Account      string `json:"account,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Iprange      string `json:"iprange,omitempty"`
+	Presharedkey string `json:"presharedkey,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Publicip     string `json:"publicip,omitempty"`
+	Publicipid   string `json:"publicipid,omitempty"`
+	State        string `json:"state,omitempty"`
+}
+
+type DeleteRemoteAccessVpnParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteRemoteAccessVpnParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["publicipid"]; found {
+		u.Set("publicipid", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteRemoteAccessVpnParams) SetPublicipid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicipid"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteRemoteAccessVpnParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewDeleteRemoteAccessVpnParams(publicipid string) *DeleteRemoteAccessVpnParams {
+	p := &DeleteRemoteAccessVpnParams{}
+	p.p = make(map[string]interface{})
+	p.p["publicipid"] = publicipid
+	return p
+}
+
+// Destroys a l2tp/ipsec remote access vpn
+func (s *VPNService) DeleteRemoteAccessVpn(p *DeleteRemoteAccessVpnParams) (*DeleteRemoteAccessVpnResponse, error) {
+	resp, err := s.cs.newRequest("deleteRemoteAccessVpn", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteRemoteAccessVpnResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteRemoteAccessVpnResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListRemoteAccessVpnsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListRemoteAccessVpnsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["publicipid"]; found {
+		u.Set("publicipid", v.(string))
+	}
+	return u
+}
+
+func (p *ListRemoteAccessVpnsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListRemoteAccessVpnsParams) SetPublicipid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["publicipid"] = v
+	return
+}
+
+// You should always use this function to get a new ListRemoteAccessVpnsParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewListRemoteAccessVpnsParams() *ListRemoteAccessVpnsParams {
+	p := &ListRemoteAccessVpnsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetRemoteAccessVpnByID(id string, opts ...OptionFunc) (*RemoteAccessVpn, int, error) {
+	p := &ListRemoteAccessVpnsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListRemoteAccessVpns(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.RemoteAccessVpns[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for RemoteAccessVpn UUID: %s!", id)
+}
+
+// Lists remote access vpns
+func (s *VPNService) ListRemoteAccessVpns(p *ListRemoteAccessVpnsParams) (*ListRemoteAccessVpnsResponse, error) {
+	resp, err := s.cs.newRequest("listRemoteAccessVpns", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListRemoteAccessVpnsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListRemoteAccessVpnsResponse struct {
+	Count            int                `json:"count"`
+	RemoteAccessVpns []*RemoteAccessVpn `json:"remoteaccessvpn"`
+}
+
+type RemoteAccessVpn struct {
+	Account      string `json:"account,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Iprange      string `json:"iprange,omitempty"`
+	Presharedkey string `json:"presharedkey,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Publicip     string `json:"publicip,omitempty"`
+	Publicipid   string `json:"publicipid,omitempty"`
+	State        string `json:"state,omitempty"`
+}
+
+type UpdateRemoteAccessVpnParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateRemoteAccessVpnParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateRemoteAccessVpnParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateRemoteAccessVpnParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateRemoteAccessVpnParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateRemoteAccessVpnParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewUpdateRemoteAccessVpnParams(id string) *UpdateRemoteAccessVpnParams {
+	p := &UpdateRemoteAccessVpnParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates remote access vpn
+func (s *VPNService) UpdateRemoteAccessVpn(p *UpdateRemoteAccessVpnParams) (*UpdateRemoteAccessVpnResponse, error) {
+	resp, err := s.cs.newRequest("updateRemoteAccessVpn", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateRemoteAccessVpnResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateRemoteAccessVpnResponse struct {
+	JobID        string `json:"jobid,omitempty"`
+	Account      string `json:"account,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Domainid     string `json:"domainid,omitempty"`
+	Fordisplay   bool   `json:"fordisplay,omitempty"`
+	Id           string `json:"id,omitempty"`
+	Iprange      string `json:"iprange,omitempty"`
+	Presharedkey string `json:"presharedkey,omitempty"`
+	Project      string `json:"project,omitempty"`
+	Projectid    string `json:"projectid,omitempty"`
+	Publicip     string `json:"publicip,omitempty"`
+	Publicipid   string `json:"publicipid,omitempty"`
+	State        string `json:"state,omitempty"`
+}
+
+type AddVpnUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddVpnUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["password"]; found {
+		u.Set("password", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *AddVpnUserParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AddVpnUserParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *AddVpnUserParams) SetPassword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["password"] = v
+	return
+}
+
+func (p *AddVpnUserParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *AddVpnUserParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new AddVpnUserParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewAddVpnUserParams(password string, username string) *AddVpnUserParams {
+	p := &AddVpnUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["password"] = password
+	p.p["username"] = username
+	return p
+}
+
+// Adds vpn users
+func (s *VPNService) AddVpnUser(p *AddVpnUserParams) (*AddVpnUserResponse, error) {
+	resp, err := s.cs.newRequest("addVpnUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddVpnUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddVpnUserResponse struct {
+	JobID     string `json:"jobid,omitempty"`
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	State     string `json:"state,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+type RemoveVpnUserParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveVpnUserParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveVpnUserParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *RemoveVpnUserParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *RemoveVpnUserParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *RemoveVpnUserParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveVpnUserParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewRemoveVpnUserParams(username string) *RemoveVpnUserParams {
+	p := &RemoveVpnUserParams{}
+	p.p = make(map[string]interface{})
+	p.p["username"] = username
+	return p
+}
+
+// Removes vpn user
+func (s *VPNService) RemoveVpnUser(p *RemoveVpnUserParams) (*RemoveVpnUserResponse, error) {
+	resp, err := s.cs.newRequest("removeVpnUser", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveVpnUserResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveVpnUserResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListVpnUsersParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVpnUsersParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["username"]; found {
+		u.Set("username", v.(string))
+	}
+	return u
+}
+
+func (p *ListVpnUsersParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVpnUsersParams) SetUsername(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["username"] = v
+	return
+}
+
+// You should always use this function to get a new ListVpnUsersParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewListVpnUsersParams() *ListVpnUsersParams {
+	p := &ListVpnUsersParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnUserByID(id string, opts ...OptionFunc) (*VpnUser, int, error) {
+	p := &ListVpnUsersParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVpnUsers(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VpnUsers[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VpnUser UUID: %s!", id)
+}
+
+// Lists vpn users
+func (s *VPNService) ListVpnUsers(p *ListVpnUsersParams) (*ListVpnUsersResponse, error) {
+	resp, err := s.cs.newRequest("listVpnUsers", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVpnUsersResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVpnUsersResponse struct {
+	Count    int        `json:"count"`
+	VpnUsers []*VpnUser `json:"vpnuser"`
+}
+
+type VpnUser struct {
+	Account   string `json:"account,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Domainid  string `json:"domainid,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Projectid string `json:"projectid,omitempty"`
+	State     string `json:"state,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+type CreateVpnCustomerGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVpnCustomerGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		u.Set("cidrlist", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["dpd"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("dpd", vv)
+	}
+	if v, found := p.p["esplifetime"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("esplifetime", vv)
+	}
+	if v, found := p.p["esppolicy"]; found {
+		u.Set("esppolicy", v.(string))
+	}
+	if v, found := p.p["forceencap"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forceencap", vv)
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["ikelifetime"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("ikelifetime", vv)
+	}
+	if v, found := p.p["ikepolicy"]; found {
+		u.Set("ikepolicy", v.(string))
+	}
+	if v, found := p.p["ipsecpsk"]; found {
+		u.Set("ipsecpsk", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetCidrlist(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetDpd(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dpd"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["esplifetime"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetEsppolicy(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["esppolicy"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetForceencap(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forceencap"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ikelifetime"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetIkepolicy(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ikepolicy"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipsecpsk"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateVpnCustomerGatewayParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVpnCustomerGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewCreateVpnCustomerGatewayParams(cidrlist string, esppolicy string, gateway string, ikepolicy string, ipsecpsk string) *CreateVpnCustomerGatewayParams {
+	p := &CreateVpnCustomerGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["cidrlist"] = cidrlist
+	p.p["esppolicy"] = esppolicy
+	p.p["gateway"] = gateway
+	p.p["ikepolicy"] = ikepolicy
+	p.p["ipsecpsk"] = ipsecpsk
+	return p
+}
+
+// Creates site to site vpn customer gateway
+func (s *VPNService) CreateVpnCustomerGateway(p *CreateVpnCustomerGatewayParams) (*CreateVpnCustomerGatewayResponse, error) {
+	resp, err := s.cs.newRequest("createVpnCustomerGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVpnCustomerGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVpnCustomerGatewayResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Account     string `json:"account,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Dpd         bool   `json:"dpd,omitempty"`
+	Esplifetime int64  `json:"esplifetime,omitempty"`
+	Esppolicy   string `json:"esppolicy,omitempty"`
+	Forceencap  bool   `json:"forceencap,omitempty"`
+	Gateway     string `json:"gateway,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ikelifetime int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy   string `json:"ikepolicy,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipsecpsk    string `json:"ipsecpsk,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Removed     string `json:"removed,omitempty"`
+}
+
+type CreateVpnGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVpnGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVpnGatewayParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateVpnGatewayParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVpnGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewCreateVpnGatewayParams(vpcid string) *CreateVpnGatewayParams {
+	p := &CreateVpnGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["vpcid"] = vpcid
+	return p
+}
+
+// Creates site to site vpn local gateway
+func (s *VPNService) CreateVpnGateway(p *CreateVpnGatewayParams) (*CreateVpnGatewayResponse, error) {
+	resp, err := s.cs.newRequest("createVpnGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVpnGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVpnGatewayResponse struct {
+	JobID      string `json:"jobid,omitempty"`
+	Account    string `json:"account,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	Domainid   string `json:"domainid,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Project    string `json:"project,omitempty"`
+	Projectid  string `json:"projectid,omitempty"`
+	Publicip   string `json:"publicip,omitempty"`
+	Removed    string `json:"removed,omitempty"`
+	Vpcid      string `json:"vpcid,omitempty"`
+}
+
+type CreateVpnConnectionParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVpnConnectionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["passive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("passive", vv)
+	}
+	if v, found := p.p["s2scustomergatewayid"]; found {
+		u.Set("s2scustomergatewayid", v.(string))
+	}
+	if v, found := p.p["s2svpngatewayid"]; found {
+		u.Set("s2svpngatewayid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVpnConnectionParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *CreateVpnConnectionParams) SetPassive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["passive"] = v
+	return
+}
+
+func (p *CreateVpnConnectionParams) SetS2scustomergatewayid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["s2scustomergatewayid"] = v
+	return
+}
+
+func (p *CreateVpnConnectionParams) SetS2svpngatewayid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["s2svpngatewayid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVpnConnectionParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewCreateVpnConnectionParams(s2scustomergatewayid string, s2svpngatewayid string) *CreateVpnConnectionParams {
+	p := &CreateVpnConnectionParams{}
+	p.p = make(map[string]interface{})
+	p.p["s2scustomergatewayid"] = s2scustomergatewayid
+	p.p["s2svpngatewayid"] = s2svpngatewayid
+	return p
+}
+
+// Create site to site vpn connection
+func (s *VPNService) CreateVpnConnection(p *CreateVpnConnectionParams) (*CreateVpnConnectionResponse, error) {
+	resp, err := s.cs.newRequest("createVpnConnection", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVpnConnectionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVpnConnectionResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidrlist             string `json:"cidrlist,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Dpd                  bool   `json:"dpd,omitempty"`
+	Esplifetime          int64  `json:"esplifetime,omitempty"`
+	Esppolicy            string `json:"esppolicy,omitempty"`
+	Forceencap           bool   `json:"forceencap,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ikelifetime          int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy            string `json:"ikepolicy,omitempty"`
+	Ipsecpsk             string `json:"ipsecpsk,omitempty"`
+	Passive              bool   `json:"passive,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	S2scustomergatewayid string `json:"s2scustomergatewayid,omitempty"`
+	S2svpngatewayid      string `json:"s2svpngatewayid,omitempty"`
+	State                string `json:"state,omitempty"`
+}
+
+type DeleteVpnCustomerGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVpnCustomerGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVpnCustomerGatewayParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVpnCustomerGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewDeleteVpnCustomerGatewayParams(id string) *DeleteVpnCustomerGatewayParams {
+	p := &DeleteVpnCustomerGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Delete site to site vpn customer gateway
+func (s *VPNService) DeleteVpnCustomerGateway(p *DeleteVpnCustomerGatewayParams) (*DeleteVpnCustomerGatewayResponse, error) {
+	resp, err := s.cs.newRequest("deleteVpnCustomerGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVpnCustomerGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVpnCustomerGatewayResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteVpnGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVpnGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVpnGatewayParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVpnGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewDeleteVpnGatewayParams(id string) *DeleteVpnGatewayParams {
+	p := &DeleteVpnGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Delete site to site vpn gateway
+func (s *VPNService) DeleteVpnGateway(p *DeleteVpnGatewayParams) (*DeleteVpnGatewayResponse, error) {
+	resp, err := s.cs.newRequest("deleteVpnGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVpnGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVpnGatewayResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type DeleteVpnConnectionParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVpnConnectionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVpnConnectionParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVpnConnectionParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewDeleteVpnConnectionParams(id string) *DeleteVpnConnectionParams {
+	p := &DeleteVpnConnectionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Delete site to site vpn connection
+func (s *VPNService) DeleteVpnConnection(p *DeleteVpnConnectionParams) (*DeleteVpnConnectionResponse, error) {
+	resp, err := s.cs.newRequest("deleteVpnConnection", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVpnConnectionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeleteVpnConnectionResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type UpdateVpnCustomerGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVpnCustomerGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["cidrlist"]; found {
+		u.Set("cidrlist", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["dpd"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("dpd", vv)
+	}
+	if v, found := p.p["esplifetime"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("esplifetime", vv)
+	}
+	if v, found := p.p["esppolicy"]; found {
+		u.Set("esppolicy", v.(string))
+	}
+	if v, found := p.p["forceencap"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forceencap", vv)
+	}
+	if v, found := p.p["gateway"]; found {
+		u.Set("gateway", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ikelifetime"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("ikelifetime", vv)
+	}
+	if v, found := p.p["ikepolicy"]; found {
+		u.Set("ikepolicy", v.(string))
+	}
+	if v, found := p.p["ipsecpsk"]; found {
+		u.Set("ipsecpsk", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetCidrlist(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["cidrlist"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetDpd(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dpd"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["esplifetime"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetEsppolicy(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["esppolicy"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetForceencap(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forceencap"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetGateway(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["gateway"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ikelifetime"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetIkepolicy(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ikepolicy"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipsecpsk"] = v
+	return
+}
+
+func (p *UpdateVpnCustomerGatewayParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVpnCustomerGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewUpdateVpnCustomerGatewayParams(cidrlist string, esppolicy string, gateway string, id string, ikepolicy string, ipsecpsk string) *UpdateVpnCustomerGatewayParams {
+	p := &UpdateVpnCustomerGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["cidrlist"] = cidrlist
+	p.p["esppolicy"] = esppolicy
+	p.p["gateway"] = gateway
+	p.p["id"] = id
+	p.p["ikepolicy"] = ikepolicy
+	p.p["ipsecpsk"] = ipsecpsk
+	return p
+}
+
+// Update site to site vpn customer gateway
+func (s *VPNService) UpdateVpnCustomerGateway(p *UpdateVpnCustomerGatewayParams) (*UpdateVpnCustomerGatewayResponse, error) {
+	resp, err := s.cs.newRequest("updateVpnCustomerGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVpnCustomerGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVpnCustomerGatewayResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Account     string `json:"account,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Dpd         bool   `json:"dpd,omitempty"`
+	Esplifetime int64  `json:"esplifetime,omitempty"`
+	Esppolicy   string `json:"esppolicy,omitempty"`
+	Forceencap  bool   `json:"forceencap,omitempty"`
+	Gateway     string `json:"gateway,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ikelifetime int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy   string `json:"ikepolicy,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipsecpsk    string `json:"ipsecpsk,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Removed     string `json:"removed,omitempty"`
+}
+
+type ResetVpnConnectionParams struct {
+	p map[string]interface{}
+}
+
+func (p *ResetVpnConnectionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ResetVpnConnectionParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ResetVpnConnectionParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ResetVpnConnectionParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ResetVpnConnectionParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewResetVpnConnectionParams(id string) *ResetVpnConnectionParams {
+	p := &ResetVpnConnectionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Reset site to site vpn connection
+func (s *VPNService) ResetVpnConnection(p *ResetVpnConnectionParams) (*ResetVpnConnectionResponse, error) {
+	resp, err := s.cs.newRequest("resetVpnConnection", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ResetVpnConnectionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ResetVpnConnectionResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidrlist             string `json:"cidrlist,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Dpd                  bool   `json:"dpd,omitempty"`
+	Esplifetime          int64  `json:"esplifetime,omitempty"`
+	Esppolicy            string `json:"esppolicy,omitempty"`
+	Forceencap           bool   `json:"forceencap,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ikelifetime          int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy            string `json:"ikepolicy,omitempty"`
+	Ipsecpsk             string `json:"ipsecpsk,omitempty"`
+	Passive              bool   `json:"passive,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	S2scustomergatewayid string `json:"s2scustomergatewayid,omitempty"`
+	S2svpngatewayid      string `json:"s2svpngatewayid,omitempty"`
+	State                string `json:"state,omitempty"`
+}
+
+type ListVpnCustomerGatewaysParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVpnCustomerGatewaysParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVpnCustomerGatewaysParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVpnCustomerGatewaysParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewListVpnCustomerGatewaysParams() *ListVpnCustomerGatewaysParams {
+	p := &ListVpnCustomerGatewaysParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnCustomerGatewayID(keyword string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVpnCustomerGatewaysParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["keyword"] = keyword
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVpnCustomerGateways(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
+	}
+
+	if l.Count == 1 {
+		return l.VpnCustomerGateways[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.VpnCustomerGateways {
+			if v.Name == keyword {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnCustomerGatewayByName(name string, opts ...OptionFunc) (*VpnCustomerGateway, int, error) {
+	id, count, err := s.GetVpnCustomerGatewayID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetVpnCustomerGatewayByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnCustomerGatewayByID(id string, opts ...OptionFunc) (*VpnCustomerGateway, int, error) {
+	p := &ListVpnCustomerGatewaysParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVpnCustomerGateways(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VpnCustomerGateways[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VpnCustomerGateway UUID: %s!", id)
+}
+
+// Lists site to site vpn customer gateways
+func (s *VPNService) ListVpnCustomerGateways(p *ListVpnCustomerGatewaysParams) (*ListVpnCustomerGatewaysResponse, error) {
+	resp, err := s.cs.newRequest("listVpnCustomerGateways", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVpnCustomerGatewaysResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVpnCustomerGatewaysResponse struct {
+	Count               int                   `json:"count"`
+	VpnCustomerGateways []*VpnCustomerGateway `json:"vpncustomergateway"`
+}
+
+type VpnCustomerGateway struct {
+	Account     string `json:"account,omitempty"`
+	Cidrlist    string `json:"cidrlist,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Dpd         bool   `json:"dpd,omitempty"`
+	Esplifetime int64  `json:"esplifetime,omitempty"`
+	Esppolicy   string `json:"esppolicy,omitempty"`
+	Forceencap  bool   `json:"forceencap,omitempty"`
+	Gateway     string `json:"gateway,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Ikelifetime int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy   string `json:"ikepolicy,omitempty"`
+	Ipaddress   string `json:"ipaddress,omitempty"`
+	Ipsecpsk    string `json:"ipsecpsk,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
+	Removed     string `json:"removed,omitempty"`
+}
+
+type ListVpnGatewaysParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVpnGatewaysParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVpnGatewaysParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVpnGatewaysParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVpnGatewaysParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewListVpnGatewaysParams() *ListVpnGatewaysParams {
+	p := &ListVpnGatewaysParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnGatewayByID(id string, opts ...OptionFunc) (*VpnGateway, int, error) {
+	p := &ListVpnGatewaysParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVpnGateways(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VpnGateways[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VpnGateway UUID: %s!", id)
+}
+
+// Lists site 2 site vpn gateways
+func (s *VPNService) ListVpnGateways(p *ListVpnGatewaysParams) (*ListVpnGatewaysResponse, error) {
+	resp, err := s.cs.newRequest("listVpnGateways", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVpnGatewaysResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVpnGatewaysResponse struct {
+	Count       int           `json:"count"`
+	VpnGateways []*VpnGateway `json:"vpngateway"`
+}
+
+type VpnGateway struct {
+	Account    string `json:"account,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	Domainid   string `json:"domainid,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Project    string `json:"project,omitempty"`
+	Projectid  string `json:"projectid,omitempty"`
+	Publicip   string `json:"publicip,omitempty"`
+	Removed    string `json:"removed,omitempty"`
+	Vpcid      string `json:"vpcid,omitempty"`
+}
+
+type ListVpnConnectionsParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVpnConnectionsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVpnConnectionsParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVpnConnectionsParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVpnConnectionsParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewListVpnConnectionsParams() *ListVpnConnectionsParams {
+	p := &ListVpnConnectionsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VPNService) GetVpnConnectionByID(id string, opts ...OptionFunc) (*VpnConnection, int, error) {
+	p := &ListVpnConnectionsParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVpnConnections(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VpnConnections[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VpnConnection UUID: %s!", id)
+}
+
+// Lists site to site vpn connection gateways
+func (s *VPNService) ListVpnConnections(p *ListVpnConnectionsParams) (*ListVpnConnectionsResponse, error) {
+	resp, err := s.cs.newRequest("listVpnConnections", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVpnConnectionsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVpnConnectionsResponse struct {
+	Count          int              `json:"count"`
+	VpnConnections []*VpnConnection `json:"vpnconnection"`
+}
+
+type VpnConnection struct {
+	Account              string `json:"account,omitempty"`
+	Cidrlist             string `json:"cidrlist,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Dpd                  bool   `json:"dpd,omitempty"`
+	Esplifetime          int64  `json:"esplifetime,omitempty"`
+	Esppolicy            string `json:"esppolicy,omitempty"`
+	Forceencap           bool   `json:"forceencap,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ikelifetime          int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy            string `json:"ikepolicy,omitempty"`
+	Ipsecpsk             string `json:"ipsecpsk,omitempty"`
+	Passive              bool   `json:"passive,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	S2scustomergatewayid string `json:"s2scustomergatewayid,omitempty"`
+	S2svpngatewayid      string `json:"s2svpngatewayid,omitempty"`
+	State                string `json:"state,omitempty"`
+}
+
+type UpdateVpnConnectionParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVpnConnectionParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVpnConnectionParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateVpnConnectionParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateVpnConnectionParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVpnConnectionParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewUpdateVpnConnectionParams(id string) *UpdateVpnConnectionParams {
+	p := &UpdateVpnConnectionParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates site to site vpn connection
+func (s *VPNService) UpdateVpnConnection(p *UpdateVpnConnectionParams) (*UpdateVpnConnectionResponse, error) {
+	resp, err := s.cs.newRequest("updateVpnConnection", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVpnConnectionResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVpnConnectionResponse struct {
+	JobID                string `json:"jobid,omitempty"`
+	Account              string `json:"account,omitempty"`
+	Cidrlist             string `json:"cidrlist,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Domainid             string `json:"domainid,omitempty"`
+	Dpd                  bool   `json:"dpd,omitempty"`
+	Esplifetime          int64  `json:"esplifetime,omitempty"`
+	Esppolicy            string `json:"esppolicy,omitempty"`
+	Forceencap           bool   `json:"forceencap,omitempty"`
+	Fordisplay           bool   `json:"fordisplay,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ikelifetime          int64  `json:"ikelifetime,omitempty"`
+	Ikepolicy            string `json:"ikepolicy,omitempty"`
+	Ipsecpsk             string `json:"ipsecpsk,omitempty"`
+	Passive              bool   `json:"passive,omitempty"`
+	Project              string `json:"project,omitempty"`
+	Projectid            string `json:"projectid,omitempty"`
+	Publicip             string `json:"publicip,omitempty"`
+	Removed              string `json:"removed,omitempty"`
+	S2scustomergatewayid string `json:"s2scustomergatewayid,omitempty"`
+	S2svpngatewayid      string `json:"s2svpngatewayid,omitempty"`
+	State                string `json:"state,omitempty"`
+}
+
+type UpdateVpnGatewayParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVpnGatewayParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["fordisplay"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("fordisplay", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVpnGatewayParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateVpnGatewayParams) SetFordisplay(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["fordisplay"] = v
+	return
+}
+
+func (p *UpdateVpnGatewayParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVpnGatewayParams instance,
+// as then you are sure you have configured all required params
+func (s *VPNService) NewUpdateVpnGatewayParams(id string) *UpdateVpnGatewayParams {
+	p := &UpdateVpnGatewayParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates site to site vpn local gateway
+func (s *VPNService) UpdateVpnGateway(p *UpdateVpnGatewayParams) (*UpdateVpnGatewayResponse, error) {
+	resp, err := s.cs.newRequest("updateVpnGateway", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVpnGatewayResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVpnGatewayResponse struct {
+	JobID      string `json:"jobid,omitempty"`
+	Account    string `json:"account,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	Domainid   string `json:"domainid,omitempty"`
+	Fordisplay bool   `json:"fordisplay,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Project    string `json:"project,omitempty"`
+	Projectid  string `json:"projectid,omitempty"`
+	Publicip   string `json:"publicip,omitempty"`
+	Removed    string `json:"removed,omitempty"`
+	Vpcid      string `json:"vpcid,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VirtualMachineService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VirtualMachineService.go
@@ -1,0 +1,5445 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type DeployVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeployVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("affinitygroupids", vv)
+	}
+	if v, found := p.p["affinitygroupnames"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("affinitygroupnames", vv)
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["deploymentplanner"]; found {
+		u.Set("deploymentplanner", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["displayname"]; found {
+		u.Set("displayname", v.(string))
+	}
+	if v, found := p.p["displayvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvm", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["group"]; found {
+		u.Set("group", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["ip6address"]; found {
+		u.Set("ip6address", v.(string))
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["iptonetworklist"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("iptonetworklist[%d].key", i), k)
+			u.Set(fmt.Sprintf("iptonetworklist[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["keyboard"]; found {
+		u.Set("keyboard", v.(string))
+	}
+	if v, found := p.p["keypair"]; found {
+		u.Set("keypair", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("networkids", vv)
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["rootdisksize"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("rootdisksize", vv)
+	}
+	if v, found := p.p["securitygroupids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("securitygroupids", vv)
+	}
+	if v, found := p.p["securitygroupnames"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("securitygroupnames", vv)
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["size"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("size", vv)
+	}
+	if v, found := p.p["startvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("startvm", vv)
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["userdata"]; found {
+		u.Set("userdata", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *DeployVirtualMachineParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetAffinitygroupids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupids"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetAffinitygroupnames(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupnames"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDeploymentplanner(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["deploymentplanner"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDisplayname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayname"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDisplayvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvm"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetGroup(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["group"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetIp6address(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6address"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetIptonetworklist(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["iptonetworklist"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetKeyboard(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyboard"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetKeypair(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keypair"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetNetworkids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkids"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetRootdisksize(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["rootdisksize"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetSecuritygroupids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupids"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetSecuritygroupnames(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupnames"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetSize(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["size"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetStartvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["startvm"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetUserdata(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userdata"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new DeployVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewDeployVirtualMachineParams(serviceofferingid string, templateid string, zoneid string) *DeployVirtualMachineParams {
+	p := &DeployVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["serviceofferingid"] = serviceofferingid
+	p.p["templateid"] = templateid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.
+func (s *VirtualMachineService) DeployVirtualMachine(p *DeployVirtualMachineParams) (*DeployVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("deployVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeployVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DeployVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type DestroyVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *DestroyVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["expunge"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("expunge", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DestroyVirtualMachineParams) SetExpunge(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["expunge"] = v
+	return
+}
+
+func (p *DestroyVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DestroyVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewDestroyVirtualMachineParams(id string) *DestroyVirtualMachineParams {
+	p := &DestroyVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Destroys a virtual machine.
+func (s *VirtualMachineService) DestroyVirtualMachine(p *DestroyVirtualMachineParams) (*DestroyVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("destroyVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DestroyVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DestroyVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type RebootVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *RebootVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RebootVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RebootVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewRebootVirtualMachineParams(id string) *RebootVirtualMachineParams {
+	p := &RebootVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Reboots a virtual machine.
+func (s *VirtualMachineService) RebootVirtualMachine(p *RebootVirtualMachineParams) (*RebootVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("rebootVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RebootVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RebootVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type StartVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *StartVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["deploymentplanner"]; found {
+		u.Set("deploymentplanner", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StartVirtualMachineParams) SetDeploymentplanner(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["deploymentplanner"] = v
+	return
+}
+
+func (p *StartVirtualMachineParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *StartVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StartVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewStartVirtualMachineParams(id string) *StartVirtualMachineParams {
+	p := &StartVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Starts a virtual machine.
+func (s *VirtualMachineService) StartVirtualMachine(p *StartVirtualMachineParams) (*StartVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("startVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StartVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StartVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type StopVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *StopVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *StopVirtualMachineParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+	return
+}
+
+func (p *StopVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new StopVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewStopVirtualMachineParams(id string) *StopVirtualMachineParams {
+	p := &StopVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Stops a virtual machine.
+func (s *VirtualMachineService) StopVirtualMachine(p *StopVirtualMachineParams) (*StopVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("stopVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r StopVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type StopVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ResetPasswordForVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *ResetPasswordForVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ResetPasswordForVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ResetPasswordForVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewResetPasswordForVirtualMachineParams(id string) *ResetPasswordForVirtualMachineParams {
+	p := &ResetPasswordForVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Resets the password for virtual machine. The virtual machine must be in a "Stopped" state and the template must already support this feature for this command to take effect. [async]
+func (s *VirtualMachineService) ResetPasswordForVirtualMachine(p *ResetPasswordForVirtualMachineParams) (*ResetPasswordForVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("resetPasswordForVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ResetPasswordForVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ResetPasswordForVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type UpdateVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["displayname"]; found {
+		u.Set("displayname", v.(string))
+	}
+	if v, found := p.p["displayvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvm", vv)
+	}
+	if v, found := p.p["group"]; found {
+		u.Set("group", v.(string))
+	}
+	if v, found := p.p["haenable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("haenable", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["instancename"]; found {
+		u.Set("instancename", v.(string))
+	}
+	if v, found := p.p["isdynamicallyscalable"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isdynamicallyscalable", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["ostypeid"]; found {
+		u.Set("ostypeid", v.(string))
+	}
+	if v, found := p.p["userdata"]; found {
+		u.Set("userdata", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVirtualMachineParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetDisplayname(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayname"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetDisplayvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvm"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetGroup(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["group"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetHaenable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["haenable"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetInstancename(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["instancename"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetIsdynamicallyscalable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isdynamicallyscalable"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetOstypeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ostypeid"] = v
+	return
+}
+
+func (p *UpdateVirtualMachineParams) SetUserdata(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userdata"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewUpdateVirtualMachineParams(id string) *UpdateVirtualMachineParams {
+	p := &UpdateVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates properties of a virtual machine. The VM has to be stopped and restarted for the new properties to take effect. UpdateVirtualMachine does not first check whether the VM is stopped. Therefore, stop the VM manually before issuing this call.
+func (s *VirtualMachineService) UpdateVirtualMachine(p *UpdateVirtualMachineParams) (*UpdateVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("updateVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateVirtualMachineResponse struct {
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ListVirtualMachinesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVirtualMachinesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupid"]; found {
+		u.Set("affinitygroupid", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("details", vv)
+	}
+	if v, found := p.p["displayvm"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvm", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["forvirtualnetwork"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forvirtualnetwork", vv)
+	}
+	if v, found := p.p["groupid"]; found {
+		u.Set("groupid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["hypervisor"]; found {
+		u.Set("hypervisor", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("ids", vv)
+	}
+	if v, found := p.p["isoid"]; found {
+		u.Set("isoid", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keypair"]; found {
+		u.Set("keypair", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["userid"]; found {
+		u.Set("userid", v.(string))
+	}
+	if v, found := p.p["vpcid"]; found {
+		u.Set("vpcid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVirtualMachinesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetAffinitygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetDetails(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetDisplayvm(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvm"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetForvirtualnetwork(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forvirtualnetwork"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetGroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["groupid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetHypervisor(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hypervisor"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetIds(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ids"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetIsoid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isoid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetKeypair(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keypair"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetUserid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["userid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetVpcid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["vpcid"] = v
+	return
+}
+
+func (p *ListVirtualMachinesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVirtualMachinesParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewListVirtualMachinesParams() *ListVirtualMachinesParams {
+	p := &ListVirtualMachinesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VirtualMachineService) GetVirtualMachineID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVirtualMachinesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVirtualMachines(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.VirtualMachines[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.VirtualMachines {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VirtualMachineService) GetVirtualMachineByName(name string, opts ...OptionFunc) (*VirtualMachine, int, error) {
+	id, count, err := s.GetVirtualMachineID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetVirtualMachineByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VirtualMachineService) GetVirtualMachineByID(id string, opts ...OptionFunc) (*VirtualMachine, int, error) {
+	p := &ListVirtualMachinesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVirtualMachines(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.VirtualMachines[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for VirtualMachine UUID: %s!", id)
+}
+
+// List the virtual machines owned by the account.
+func (s *VirtualMachineService) ListVirtualMachines(p *ListVirtualMachinesParams) (*ListVirtualMachinesResponse, error) {
+	resp, err := s.cs.newRequest("listVirtualMachines", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVirtualMachinesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVirtualMachinesResponse struct {
+	Count           int               `json:"count"`
+	VirtualMachines []*VirtualMachine `json:"virtualmachine"`
+}
+
+type VirtualMachine struct {
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type GetVMPasswordParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetVMPasswordParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *GetVMPasswordParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new GetVMPasswordParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewGetVMPasswordParams(id string) *GetVMPasswordParams {
+	p := &GetVMPasswordParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Returns an encrypted password for the VM
+func (s *VirtualMachineService) GetVMPassword(p *GetVMPasswordParams) (*GetVMPasswordResponse, error) {
+	resp, err := s.cs.newRequest("getVMPassword", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetVMPasswordResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetVMPasswordResponse struct {
+	Encryptedpassword string `json:"encryptedpassword,omitempty"`
+}
+
+type RestoreVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *RestoreVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["templateid"]; found {
+		u.Set("templateid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *RestoreVirtualMachineParams) SetTemplateid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["templateid"] = v
+	return
+}
+
+func (p *RestoreVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new RestoreVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewRestoreVirtualMachineParams(virtualmachineid string) *RestoreVirtualMachineParams {
+	p := &RestoreVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Restore a VM to original template/ISO or new template/ISO
+func (s *VirtualMachineService) RestoreVirtualMachine(p *RestoreVirtualMachineParams) (*RestoreVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("restoreVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RestoreVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RestoreVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ChangeServiceForVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *ChangeServiceForVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *ChangeServiceForVirtualMachineParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ChangeServiceForVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ChangeServiceForVirtualMachineParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new ChangeServiceForVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewChangeServiceForVirtualMachineParams(id string, serviceofferingid string) *ChangeServiceForVirtualMachineParams {
+	p := &ChangeServiceForVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["serviceofferingid"] = serviceofferingid
+	return p
+}
+
+// Changes the service offering for a virtual machine. The virtual machine must be in a "Stopped" state for this command to take effect.
+func (s *VirtualMachineService) ChangeServiceForVirtualMachine(p *ChangeServiceForVirtualMachineParams) (*ChangeServiceForVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("changeServiceForVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ChangeServiceForVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ChangeServiceForVirtualMachineResponse struct {
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ScaleVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *ScaleVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["serviceofferingid"]; found {
+		u.Set("serviceofferingid", v.(string))
+	}
+	return u
+}
+
+func (p *ScaleVirtualMachineParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *ScaleVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ScaleVirtualMachineParams) SetServiceofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["serviceofferingid"] = v
+	return
+}
+
+// You should always use this function to get a new ScaleVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewScaleVirtualMachineParams(id string, serviceofferingid string) *ScaleVirtualMachineParams {
+	p := &ScaleVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["serviceofferingid"] = serviceofferingid
+	return p
+}
+
+// Scales the virtual machine to a new service offering.
+func (s *VirtualMachineService) ScaleVirtualMachine(p *ScaleVirtualMachineParams) (*ScaleVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("scaleVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ScaleVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ScaleVirtualMachineResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AssignVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *AssignVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["networkids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("networkids", vv)
+	}
+	if v, found := p.p["securitygroupids"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("securitygroupids", vv)
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *AssignVirtualMachineParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *AssignVirtualMachineParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *AssignVirtualMachineParams) SetNetworkids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkids"] = v
+	return
+}
+
+func (p *AssignVirtualMachineParams) SetSecuritygroupids(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupids"] = v
+	return
+}
+
+func (p *AssignVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new AssignVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewAssignVirtualMachineParams(account string, domainid string, virtualmachineid string) *AssignVirtualMachineParams {
+	p := &AssignVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["account"] = account
+	p.p["domainid"] = domainid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Change ownership of a VM from one account to another. This API is available for Basic zones with security groups and Advanced zones with guest networks. A root administrator can reassign a VM from any account to any other account in any domain. A domain administrator can reassign a VM to any account in the same domain.
+func (s *VirtualMachineService) AssignVirtualMachine(p *AssignVirtualMachineParams) (*AssignVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("assignVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssignVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type AssignVirtualMachineResponse struct {
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type MigrateVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *MigrateVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *MigrateVirtualMachineParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *MigrateVirtualMachineParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *MigrateVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new MigrateVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewMigrateVirtualMachineParams(virtualmachineid string) *MigrateVirtualMachineParams {
+	p := &MigrateVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Attempts Migration of a VM to a different host or Root volume of the vm to a different storage pool
+func (s *VirtualMachineService) MigrateVirtualMachine(p *MigrateVirtualMachineParams) (*MigrateVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("migrateVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r MigrateVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type MigrateVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type MigrateVirtualMachineWithVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["migrateto"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("migrateto[%d].key", i), k)
+			u.Set(fmt.Sprintf("migrateto[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) SetMigrateto(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["migrateto"] = v
+	return
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new MigrateVirtualMachineWithVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewMigrateVirtualMachineWithVolumeParams(hostid string, virtualmachineid string) *MigrateVirtualMachineWithVolumeParams {
+	p := &MigrateVirtualMachineWithVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["hostid"] = hostid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Attempts Migration of a VM with its volumes to a different host
+func (s *VirtualMachineService) MigrateVirtualMachineWithVolume(p *MigrateVirtualMachineWithVolumeParams) (*MigrateVirtualMachineWithVolumeResponse, error) {
+	resp, err := s.cs.newRequest("migrateVirtualMachineWithVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r MigrateVirtualMachineWithVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type MigrateVirtualMachineWithVolumeResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type RecoverVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *RecoverVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RecoverVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new RecoverVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewRecoverVirtualMachineParams(id string) *RecoverVirtualMachineParams {
+	p := &RecoverVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Recovers a virtual machine.
+func (s *VirtualMachineService) RecoverVirtualMachine(p *RecoverVirtualMachineParams) (*RecoverVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("recoverVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RecoverVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type RecoverVirtualMachineResponse struct {
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ExpungeVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *ExpungeVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *ExpungeVirtualMachineParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new ExpungeVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewExpungeVirtualMachineParams(id string) *ExpungeVirtualMachineParams {
+	p := &ExpungeVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Expunge a virtual machine. Once expunged, it cannot be recoverd.
+func (s *VirtualMachineService) ExpungeVirtualMachine(p *ExpungeVirtualMachineParams) (*ExpungeVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("expungeVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ExpungeVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ExpungeVirtualMachineResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type CleanVMReservationsParams struct {
+	p map[string]interface{}
+}
+
+func (p *CleanVMReservationsParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	return u
+}
+
+// You should always use this function to get a new CleanVMReservationsParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewCleanVMReservationsParams() *CleanVMReservationsParams {
+	p := &CleanVMReservationsParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Cleanups VM reservations in the database.
+func (s *VirtualMachineService) CleanVMReservations(p *CleanVMReservationsParams) (*CleanVMReservationsResponse, error) {
+	resp, err := s.cs.newRequest("cleanVMReservations", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CleanVMReservationsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CleanVMReservationsResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type AddNicToVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddNicToVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["ipaddress"]; found {
+		u.Set("ipaddress", v.(string))
+	}
+	if v, found := p.p["networkid"]; found {
+		u.Set("networkid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *AddNicToVirtualMachineParams) SetIpaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ipaddress"] = v
+	return
+}
+
+func (p *AddNicToVirtualMachineParams) SetNetworkid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networkid"] = v
+	return
+}
+
+func (p *AddNicToVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new AddNicToVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewAddNicToVirtualMachineParams(networkid string, virtualmachineid string) *AddNicToVirtualMachineParams {
+	p := &AddNicToVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["networkid"] = networkid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Adds VM to specified network by creating a NIC
+func (s *VirtualMachineService) AddNicToVirtualMachine(p *AddNicToVirtualMachineParams) (*AddNicToVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("addNicToVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddNicToVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AddNicToVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type RemoveNicFromVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveNicFromVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["nicid"]; found {
+		u.Set("nicid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveNicFromVirtualMachineParams) SetNicid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicid"] = v
+	return
+}
+
+func (p *RemoveNicFromVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new RemoveNicFromVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewRemoveNicFromVirtualMachineParams(nicid string, virtualmachineid string) *RemoveNicFromVirtualMachineParams {
+	p := &RemoveNicFromVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["nicid"] = nicid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Removes VM from specified network by deleting a NIC
+func (s *VirtualMachineService) RemoveNicFromVirtualMachine(p *RemoveNicFromVirtualMachineParams) (*RemoveNicFromVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("removeNicFromVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveNicFromVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type RemoveNicFromVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type UpdateDefaultNicForVirtualMachineParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateDefaultNicForVirtualMachineParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["nicid"]; found {
+		u.Set("nicid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateDefaultNicForVirtualMachineParams) SetNicid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicid"] = v
+	return
+}
+
+func (p *UpdateDefaultNicForVirtualMachineParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateDefaultNicForVirtualMachineParams instance,
+// as then you are sure you have configured all required params
+func (s *VirtualMachineService) NewUpdateDefaultNicForVirtualMachineParams(nicid string, virtualmachineid string) *UpdateDefaultNicForVirtualMachineParams {
+	p := &UpdateDefaultNicForVirtualMachineParams{}
+	p.p = make(map[string]interface{})
+	p.p["nicid"] = nicid
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Changes the default NIC on a VM
+func (s *VirtualMachineService) UpdateDefaultNicForVirtualMachine(p *UpdateDefaultNicForVirtualMachineParams) (*UpdateDefaultNicForVirtualMachineResponse, error) {
+	resp, err := s.cs.newRequest("updateDefaultNicForVirtualMachine", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateDefaultNicForVirtualMachineResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateDefaultNicForVirtualMachineResponse struct {
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Affinitygroup []struct {
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Project           string   `json:"project,omitempty"`
+		Projectid         string   `json:"projectid,omitempty"`
+		Type              string   `json:"type,omitempty"`
+		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
+	} `json:"affinitygroup,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
+	Diskofferingid        string            `json:"diskofferingid,omitempty"`
+	Diskofferingname      string            `json:"diskofferingname,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string `json:"broadcasturi,omitempty"`
+		Deviceid     string `json:"deviceid,omitempty"`
+		Gateway      string `json:"gateway,omitempty"`
+		Id           string `json:"id,omitempty"`
+		Ip6address   string `json:"ip6address,omitempty"`
+		Ip6cidr      string `json:"ip6cidr,omitempty"`
+		Ip6gateway   string `json:"ip6gateway,omitempty"`
+		Ipaddress    string `json:"ipaddress,omitempty"`
+		Isdefault    bool   `json:"isdefault,omitempty"`
+		Isolationuri string `json:"isolationuri,omitempty"`
+		Macaddress   string `json:"macaddress,omitempty"`
+		Netmask      string `json:"netmask,omitempty"`
+		Networkid    string `json:"networkid,omitempty"`
+		Networkname  string `json:"networkname,omitempty"`
+		Secondaryip  []struct {
+			Id        string `json:"id,omitempty"`
+			Ipaddress string `json:"ipaddress,omitempty"`
+		} `json:"secondaryip,omitempty"`
+		Traffictype      string `json:"traffictype,omitempty"`
+		Type             string `json:"type,omitempty"`
+		Virtualmachineid string `json:"virtualmachineid,omitempty"`
+	} `json:"nic,omitempty"`
+	Ostypeid        int64  `json:"ostypeid,omitempty"`
+	Password        string `json:"password,omitempty"`
+	Passwordenabled bool   `json:"passwordenabled,omitempty"`
+	Project         string `json:"project,omitempty"`
+	Projectid       string `json:"projectid,omitempty"`
+	Publicip        string `json:"publicip,omitempty"`
+	Publicipid      string `json:"publicipid,omitempty"`
+	Rootdeviceid    int64  `json:"rootdeviceid,omitempty"`
+	Rootdevicetype  string `json:"rootdevicetype,omitempty"`
+	Securitygroup   []struct {
+		Account     string `json:"account,omitempty"`
+		Description string `json:"description,omitempty"`
+		Domain      string `json:"domain,omitempty"`
+		Domainid    string `json:"domainid,omitempty"`
+		Egressrule  []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"egressrule,omitempty"`
+		Id          string `json:"id,omitempty"`
+		Ingressrule []struct {
+			Account           string `json:"account,omitempty"`
+			Cidr              string `json:"cidr,omitempty"`
+			Endport           int    `json:"endport,omitempty"`
+			Icmpcode          int    `json:"icmpcode,omitempty"`
+			Icmptype          int    `json:"icmptype,omitempty"`
+			Protocol          string `json:"protocol,omitempty"`
+			Ruleid            string `json:"ruleid,omitempty"`
+			Securitygroupname string `json:"securitygroupname,omitempty"`
+			Startport         int    `json:"startport,omitempty"`
+			Tags              []struct {
+				Account      string `json:"account,omitempty"`
+				Customer     string `json:"customer,omitempty"`
+				Domain       string `json:"domain,omitempty"`
+				Domainid     string `json:"domainid,omitempty"`
+				Key          string `json:"key,omitempty"`
+				Project      string `json:"project,omitempty"`
+				Projectid    string `json:"projectid,omitempty"`
+				Resourceid   string `json:"resourceid,omitempty"`
+				Resourcetype string `json:"resourcetype,omitempty"`
+				Value        string `json:"value,omitempty"`
+			} `json:"tags,omitempty"`
+		} `json:"ingressrule,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Project   string `json:"project,omitempty"`
+		Projectid string `json:"projectid,omitempty"`
+		Tags      []struct {
+			Account      string `json:"account,omitempty"`
+			Customer     string `json:"customer,omitempty"`
+			Domain       string `json:"domain,omitempty"`
+			Domainid     string `json:"domainid,omitempty"`
+			Key          string `json:"key,omitempty"`
+			Project      string `json:"project,omitempty"`
+			Projectid    string `json:"projectid,omitempty"`
+			Resourceid   string `json:"resourceid,omitempty"`
+			Resourcetype string `json:"resourcetype,omitempty"`
+			Value        string `json:"value,omitempty"`
+		} `json:"tags,omitempty"`
+		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	} `json:"securitygroup,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname string `json:"serviceofferingname,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
+	Tags                []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Userid              string `json:"userid,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Vgpu                string `json:"vgpu,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/VolumeService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/VolumeService.go
@@ -1,0 +1,2275 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type AttachVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *AttachVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["deviceid"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("deviceid", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *AttachVolumeParams) SetDeviceid(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["deviceid"] = v
+	return
+}
+
+func (p *AttachVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *AttachVolumeParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new AttachVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewAttachVolumeParams(id string, virtualmachineid string) *AttachVolumeParams {
+	p := &AttachVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["virtualmachineid"] = virtualmachineid
+	return p
+}
+
+// Attaches a disk volume to a virtual machine.
+func (s *VolumeService) AttachVolume(p *AttachVolumeParams) (*AttachVolumeResponse, error) {
+	resp, err := s.cs.newRequest("attachVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AttachVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type AttachVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type UploadVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *UploadVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["checksum"]; found {
+		u.Set("checksum", v.(string))
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["imagestoreuuid"]; found {
+		u.Set("imagestoreuuid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *UploadVolumeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetChecksum(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["checksum"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetImagestoreuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["imagestoreuuid"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *UploadVolumeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new UploadVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewUploadVolumeParams(format string, name string, url string, zoneid string) *UploadVolumeParams {
+	p := &UploadVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["format"] = format
+	p.p["name"] = name
+	p.p["url"] = url
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Uploads a data disk.
+func (s *VolumeService) UploadVolume(p *UploadVolumeParams) (*UploadVolumeResponse, error) {
+	resp, err := s.cs.newRequest("uploadVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UploadVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UploadVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type DetachVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DetachVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["deviceid"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("deviceid", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	return u
+}
+
+func (p *DetachVolumeParams) SetDeviceid(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["deviceid"] = v
+	return
+}
+
+func (p *DetachVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *DetachVolumeParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+// You should always use this function to get a new DetachVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewDetachVolumeParams() *DetachVolumeParams {
+	p := &DetachVolumeParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Detaches a disk volume from a virtual machine.
+func (s *VolumeService) DetachVolume(p *DetachVolumeParams) (*DetachVolumeResponse, error) {
+	resp, err := s.cs.newRequest("detachVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DetachVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DetachVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type CreateVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["displayvolume"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvolume", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["maxiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("maxiops", vv)
+	}
+	if v, found := p.p["miniops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("miniops", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["size"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("size", vv)
+	}
+	if v, found := p.p["snapshotid"]; found {
+		u.Set("snapshotid", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *CreateVolumeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetDisplayvolume(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvolume"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetMaxiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxiops"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetMiniops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["miniops"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetSize(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["size"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetSnapshotid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["snapshotid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *CreateVolumeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new CreateVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewCreateVolumeParams() *CreateVolumeParams {
+	p := &CreateVolumeParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Creates a disk volume from a disk offering. This disk volume must still be attached to a virtual machine to make use of it.
+func (s *VolumeService) CreateVolume(p *CreateVolumeParams) (*CreateVolumeResponse, error) {
+	resp, err := s.cs.newRequest("createVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type CreateVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type DeleteVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewDeleteVolumeParams(id string) *DeleteVolumeParams {
+	p := &DeleteVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a detached disk volume.
+func (s *VolumeService) DeleteVolume(p *DeleteVolumeParams) (*DeleteVolumeResponse, error) {
+	resp, err := s.cs.newRequest("deleteVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteVolumeResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListVolumesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListVolumesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["displayvolume"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvolume", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["hostid"]; found {
+		u.Set("hostid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isrecursive"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isrecursive", vv)
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["listall"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("listall", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["podid"]; found {
+		u.Set("podid", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["type"]; found {
+		u.Set("type", v.(string))
+	}
+	if v, found := p.p["virtualmachineid"]; found {
+		u.Set("virtualmachineid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListVolumesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetDisplayvolume(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvolume"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetHostid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["hostid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetIsrecursive(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isrecursive"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetListall(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["listall"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetPodid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["podid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetType(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeType"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetVirtualmachineid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["virtualmachineid"] = v
+	return
+}
+
+func (p *ListVolumesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListVolumesParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewListVolumesParams() *ListVolumesParams {
+	p := &ListVolumesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VolumeService) GetVolumeID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListVolumesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListVolumes(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Volumes[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Volumes {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VolumeService) GetVolumeByName(name string, opts ...OptionFunc) (*Volume, int, error) {
+	id, count, err := s.GetVolumeID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetVolumeByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *VolumeService) GetVolumeByID(id string, opts ...OptionFunc) (*Volume, int, error) {
+	p := &ListVolumesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListVolumes(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Volumes[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Volume UUID: %s!", id)
+}
+
+// Lists all volumes.
+func (s *VolumeService) ListVolumes(p *ListVolumesParams) (*ListVolumesResponse, error) {
+	resp, err := s.cs.newRequest("listVolumes", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVolumesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListVolumesResponse struct {
+	Count   int       `json:"count"`
+	Volumes []*Volume `json:"volume"`
+}
+
+type Volume struct {
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ExtractVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *ExtractVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["mode"]; found {
+		u.Set("mode", v.(string))
+	}
+	if v, found := p.p["url"]; found {
+		u.Set("url", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ExtractVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ExtractVolumeParams) SetMode(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["mode"] = v
+	return
+}
+
+func (p *ExtractVolumeParams) SetUrl(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["url"] = v
+	return
+}
+
+func (p *ExtractVolumeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ExtractVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewExtractVolumeParams(id string, mode string, zoneid string) *ExtractVolumeParams {
+	p := &ExtractVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	p.p["mode"] = mode
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Extracts volume
+func (s *VolumeService) ExtractVolume(p *ExtractVolumeParams) (*ExtractVolumeResponse, error) {
+	resp, err := s.cs.newRequest("extractVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ExtractVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ExtractVolumeResponse struct {
+	JobID            string `json:"jobid,omitempty"`
+	Accountid        string `json:"accountid,omitempty"`
+	Created          string `json:"created,omitempty"`
+	ExtractId        string `json:"extractId,omitempty"`
+	ExtractMode      string `json:"extractMode,omitempty"`
+	Id               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Resultstring     string `json:"resultstring,omitempty"`
+	State            string `json:"state,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Storagetype      string `json:"storagetype,omitempty"`
+	Uploadpercentage int    `json:"uploadpercentage,omitempty"`
+	Url              string `json:"url,omitempty"`
+	Zoneid           string `json:"zoneid,omitempty"`
+	Zonename         string `json:"zonename,omitempty"`
+}
+
+type MigrateVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *MigrateVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["livemigrate"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("livemigrate", vv)
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *MigrateVolumeParams) SetLivemigrate(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["livemigrate"] = v
+	return
+}
+
+func (p *MigrateVolumeParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *MigrateVolumeParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new MigrateVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewMigrateVolumeParams(storageid string, volumeid string) *MigrateVolumeParams {
+	p := &MigrateVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["storageid"] = storageid
+	p.p["volumeid"] = volumeid
+	return p
+}
+
+// Migrate volume
+func (s *VolumeService) MigrateVolume(p *MigrateVolumeParams) (*MigrateVolumeResponse, error) {
+	resp, err := s.cs.newRequest("migrateVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r MigrateVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type MigrateVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type ResizeVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *ResizeVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["maxiops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("maxiops", vv)
+	}
+	if v, found := p.p["miniops"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("miniops", vv)
+	}
+	if v, found := p.p["shrinkok"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("shrinkok", vv)
+	}
+	if v, found := p.p["size"]; found {
+		vv := strconv.FormatInt(v.(int64), 10)
+		u.Set("size", vv)
+	}
+	return u
+}
+
+func (p *ResizeVolumeParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *ResizeVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ResizeVolumeParams) SetMaxiops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["maxiops"] = v
+	return
+}
+
+func (p *ResizeVolumeParams) SetMiniops(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["miniops"] = v
+	return
+}
+
+func (p *ResizeVolumeParams) SetShrinkok(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["shrinkok"] = v
+	return
+}
+
+func (p *ResizeVolumeParams) SetSize(v int64) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["size"] = v
+	return
+}
+
+// You should always use this function to get a new ResizeVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewResizeVolumeParams(id string) *ResizeVolumeParams {
+	p := &ResizeVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Resizes a volume
+func (s *VolumeService) ResizeVolume(p *ResizeVolumeParams) (*ResizeVolumeResponse, error) {
+	resp, err := s.cs.newRequest("resizeVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ResizeVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ResizeVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type UpdateVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["chaininfo"]; found {
+		u.Set("chaininfo", v.(string))
+	}
+	if v, found := p.p["customid"]; found {
+		u.Set("customid", v.(string))
+	}
+	if v, found := p.p["displayvolume"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("displayvolume", vv)
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["path"]; found {
+		u.Set("path", v.(string))
+	}
+	if v, found := p.p["state"]; found {
+		u.Set("state", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateVolumeParams) SetChaininfo(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["chaininfo"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetCustomid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["customid"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetDisplayvolume(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["displayvolume"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetPath(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["path"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetState(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["state"] = v
+	return
+}
+
+func (p *UpdateVolumeParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewUpdateVolumeParams() *UpdateVolumeParams {
+	p := &UpdateVolumeParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// Updates the volume.
+func (s *VolumeService) UpdateVolume(p *UpdateVolumeParams) (*UpdateVolumeResponse, error) {
+	resp, err := s.cs.newRequest("updateVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type UpdateVolumeResponse struct {
+	JobID                      string `json:"jobid,omitempty"`
+	Account                    string `json:"account,omitempty"`
+	Attached                   string `json:"attached,omitempty"`
+	Chaininfo                  string `json:"chaininfo,omitempty"`
+	Created                    string `json:"created,omitempty"`
+	Destroyed                  bool   `json:"destroyed,omitempty"`
+	Deviceid                   int64  `json:"deviceid,omitempty"`
+	DiskBytesReadRate          int64  `json:"diskBytesReadRate,omitempty"`
+	DiskBytesWriteRate         int64  `json:"diskBytesWriteRate,omitempty"`
+	DiskIopsReadRate           int64  `json:"diskIopsReadRate,omitempty"`
+	DiskIopsWriteRate          int64  `json:"diskIopsWriteRate,omitempty"`
+	Diskofferingdisplaytext    string `json:"diskofferingdisplaytext,omitempty"`
+	Diskofferingid             string `json:"diskofferingid,omitempty"`
+	Diskofferingname           string `json:"diskofferingname,omitempty"`
+	Displayvolume              bool   `json:"displayvolume,omitempty"`
+	Domain                     string `json:"domain,omitempty"`
+	Domainid                   string `json:"domainid,omitempty"`
+	Hypervisor                 string `json:"hypervisor,omitempty"`
+	Id                         string `json:"id,omitempty"`
+	Isextractable              bool   `json:"isextractable,omitempty"`
+	Isodisplaytext             string `json:"isodisplaytext,omitempty"`
+	Isoid                      string `json:"isoid,omitempty"`
+	Isoname                    string `json:"isoname,omitempty"`
+	Maxiops                    int64  `json:"maxiops,omitempty"`
+	Miniops                    int64  `json:"miniops,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	Path                       string `json:"path,omitempty"`
+	Project                    string `json:"project,omitempty"`
+	Projectid                  string `json:"projectid,omitempty"`
+	Provisioningtype           string `json:"provisioningtype,omitempty"`
+	Quiescevm                  bool   `json:"quiescevm,omitempty"`
+	Serviceofferingdisplaytext string `json:"serviceofferingdisplaytext,omitempty"`
+	Serviceofferingid          string `json:"serviceofferingid,omitempty"`
+	Serviceofferingname        string `json:"serviceofferingname,omitempty"`
+	Size                       int64  `json:"size,omitempty"`
+	Snapshotid                 string `json:"snapshotid,omitempty"`
+	State                      string `json:"state,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Storage                    string `json:"storage,omitempty"`
+	Storageid                  string `json:"storageid,omitempty"`
+	Storagetype                string `json:"storagetype,omitempty"`
+	Tags                       []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Type                string `json:"type,omitempty"`
+	Virtualmachineid    string `json:"virtualmachineid,omitempty"`
+	Vmdisplayname       string `json:"vmdisplayname,omitempty"`
+	Vmname              string `json:"vmname,omitempty"`
+	Vmstate             string `json:"vmstate,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
+}
+
+type GetSolidFireVolumeSizeParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetSolidFireVolumeSizeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *GetSolidFireVolumeSizeParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+func (p *GetSolidFireVolumeSizeParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new GetSolidFireVolumeSizeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewGetSolidFireVolumeSizeParams(storageid string, volumeid string) *GetSolidFireVolumeSizeParams {
+	p := &GetSolidFireVolumeSizeParams{}
+	p.p = make(map[string]interface{})
+	p.p["storageid"] = storageid
+	p.p["volumeid"] = volumeid
+	return p
+}
+
+// Get the SF volume size including Hypervisor Snapshot Reserve
+func (s *VolumeService) GetSolidFireVolumeSize(p *GetSolidFireVolumeSizeParams) (*GetSolidFireVolumeSizeResponse, error) {
+	resp, err := s.cs.newRequest("getSolidFireVolumeSize", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetSolidFireVolumeSizeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetSolidFireVolumeSizeResponse struct {
+	SolidFireVolumeSize int64 `json:"solidFireVolumeSize,omitempty"`
+}
+
+type GetSolidFireVolumeAccessGroupIdParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetSolidFireVolumeAccessGroupIdParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["clusterid"]; found {
+		u.Set("clusterid", v.(string))
+	}
+	if v, found := p.p["storageid"]; found {
+		u.Set("storageid", v.(string))
+	}
+	return u
+}
+
+func (p *GetSolidFireVolumeAccessGroupIdParams) SetClusterid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["clusterid"] = v
+	return
+}
+
+func (p *GetSolidFireVolumeAccessGroupIdParams) SetStorageid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["storageid"] = v
+	return
+}
+
+// You should always use this function to get a new GetSolidFireVolumeAccessGroupIdParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewGetSolidFireVolumeAccessGroupIdParams(clusterid string, storageid string) *GetSolidFireVolumeAccessGroupIdParams {
+	p := &GetSolidFireVolumeAccessGroupIdParams{}
+	p.p = make(map[string]interface{})
+	p.p["clusterid"] = clusterid
+	p.p["storageid"] = storageid
+	return p
+}
+
+// Get the SF Volume Access Group ID
+func (s *VolumeService) GetSolidFireVolumeAccessGroupId(p *GetSolidFireVolumeAccessGroupIdParams) (*GetSolidFireVolumeAccessGroupIdResponse, error) {
+	resp, err := s.cs.newRequest("getSolidFireVolumeAccessGroupId", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetSolidFireVolumeAccessGroupIdResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetSolidFireVolumeAccessGroupIdResponse struct {
+	SolidFireVolumeAccessGroupId int64 `json:"solidFireVolumeAccessGroupId,omitempty"`
+}
+
+type GetSolidFireVolumeIscsiNameParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetSolidFireVolumeIscsiNameParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["volumeid"]; found {
+		u.Set("volumeid", v.(string))
+	}
+	return u
+}
+
+func (p *GetSolidFireVolumeIscsiNameParams) SetVolumeid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["volumeid"] = v
+	return
+}
+
+// You should always use this function to get a new GetSolidFireVolumeIscsiNameParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewGetSolidFireVolumeIscsiNameParams(volumeid string) *GetSolidFireVolumeIscsiNameParams {
+	p := &GetSolidFireVolumeIscsiNameParams{}
+	p.p = make(map[string]interface{})
+	p.p["volumeid"] = volumeid
+	return p
+}
+
+// Get SolidFire Volume's Iscsi Name
+func (s *VolumeService) GetSolidFireVolumeIscsiName(p *GetSolidFireVolumeIscsiNameParams) (*GetSolidFireVolumeIscsiNameResponse, error) {
+	resp, err := s.cs.newRequest("getSolidFireVolumeIscsiName", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetSolidFireVolumeIscsiNameResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetSolidFireVolumeIscsiNameResponse struct {
+	SolidFireVolumeIscsiName string `json:"solidFireVolumeIscsiName,omitempty"`
+}
+
+type GetUploadParamsForVolumeParams struct {
+	p map[string]interface{}
+}
+
+func (p *GetUploadParamsForVolumeParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["checksum"]; found {
+		u.Set("checksum", v.(string))
+	}
+	if v, found := p.p["diskofferingid"]; found {
+		u.Set("diskofferingid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["format"]; found {
+		u.Set("format", v.(string))
+	}
+	if v, found := p.p["imagestoreuuid"]; found {
+		u.Set("imagestoreuuid", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["projectid"]; found {
+		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *GetUploadParamsForVolumeParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetChecksum(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["checksum"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetDiskofferingid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["diskofferingid"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetFormat(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["format"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetImagestoreuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["imagestoreuuid"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetProjectid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["projectid"] = v
+	return
+}
+
+func (p *GetUploadParamsForVolumeParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new GetUploadParamsForVolumeParams instance,
+// as then you are sure you have configured all required params
+func (s *VolumeService) NewGetUploadParamsForVolumeParams(format string, name string, zoneid string) *GetUploadParamsForVolumeParams {
+	p := &GetUploadParamsForVolumeParams{}
+	p.p = make(map[string]interface{})
+	p.p["format"] = format
+	p.p["name"] = name
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Upload a data disk to the cloudstack cloud.
+func (s *VolumeService) GetUploadParamsForVolume(p *GetUploadParamsForVolumeParams) (*GetUploadParamsForVolumeResponse, error) {
+	resp, err := s.cs.newRequest("getUploadParamsForVolume", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r GetUploadParamsForVolumeResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type GetUploadParamsForVolumeResponse struct {
+	Expires   string `json:"expires,omitempty"`
+	Id        string `json:"id,omitempty"`
+	Metadata  string `json:"metadata,omitempty"`
+	PostURL   string `json:"postURL,omitempty"`
+	Signature string `json:"signature,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ZoneService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ZoneService.go
@@ -1,0 +1,1167 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type CreateZoneParams struct {
+	p map[string]interface{}
+}
+
+func (p *CreateZoneParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["dns1"]; found {
+		u.Set("dns1", v.(string))
+	}
+	if v, found := p.p["dns2"]; found {
+		u.Set("dns2", v.(string))
+	}
+	if v, found := p.p["domain"]; found {
+		u.Set("domain", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["guestcidraddress"]; found {
+		u.Set("guestcidraddress", v.(string))
+	}
+	if v, found := p.p["internaldns1"]; found {
+		u.Set("internaldns1", v.(string))
+	}
+	if v, found := p.p["internaldns2"]; found {
+		u.Set("internaldns2", v.(string))
+	}
+	if v, found := p.p["ip6dns1"]; found {
+		u.Set("ip6dns1", v.(string))
+	}
+	if v, found := p.p["ip6dns2"]; found {
+		u.Set("ip6dns2", v.(string))
+	}
+	if v, found := p.p["localstorageenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("localstorageenabled", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networktype"]; found {
+		u.Set("networktype", v.(string))
+	}
+	if v, found := p.p["securitygroupenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("securitygroupenabled", vv)
+	}
+	return u
+}
+
+func (p *CreateZoneParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetDns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dns1"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetDns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dns2"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetDomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domain"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetGuestcidraddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestcidraddress"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetInternaldns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["internaldns1"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetInternaldns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["internaldns2"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetIp6dns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6dns1"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetIp6dns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6dns2"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetLocalstorageenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["localstorageenabled"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetNetworktype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networktype"] = v
+	return
+}
+
+func (p *CreateZoneParams) SetSecuritygroupenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["securitygroupenabled"] = v
+	return
+}
+
+// You should always use this function to get a new CreateZoneParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewCreateZoneParams(dns1 string, internaldns1 string, name string, networktype string) *CreateZoneParams {
+	p := &CreateZoneParams{}
+	p.p = make(map[string]interface{})
+	p.p["dns1"] = dns1
+	p.p["internaldns1"] = internaldns1
+	p.p["name"] = name
+	p.p["networktype"] = networktype
+	return p
+}
+
+// Creates a Zone.
+func (s *ZoneService) CreateZone(p *CreateZoneParams) (*CreateZoneResponse, error) {
+	resp, err := s.cs.newRequest("createZone", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateZoneResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type CreateZoneResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	Dhcpprovider          string            `json:"dhcpprovider,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Dns1                  string            `json:"dns1,omitempty"`
+	Dns2                  string            `json:"dns2,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Domainname            string            `json:"domainname,omitempty"`
+	Guestcidraddress      string            `json:"guestcidraddress,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Internaldns1          string            `json:"internaldns1,omitempty"`
+	Internaldns2          string            `json:"internaldns2,omitempty"`
+	Ip6dns1               string            `json:"ip6dns1,omitempty"`
+	Ip6dns2               string            `json:"ip6dns2,omitempty"`
+	Localstorageenabled   bool              `json:"localstorageenabled,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networktype           string            `json:"networktype,omitempty"`
+	Resourcedetails       map[string]string `json:"resourcedetails,omitempty"`
+	Securitygroupsenabled bool              `json:"securitygroupsenabled,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zonetoken string `json:"zonetoken,omitempty"`
+}
+
+type UpdateZoneParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateZoneParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["allocationstate"]; found {
+		u.Set("allocationstate", v.(string))
+	}
+	if v, found := p.p["details"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
+			i++
+		}
+	}
+	if v, found := p.p["dhcpprovider"]; found {
+		u.Set("dhcpprovider", v.(string))
+	}
+	if v, found := p.p["dns1"]; found {
+		u.Set("dns1", v.(string))
+	}
+	if v, found := p.p["dns2"]; found {
+		u.Set("dns2", v.(string))
+	}
+	if v, found := p.p["dnssearchorder"]; found {
+		vv := strings.Join(v.([]string), ",")
+		u.Set("dnssearchorder", vv)
+	}
+	if v, found := p.p["domain"]; found {
+		u.Set("domain", v.(string))
+	}
+	if v, found := p.p["guestcidraddress"]; found {
+		u.Set("guestcidraddress", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["internaldns1"]; found {
+		u.Set("internaldns1", v.(string))
+	}
+	if v, found := p.p["internaldns2"]; found {
+		u.Set("internaldns2", v.(string))
+	}
+	if v, found := p.p["ip6dns1"]; found {
+		u.Set("ip6dns1", v.(string))
+	}
+	if v, found := p.p["ip6dns2"]; found {
+		u.Set("ip6dns2", v.(string))
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
+	if v, found := p.p["localstorageenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("localstorageenabled", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *UpdateZoneParams) SetAllocationstate(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["allocationstate"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDetails(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["details"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDhcpprovider(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dhcpprovider"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dns1"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dns2"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDnssearchorder(v []string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["dnssearchorder"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetDomain(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domain"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetGuestcidraddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["guestcidraddress"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetInternaldns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["internaldns1"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetInternaldns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["internaldns2"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetIp6dns1(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6dns1"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetIp6dns2(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ip6dns2"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetLocalstorageenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["localstorageenabled"] = v
+	return
+}
+
+func (p *UpdateZoneParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+// You should always use this function to get a new UpdateZoneParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewUpdateZoneParams(id string) *UpdateZoneParams {
+	p := &UpdateZoneParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates a Zone.
+func (s *ZoneService) UpdateZone(p *UpdateZoneParams) (*UpdateZoneResponse, error) {
+	resp, err := s.cs.newRequest("updateZone", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateZoneResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type UpdateZoneResponse struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	Dhcpprovider          string            `json:"dhcpprovider,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Dns1                  string            `json:"dns1,omitempty"`
+	Dns2                  string            `json:"dns2,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Domainname            string            `json:"domainname,omitempty"`
+	Guestcidraddress      string            `json:"guestcidraddress,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Internaldns1          string            `json:"internaldns1,omitempty"`
+	Internaldns2          string            `json:"internaldns2,omitempty"`
+	Ip6dns1               string            `json:"ip6dns1,omitempty"`
+	Ip6dns2               string            `json:"ip6dns2,omitempty"`
+	Localstorageenabled   bool              `json:"localstorageenabled,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networktype           string            `json:"networktype,omitempty"`
+	Resourcedetails       map[string]string `json:"resourcedetails,omitempty"`
+	Securitygroupsenabled bool              `json:"securitygroupsenabled,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zonetoken string `json:"zonetoken,omitempty"`
+}
+
+type DeleteZoneParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteZoneParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteZoneParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+// You should always use this function to get a new DeleteZoneParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewDeleteZoneParams(id string) *DeleteZoneParams {
+	p := &DeleteZoneParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes a Zone.
+func (s *ZoneService) DeleteZone(p *DeleteZoneParams) (*DeleteZoneResponse, error) {
+	resp, err := s.cs.newRequest("deleteZone", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteZoneResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type DeleteZoneResponse struct {
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     string `json:"success,omitempty"`
+}
+
+type ListZonesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListZonesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["available"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("available", vv)
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["networktype"]; found {
+		u.Set("networktype", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["showcapacities"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showcapacities", vv)
+	}
+	if v, found := p.p["tags"]; found {
+		i := 0
+		for k, vv := range v.(map[string]string) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
+			i++
+		}
+	}
+	return u
+}
+
+func (p *ListZonesParams) SetAvailable(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["available"] = v
+	return
+}
+
+func (p *ListZonesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListZonesParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+	return
+}
+
+func (p *ListZonesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListZonesParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+	return
+}
+
+func (p *ListZonesParams) SetNetworktype(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["networktype"] = v
+	return
+}
+
+func (p *ListZonesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListZonesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListZonesParams) SetShowcapacities(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showcapacities"] = v
+	return
+}
+
+func (p *ListZonesParams) SetTags(v map[string]string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["tags"] = v
+	return
+}
+
+// You should always use this function to get a new ListZonesParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewListZonesParams() *ListZonesParams {
+	p := &ListZonesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ZoneService) GetZoneID(name string, opts ...OptionFunc) (string, int, error) {
+	p := &ListZonesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["name"] = name
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return "", -1, err
+		}
+	}
+
+	l, err := s.ListZones(p)
+	if err != nil {
+		return "", -1, err
+	}
+
+	if l.Count == 0 {
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
+	}
+
+	if l.Count == 1 {
+		return l.Zones[0].Id, l.Count, nil
+	}
+
+	if l.Count > 1 {
+		for _, v := range l.Zones {
+			if v.Name == name {
+				return v.Id, l.Count, nil
+			}
+		}
+	}
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ZoneService) GetZoneByName(name string, opts ...OptionFunc) (*Zone, int, error) {
+	id, count, err := s.GetZoneID(name, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+
+	r, count, err := s.GetZoneByID(id, opts...)
+	if err != nil {
+		return nil, count, err
+	}
+	return r, count, nil
+}
+
+// This is a courtesy helper function, which in some cases may not work as expected!
+func (s *ZoneService) GetZoneByID(id string, opts ...OptionFunc) (*Zone, int, error) {
+	p := &ListZonesParams{}
+	p.p = make(map[string]interface{})
+
+	p.p["id"] = id
+
+	for _, fn := range opts {
+		if err := fn(s.cs, p); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	l, err := s.ListZones(p)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", id)) {
+			return nil, 0, fmt.Errorf("No match found for %s: %+v", id, l)
+		}
+		return nil, -1, err
+	}
+
+	if l.Count == 0 {
+		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)
+	}
+
+	if l.Count == 1 {
+		return l.Zones[0], l.Count, nil
+	}
+	return nil, l.Count, fmt.Errorf("There is more then one result for Zone UUID: %s!", id)
+}
+
+// Lists zones
+func (s *ZoneService) ListZones(p *ListZonesParams) (*ListZonesResponse, error) {
+	resp, err := s.cs.newRequest("listZones", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListZonesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListZonesResponse struct {
+	Count int     `json:"count"`
+	Zones []*Zone `json:"zone"`
+}
+
+type Zone struct {
+	Allocationstate string `json:"allocationstate,omitempty"`
+	Capacity        []struct {
+		Capacitytotal int64  `json:"capacitytotal,omitempty"`
+		Capacityused  int64  `json:"capacityused,omitempty"`
+		Clusterid     string `json:"clusterid,omitempty"`
+		Clustername   string `json:"clustername,omitempty"`
+		Percentused   string `json:"percentused,omitempty"`
+		Podid         string `json:"podid,omitempty"`
+		Podname       string `json:"podname,omitempty"`
+		Type          int    `json:"type,omitempty"`
+		Zoneid        string `json:"zoneid,omitempty"`
+		Zonename      string `json:"zonename,omitempty"`
+	} `json:"capacity,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	Dhcpprovider          string            `json:"dhcpprovider,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Dns1                  string            `json:"dns1,omitempty"`
+	Dns2                  string            `json:"dns2,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Domainname            string            `json:"domainname,omitempty"`
+	Guestcidraddress      string            `json:"guestcidraddress,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Internaldns1          string            `json:"internaldns1,omitempty"`
+	Internaldns2          string            `json:"internaldns2,omitempty"`
+	Ip6dns1               string            `json:"ip6dns1,omitempty"`
+	Ip6dns2               string            `json:"ip6dns2,omitempty"`
+	Localstorageenabled   bool              `json:"localstorageenabled,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networktype           string            `json:"networktype,omitempty"`
+	Resourcedetails       map[string]string `json:"resourcedetails,omitempty"`
+	Securitygroupsenabled bool              `json:"securitygroupsenabled,omitempty"`
+	Tags                  []struct {
+		Account      string `json:"account,omitempty"`
+		Customer     string `json:"customer,omitempty"`
+		Domain       string `json:"domain,omitempty"`
+		Domainid     string `json:"domainid,omitempty"`
+		Key          string `json:"key,omitempty"`
+		Project      string `json:"project,omitempty"`
+		Projectid    string `json:"projectid,omitempty"`
+		Resourceid   string `json:"resourceid,omitempty"`
+		Resourcetype string `json:"resourcetype,omitempty"`
+		Value        string `json:"value,omitempty"`
+	} `json:"tags,omitempty"`
+	Zonetoken string `json:"zonetoken,omitempty"`
+}
+
+type DedicateZoneParams struct {
+	p map[string]interface{}
+}
+
+func (p *DedicateZoneParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *DedicateZoneParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *DedicateZoneParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *DedicateZoneParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new DedicateZoneParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewDedicateZoneParams(domainid string, zoneid string) *DedicateZoneParams {
+	p := &DedicateZoneParams{}
+	p.p = make(map[string]interface{})
+	p.p["domainid"] = domainid
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Dedicates a zones.
+func (s *ZoneService) DedicateZone(p *DedicateZoneParams) (*DedicateZoneResponse, error) {
+	resp, err := s.cs.newRequest("dedicateZone", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DedicateZoneResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		b, err = getRawValue(b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type DedicateZoneResponse struct {
+	JobID           string `json:"jobid,omitempty"`
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+	Zoneid          string `json:"zoneid,omitempty"`
+	Zonename        string `json:"zonename,omitempty"`
+}
+
+type ReleaseDedicatedZoneParams struct {
+	p map[string]interface{}
+}
+
+func (p *ReleaseDedicatedZoneParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ReleaseDedicatedZoneParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ReleaseDedicatedZoneParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewReleaseDedicatedZoneParams(zoneid string) *ReleaseDedicatedZoneParams {
+	p := &ReleaseDedicatedZoneParams{}
+	p.p = make(map[string]interface{})
+	p.p["zoneid"] = zoneid
+	return p
+}
+
+// Release dedication of zone
+func (s *ZoneService) ReleaseDedicatedZone(p *ReleaseDedicatedZoneParams) (*ReleaseDedicatedZoneResponse, error) {
+	resp, err := s.cs.newRequest("releaseDedicatedZone", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ReleaseDedicatedZoneResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	// If we have a async client, we need to wait for the async result
+	if s.cs.async {
+		b, err := s.cs.GetAsyncJobResult(r.JobID, s.cs.timeout)
+		if err != nil {
+			if err == AsyncTimeoutErr {
+				return &r, err
+			}
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ReleaseDedicatedZoneResponse struct {
+	JobID       string `json:"jobid,omitempty"`
+	Displaytext string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+}
+
+type ListDedicatedZonesParams struct {
+	p map[string]interface{}
+}
+
+func (p *ListDedicatedZonesParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["account"]; found {
+		u.Set("account", v.(string))
+	}
+	if v, found := p.p["affinitygroupid"]; found {
+		u.Set("affinitygroupid", v.(string))
+	}
+	if v, found := p.p["domainid"]; found {
+		u.Set("domainid", v.(string))
+	}
+	if v, found := p.p["keyword"]; found {
+		u.Set("keyword", v.(string))
+	}
+	if v, found := p.p["page"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("page", vv)
+	}
+	if v, found := p.p["pagesize"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("pagesize", vv)
+	}
+	if v, found := p.p["zoneid"]; found {
+		u.Set("zoneid", v.(string))
+	}
+	return u
+}
+
+func (p *ListDedicatedZonesParams) SetAccount(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["account"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetAffinitygroupid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["affinitygroupid"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetDomainid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["domainid"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetKeyword(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["keyword"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetPage(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["page"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetPagesize(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListDedicatedZonesParams) SetZoneid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["zoneid"] = v
+	return
+}
+
+// You should always use this function to get a new ListDedicatedZonesParams instance,
+// as then you are sure you have configured all required params
+func (s *ZoneService) NewListDedicatedZonesParams() *ListDedicatedZonesParams {
+	p := &ListDedicatedZonesParams{}
+	p.p = make(map[string]interface{})
+	return p
+}
+
+// List dedicated zones.
+func (s *ZoneService) ListDedicatedZones(p *ListDedicatedZonesParams) (*ListDedicatedZonesResponse, error) {
+	resp, err := s.cs.newRequest("listDedicatedZones", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListDedicatedZonesResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+type ListDedicatedZonesResponse struct {
+	Count          int              `json:"count"`
+	DedicatedZones []*DedicatedZone `json:"dedicatedzone"`
+}
+
+type DedicatedZone struct {
+	Accountid       string `json:"accountid,omitempty"`
+	Affinitygroupid string `json:"affinitygroupid,omitempty"`
+	Domainid        string `json:"domainid,omitempty"`
+	Id              string `json:"id,omitempty"`
+	Zoneid          string `json:"zoneid,omitempty"`
+	Zonename        string `json:"zonename,omitempty"`
+}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/cloudstack.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/cloudstack.go
@@ -1,0 +1,936 @@
+//
+// Copyright 2016, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudstack
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// UnlimitedResourceID is a special ID to define an unlimited resource
+const UnlimitedResourceID = "-1"
+
+var idRegex = regexp.MustCompile(`^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|-1)$`)
+
+// IsID return true if the passed ID is either a UUID or a UnlimitedResourceID
+func IsID(id string) bool {
+	return idRegex.MatchString(id)
+}
+
+// OptionFunc can be passed to the courtesy helper functions to set additional parameters
+type OptionFunc func(*CloudStackClient, interface{}) error
+
+type CSError struct {
+	ErrorCode   int    `json:"errorcode"`
+	CSErrorCode int    `json:"cserrorcode"`
+	ErrorText   string `json:"errortext"`
+}
+
+func (e *CSError) Error() error {
+	return fmt.Errorf("CloudStack API error %d (CSExceptionErrorCode: %d): %s", e.ErrorCode, e.CSErrorCode, e.ErrorText)
+}
+
+type CloudStackClient struct {
+	HTTPGETOnly bool // If `true` only use HTTP GET calls
+
+	client  *http.Client // The http client for communicating
+	baseURL string       // The base URL of the API
+	apiKey  string       // Api key
+	secret  string       // Secret key
+	async   bool         // Wait for async calls to finish
+	timeout int64        // Max waiting timeout in seconds for async jobs to finish; defaults to 300 seconds
+
+	APIDiscovery     *APIDiscoveryService
+	Account          *AccountService
+	Address          *AddressService
+	AffinityGroup    *AffinityGroupService
+	Alert            *AlertService
+	Asyncjob         *AsyncjobService
+	Authentication   *AuthenticationService
+	AutoScale        *AutoScaleService
+	Baremetal        *BaremetalService
+	Certificate      *CertificateService
+	CloudIdentifier  *CloudIdentifierService
+	Cluster          *ClusterService
+	Configuration    *ConfigurationService
+	DiskOffering     *DiskOfferingService
+	Domain           *DomainService
+	Event            *EventService
+	Firewall         *FirewallService
+	GuestOS          *GuestOSService
+	Host             *HostService
+	Hypervisor       *HypervisorService
+	ISO              *ISOService
+	ImageStore       *ImageStoreService
+	InternalLB       *InternalLBService
+	LDAP             *LDAPService
+	Limit            *LimitService
+	LoadBalancer     *LoadBalancerService
+	NAT              *NATService
+	NetworkACL       *NetworkACLService
+	NetworkDevice    *NetworkDeviceService
+	NetworkOffering  *NetworkOfferingService
+	Network          *NetworkService
+	Nic              *NicService
+	NiciraNVP        *NiciraNVPService
+	OvsElement       *OvsElementService
+	Pod              *PodService
+	Pool             *PoolService
+	PortableIP       *PortableIPService
+	Project          *ProjectService
+	Quota            *QuotaService
+	Region           *RegionService
+	Resourcemetadata *ResourcemetadataService
+	Resourcetags     *ResourcetagsService
+	Router           *RouterService
+	SSH              *SSHService
+	SecurityGroup    *SecurityGroupService
+	ServiceOffering  *ServiceOfferingService
+	Snapshot         *SnapshotService
+	StoragePool      *StoragePoolService
+	StratosphereSSP  *StratosphereSSPService
+	Swift            *SwiftService
+	SystemCapacity   *SystemCapacityService
+	SystemVM         *SystemVMService
+	Template         *TemplateService
+	UCS              *UCSService
+	Usage            *UsageService
+	User             *UserService
+	VLAN             *VLANService
+	VMGroup          *VMGroupService
+	VPC              *VPCService
+	VPN              *VPNService
+	VirtualMachine   *VirtualMachineService
+	Volume           *VolumeService
+	Zone             *ZoneService
+}
+
+// Creates a new client for communicating with CloudStack
+func newClient(apiurl string, apikey string, secret string, async bool, verifyssl bool) *CloudStackClient {
+	cs := &CloudStackClient{
+		client: &http.Client{
+			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyssl}, // If verifyssl is true, skipping the verify should be false and vice versa
+			},
+			Timeout: time.Duration(60 * time.Second),
+		},
+		baseURL: apiurl,
+		apiKey:  apikey,
+		secret:  secret,
+		async:   async,
+		timeout: 300,
+	}
+	cs.APIDiscovery = NewAPIDiscoveryService(cs)
+	cs.Account = NewAccountService(cs)
+	cs.Address = NewAddressService(cs)
+	cs.AffinityGroup = NewAffinityGroupService(cs)
+	cs.Alert = NewAlertService(cs)
+	cs.Asyncjob = NewAsyncjobService(cs)
+	cs.Authentication = NewAuthenticationService(cs)
+	cs.AutoScale = NewAutoScaleService(cs)
+	cs.Baremetal = NewBaremetalService(cs)
+	cs.Certificate = NewCertificateService(cs)
+	cs.CloudIdentifier = NewCloudIdentifierService(cs)
+	cs.Cluster = NewClusterService(cs)
+	cs.Configuration = NewConfigurationService(cs)
+	cs.DiskOffering = NewDiskOfferingService(cs)
+	cs.Domain = NewDomainService(cs)
+	cs.Event = NewEventService(cs)
+	cs.Firewall = NewFirewallService(cs)
+	cs.GuestOS = NewGuestOSService(cs)
+	cs.Host = NewHostService(cs)
+	cs.Hypervisor = NewHypervisorService(cs)
+	cs.ISO = NewISOService(cs)
+	cs.ImageStore = NewImageStoreService(cs)
+	cs.InternalLB = NewInternalLBService(cs)
+	cs.LDAP = NewLDAPService(cs)
+	cs.Limit = NewLimitService(cs)
+	cs.LoadBalancer = NewLoadBalancerService(cs)
+	cs.NAT = NewNATService(cs)
+	cs.NetworkACL = NewNetworkACLService(cs)
+	cs.NetworkDevice = NewNetworkDeviceService(cs)
+	cs.NetworkOffering = NewNetworkOfferingService(cs)
+	cs.Network = NewNetworkService(cs)
+	cs.Nic = NewNicService(cs)
+	cs.NiciraNVP = NewNiciraNVPService(cs)
+	cs.OvsElement = NewOvsElementService(cs)
+	cs.Pod = NewPodService(cs)
+	cs.Pool = NewPoolService(cs)
+	cs.PortableIP = NewPortableIPService(cs)
+	cs.Project = NewProjectService(cs)
+	cs.Quota = NewQuotaService(cs)
+	cs.Region = NewRegionService(cs)
+	cs.Resourcemetadata = NewResourcemetadataService(cs)
+	cs.Resourcetags = NewResourcetagsService(cs)
+	cs.Router = NewRouterService(cs)
+	cs.SSH = NewSSHService(cs)
+	cs.SecurityGroup = NewSecurityGroupService(cs)
+	cs.ServiceOffering = NewServiceOfferingService(cs)
+	cs.Snapshot = NewSnapshotService(cs)
+	cs.StoragePool = NewStoragePoolService(cs)
+	cs.StratosphereSSP = NewStratosphereSSPService(cs)
+	cs.Swift = NewSwiftService(cs)
+	cs.SystemCapacity = NewSystemCapacityService(cs)
+	cs.SystemVM = NewSystemVMService(cs)
+	cs.Template = NewTemplateService(cs)
+	cs.UCS = NewUCSService(cs)
+	cs.Usage = NewUsageService(cs)
+	cs.User = NewUserService(cs)
+	cs.VLAN = NewVLANService(cs)
+	cs.VMGroup = NewVMGroupService(cs)
+	cs.VPC = NewVPCService(cs)
+	cs.VPN = NewVPNService(cs)
+	cs.VirtualMachine = NewVirtualMachineService(cs)
+	cs.Volume = NewVolumeService(cs)
+	cs.Zone = NewZoneService(cs)
+	return cs
+}
+
+// Default non-async client. So for async calls you need to implement and check the async job result yourself. When using
+// HTTPS with a self-signed certificate to connect to your CloudStack API, you would probably want to set 'verifyssl' to
+// false so the call ignores the SSL errors/warnings.
+func NewClient(apiurl string, apikey string, secret string, verifyssl bool) *CloudStackClient {
+	cs := newClient(apiurl, apikey, secret, false, verifyssl)
+	return cs
+}
+
+// For sync API calls this client behaves exactly the same as a standard client call, but for async API calls
+// this client will wait until the async job is finished or until the configured AsyncTimeout is reached. When the async
+// job finishes successfully it will return actual object received from the API and nil, but when the timout is
+// reached it will return the initial object containing the async job ID for the running job and a warning.
+func NewAsyncClient(apiurl string, apikey string, secret string, verifyssl bool) *CloudStackClient {
+	cs := newClient(apiurl, apikey, secret, true, verifyssl)
+	return cs
+}
+
+// When using the async client an api call will wait for the async call to finish before returning. The default is to poll for 300 seconds
+// seconds, to check if the async job is finished.
+func (cs *CloudStackClient) AsyncTimeout(timeoutInSeconds int64) {
+	cs.timeout = timeoutInSeconds
+}
+
+var AsyncTimeoutErr = errors.New("Timeout while waiting for async job to finish")
+
+// A helper function that you can use to get the result of a running async job. If the job is not finished within the configured
+// timeout, the async job returns a AsyncTimeoutErr.
+func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (json.RawMessage, error) {
+	var timer time.Duration
+	currentTime := time.Now().Unix()
+
+	for {
+		p := cs.Asyncjob.NewQueryAsyncJobResultParams(jobid)
+		r, err := cs.Asyncjob.QueryAsyncJobResult(p)
+		if err != nil {
+			return nil, err
+		}
+
+		// Status 1 means the job is finished successfully
+		if r.Jobstatus == 1 {
+			return r.Jobresult, nil
+		}
+
+		// When the status is 2, the job has failed
+		if r.Jobstatus == 2 {
+			if r.Jobresulttype == "text" {
+				return nil, fmt.Errorf(string(r.Jobresult))
+			} else {
+				return nil, fmt.Errorf("Undefined error: %s", string(r.Jobresult))
+			}
+		}
+
+		if time.Now().Unix()-currentTime > timeout {
+			return nil, AsyncTimeoutErr
+		}
+
+		// Add an (extremely simple) exponential backoff like feature to prevent
+		// flooding the CloudStack API
+		if timer < 15 {
+			timer++
+		}
+
+		time.Sleep(timer * time.Second)
+	}
+}
+
+// Execute the request against a CS API. Will return the raw JSON data returned by the API and nil if
+// no error occured. If the API returns an error the result will be nil and the HTTP error code and CS
+// error details. If a processing (code) error occurs the result will be nil and the generated error
+func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
+	params.Set("apiKey", cs.apiKey)
+	params.Set("command", api)
+	params.Set("response", "json")
+
+	// Generate signature for API call
+	// * Serialize parameters, URL encoding only values and sort them by key, done by encodeValues
+	// * Convert the entire argument string to lowercase
+	// * Replace all instances of '+' to '%20'
+	// * Calculate HMAC SHA1 of argument string with CloudStack secret
+	// * URL encode the string and convert to base64
+	s := encodeValues(params)
+	s2 := strings.ToLower(s)
+	s3 := strings.Replace(s2, "+", "%20", -1)
+	mac := hmac.New(sha1.New, []byte(cs.secret))
+	mac.Write([]byte(s3))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	var err error
+	var resp *http.Response
+	if !cs.HTTPGETOnly && (api == "deployVirtualMachine" || api == "updateVirtualMachine") {
+		// The deployVirtualMachine API should be called using a POST call
+		// so we don't have to worry about the userdata size
+
+		// Add the unescaped signature to the POST params
+		params.Set("signature", signature)
+
+		// Make a POST call
+		resp, err = cs.client.PostForm(cs.baseURL, params)
+	} else {
+		// Create the final URL before we issue the request
+		url := cs.baseURL + "?" + s + "&signature=" + url.QueryEscape(signature)
+
+		// Make a GET call
+		resp, err = cs.client.Get(url)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Need to get the raw value to make the result play nice
+	b, err = getRawValue(b)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		var e CSError
+		if err := json.Unmarshal(b, &e); err != nil {
+			return nil, err
+		}
+		return nil, e.Error()
+	}
+	return b, nil
+}
+
+// Custom version of net/url Encode that only URL escapes values
+// Unmodified portions here remain under BSD license of The Go Authors: https://go.googlesource.com/go/+/master/LICENSE
+func encodeValues(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := k + "="
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			buf.WriteString(url.QueryEscape(v))
+		}
+	}
+	return buf.String()
+}
+
+// Generic function to get the first raw value from a response as json.RawMessage
+func getRawValue(b json.RawMessage) (json.RawMessage, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	for _, v := range m {
+		return v, nil
+	}
+	return nil, fmt.Errorf("Unable to extract the raw value from:\n\n%s\n\n", string(b))
+}
+
+// ProjectIDSetter is an interface that every type that can set a project ID must implement
+type ProjectIDSetter interface {
+	SetProjectid(string)
+}
+
+// WithProject takes either a project name or ID and sets the `projectid` parameter
+func WithProject(project string) OptionFunc {
+	return func(cs *CloudStackClient, p interface{}) error {
+		ps, ok := p.(ProjectIDSetter)
+
+		if !ok || project == "" {
+			return nil
+		}
+
+		if !IsID(project) {
+			id, _, err := cs.Project.GetProjectID(project)
+			if err != nil {
+				return err
+			}
+			project = id
+		}
+
+		ps.SetProjectid(project)
+
+		return nil
+	}
+}
+
+// VPCIDSetter is an interface that every type that can set a vpc ID must implement
+type VPCIDSetter interface {
+	SetVpcid(string)
+}
+
+// WithVPCID takes a vpc ID and sets the `vpcid` parameter
+func WithVPCID(id string) OptionFunc {
+	return func(cs *CloudStackClient, p interface{}) error {
+		vs, ok := p.(VPCIDSetter)
+
+		if !ok || id == "" {
+			return nil
+		}
+
+		vs.SetVpcid(id)
+
+		return nil
+	}
+}
+
+type APIDiscoveryService struct {
+	cs *CloudStackClient
+}
+
+func NewAPIDiscoveryService(cs *CloudStackClient) *APIDiscoveryService {
+	return &APIDiscoveryService{cs: cs}
+}
+
+type AccountService struct {
+	cs *CloudStackClient
+}
+
+func NewAccountService(cs *CloudStackClient) *AccountService {
+	return &AccountService{cs: cs}
+}
+
+type AddressService struct {
+	cs *CloudStackClient
+}
+
+func NewAddressService(cs *CloudStackClient) *AddressService {
+	return &AddressService{cs: cs}
+}
+
+type AffinityGroupService struct {
+	cs *CloudStackClient
+}
+
+func NewAffinityGroupService(cs *CloudStackClient) *AffinityGroupService {
+	return &AffinityGroupService{cs: cs}
+}
+
+type AlertService struct {
+	cs *CloudStackClient
+}
+
+func NewAlertService(cs *CloudStackClient) *AlertService {
+	return &AlertService{cs: cs}
+}
+
+type AsyncjobService struct {
+	cs *CloudStackClient
+}
+
+func NewAsyncjobService(cs *CloudStackClient) *AsyncjobService {
+	return &AsyncjobService{cs: cs}
+}
+
+type AuthenticationService struct {
+	cs *CloudStackClient
+}
+
+func NewAuthenticationService(cs *CloudStackClient) *AuthenticationService {
+	return &AuthenticationService{cs: cs}
+}
+
+type AutoScaleService struct {
+	cs *CloudStackClient
+}
+
+func NewAutoScaleService(cs *CloudStackClient) *AutoScaleService {
+	return &AutoScaleService{cs: cs}
+}
+
+type BaremetalService struct {
+	cs *CloudStackClient
+}
+
+func NewBaremetalService(cs *CloudStackClient) *BaremetalService {
+	return &BaremetalService{cs: cs}
+}
+
+type CertificateService struct {
+	cs *CloudStackClient
+}
+
+func NewCertificateService(cs *CloudStackClient) *CertificateService {
+	return &CertificateService{cs: cs}
+}
+
+type CloudIdentifierService struct {
+	cs *CloudStackClient
+}
+
+func NewCloudIdentifierService(cs *CloudStackClient) *CloudIdentifierService {
+	return &CloudIdentifierService{cs: cs}
+}
+
+type ClusterService struct {
+	cs *CloudStackClient
+}
+
+func NewClusterService(cs *CloudStackClient) *ClusterService {
+	return &ClusterService{cs: cs}
+}
+
+type ConfigurationService struct {
+	cs *CloudStackClient
+}
+
+func NewConfigurationService(cs *CloudStackClient) *ConfigurationService {
+	return &ConfigurationService{cs: cs}
+}
+
+type DiskOfferingService struct {
+	cs *CloudStackClient
+}
+
+func NewDiskOfferingService(cs *CloudStackClient) *DiskOfferingService {
+	return &DiskOfferingService{cs: cs}
+}
+
+type DomainService struct {
+	cs *CloudStackClient
+}
+
+func NewDomainService(cs *CloudStackClient) *DomainService {
+	return &DomainService{cs: cs}
+}
+
+type EventService struct {
+	cs *CloudStackClient
+}
+
+func NewEventService(cs *CloudStackClient) *EventService {
+	return &EventService{cs: cs}
+}
+
+type FirewallService struct {
+	cs *CloudStackClient
+}
+
+func NewFirewallService(cs *CloudStackClient) *FirewallService {
+	return &FirewallService{cs: cs}
+}
+
+type GuestOSService struct {
+	cs *CloudStackClient
+}
+
+func NewGuestOSService(cs *CloudStackClient) *GuestOSService {
+	return &GuestOSService{cs: cs}
+}
+
+type HostService struct {
+	cs *CloudStackClient
+}
+
+func NewHostService(cs *CloudStackClient) *HostService {
+	return &HostService{cs: cs}
+}
+
+type HypervisorService struct {
+	cs *CloudStackClient
+}
+
+func NewHypervisorService(cs *CloudStackClient) *HypervisorService {
+	return &HypervisorService{cs: cs}
+}
+
+type ISOService struct {
+	cs *CloudStackClient
+}
+
+func NewISOService(cs *CloudStackClient) *ISOService {
+	return &ISOService{cs: cs}
+}
+
+type ImageStoreService struct {
+	cs *CloudStackClient
+}
+
+func NewImageStoreService(cs *CloudStackClient) *ImageStoreService {
+	return &ImageStoreService{cs: cs}
+}
+
+type InternalLBService struct {
+	cs *CloudStackClient
+}
+
+func NewInternalLBService(cs *CloudStackClient) *InternalLBService {
+	return &InternalLBService{cs: cs}
+}
+
+type LDAPService struct {
+	cs *CloudStackClient
+}
+
+func NewLDAPService(cs *CloudStackClient) *LDAPService {
+	return &LDAPService{cs: cs}
+}
+
+type LimitService struct {
+	cs *CloudStackClient
+}
+
+func NewLimitService(cs *CloudStackClient) *LimitService {
+	return &LimitService{cs: cs}
+}
+
+type LoadBalancerService struct {
+	cs *CloudStackClient
+}
+
+func NewLoadBalancerService(cs *CloudStackClient) *LoadBalancerService {
+	return &LoadBalancerService{cs: cs}
+}
+
+type NATService struct {
+	cs *CloudStackClient
+}
+
+func NewNATService(cs *CloudStackClient) *NATService {
+	return &NATService{cs: cs}
+}
+
+type NetworkACLService struct {
+	cs *CloudStackClient
+}
+
+func NewNetworkACLService(cs *CloudStackClient) *NetworkACLService {
+	return &NetworkACLService{cs: cs}
+}
+
+type NetworkDeviceService struct {
+	cs *CloudStackClient
+}
+
+func NewNetworkDeviceService(cs *CloudStackClient) *NetworkDeviceService {
+	return &NetworkDeviceService{cs: cs}
+}
+
+type NetworkOfferingService struct {
+	cs *CloudStackClient
+}
+
+func NewNetworkOfferingService(cs *CloudStackClient) *NetworkOfferingService {
+	return &NetworkOfferingService{cs: cs}
+}
+
+type NetworkService struct {
+	cs *CloudStackClient
+}
+
+func NewNetworkService(cs *CloudStackClient) *NetworkService {
+	return &NetworkService{cs: cs}
+}
+
+type NicService struct {
+	cs *CloudStackClient
+}
+
+func NewNicService(cs *CloudStackClient) *NicService {
+	return &NicService{cs: cs}
+}
+
+type NiciraNVPService struct {
+	cs *CloudStackClient
+}
+
+func NewNiciraNVPService(cs *CloudStackClient) *NiciraNVPService {
+	return &NiciraNVPService{cs: cs}
+}
+
+type OvsElementService struct {
+	cs *CloudStackClient
+}
+
+func NewOvsElementService(cs *CloudStackClient) *OvsElementService {
+	return &OvsElementService{cs: cs}
+}
+
+type PodService struct {
+	cs *CloudStackClient
+}
+
+func NewPodService(cs *CloudStackClient) *PodService {
+	return &PodService{cs: cs}
+}
+
+type PoolService struct {
+	cs *CloudStackClient
+}
+
+func NewPoolService(cs *CloudStackClient) *PoolService {
+	return &PoolService{cs: cs}
+}
+
+type PortableIPService struct {
+	cs *CloudStackClient
+}
+
+func NewPortableIPService(cs *CloudStackClient) *PortableIPService {
+	return &PortableIPService{cs: cs}
+}
+
+type ProjectService struct {
+	cs *CloudStackClient
+}
+
+func NewProjectService(cs *CloudStackClient) *ProjectService {
+	return &ProjectService{cs: cs}
+}
+
+type QuotaService struct {
+	cs *CloudStackClient
+}
+
+func NewQuotaService(cs *CloudStackClient) *QuotaService {
+	return &QuotaService{cs: cs}
+}
+
+type RegionService struct {
+	cs *CloudStackClient
+}
+
+func NewRegionService(cs *CloudStackClient) *RegionService {
+	return &RegionService{cs: cs}
+}
+
+type ResourcemetadataService struct {
+	cs *CloudStackClient
+}
+
+func NewResourcemetadataService(cs *CloudStackClient) *ResourcemetadataService {
+	return &ResourcemetadataService{cs: cs}
+}
+
+type ResourcetagsService struct {
+	cs *CloudStackClient
+}
+
+func NewResourcetagsService(cs *CloudStackClient) *ResourcetagsService {
+	return &ResourcetagsService{cs: cs}
+}
+
+type RouterService struct {
+	cs *CloudStackClient
+}
+
+func NewRouterService(cs *CloudStackClient) *RouterService {
+	return &RouterService{cs: cs}
+}
+
+type SSHService struct {
+	cs *CloudStackClient
+}
+
+func NewSSHService(cs *CloudStackClient) *SSHService {
+	return &SSHService{cs: cs}
+}
+
+type SecurityGroupService struct {
+	cs *CloudStackClient
+}
+
+func NewSecurityGroupService(cs *CloudStackClient) *SecurityGroupService {
+	return &SecurityGroupService{cs: cs}
+}
+
+type ServiceOfferingService struct {
+	cs *CloudStackClient
+}
+
+func NewServiceOfferingService(cs *CloudStackClient) *ServiceOfferingService {
+	return &ServiceOfferingService{cs: cs}
+}
+
+type SnapshotService struct {
+	cs *CloudStackClient
+}
+
+func NewSnapshotService(cs *CloudStackClient) *SnapshotService {
+	return &SnapshotService{cs: cs}
+}
+
+type StoragePoolService struct {
+	cs *CloudStackClient
+}
+
+func NewStoragePoolService(cs *CloudStackClient) *StoragePoolService {
+	return &StoragePoolService{cs: cs}
+}
+
+type StratosphereSSPService struct {
+	cs *CloudStackClient
+}
+
+func NewStratosphereSSPService(cs *CloudStackClient) *StratosphereSSPService {
+	return &StratosphereSSPService{cs: cs}
+}
+
+type SwiftService struct {
+	cs *CloudStackClient
+}
+
+func NewSwiftService(cs *CloudStackClient) *SwiftService {
+	return &SwiftService{cs: cs}
+}
+
+type SystemCapacityService struct {
+	cs *CloudStackClient
+}
+
+func NewSystemCapacityService(cs *CloudStackClient) *SystemCapacityService {
+	return &SystemCapacityService{cs: cs}
+}
+
+type SystemVMService struct {
+	cs *CloudStackClient
+}
+
+func NewSystemVMService(cs *CloudStackClient) *SystemVMService {
+	return &SystemVMService{cs: cs}
+}
+
+type TemplateService struct {
+	cs *CloudStackClient
+}
+
+func NewTemplateService(cs *CloudStackClient) *TemplateService {
+	return &TemplateService{cs: cs}
+}
+
+type UCSService struct {
+	cs *CloudStackClient
+}
+
+func NewUCSService(cs *CloudStackClient) *UCSService {
+	return &UCSService{cs: cs}
+}
+
+type UsageService struct {
+	cs *CloudStackClient
+}
+
+func NewUsageService(cs *CloudStackClient) *UsageService {
+	return &UsageService{cs: cs}
+}
+
+type UserService struct {
+	cs *CloudStackClient
+}
+
+func NewUserService(cs *CloudStackClient) *UserService {
+	return &UserService{cs: cs}
+}
+
+type VLANService struct {
+	cs *CloudStackClient
+}
+
+func NewVLANService(cs *CloudStackClient) *VLANService {
+	return &VLANService{cs: cs}
+}
+
+type VMGroupService struct {
+	cs *CloudStackClient
+}
+
+func NewVMGroupService(cs *CloudStackClient) *VMGroupService {
+	return &VMGroupService{cs: cs}
+}
+
+type VPCService struct {
+	cs *CloudStackClient
+}
+
+func NewVPCService(cs *CloudStackClient) *VPCService {
+	return &VPCService{cs: cs}
+}
+
+type VPNService struct {
+	cs *CloudStackClient
+}
+
+func NewVPNService(cs *CloudStackClient) *VPNService {
+	return &VPNService{cs: cs}
+}
+
+type VirtualMachineService struct {
+	cs *CloudStackClient
+}
+
+func NewVirtualMachineService(cs *CloudStackClient) *VirtualMachineService {
+	return &VirtualMachineService{cs: cs}
+}
+
+type VolumeService struct {
+	cs *CloudStackClient
+}
+
+func NewVolumeService(cs *CloudStackClient) *VolumeService {
+	return &VolumeService{cs: cs}
+}
+
+type ZoneService struct {
+	cs *CloudStackClient
+}
+
+func NewZoneService(cs *CloudStackClient) *ZoneService {
+	return &ZoneService{cs: cs}
+}


### PR DESCRIPTION
This PR is superseding PR #26165 is which some groundwork for this PR has been done. So this PR now fixes #26165 and fixes #26045.

I've been in contact with @ngtuna about this updated version of his earlier work (which is still in this PR as one squashed commit) and he has given his 👍  for this :wink:

This PR adds additional logic for allocating and associating a public IP, if the `—load-balancer-ip` option is not used. It will do proper management of public IP’s that are allocated by this provider ( so IP’s that are no longer needed/used will also be released again).

Additionally the provider can now also work with CloudStack projects and advanced (VPC) networks. And lastly the Zone interface now returns an actual zone (supplied by the cloud config), a few logical errors are fixed and the first few tests are added.

All the functionality is extensively tested against both basic and advanced (VPC) networks and of course all new and existing (integration) tests are all passing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29740)

<!-- Reviewable:end -->
