### PR TITLE
Make verify-godeps check the results

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -104,5 +104,12 @@ if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-m
   exit 1
 fi
 
+if ! _out="$(diff -Naupr ${KUBE_ROOT}/vendor ${_kubetmp}/vendor)"; then
+  echo "Your vendored results are different:"
+  echo "${_out}"
+  echo "Godeps Verify failed."
+  exit 1
+fi
+
 echo "Godeps Verified."
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
Verify the results of godep restore/save.  When forced to run this finds a handful of real deltas that need to be resolved.

Fixes #29402

@rmmh because you wrote  #29571 which is the major culprit
