### PR TITLE
Do not re-initialize the output on label selector conversion

### DIFF
--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -234,6 +234,9 @@ func Convert_resource_Quantity_To_resource_Quantity(in *resource.Quantity, out *
 }
 
 func Convert_map_to_unversioned_LabelSelector(in *map[string]string, out *unversioned.LabelSelector, s conversion.Scope) error {
+	if in == nil {
+		return nil
+	}
 	out = new(unversioned.LabelSelector)
 	for labelKey, labelValue := range *in {
 		utillabels.AddLabelToSelector(out, labelKey, labelValue)


### PR DESCRIPTION
This conversion will always kill whatever is passed in the output.

@kargakis @deads2k PTAL

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29841)

<!-- Reviewable:end -->
