### PR TITLE
Fix make rule verify for MacOS

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -21,7 +21,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/lib/util.sh"
 
-if [ -n "${VERBOSE}" ]; then
+if [ -n "${VERBOSE:-}" ]; then
     SILENT=false
 else
     SILENT=true


### PR DESCRIPTION
@thockin running `make verify` returns an error on MacOS (I think because of the old bash version 3.2):

``` bash
$ make verify
hack/make-rules/verify.sh: line 24: VERBOSE: unbound variable
make: *** [verify] Error 1
```

This PR sets the Variable to a zero length string if `Verbose` is not set on the system and allows Mac users to run `make verify`.
