### PR TITLE
Use "fmt.Sprintf" instead of the codeToString function

### DIFF
--- a/pkg/apiserver/metrics/metrics.go
+++ b/pkg/apiserver/metrics/metrics.go
@@ -18,9 +18,9 @@ package metrics
 
 import (
 	"bufio"
+	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"time"
 
 	utilnet "k8s.io/kubernetes/pkg/util/net"
@@ -68,7 +68,8 @@ func Register() {
 
 func Monitor(verb, resource *string, client, contentType string, httpCode int, reqStart time.Time) {
 	elapsed := float64((time.Since(reqStart)) / time.Microsecond)
-	requestCounter.WithLabelValues(*verb, *resource, client, contentType, codeToString(httpCode)).Inc()
+	httpCodeStr := fmt.Sprintf("%d", httpCode)
+	requestCounter.WithLabelValues(*verb, *resource, client, contentType, httpCodeStr).Inc()
 	requestLatencies.WithLabelValues(*verb, *resource).Observe(elapsed)
 	requestLatenciesSummary.WithLabelValues(*verb, *resource).Observe(elapsed)
 }
@@ -140,106 +141,4 @@ func (f *fancyResponseWriterDelegator) Flush() {
 
 func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return f.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-// Small optimization over Itoa
-func codeToString(s int) string {
-	switch s {
-	case 100:
-		return "100"
-	case 101:
-		return "101"
-
-	case 200:
-		return "200"
-	case 201:
-		return "201"
-	case 202:
-		return "202"
-	case 203:
-		return "203"
-	case 204:
-		return "204"
-	case 205:
-		return "205"
-	case 206:
-		return "206"
-
-	case 300:
-		return "300"
-	case 301:
-		return "301"
-	case 302:
-		return "302"
-	case 304:
-		return "304"
-	case 305:
-		return "305"
-	case 307:
-		return "307"
-
-	case 400:
-		return "400"
-	case 401:
-		return "401"
-	case 402:
-		return "402"
-	case 403:
-		return "403"
-	case 404:
-		return "404"
-	case 405:
-		return "405"
-	case 406:
-		return "406"
-	case 407:
-		return "407"
-	case 408:
-		return "408"
-	case 409:
-		return "409"
-	case 410:
-		return "410"
-	case 411:
-		return "411"
-	case 412:
-		return "412"
-	case 413:
-		return "413"
-	case 414:
-		return "414"
-	case 415:
-		return "415"
-	case 416:
-		return "416"
-	case 417:
-		return "417"
-	case 418:
-		return "418"
-
-	case 500:
-		return "500"
-	case 501:
-		return "501"
-	case 502:
-		return "502"
-	case 503:
-		return "503"
-	case 504:
-		return "504"
-	case 505:
-		return "505"
-
-	case 428:
-		return "428"
-	case 429:
-		return "429"
-	case 431:
-		return "431"
-	case 511:
-		return "511"
-
-	default:
-		return strconv.Itoa(s)
-	}
 }


### PR DESCRIPTION
The PR use "fmt.Sprintf" instead of the codeToString function in metrics.go. The codeToString function is redundant, I think. It need to change according to HTTP status. It's very easy to miss, and   actually it has missed the StatusUnavailableForLegalReasons(451). It seem more concise with "fmt.Sprintf".
