### PR TITLE
[WIP] Update hyperkube for self-hosted flannel and proxy

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -42,15 +42,11 @@ COPY hyperkube /hyperkube
 COPY static-pods/master.json /etc/kubernetes/manifests/
 COPY static-pods/etcd.json /etc/kubernetes/manifests/
 COPY static-pods/addon-manager.json /etc/kubernetes/manifests/
-
-# TODO: Move out kube-proxy to a DaemonSet again
 COPY static-pods/kube-proxy.json /etc/kubernetes/manifests/
 
 # Manifests for the docker-multinode guide
 COPY static-pods/master-multi.json /etc/kubernetes/manifests-multi/
 COPY static-pods/addon-manager.json /etc/kubernetes/manifests-multi/
-
-# TODO: Move out kube-proxy to a DaemonSet again
 COPY static-pods/kube-proxy.json /etc/kubernetes/manifests-multi/
 
 # Copy over all addons
@@ -70,6 +66,12 @@ COPY cni /opt/cni
 
 # Copy overlay configuration to default directory
 COPY cni-conf /etc/cni/net.d
+
+# Copy flannel and proxy daemonsets
+COPY daemonsets /daemonsets
+
+# Copy the kubelet wrapper
+COPY run-kubelet /
 
 # Create symlinks for each hyperkube server
 # TODO: this is unreliable for now (e.g. running "/kubelet" panics)

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -16,8 +16,8 @@
 #
 # Usage:
 #   [ARCH=amd64] [REGISTRY="gcr.io/google_containers"] make (build|push) VERSION={some_version_number e.g. v1.2.0}
-
-REGISTRY?=gcr.io/google_containers
+VERSION=v1.3.0
+REGISTRY?=taimir93
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 CNI_RELEASE=8a936732094c0941e1543ef5d292a1f4fffa1ac5
@@ -61,17 +61,17 @@ endif
 	cp ../../addons/dns/skydns-svc.yaml.base ${TEMP_DIR}/addons/skydns-svc.yaml
 	cp ../../addons/dashboard/dashboard-controller.yaml ${TEMP_DIR}/addons
 	cp ../../addons/dashboard/dashboard-service.yaml ${TEMP_DIR}/addons
-	
+
 	# TODO: Move out kube-proxy to a DaemonSet again
 	#cp kube-proxy-ds.yaml ${TEMP_DIR}/addons/kube-proxy.yaml
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
 
