### PR TITLE
Updated container runtime interface to represent all sandbox resources.

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -30,7 +30,7 @@ It has these top-level messages:
 	DNSOption
 	PortMapping
 	Mount
-	ResourceRequirements
+	ScalarResourceRequirement
 	PodSandboxResources
 	NamespaceOption
 	LinuxPodSandboxConfig
@@ -405,60 +405,52 @@ func (m *Mount) GetSelinuxRelabel() bool {
 	return false
 }
 
-// ResourceRequirements contains a set of resources
-// Valid resources are:
-// - cpu, in cores. (500m = .5 cores)
-// - memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-type ResourceRequirements struct {
-	// The maximum amount of compute resources allowed.
-	Limits *float64 `protobuf:"fixed64,1,opt,name=limits" json:"limits,omitempty"`
-	// The minimum amount of compute resources required.
-	// If Request is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value
-	Requests         *float64 `protobuf:"fixed64,2,opt,name=requests" json:"requests,omitempty"`
+// ScalarResourceRequirement describes a single scalar resource dimension.
+// Resource quantities should be expressed in base units. For example:
+// - cpu (in cores): 500m = .5 cores
+// - memory (in bytes): 500Gi = 500GiB = 500 * 1024 * 1024 * 1024
+type ScalarResourceRequirement struct {
+	// The maximum amount of a resource allowed.
+	Limit *float64 `protobuf:"fixed64,1,opt,name=limit" json:"limit,omitempty"`
+	// The minimum amount of a resource required.
+	// If Request is omitted for a container, it defaults to Limit if that is
+	// explicitly specified, otherwise to an implementation-defined value.
+	Request          *float64 `protobuf:"fixed64,2,opt,name=request" json:"request,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
-func (m *ResourceRequirements) Reset()         { *m = ResourceRequirements{} }
-func (m *ResourceRequirements) String() string { return proto.CompactTextString(m) }
-func (*ResourceRequirements) ProtoMessage()    {}
+func (m *ScalarResourceRequirement) Reset()         { *m = ScalarResourceRequirement{} }
+func (m *ScalarResourceRequirement) String() string { return proto.CompactTextString(m) }
+func (*ScalarResourceRequirement) ProtoMessage()    {}
 
-func (m *ResourceRequirements) GetLimits() float64 {
-	if m != nil && m.Limits != nil {
-		return *m.Limits
+func (m *ScalarResourceRequirement) GetLimit() float64 {
+	if m != nil && m.Limit != nil {
+		return *m.Limit
 	}
 	return 0
 }
 
-func (m *ResourceRequirements) GetRequests() float64 {
-	if m != nil && m.Requests != nil {
-		return *m.Requests
+func (m *ScalarResourceRequirement) GetRequest() float64 {
+	if m != nil && m.Request != nil {
+		return *m.Request
 	}
 	return 0
 }
 
-// PodSandboxResources contains the CPU/memory resource requirements.
+// PodSandboxResources contains the requirements for each resource type.
 type PodSandboxResources struct {
-	// CPU resource requirement.
-	Cpu *ResourceRequirements `protobuf:"bytes,1,opt,name=cpu" json:"cpu,omitempty"`
-	// Memory resource requirement.
-	Memory           *ResourceRequirements `protobuf:"bytes,2,opt,name=memory" json:"memory,omitempty"`
-	XXX_unrecognized []byte                `json:"-"`
+	// Runtimes generally expect mappings for "cpu" and "memory".
+	ScalarRequirements map[string]*ScalarResourceRequirement `protobuf:"bytes,1,rep,name=scalarRequirements" json:"scalarRequirements,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	XXX_unrecognized   []byte                                `json:"-"`
 }
 
 func (m *PodSandboxResources) Reset()         { *m = PodSandboxResources{} }
 func (m *PodSandboxResources) String() string { return proto.CompactTextString(m) }
 func (*PodSandboxResources) ProtoMessage()    {}
 
