### PR TITLE
Add dry run capability to cherry_pick_pull.sh

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -16,7 +16,8 @@
 
 # Checkout a PR from GitHub. (Yes, this is sitting in a Git tree. How
 # meta.) Assumes you care about pulls from remote "upstream" and
-# checks thems out to a branch named pull_12345.
+# checks thems out to a branch named:
+#  automated-cherry-pick-of-<pr>-<target branch>-<timestamp>
 
 set -o errexit
 set -o nounset
@@ -27,6 +28,7 @@ cd "${KUBE_ROOT}"
 
 declare -r STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r REBASEMAGIC="${KUBE_ROOT}/.git/rebase-apply"
+DRY_RUN=${DRY_RUN:-""}
 
 if [[ -z ${GITHUB_USER:-} ]]; then
   echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
@@ -40,11 +42,15 @@ fi
 
 if [[ "$#" -lt 2 ]]; then
   echo "${0} <remote branch> <pr-number>...: cherry pick one or more <pr> onto <remote branch> and leave instructions for proposing pull request"
-  echo ""
+  echo
   echo "  Checks out <remote branch> and handles the cherry-pick of <pr> (possibly multiple) for you."
   echo "  Examples:"
   echo "    $0 upstream/release-3.14 12345        # Cherry-picks PR 12345 onto upstream/release-3.14 and proposes that as a PR."
   echo "    $0 upstream/release-3.14 12345 56789  # Cherry-picks PR 12345, then 56789 and proposes the combination as a single PR."
+  echo
+  echo "  Set the DRY_RUN environment var to skip git push and creating PR."
+  echo "  This is useful for creating patches to a release branch without making a PR."
+  echo "  When DRY_RUN is set the script will leave you in a branch containing the commits you cherry-picked."
   exit 2
 fi
 
@@ -67,7 +73,7 @@ declare -r PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#123
 declare -r PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
 
 echo "+++ Updating remotes..."
-git remote update
+git remote update upstream origin
 
 if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
   echo "!!! '${BRANCH}' not found. The second argument should be something like upstream/release-0.21."
@@ -84,20 +90,45 @@ cleanbranch=""
 prtext=""
 gitamcleanup=false
 function return_to_kansas {
-  echo ""
-  echo "+++ Returning you to the ${STARTINGBRANCH} branch and cleaning up."
   if [[ "${gitamcleanup}" == "true" ]]; then
+    echo
+    echo "+++ Aborting in-progress git am."
     git am --abort >/dev/null 2>&1 || true
   fi
-  git checkout -f "${STARTINGBRANCH}" >/dev/null 2>&1 || true
-  if [[ -n "${cleanbranch}" ]]; then
-    git branch -D "${cleanbranch}" >/dev/null 2>&1 || true
-  fi
-  if [[ -n "${prtext}" ]]; then
-    rm "${prtext}"
+
+  # return to the starting branch and delete the PR text file
+  if [[ -z "${DRY_RUN}" ]]; then
+    echo
+    echo "+++ Returning you to the ${STARTINGBRANCH} branch and cleaning up."
+    git checkout -f "${STARTINGBRANCH}" >/dev/null 2>&1 || true
+    if [[ -n "${cleanbranch}" ]]; then
+      git branch -D "${cleanbranch}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${prtext}" ]]; then
+      rm "${prtext}"
+    fi
   fi
 }
 trap return_to_kansas EXIT
+
+function make-a-pr() {
+  local rel="$(basename "${BRANCH}")"
+  echo
+  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
+
+  # This looks like an unnecessary use of a tmpfile, but it avoids
+  # https://github.com/github/hub/issues/976 Otherwise stdin is stolen
+  # when we shove the heredoc at hub directly, tickling the ioctl
+  # crash.
+  prtext="$(mktemp -t prtext.XXXX)" # cleaned in return_to_kansas
+  cat >"${prtext}" <<EOF
+Automated cherry pick of ${PULLSUBJ}
+
+Cherry pick of ${PULLSUBJ} on ${rel}.
+EOF
+
+  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}"
+}
 
 git checkout -b "${NEWBRANCHUNIQ}" "${BRANCH}"
 cleanbranch="${NEWBRANCHUNIQ}"
@@ -137,23 +168,17 @@ for pull in "${PULLS[@]}"; do
 done
 gitamcleanup=false
 
-function make-a-pr() {
-  local rel="$(basename "${BRANCH}")"
-  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
-
-  # This looks like an unnecessary use of a tmpfile, but it avoids
-  # https://github.com/github/hub/issues/976 Otherwise stdin is stolen
-  # when we shove the heredoc at hub directly, tickling the ioctl
-  # crash.
-  prtext="$(mktemp -t prtext.XXXX)" # cleaned in return_to_kansas
-  cat >"${prtext}" <<EOF
-Automated cherry pick of ${PULLSUBJ}
-
-Cherry pick of ${PULLSUBJ} on ${rel}.
-EOF
-
-  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}"
-}
+if [[ -n "${DRY_RUN}" ]]; then
+  echo "!!! Skipping git push and PR creation because you set DRY_RUN."
+  echo "To return to the branch you were in when you invoked this script:"
+  echo
+  echo "  git checkout ${STARTINGBRANCH}"
+  echo
+  echo "To delete this branch:"
+  echo
+  echo "  git branch -D ${NEWBRANCHUNIQ}"
+  exit 0
+fi
 
 if git remote -v | grep ^origin | grep kubernetes/kubernetes.git; then
   echo "!!! You have 'origin' configured as your kubernetes/kubernetes.git"


### PR DESCRIPTION
When creating patches for downstream projects like OpenShift, I found it to be helpful to have a dry run mode for the cherry-pick script.

@k8s-oncall

cc @kubernetes/rh-cluster-infra 
