### PR TITLE
pkg/controller/garbagecollector: simplify mutexes.

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -67,7 +67,7 @@ func (s objectReference) String() string {
 type node struct {
 	identity objectReference
 	// dependents will be read by the orphan() routine, we need to protect it with a lock.
-	dependentsLock *sync.RWMutex
+	dependentsLock sync.RWMutex
 	dependents     map[*node]struct{}
 	// When processing an Update event, we need to compare the updated
 	// ownerReferences with the owners recorded in the graph.
@@ -151,8 +151,7 @@ func (p *Propagator) addDependentToOwners(n *node, owners []metatypes.OwnerRefer
 					OwnerReference: owner,
 					Namespace:      n.identity.Namespace,
 				},
-				dependentsLock: &sync.RWMutex{},
-				dependents:     make(map[*node]struct{}),
+				dependents: make(map[*node]struct{}),
 			}
 			p.uidToNode.Write(ownerNode)
 			p.gc.dirtyQueue.Add(ownerNode)
@@ -378,9 +377,8 @@ func (p *Propagator) processEvent() {
 				},
 				Namespace: accessor.GetNamespace(),
 			},
-			dependentsLock: &sync.RWMutex{},
-			dependents:     make(map[*node]struct{}),
-			owners:         accessor.GetOwnerReferences(),
+			dependents: make(map[*node]struct{}),
+			owners:     accessor.GetOwnerReferences(),
 		}
 		p.insertNode(newNode)
 		// the underlying delta_fifo may combine a creation and deletion into one event

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -301,7 +301,7 @@ func TestDependentsRace(t *testing.T) {
 	}
 
 	const updates = 100
-	owner := &node{dependentsLock: &sync.RWMutex{}, dependents: make(map[*node]struct{})}
+	owner := &node{dependents: make(map[*node]struct{})}
 	ownerUID := types.UID("owner")
 	gc.propagator.uidToNode.Write(owner)
 	go func() {


### PR DESCRIPTION
pkg/controller/garbagecollector: simplified synchronization and made idiomatic.

Similar to #29598, we can rely on the zero-value construction behavior
to embed `sync.Mutex` into parent structs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29898)

<!-- Reviewable:end -->
