### PR TITLE
Node E2E: Change node e2e test infrastructrue to start etcd and apiserver in containers

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -57,19 +57,19 @@ fi
 # Parse the flags to pass to ginkgo
 ginkgoflags=""
 if [[ $parallelism > 1 ]]; then
-  ginkgoflags="$ginkgoflags -nodes=$parallelism "
+  ginkgoflags="$ginkgoflags --nodes=$parallelism "
 fi
 
 if [[ $focus != "" ]]; then
-  ginkgoflags="$ginkgoflags -focus=$focus "
+  ginkgoflags="$ginkgoflags --focus=$focus "
 fi
 
 if [[ $skip != "" ]]; then
-  ginkgoflags="$ginkgoflags -skip=$skip "
+  ginkgoflags="$ginkgoflags --skip=$skip "
 fi
 
 if [[ $run_until_failure != "" ]]; then
-  ginkgoflags="$ginkgoflags -untilItFails=$run_until_failure "
+  ginkgoflags="$ginkgoflags --untilItFails=$run_until_failure "
 fi
 
 
@@ -126,7 +126,7 @@ if [ $remote = true ] ; then
   echo "Ginkgo Flags: $ginkgoflags"
   echo "Instance Metadata: $metadata"
   # Invoke the runner
-  go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
+  go run test/e2e_node/runner/e2e/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
     --zone="$zone" --project="$project"  \
     --hosts="$hosts" --images="$images" --cleanup="$cleanup" \
     --results-dir="$artifacts" --ginkgo-flags="$ginkgoflags" \
@@ -161,8 +161,9 @@ else
 
   # Test using the host the script was run on
   # Provided for backwards compatibility
-  "${ginkgo}" $ginkgoflags "${KUBE_ROOT}/test/e2e_node/" --report-dir=${report} \
-    -- --alsologtostderr --v 2 --node-name $(hostname) --build-services=true \
-    --start-services=true --stop-services=true $test_args
+  go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \
+    --test-flags=" --report-dir=${report} --alsologtostderr --v 2 --node-name $(hostname) \
+    --start-services=true --stop-services=true $test_args" --build-dependencies=true \
+    --logtostderr --v 2
   exit $?
 fi

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -15,7 +15,9 @@ api-server-port
 api-servers
 api-token
 api-version
+apiserver-binary
 apiserver-count
+apiserver-image
 auth-path
 authentication-token-webhook-cache-ttl
 authentication-token-webhook-config-file
@@ -35,8 +37,9 @@ bind-address
 bind-pods-burst
 bind-pods-qps
 bounding-dirs
+build-dependencies
+build-images
 build-only
-build-services
 build-tag
 cadvisor-port
 cert-dir
@@ -132,9 +135,11 @@ enable-hostpath-provisioner
 enable-server
 enable-swagger-ui
 enable-garbage-collector
+etcd-binary
 etcd-cafile
 etcd-certfile
 etcd-config
+etcd-image
 etcd-keyfile
 etcd-mutation-timeout
 etcd-prefix
@@ -470,6 +475,7 @@ system-reserved
 target-port
 tcp-services
 terminated-pod-gc-threshold
