### PR TITLE
Handle pod no NodeSelector in Scheduler PodSelectorMatches algorithm

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -489,6 +489,11 @@ func nodeMatchesNodeSelectorTerms(node *api.Node, nodeSelectorTerms []api.NodeSe
 
 // The pod can only schedule onto nodes that satisfy requirements in both NodeAffinity and nodeSelector.
 func podMatchesNodeLabels(pod *api.Pod, node *api.Node) bool {
+	// If pod has no NodeSelector, match the node directly.
+	if len(pod.Spec.NodeSelector) == 0 {
+		return true
+	}
+
 	// Check if node.Labels match pod.Spec.NodeSelector.
 	if len(pod.Spec.NodeSelector) > 0 {
 		selector := labels.SelectorFromSet(pod.Spec.NodeSelector)


### PR DESCRIPTION
If pod has no NodeSelector, should match the node directly.

```
func podMatchesNodeLabels(pod *api.Pod, node *api.Node) bool {
// If pod has no NodeSelector, match the node directly.
if len(pod.Spec.NodeSelector) == 0 {
    return true
}

// Check if node.Labels match pod.Spec.NodeSelector.
if len(pod.Spec.NodeSelector) > 0 {
    selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
    if !selector.Matches(labels.Set(node.Labels)) {
        return false
    }
}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29777)

<!-- Reviewable:end -->
