### PR TITLE
Publish DNS records for ingress resources in KubeDNS.

### DIFF
--- a/pkg/dns/treecache.go
+++ b/pkg/dns/treecache.go
@@ -206,6 +206,10 @@ func (cache *TreeCache) ensureChildNode(path ...string) *TreeCache {
 	return childNode
 }
 
+func (cache *TreeCache) numEntries() int {
+	return len(cache.Entries)
+}
+
 // unused function. keeping it around in commented-fashion
 // in the future, we might need some form of this function so that
 // we can serialize to a file in a mounted empty dir..


### PR DESCRIPTION
Fixes issue #29345

E2E tests on the way.

``` release-note
KubeDNS now publishes DNS A/CNAME records for Ingress resources and can thus be used for Ingress discovery. The domain names are of the form `<ingressname>.<namespace>.ing.cluster.local.`. Clients can drop the `.cluster.local.` part in their DNS requests. 

Since Ingress only supports HTTP and HTTPS through ports 80 and 443 respectively for now, we do not publish SRV records for these resources. Please let us know if this is important for you.
```

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29768)

<!-- Reviewable:end -->
