### PR TITLE
Delete useless code

### DIFF
--- a/federation/pkg/federation-controller/service/cluster_helper.go
+++ b/federation/pkg/federation-controller/service/cluster_helper.go
@@ -181,7 +181,6 @@ func (cc *clusterClientCache) delFromClusterSet(obj interface{}) {
 // addToClusterSet inserts the new cluster to clusterSet and creates a corresponding
 // restclient to map clusterKubeClientMap
 func (cc *clusterClientCache) addToClientMap(obj interface{}) {
-	cluster := obj.(*v1beta1.Cluster)
 	cc.rwlock.Lock()
 	defer cc.rwlock.Unlock()
 	cluster, ok := obj.(*v1beta1.Cluster)


### PR DESCRIPTION
The correct code is `cluster, ok := obj.(*v1beta1.Cluster)`, so the above `cluster := obj.(*v1beta1.Cluster)` is useless.