-func (m *PodSandboxResources) GetCpu() *ResourceRequirements {
+func (m *PodSandboxResources) GetScalarRequirements() map[string]*ScalarResourceRequirement {
 	if m != nil {
-		return m.Cpu
-	}
-	return nil
-}
-
-func (m *PodSandboxResources) GetMemory() *ResourceRequirements {
-	if m != nil {
-		return m.Memory
+		return m.ScalarRequirements
 	}
 	return nil
 }
@@ -2246,7 +2238,7 @@ func init() {
 	proto.RegisterType((*DNSOption)(nil), "runtime.DNSOption")
 	proto.RegisterType((*PortMapping)(nil), "runtime.PortMapping")
 	proto.RegisterType((*Mount)(nil), "runtime.Mount")
-	proto.RegisterType((*ResourceRequirements)(nil), "runtime.ResourceRequirements")
+	proto.RegisterType((*ScalarResourceRequirement)(nil), "runtime.ScalarResourceRequirement")
 	proto.RegisterType((*PodSandboxResources)(nil), "runtime.PodSandboxResources")
 	proto.RegisterType((*NamespaceOption)(nil), "runtime.NamespaceOption")
 	proto.RegisterType((*LinuxPodSandboxConfig)(nil), "runtime.LinuxPodSandboxConfig")

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -1,4 +1,4 @@
-// api.pb.go could be generate by hack/update-generate-runtime.sh
+// To regenerate api.pb.go run hack/update-generated-runtime.sh
 syntax = 'proto2';
 
 package runtime;
@@ -112,24 +112,23 @@ message Mount {
     optional bool selinux_relabel = 5;
 }
 
-// ResourceRequirements contains a set of resources
-// Valid resources are:
-// - cpu, in cores. (500m = .5 cores)
-// - memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-message ResourceRequirements {
-    // The maximum amount of compute resources allowed.
-    optional double limits = 1;
-    // The minimum amount of compute resources required.
-    // If Request is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value
-    optional double requests = 2;
+// ScalarResourceRequirement describes a single scalar resource dimension.
+// Resource quantities should be expressed in base units. For example:
+// - cpu (in cores): 500m = .5 cores
+// - memory (in bytes): 500Gi = 500GiB = 500 * 1024 * 1024 * 1024
+message ScalarResourceRequirement {
+    // The maximum amount of a resource allowed.
+    optional double limit = 1;
+    // The minimum amount of a resource required.
+    // If Request is omitted for a container, it defaults to Limit if that is
+    // explicitly specified, otherwise to an implementation-defined value.
+    optional double request = 2;
 }
 
-// PodSandboxResources contains the CPU/memory resource requirements.
+// PodSandboxResources contains the requirements for each resource type.
 message PodSandboxResources {
-    // CPU resource requirement.
-    optional ResourceRequirements cpu = 1;
-    // Memory resource requirement.
-    optional ResourceRequirements memory = 2;
+    // Runtimes generally expect mappings for "cpu" and "memory".
+    map<string, ScalarResourceRequirement> scalarRequirements = 1;
 }
 
 // NamespaceOption provides options for Linux namespaces.
@@ -146,7 +145,7 @@ message NamespaceOption {
 // host platforms and Linux-based containers.
 message LinuxPodSandboxConfig {
     // The parent cgroup of the pod sandbox.
-    // The cgroupfs style syntax will be used, but the container runtime can 
+    // The cgroupfs style syntax will be used, but the container runtime can
     // convert it to systemd semantices if needed.
     optional string cgroup_parent = 1;
     // The configurations for the sandbox's namespaces.
@@ -318,8 +317,8 @@ message ListPodSandboxResponse {
 }
 
 // ImageSpec is an internal representation of an image.  Currently, it wraps the
-// value of a Container's Image field (e.g. imageName, imageName:tag, or 
-// imageName:digest), but in the future it will include more detailed 
+// value of a Container's Image field (e.g. imageName, imageName:tag, or
+// imageName:digest), but in the future it will include more detailed
 // information about the different image types.
 message ImageSpec {
     optional string image = 1;


### PR DESCRIPTION
Updated CRI to represent all sandbox resources.

Previously only CPU and memory resources were encoded in the pod sandbox
resources protobuf.
- Changed name of `runtime.ResourceRequirements` to be singular and more precise: `runtime.ScalarResourceRequirement`.
- Regenerated gRPC stubs for container runtime.
- Made minor comment updates for the container runtime protobuf definitions.

/cc @derekwaynecarr @yujuhong @balajismaniam 

xref #28312
