### PR TITLE
Updated fluentd configuration to spawn multiple threads for processing

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -266,4 +266,6 @@
    max_retry_wait 30
    # Disable the limit on the number of retries (retry forever).
    disable_retry_limit
+   # Use multiple threads for processing.
+   num_threads 8
 </match>

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
@@ -234,6 +234,8 @@
   max_retry_wait 30
   # Disable the limit on the number of retries (retry forever).
   disable_retry_limit
+  # Use multiple threads for processing.
+  num_threads 8
 </match>
 
 # Keep a smaller buffer here since these logs are less important than the user's
@@ -246,4 +248,5 @@
   flush_interval 5s
   max_retry_wait 30
   disable_retry_limit
+  num_threads 8
 </match>

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -218,6 +218,8 @@
   max_retry_wait 30
   # Disable the limit on the number of retries (retry forever).
   disable_retry_limit
+  # Use multiple threads for processing.
+  num_threads 8
 </match>
 
 # Keep a smaller buffer here since these logs are less important than the user's
@@ -230,4 +232,5 @@
   flush_interval 5s
   max_retry_wait 30
   disable_retry_limit
+  num_threads 8
 </match>


### PR DESCRIPTION
(by default, fluentd uses a single thread).

@a-robinson @igorpeshansky

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29801)

<!-- Reviewable:end -->
