### PR TITLE
Update the AppArmor design proposal

### DIFF
--- a/docs/proposals/apparmor.md
+++ b/docs/proposals/apparmor.md
@@ -180,13 +180,13 @@ Enforcement of the policy is standard. See the
 
 ## Deploying profiles
 
-We will provide a reference implementation of a pod for loading profiles on nodes, but there will
-not be an official mechanism or API in the initial version (see
+We will provide a reference implementation of a DaemonSet pod for loading profiles on nodes, but
+there will not be an official mechanism or API in the initial version (see
 [future work](#deploying-profiles-1)).  The reference container will contain the `apparmor_parser`
 tool and a script for using the tool to load all profiles in a set of (configurable)
-directories. The initial implementation will be designed to run once to completion, as opposed to
-watching the directories for changes. It can be run in a DaemonSet to load the profiles onto all
-nodes. The pod will need to be run in privileged mode.
+directories. The initial implementation will poll (with a configurable interval) the directories for
+additions, but will not update or unload existing profiles. The pod can be run in a DaemonSet to
+load the profiles onto all nodes. The pod will need to be run in privileged mode.
 
 This simple design should be sufficient to deploy AppArmor profiles from any volume source, such as
 a ConfigMap or PersistentDisk. Users seeking more advanced features should be able extend this

--- a/docs/proposals/apparmor.md
+++ b/docs/proposals/apparmor.md
@@ -106,8 +106,8 @@ but an official supported mechanism for deploying profiles is out of scope for a
 
 ## Overview
 
-An AppArmor profile can be specified for either a pod or container through the Kubernetes API with a
-pod annotation. If a profile is specified, the Kubelet will verify that the node meets the required
+An AppArmor profile can be specified for a container through the Kubernetes API with a pod
+annotation. If a profile is specified, the Kubelet will verify that the node meets the required
 [prerequisites](#prerequisites) (e.g. the profile is already configured on the node) before starting
 the container, and will not run the container if the profile cannot be applied. If the requirements
 are met, the container runtime will configure the appropriate options to apply the profile. Profile
@@ -142,13 +142,12 @@ Ubuntu system. The profiles can be found at `{securityfs}/apparmor/profiles`
 
 The intial alpha support of AppArmor will follow the pattern
 [used by seccomp](https://github.com/kubernetes/kubernetes/pull/25324) and specify profiles through
-annotations. Profiles can be specified through pod annotations, as either a container
-profile, a pod profile (applied to all pod containers), or both (in which case the container
-annotation overrides the pod annotation). The annotation format is a URI key, and a profile name
-value:
+annotations. Profiles can be specified per-container through pod annotations. The annotation format
+is a key matching the container, and a profile name value:
 
-- `apparmor.security.alpha.kubernetes.io/container/<container_name>`
-- `apparmor.security.alpha.kubernetes.io/pod`
+```
+container.apparmor.security.alpha.kubernetes.io/<container_name>=<profile_name>
+```
 
 The profiles can be specified in the following formats (following the convention used by [seccomp](../../docs/design/seccomp.md#api-changes)):
 
@@ -165,7 +164,7 @@ The profiles can be specified in the following formats (following the convention
 ### Pod Security Policy
 
 The [PodSecurityPolicy](security-context-constraints.md) allows cluster administrators to control
-the security context for a pod its containers. An annotation can be specified on the
+the security context for a pod and its containers. An annotation can be specified on the
 PodSecurityPolicy to restrict which AppArmor profiles can be used, and specify a default if no
 profile is specified.
 
@@ -205,8 +204,6 @@ e2e test suite on an AppArmor enabled node. The cases we should test are:
 - *Node AppArmor enforcement* - These tests need to run on AppArmor enabled nodes, in the node e2e
   suite.
   - A valid container profile gets applied
-  - A valid pod profile is applied to all containers
-  - A valid pod and container profile uses the container profile
   - An unloaded profile will be rejected
 
 # Future work


### PR DESCRIPTION
3 modifications to the original AppArmor design proposal:
1. Remove the pod-level AppArmor profile specification, since it was unnecessary complexity. I think the typical multi-container case is a main app, some side-cars (e.g. log helpers), and maybe some init containers. All of those containers are likely to have very different permissions needs, so I do not see benefit to the pod-level profile. If there is sufficient demand (i.e. user feedback) for this feature we can add it back.
2. Added a proposal for the beta (and GA) API. Beginning the discussion of this API now will smooth the transition from alpha, and guide the implementation of the internal API.
3. [EDIT] The profile deployment pod will poll the source directories for changes. This change is motivated by the fact that DaemonSets must run with RestartAlways.

/cc @bgrant0607 @erictune @pmorie @pweil-
