### PR TITLE
In cluster scripts correct gcloud list arg from '--zone' to '--zones'

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -74,11 +74,11 @@ echo "Provider: ${KUBERNETES_PROVIDER:-}"
 # List resources related to instances, filtering by the instance prefix if
 # provided.
 gcloud-compute-list instance-templates --regexp="${INSTANCE_PREFIX}.*"
-gcloud-compute-list instance-groups ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
-gcloud-compute-list instances ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list instance-groups ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list instances ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
 
 # List disk resources, filterying by instance prefix if provided.
-gcloud-compute-list disks ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list disks ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
 
 # List network resources. We include names starting with "a", corresponding to
 # those that Kubernetes creates.

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -221,7 +221,7 @@ function do-node-upgrade() {
   for group in ${INSTANCE_GROUPS[@]}; do
     old_templates+=($(gcloud compute instance-groups managed list \
         --project="${PROJECT}" \
-        --zone="${ZONE}" \
+        --zones="${ZONE}" \
         --regexp="${group}" \
         --format='value(instanceTemplate)' || true))
     update=$(gcloud alpha compute rolling-updates \

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -333,7 +333,7 @@ function detect-node-names {
   detect-project
   INSTANCE_GROUPS=()
   INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
-    --zone "${ZONE}" --project "${PROJECT}" \
+    --zones "${ZONE}" --project "${PROJECT}" \
     --regexp "${NODE_INSTANCE_PREFIX}-.+" \
     --format='value(instanceGroup)' || true))
   NODE_NAMES=()
@@ -1163,7 +1163,7 @@ function kube-down {
   # Find out what minions are running.
   local -a minions
   minions=( $(gcloud compute instances list \
-                --project "${PROJECT}" --zone "${ZONE}" \
+                --project "${PROJECT}" --zones "${ZONE}" \
                 --regexp "${NODE_INSTANCE_PREFIX}-.+" \
                 --format='value(name)') )
   # If any minions are running, delete them in batches.
@@ -1275,7 +1275,7 @@ function check-resources {
   # Find out what minions are running.
   local -a minions
   minions=( $(gcloud compute instances list \
-                --project "${PROJECT}" --zone "${ZONE}" \
+                --project "${PROJECT}" --zones "${ZONE}" \
                 --regexp "${NODE_INSTANCE_PREFIX}-.+" \
                 --format='value(name)') )
   if (( "${#minions[@]}" > 0 )); then


### PR DESCRIPTION
I started getting these messages when doing `kube-up` and similar operations:

```
WARNING: Abbreviated flag [--zone] will be disabled in release 132.0.0, use the full name [--zones].
```

This PR corrects the flag where used.

Note there are many uses of `--zone` on commands like `gcloud instances describe` which are still correct - those commands do not accept multiple zones.
