### PR TITLE
Fix NFS folder sync on Fedora

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,7 +149,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   def customize_vm(config, vm_mem)
 
     if $use_nfs then
-      config.vm.synced_folder ".", "/vagrant", nfs: true
+      config.vm.synced_folder ".", "/vagrant", nfs: true, mount_options: ['vers=3']
     end
 
     # Try VMWare Fusion first (see


### PR DESCRIPTION
Vagrant on Fedora needs an explicit vers=3 mount option to get NFS folder syncs working.

Fixes #29916

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29917)

<!-- Reviewable:end -->
