### PR TITLE
Verify if Secure and InsecurePort are equal for apiserver

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -585,16 +585,18 @@ func verifyEtcdServersList(options *options.ServerRunOptions) {
 	}
 }
 
-func verifySecurePort(options *options.ServerRunOptions) {
+func verifySecureAndInsecurePort(options *options.ServerRunOptions) {
 	if options.SecurePort < 0 || options.SecurePort > 65535 {
 		glog.Fatalf("--secure-port %v must be between 0 and 65535, inclusive. 0 for turning off secure port.", options.SecurePort)
 	}
-}
 
-// TODO: Allow 0 to turn off insecure port.
-func verifyInsecurePort(options *options.ServerRunOptions) {
+	// TODO: Allow 0 to turn off insecure port.
 	if options.InsecurePort < 1 || options.InsecurePort > 65535 {
 		glog.Fatalf("--insecure-port %v must be between 1 and 65535, inclusive.", options.InsecurePort)
+	}
+
+	if options.SecurePort == options.InsecurePort {
+		glog.Fatalf("--secure-port and --insecure-port cannot use the same port.")
 	}
 }
 
@@ -602,8 +604,7 @@ func ValidateRunOptions(options *options.ServerRunOptions) {
 	verifyClusterIPFlags(options)
 	verifyServiceNodePort(options)
 	verifyEtcdServersList(options)
-	verifySecurePort(options)
-	verifyInsecurePort(options)
+	verifySecureAndInsecurePort(options)
 }
 
 func DefaultAndValidateRunOptions(options *options.ServerRunOptions) {


### PR DESCRIPTION
If we specify the kube-apiserver flags `--secure-port` and `--insecure-port` with the same port, the server will print the below error info repeatedly. In fact, it's meaningless to do this. It should verify if the two flags are equal. If so, the server should give error info and exit directly.

```
root@vm:~# [restful] 2016/08/01 13:11:52 log.go:30: [restful/swagger] listing is available at https://172.16.1.11:8888/swaggerapi/
[restful] 2016/08/01 13:11:52 log.go:30: [restful/swagger] https://172.16.1.11:8888/swaggerui/ is mapped to folder /swagger-ui/
E0801 13:11:53.102232    2481 genericapiserver.go:733] Unable to listen for secure (listen tcp 0.0.0.0:8888: bind: address already in use); will try again.
E0801 13:12:08.116463    2481 genericapiserver.go:733] Unable to listen for secure (listen tcp 0.0.0.0:8888: bind: address already in use); will try again.
```

After fixing, the print is like this:

```
root@vm:~# F0801 11:51:44.308180    1921 genericapiserver.go:599] --secure-port and --insecure-port cannot use the same port.
goroutine 1 [running]:
k8s.io/kubernetes/vendor/github.com/golang/glog.stacks(0x4871d00, 0x0, 0x0, 0x0)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:766 +0xb8
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).output(0x48517c0, 0xc800000003, 0xc820368000, 0x470aeab, 0x13, 0x257, 0x0)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:717 +0x259
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).printf(0x48517c0, 0xc800000003, 0x3518280, 0x3b, 0x0, 0x0, 0x0)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:655 +0x1d4
k8s.io/kubernetes/vendor/github.com/golang/glog.Fatalf(0x3518280, 0x3b, 0x0, 0x0, 0x0)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:1145 +0x5d
k8s.io/kubernetes/pkg/genericapiserver.verifySecureAndInsecurePort(0xc820132800)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:599 +0xad
k8s.io/kubernetes/pkg/genericapiserver.ValidateRunOptions(0xc820132800)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:607 +0x4b
k8s.io/kubernetes/pkg/genericapiserver.DefaultAndValidateRunOptions(0xc820132800)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:611 +0x4e
k8s.io/kubernetes/cmd/kube-apiserver/app.Run(0xc8202c9560, 0x0, 0x0)
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:84 +0x8e
main.main()
    /home/paas/zxp/code/k8s/fork/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/apiserver.go:48 +0x111

[2]+  Exit 255
```

This will fix the same issue of federation-apiserver.

cc @lavalamp @quinton-hoole 
