### PR TITLE
Return nil directly when err is nil.

### DIFF
--- a/federation/pkg/federation-controller/cluster/cluster_client.go
+++ b/federation/pkg/federation-controller/cluster/cluster_client.go
@@ -60,7 +60,7 @@ func NewClusterClientSet(c *federation_v1beta1.Cluster) (*ClusterClient, error) 
 			return nil, nil
 		}
 	}
-	return &clusterClientSet, err
+	return &clusterClientSet, nil
 }
 
 // GetClusterHealthStatus gets the kubernetes cluster health status by requesting "/healthz"


### PR DESCRIPTION
When err is nil, return nil directly instead of `err` to avoid confusion.
