### PR TITLE
e2e-runner: Remove quotes from jq output

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -184,8 +184,8 @@ function dump_cluster_logs() {
 function setup_gci_vars() {
   local -r gci_staging_project=container-vm-image-staging
   local -r image_info="$(gcloud compute images describe-from-family ${JENKINS_GCI_IMAGE_FAMILY} --project=${gci_staging_project} --format=json)"
-  local -r image_description="$(echo ${image_info} | jq '.description')"
-  local -r image_name="$(echo ${image_info} | jq '.name')"
+  local -r image_description="$(echo ${image_info} | jq -r '.description')"
+  local -r image_name="$(echo ${image_info} | jq -r '.name')"
 
   if [[ "${JENKINS_USE_GCI_VERSION:-}" =~ ^[yY]$ ]]; then
     # GCI QA jobs use the builtin k8s version.


### PR DESCRIPTION
Recent GCI e2e test failures suggest that the image name was double quoted when
passed to gcloud. E.g.,

```
09:59:51  - Invalid value for field
'resource.disks[0].initializeParams.sourceImage':
'https://www.googleapis.com/compute/v1/projects/container-vm-image-staging/global/images/"gci-base-53-8530-36-0"'.
The referenced image resource cannot be found.
```

The `-r`, or `--raw-output` option strips quotes from jq's output. With this
change, the output looks like:

```
+ export KUBE_GCE_MASTER_IMAGE=gci-base-54-8650-0-0  # Not quoted
```

@spxtr Can you review this XS PR? All of our e2e jobs are failing due to this.

Also, this was a bug introduced by #29631. I tried several times to duplicate the Kubekins instance locally, but still couldn't get it running. It would be GREAT if Jenkins changes can be tested before getting merged. :)
