### PR TITLE
Clarify documentation that new admission control plugin must be imported

### DIFF
--- a/docs/design/admission_control.md
+++ b/docs/design/admission_control.md
@@ -104,6 +104,17 @@ func init() {
 }
 ```
 
+A **plug-in** must be added to the imports in [plugins.go](../../cmd/kube-apiserver/app/plugins.go)
+
+```go
+  // Admission policies
+  _ "k8s.io/kubernetes/plugin/pkg/admission/admit"
+  _ "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
+  _ "k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
+  ...
+  _ "<YOUR NEW PLUGIN>"
+```
+
 Invocation of admission control is handled by the **APIServer** and not
 individual **RESTStorage** implementations.
 


### PR DESCRIPTION
``` release-note
```

Admission control design doc doesn't mention importing the plugin to plugins.go. I was unable to get the plugin to build into my binary without it. Updated documentation to prevent future confusion.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29785)

<!-- Reviewable:end -->