-	cd ${TEMP_DIR} && sed -i.back "s|VERSION|${VERSION}|g" addons/*.yaml static-pods/*.json
-	cd ${TEMP_DIR} && sed -i.back "s|REGISTRY|${REGISTRY}|g" addons/*.yaml static-pods/*.json
-	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g" addons/*.yaml static-pods/*.json
+	cd ${TEMP_DIR} && sed -i.back "s|VERSION|${VERSION}|g" daemonsets/*.yaml static-pods/*.json
+	cd ${TEMP_DIR} && sed -i.back "s|REGISTRY|${REGISTRY}|g" daemonsets/*.yaml static-pods/*.json
+	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g" daemonsets/*.yaml static-pods/*.json
 	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${QEMUARCH}|g" Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
-	cd ${TEMP_DIR} && sed -i.back "s|-amd64|-${ARCH}|g" addons/*.yaml
+	cd ${TEMP_DIR} && sed -i.back "s|-amd64|-${ARCH}|g" daemonsets/*.yaml
 	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__REPLICAS__|1|g;s|__PILLAR__DNS__SERVER__|10.0.0.10|g;" addons/skydns*.yaml
 	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g;s|__PILLAR__FEDERATIONS__DOMAIN__MAP__||g;" addons/skydns*.yaml
 	rm ${TEMP_DIR}/addons/*.back

--- a/cluster/images/hyperkube/copy-addons.sh
+++ b/cluster/images/hyperkube/copy-addons.sh
@@ -20,6 +20,16 @@
 # This way we're using the latest manifests from hyperkube without updating
 # kube-addon-manager which is used for other deployments too
 
+if [[ ${USE_CNI} == true ]]; then
+	# copy the daemonsets
+	cp /daemonsets/flannel-ds.yaml /etc/kubernetes/addons/
+	cp /daemonsets/kube-proxy-ds.yaml /etc/kubernetes/addons/
+
+	# configure the master IP in the templates
+	sed -i -e "s#MASTER_IP#${MASTER_IP}#g" /etc/kubernetes/addons/flannel-ds.yaml
+	sed -i -e "s#MASTER_IP#${MASTER_IP}#g" /etc/kubernetes/addons/kube-proxy-ds.yaml
+fi
+
 # While there is no data copied over to the emptyDir, try to copy it.
 while [[ ! -d /srv/kubernetes/addons ]]; do
 	cp -r /etc/kubernetes/* /srv/kubernetes/

--- a/cluster/images/hyperkube/daemonsets/flannel-ds.yaml
+++ b/cluster/images/hyperkube/daemonsets/flannel-ds.yaml
@@ -1,0 +1,46 @@
+---
+  apiVersion: extensions/v1beta1
+  kind: DaemonSet
+  metadata:
+    name: k8s-flannel
+    namespace: kube-system
+    labels:
+      name: k8s-flannel
+      version: v1
+      kubernetes.io/cluster-service: "true"
+  spec:
+    template:
+      metadata:
+        labels:
+          name: k8s-flannel
+          version: v1
+          kubernetes.io/cluster-service: "true"
+      spec:
+        hostNetwork: true
+        containers:
+          -
+            securityContext:
+              privileged: true
+            name: k8s-flannel
+            image: quay.io/coreos/flannel:0.5.5
+            command:
+              - /opt/bin/flanneld
+              - --ip-masq=true
+              - --iface=eth0
+              - --etcd-endpoints=http://MASTER_IP:4001
+            volumeMounts:
+              -
+                name: devnet
+                mountPath: /dev/net
+              -
+                name: flannel-subnet
+                mountPath: /run/flannel
+        volumes:
+          -
+            name: devnet
+            hostPath:
+              path: /dev/net
+          -
+            name: flannel-subnet
+            hostPath:
+              path: /run/flannel

--- a/cluster/images/hyperkube/daemonsets/kube-proxy-ds.yaml
+++ b/cluster/images/hyperkube/daemonsets/kube-proxy-ds.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Move out kube-proxy to a DaemonSet again
-# This is disabled for the v1.3 release, due to bootstrapping complexities
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -38,7 +36,7 @@ spec:
         command:
         - /hyperkube
         - proxy
-        - --master=http://127.0.0.1:8080
+        - --master=http://MASTER_IP:8080
         - --v=2
         - --resource-container=""
         securityContext:

--- a/cluster/images/hyperkube/run-kubelet
+++ b/cluster/images/hyperkube/run-kubelet
@@ -1,0 +1,19 @@
+#!/bin/bash
+export command=$@
+
+echo "Master ip: ${MASTER_IP}"
+echo "User CNI: ${USE_CNI}"
+
+sed -i -e "s#MASTER_IP_VALUE#${MASTER_IP}#g" /etc/kubernetes/manifests/addon-manager.json
+sed -i -e "s#USE_CNI_VALUE#${USE_CNI}#g" /etc/kubernetes/manifests/addon-manager.json
+sed -i -e "s#MASTER_IP_VALUE#${MASTER_IP}#g" /etc/kubernetes/manifests-multi/addon-manager.json
+sed -i -e "s#USE_CNI_VALUE#${USE_CNI}#g" /etc/kubernetes/manifests-multi/addon-manager.json
+
+if [[ ${USE_CNI} == true ]]; then
+  # remove kube-proxy static pod if present
+  rm -rf /etc/kubernetes/manifests-multi/kube-proxy.json
+  rm -rf etc/kubernetes/manifests/kube-proxy.json
+fi
+
+# RUN kubelet with specified command
+/hyperkube kubelet $command

--- a/cluster/images/hyperkube/static-pods/addon-manager.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager.json
@@ -38,6 +38,16 @@
             "mountPath": "/srv/kubernetes/",
             "readOnly": false
           }
+        ],
+        "env": [
+          {
+            "name": "MASTER_IP",
+            "value": "MASTER_IP_VALUE"
+          },
+          {
+            "name": "USE_CNI",
+            "value": "USE_CNI_VALUE"
+          }
         ]
       }
     ],


### PR DESCRIPTION
#### [WIP] Please do not merge yet

See https://github.com/kubernetes/kube-deploy/pull/184.

This pull-request should enable self-hosting of `flannel` and `kube-proxy` in the `docker-multinode` cluster provisioning, from the `kube-deploy` project.

So far I've added 2 daemonset definitions for `flannel` and `kube-proxy`, respectively. The biggest issue I've had was how I could propagate the `MASTER_IP` to the daemon-sets. Obviously this configuration has to be updated during cluster creation. Is there any reasonable alternative to `sed -i` at this point? I would really want to avoid the `sed` hacks ...

Right now the `run-kubelet` wrapper `sed`-s the static pod for the `addon-manager`, which in turn `sed`-s the daemonset definitions in the addons folder. 

cc @luxas @zreigz @cheld

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29848)

<!-- Reviewable:end -->
