### PR TITLE
Bump exechealthz image

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -97,7 +97,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -97,7 +97,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -96,7 +96,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
With the new image at least if we observe an exec container taking more ram than it should (like the oom situation, which shouldn't happen today because of the increased limits), we can kubectl exec and check the pprof endpoints. 

Note that I'm not bumping the rc version, because I just did so with: https://github.com/kubernetes/kubernetes/pull/29693.
