### PR TITLE
Clone kubernetes/release into something other than /release due to conflict with /release.

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -60,20 +60,21 @@ go run ./hack/e2e.go -v --build
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then
   echo "Not pushed to GCS..."
-elif $RELEASE_INFRA_PUSH; then
-  git clone https://github.com/kubernetes/release $WORKSPACE/release
-  readonly release_infra_clone=$WORKSPACE/release
+elif ${RELEASE_INFRA_PUSH-}; then
+  readonly release_infra_clone="${WORKSPACE}/_tmp/release.git"
+  mkdir -p ${WORKSPACE}/_tmp
+  git clone https://github.com/kubernetes/release ${release_infra_clone}
 
-  if [[ ! -x $release_infra_clone/push-ci-build.sh ]]; then
+  if [[ ! -x ${release_infra_clone}/push-ci-build.sh ]]; then
     echo "FATAL: Something went wrong." \
-         "$release_infra_clone/push-ci-build.sh isn't available. Exiting..." >&2
+         "${release_infra_clone}/push-ci-build.sh isn't available. Exiting..." >&2
     exit 1
   fi
 
-  $FEDERATION && federation_flag="--federation"
+  ${FEDERATION} && federation_flag="--federation"
   # Use --nomock to do the real thing
   #$release_infra_clone/push-ci-build.sh --nomock ${federation_flag-}
-  $release_infra_clone/push-ci-build.sh ${federation_flag-}
+  ${release_infra_clone}/push-ci-build.sh ${federation_flag-}
 else
   ./build/push-ci-build.sh
 fi


### PR DESCRIPTION
It looks like $WORKSPACE is the root of the kubernetes clone.  I think ideally we'd move that down a level and allow subdirectories of different repos.  I think this may become the norm as we split things up further as well.  What do you think and how should we proceed here?  @ixdy @spxtr 