+test-flags
 test-timeout
 tls-cert-file
 tls-private-key-file

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -99,10 +99,6 @@ func TestE2eNode(t *testing.T) {
 
 // Setup the kubelet on the node
 var _ = SynchronizedBeforeSuite(func() []byte {
-	if *buildServices {
-		buildGo()
-	}
-
 	// Pre-pull the images tests depend on so we can fail immediately if there is an image pull issue
 	// This helps with debugging test flakes since it is hard to tell when a test failure is due to image pulling.
 	if *prePullImages {
@@ -196,5 +192,6 @@ func startNamespaceController() {
 	resources, err := client.Discovery().ServerPreferredNamespacedResources()
 	Expect(err).NotTo(HaveOccurred())
 	nc := namespacecontroller.NewNamespaceController(client, clientPool, resources, ncResyncPeriod, api.FinalizerKubernetes)
+	// TODO(random-liu): Stop namespace controller in after suite.
 	go nc.Run(ncConcurrency, wait.NeverStop)
 }

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -37,6 +37,11 @@ import (
 
 var serverStartTimeout = flag.Duration("server-start-timeout", time.Second*120, "Time to wait for each server to become healthy.")
 var reportDir = flag.String("report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+var containerize = flag.Bool("containerize", true, "If true, start services in containers.")
+var apiserverImage = flag.String("apiserver-image", "gcr.io/google_containers/kube-apiserver", "Container image of apiserver.")
+var apiserverBinary = flag.String("apiserver-binary", "/usr/local/bin/kube-apiserver", "Apiserver binary in the container image.")
+var etcdImage = flag.String("etcd-image", "gcr.io/google_containers/etcd:2.2.1", "Container image of etcd.")
+var etcdBinary = flag.String("etcd-binary", "/usr/local/bin/etcd", "Etcd binary in the container image.")
 
 type e2eService struct {
 	killCmds []*killCmd
@@ -176,22 +181,40 @@ func (es *e2eService) stop() {
 	}
 }
 
+func getEtcdStartCommand() ([]string, error) {
+	// TODO(random-liu): Always containerize in the future.
+	if *containerize {
+		// TODO(random-liu): runtime abstraction
+		return []string{
+			"sudo", "docker", "run",
+			"--rm=true", "--net=host",
+			*etcdImage, *etcdBinary,
+		}, nil
+	} else {
+		etcdPath, err := exec.LookPath("etcd")
+		if err != nil {
+			glog.Infof("etcd not found in PATH. Defaulting to %s...", defaultEtcdPath)
+			_, err = os.Stat(defaultEtcdPath)
+			if err != nil {
+				return nil, fmt.Errorf("etcd binary not found")
+			}
+			etcdPath = defaultEtcdPath
+		}
+		return []string{etcdPath}, nil
+	}
+}
+
 func (es *e2eService) startEtcd() (*killCmd, error) {
 	dataDir, err := ioutil.TempDir("", "node-e2e")
 	if err != nil {
 		return nil, err
 	}
 	es.etcdDataDir = dataDir
-	etcdPath, err := exec.LookPath("etcd")
+	startCmd, err := getEtcdStartCommand()
 	if err != nil {
-		glog.Infof("etcd not found in PATH. Defaulting to %s...", defaultEtcdPath)
-		_, err = os.Stat(defaultEtcdPath)
-		if err != nil {
-			return nil, fmt.Errorf("etcd binary not found")
-		}
-		etcdPath = defaultEtcdPath
+		return nil, err
 	}
-	cmd := exec.Command(etcdPath)
+	cmd := exec.Command(startCmd[0], startCmd[1:]...)
 	// Execute etcd in the data directory instead of using --data-dir because the flag sometimes requires additional
 	// configuration (e.g. --name in version 0.4.9)
 	cmd.Dir = es.etcdDataDir
@@ -202,14 +225,27 @@ func (es *e2eService) startEtcd() (*killCmd, error) {
 	return &killCmd{name: "etcd", cmd: cmd}, es.startServer(hcc)
 }
 
+func getApiserverStartCommand() []string {
+	if *containerize {
+		return []string{
+			"sudo", "docker", "run",
+			"--rm=true", "--net=host",
+			*apiserverImage, *apiserverBinary,
+		}
+	} else {
+		return []string{"sudo", getApiServerBin()}
+	}
+}
+
 func (es *e2eService) startApiServer() (*killCmd, error) {
-	cmd := exec.Command("sudo", getApiServerBin(),
+	startCmd := getApiserverStartCommand()
+	cmd := exec.Command(startCmd[0], append(startCmd[1:],
 		"--etcd-servers", "http://127.0.0.1:4001",
 		"--insecure-bind-address", "0.0.0.0",
 		"--service-cluster-ip-range", "10.0.0.1/24",
 		"--kubelet-port", "10250",
 		"--allow-privileged", "true",
-		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
+		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr")...,
 	)
 	hcc := newHealthCheckCommand(
 		"http://127.0.0.1:8080/healthz",
@@ -266,7 +302,8 @@ func (es *e2eService) startKubeletServer() (*killCmd, error) {
 		}
 		cmdArgs = append(cmdArgs,
 			"--network-plugin=kubenet",
-			"--network-plugin-dir", filepath.Join(cwd, CNIDirectory, "bin")) // Enable kubenet
+			// TODO(random-liu): Change the network plugin directory to be a flag
+			"--network-plugin-dir", filepath.Join(cwd, "cni", "bin")) // Enable kubenet
 	}
 
 	cmd := exec.Command("sudo", cmdArgs...)
@@ -341,6 +378,7 @@ type killCmd struct {
 	override *exec.Cmd
 }
 
+// TODO(random-liu): Use docker stop to stop services started with docker.
 func (k *killCmd) Kill() error {
 	name := k.name
 	cmd := k.cmd

--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -39,7 +39,7 @@ WORKSPACE=${WORKSPACE:-"/tmp/"}
 ARTIFACTS=${WORKSPACE}/_artifacts
 
 mkdir -p ${ARTIFACTS}
-go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
+go run test/e2e_node/runner/e2e/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
   --zone="$GCE_ZONE" --project="$GCE_PROJECT" --hosts="$GCE_HOSTS" \
   --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
   --image-config-file="$GCE_IMAGE_CONFIG_PATH" --cleanup="$CLEANUP" \

--- a/test/e2e_node/runner/e2e/remote/remote.go
+++ b/test/e2e_node/runner/e2e/remote/remote.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e_node
+package remote
 
 import (
 	"flag"
@@ -29,7 +29,9 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e_node"
 )
 
 var sshOptions = flag.String("ssh-options", "", "Commandline options passed to ssh.")
@@ -82,10 +84,10 @@ func GetHostnameOrIp(hostname string) string {
 // the binaries k8s required for node e2e tests
 func CreateTestArchive() (string, error) {
 	// Build the executables
-	buildGo()
+	e2e_node.BuildGo()
 
 	// Make sure we can find the newly built binaries
-	buildOutputDir, err := getK8sBuildOutputDir()
+	buildOutputDir, err := e2e_node.GetK8sBuildOutputDir()
 	if err != nil {
 		glog.Fatalf("Failed to locate kubernetes build output directory %v", err)
 	}
@@ -214,7 +216,8 @@ func RunRemote(archive string, host string, cleanup bool, junitFileNumber int, s
 	// Run the tests
 	cmd = getSshCommand(" && ",
 		fmt.Sprintf("cd %s", tmp),
-		fmt.Sprintf("timeout -k 30s %ds ./ginkgo %s ./e2e_node.test -- --logtostderr --v 2 --build-services=false --stop-services=%t --node-name=%s --report-dir=%s/results --junit-file-number=%d %s", *testTimeoutSeconds, *ginkgoFlags, cleanup, host, tmp, junitFileNumber, testArgs),
+		// TODO(random-liu): Containerize the remote test.
+		fmt.Sprintf("timeout -k 30s %ds ./ginkgo %s ./e2e_node.test -- --logtostderr --v 2 --containerize=false --stop-services=%t --node-name=%s --report-dir=%s/results --junit-file-number=%d %s", *testTimeoutSeconds, *ginkgoFlags, cleanup, host, tmp, junitFileNumber, testArgs),
 	)
 	aggErrs := []error{}
 

--- a/test/e2e_node/runner/e2e/run_e2e.go
+++ b/test/e2e_node/runner/e2e/run_e2e.go
@@ -31,14 +31,14 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/test/e2e_node"
-
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/pborman/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
+
+	"k8s.io/kubernetes/test/e2e_node/runner/e2e/remote"
 )
 
 var testArgs = flag.String("test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
@@ -106,7 +106,7 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 	if *buildOnly {
 		// Build the archive and exit
-		e2e_node.CreateTestArchive()
+		remote.CreateTestArchive()
 		return
 	}
 
@@ -235,7 +235,7 @@ func main() {
 }
 
 func (a *Archive) getArchive() (string, error) {
-	a.Do(func() { a.path, a.err = e2e_node.CreateTestArchive() })
+	a.Do(func() { a.path, a.err = remote.CreateTestArchive() })
 	return a.path, a.err
 }
 
@@ -286,7 +286,7 @@ func testHost(host string, deleteFiles bool, junitFileNum int, setupNode bool) *
 	}
 	externalIp := getExternalIp(instance)
 	if len(externalIp) > 0 {
-		e2e_node.AddHostnameIp(host, externalIp)
+		remote.AddHostnameIp(host, externalIp)
 	}
 
 	path, err := arc.getArchive()
@@ -297,7 +297,7 @@ func testHost(host string, deleteFiles bool, junitFileNum int, setupNode bool) *
 		}
 	}
 
-	output, exitOk, err := e2e_node.RunRemote(path, host, deleteFiles, junitFileNum, setupNode, *testArgs)
+	output, exitOk, err := remote.RunRemote(path, host, deleteFiles, junitFileNum, setupNode, *testArgs)
 	return &TestResult{
 		output: output,
 		err:    err,
@@ -376,10 +376,10 @@ func createInstance(image *internalGCEImage) (string, error) {
 		}
 		externalIp := getExternalIp(instance)
 		if len(externalIp) > 0 {
-			e2e_node.AddHostnameIp(name, externalIp)
+			remote.AddHostnameIp(name, externalIp)
 		}
 		var output string
-		output, err = e2e_node.RunSshCommand("ssh", e2e_node.GetHostnameOrIp(name), "--", "sudo", "docker", "version")
+		output, err = remote.RunSshCommand("ssh", remote.GetHostnameOrIp(name), "--", "sudo", "docker", "version")
 		if err != nil {
 			err = fmt.Errorf("instance %s not running docker daemon - Command failed: %s", name, output)
 			continue

--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"strings"
+
+	"k8s.io/kubernetes/test/e2e_node"
+
+	"github.com/golang/glog"
+)
+
+var buildDependencies = flag.Bool("build-dependencies", true, "If true, build all dependencies.")
+var buildImages = flag.Bool("build-images", true, "If true, build all container images.")
+var ginkgoFlags = flag.String("ginkgo-flags", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
+var testFlags = flag.String("test-flags", "", "Space-separated list of arguments to pass to node e2e test.")
+
+const apiserver = "kube-apiserver"
+
+func main() {
+	flag.Parse()
+
+	// Build dependencies - ginkgo, kubelet and apiserver.
+	if *buildDependencies {
+		e2e_node.BuildGo()
+	}
+
+	// Build image for test infra and apiserver container.
+	if *buildImages {
+		images := e2e_node.BuildContainerImage()
+		// Cleanup the images
+		defer cleanupContainerImages(images)
+		loadContainerImages(images)
+		// Must not specify apiserver-image if buildImages is enabled.
+		flags := *testFlags + " --apiserver-image=" + images[apiserver].Tag
+		// Overwrite the flag.
+		testFlags = &flags
+	}
+
+	// Run node e2e test
+	ginkgo := e2e_node.GetGinkgoBin()
+	test, err := e2e_node.GetK8sNodeTestDir()
+	if err != nil {
+		glog.Fatalf("Failed to get node test directory: %v", err)
+	}
+	runCommand(ginkgo, *ginkgoFlags, test, "--", *testFlags)
+	return
+}
+
+func loadContainerImages(images map[string]e2e_node.ImageInfo) {
+	glog.Info("Loading k8s container images...")
+	for _, image := range images {
+		err := runCommand("sudo", "docker", "load", "-i", image.Tar)
+		if err != nil {
+			glog.Fatalf("Failed to load container image %v: %v\n", image.Tar, err)
+		}
+	}
+}
+
+func cleanupContainerImages(images map[string]e2e_node.ImageInfo) {
+	glog.Info("Cleanup k8s container images...")
+	for _, image := range images {
+		err := runCommand("sudo", "docker", "rmi", image.Tag)
+		if err != nil {
+			glog.Fatalf("Failed to remove container image %v: %v\n", image.Tag, err)
+		}
+	}
+}
+
+func runCommand(name string, args ...string) error {
+	cmd := exec.Command("sh", "-c", strings.Join(append([]string{name}, args...), " "))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -23,7 +23,6 @@ import (
 var kubeletAddress = flag.String("kubelet-address", "http://127.0.0.1:10255", "Host and port of the kubelet")
 
 var disableKubenet = flag.Bool("disable-kubenet", false, "If true, start kubelet without kubenet")
-var buildServices = flag.Bool("build-services", true, "If true, build local executables")
 var startServices = flag.Bool("start-services", true, "If true, start local node services")
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
 


### PR DESCRIPTION
This is the first step of node conformance test.

This PR changed the local node e2e test to start apiserver and etcd in container.
Add local node test runner `runner/local/run_local.go` to:
1) Build apiserver docker image
2) Load apiserver docker image;
3) Run node e2e test with apiserver and etcd started in container.
4) Cleanup docker image.

Some following working items after this PR:
- Change `runner/common/run_e2e.go` to start etcd and apiserver in container.
- Containerize the test infrastructure.
- Add node conformance test image into release process.
- Add node configuration validation test. (Optional)

@yujuhong Can I add you as reviewer? Feel free to tell me if you don't have bandwidth for this. :)

/cc @kubernetes/sig-node 
