### PR TITLE
[Federation] Downsize the release binary distribution v2.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -106,8 +106,6 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,busybox
           kube-scheduler,busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v3
-          federation-apiserver,busybox
-          federation-controller-manager,busybox
         );;
     "arm")
         local targets=(
@@ -115,8 +113,6 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,armel/busybox
           kube-scheduler,armel/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-arm:v3
-          federation-apiserver,armel/busybox
-          federation-controller-manager,armel/busybox
         );;
     "arm64")
         local targets=(
@@ -124,8 +120,6 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,aarch64/busybox
           kube-scheduler,aarch64/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-arm64:v3
-          federation-apiserver,aarch64/busybox
-          federation-controller-manager,aarch64/busybox
         );;
     "ppc64le")
         local targets=(
@@ -133,8 +127,6 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v3
-          federation-apiserver,ppc64le/busybox
-          federation-controller-manager,ppc64le/busybox
         );;
   esac
 
@@ -1553,8 +1545,6 @@ function kube::release::docker::release() {
     "kube-scheduler"
     "kube-proxy"
     "hyperkube"
-    "federation-apiserver"
-    "federation-controller-manager"
   )
 
   local docker_push_cmd=("${DOCKER[@]}")

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -52,27 +52,25 @@ KUBE_PLATFORM=${KUBE_PLATFORM:-linux}
 KUBE_ARCH=${KUBE_ARCH:-amd64}
 KUBE_BUILD_STAGE=${KUBE_BUILD_STAGE:-release-stage}
 
-source "${KUBE_ROOT}/build/common.sh"
 source "${KUBE_ROOT}/cluster/common.sh"
-source "${KUBE_ROOT}/hack/lib/util.sh"
 
 host_kubectl="${KUBE_ROOT}/cluster/kubectl.sh --namespace=${FEDERATION_NAMESPACE}"
 
 # required:
 # FEDERATION_PUSH_REPO_BASE: repo to which federated container images will be pushed
-
-# Optional
-# FEDERATION_IMAGE_TAG: reference and pull all federated images with this tag. Used for ci testing
+# FEDERATION_IMAGE_TAG: reference and pull all federated images with this tag.
 function create-federation-api-objects {
 (
     : "${FEDERATION_PUSH_REPO_BASE?Must set FEDERATION_PUSH_REPO_BASE env var}"
+    : "${FEDERATION_IMAGE_TAG?Must set FEDERATION_IMAGE_TAG env var}"
+
     export FEDERATION_APISERVER_DEPLOYMENT_NAME="federation-apiserver"
     export FEDERATION_APISERVER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/hyperkube"
-    export FEDERATION_APISERVER_IMAGE_TAG="${FEDERATION_IMAGE_TAG:-$(cat ${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin/federation-apiserver.docker_tag)}"
+    export FEDERATION_APISERVER_IMAGE_TAG="${FEDERATION_IMAGE_TAG}"
 
     export FEDERATION_CONTROLLER_MANAGER_DEPLOYMENT_NAME="federation-controller-manager"
     export FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/hyperkube"
-    export FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG="${FEDERATION_IMAGE_TAG:-$(cat ${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin/federation-controller-manager.docker_tag)}"
+    export FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG="${FEDERATION_IMAGE_TAG}"
 
     if [[ -z "${FEDERATION_DNS_PROVIDER:-}" ]]; then
       # Set the appropriate value based on cloud provider.
@@ -272,6 +270,10 @@ function create-federation-apiserver-certs {
 function push-federation-images {
     : "${FEDERATION_PUSH_REPO_BASE?Must set FEDERATION_PUSH_REPO_BASE env var}"
     : "${FEDERATION_IMAGE_TAG?Must set FEDERATION_IMAGE_TAG env var}"
+
+    source "${KUBE_ROOT}/build/common.sh"
+    source "${KUBE_ROOT}/hack/lib/util.sh"
+
     local FEDERATION_BINARIES=${FEDERATION_BINARIES:-"hyperkube"}
 
     local bin_dir="${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin"

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -52,6 +52,7 @@ KUBE_PLATFORM=${KUBE_PLATFORM:-linux}
 KUBE_ARCH=${KUBE_ARCH:-amd64}
 KUBE_BUILD_STAGE=${KUBE_BUILD_STAGE:-release-stage}
 
+source "${KUBE_ROOT}/build/common.sh"
 source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
@@ -66,11 +67,11 @@ function create-federation-api-objects {
 (
     : "${FEDERATION_PUSH_REPO_BASE?Must set FEDERATION_PUSH_REPO_BASE env var}"
     export FEDERATION_APISERVER_DEPLOYMENT_NAME="federation-apiserver"
-    export FEDERATION_APISERVER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/federation-apiserver"
+    export FEDERATION_APISERVER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/hyperkube"
     export FEDERATION_APISERVER_IMAGE_TAG="${FEDERATION_IMAGE_TAG:-$(cat ${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin/federation-apiserver.docker_tag)}"
 
     export FEDERATION_CONTROLLER_MANAGER_DEPLOYMENT_NAME="federation-controller-manager"
-    export FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/federation-controller-manager"
+    export FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO="${FEDERATION_PUSH_REPO_BASE}/hyperkube"
     export FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG="${FEDERATION_IMAGE_TAG:-$(cat ${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin/federation-controller-manager.docker_tag)}"
 
     if [[ -z "${FEDERATION_DNS_PROVIDER:-}" ]]; then
@@ -267,58 +268,64 @@ function create-federation-apiserver-certs {
 
 # Required
 # FEDERATION_PUSH_REPO_BASE: the docker repo where federated images will be pushed
-
-# Optional
-# FEDERATION_IMAGE_TAG: push all federated images with this tag. Used for ci testing
+# FEDERATION_IMAGE_TAG: the tag of the image to be pushed
 function push-federation-images {
     : "${FEDERATION_PUSH_REPO_BASE?Must set FEDERATION_PUSH_REPO_BASE env var}"
-    local FEDERATION_BINARIES=${FEDERATION_BINARIES:-"federation-apiserver federation-controller-manager"}
+    : "${FEDERATION_IMAGE_TAG?Must set FEDERATION_IMAGE_TAG env var}"
+    local FEDERATION_BINARIES=${FEDERATION_BINARIES:-"hyperkube"}
 
-    local imageFolder="${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin"
+    local bin_dir="${KUBE_ROOT}/_output/${KUBE_BUILD_STAGE}/server/${KUBE_PLATFORM}-${KUBE_ARCH}/kubernetes/server/bin"
 
-    if [[ ! -d "$imageFolder" ]];then
-	echo "${imageFolder} does not exist! Run make quick-release or make release"
-	exit 1
+    if [[ ! -d "${bin_dir}" ]];then
+        echo "${bin_dir} does not exist! Run make quick-release or make release"
+        exit 1
     fi
 
-    for binary in $FEDERATION_BINARIES;do
-	local imageFile="${imageFolder}/${binary}.tar"
+    for binary in ${FEDERATION_BINARIES}; do
+        local bin_path="${bin_dir}/${binary}"
 
-	if [[ ! -f "$imageFile" ]];then
-	    echo "${imageFile} does not exist!"
-	    exit 1
-	fi
+        if [[ ! -f "${bin_path}" ]]; then
+            echo "${bin_path} does not exist!"
+            exit 1
+        fi
 
-	echo "Load: ${imageFile}"
-	# Load the image. Trust we know what it's called, as docker load provides no help there :(
-	docker load < "${imageFile}"
+        local docker_build_path="${bin_path}.dockerbuild"
+        local docker_file_path="${docker_build_path}/Dockerfile"
 
-	local srcImageTag="$(cat ${imageFolder}/${binary}.docker_tag)"
-	local dstImageTag="${FEDERATION_IMAGE_TAG:-$srcImageTag}"
-	local srcImageName="${FEDERATION_IMAGE_REPO_BASE}/${binary}:${srcImageTag}"
-	local dstImageName="${FEDERATION_PUSH_REPO_BASE}/${binary}:${dstImageTag}"
+        rm -rf ${docker_build_path}
+        mkdir -p ${docker_build_path}
 
-	echo "Tag: ${srcImageName} --> ${dstImageName}"
-	docker tag -f "$srcImageName" "$dstImageName"
+        ln "${bin_path}" "${docker_build_path}/${binary}"
+        printf " FROM debian:jessie \n ADD ${binary} /usr/local/bin/${binary}\n" > ${docker_file_path}
 
-	echo "Push: $dstImageName"
-	if [[ "${FEDERATION_PUSH_REPO_BASE}" == "gcr.io/"* ]];then
-	    echo " -> GCR repository detected. Using gcloud"
-	    gcloud docker push "$dstImageName"
-	else
-	    docker push "$dstImageName"
-	fi
+        local docker_image_tag="${FEDERATION_PUSH_REPO_BASE}/${binary}:${FEDERATION_IMAGE_TAG}"
 
-	echo "Remove: $srcImageName"
-	docker rmi "$srcImageName"
+        # Build the docker image on-the-fly.
+        #
+        # NOTE: This is only a temporary fix until the proposal in issue
+        # https://github.com/kubernetes/kubernetes/issues/28630 is implemented.
+        # Also, the new turn up mechanism completely obviates this step.
+        #
+        # TODO(madhusudancs): Remove this code when the new turn up mechanism work
+        # is merged.
+        kube::log::status "Building docker image ${docker_image_tag} from the binary"
+        docker build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
 
-	if [[ "$srcImageName" != "dstImageName" ]];then
-	    echo "Remove: $dstImageName"
-	    docker rmi "$dstImageName"
-	fi
+        rm -rf ${docker_build_path}
 
+        kube::log::status "Pushing ${docker_image_tag}"
+        if [[ "${FEDERATION_PUSH_REPO_BASE}" == "gcr.io/"* ]]; then
+            echo " -> GCR repository detected. Using gcloud"
+            gcloud docker push "${docker_image_tag}"
+        else
+            docker push "${docker_image_tag}"
+        fi
+
+        kube::log::status "Deleting docker image ${docker_image_tag}"
+        docker rmi "${docker_image_tag}" 2>/dev/null || true
     done
 }
+
 function cleanup-federation-api-objects {
   # Delete all resources with the federated-cluster label.
   $host_kubectl delete pods,svc,rc,deployment,secret -lapp=federated-cluster

--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -17,7 +17,8 @@ spec:
       - name: apiserver
         image: {{.FEDERATION_APISERVER_IMAGE_REPO}}:{{.FEDERATION_APISERVER_IMAGE_TAG}}
         command:
-        - /usr/local/bin/federation-apiserver
+        - /usr/local/bin/hyperkube
+        - federation-apiserver
         - --bind-address=0.0.0.0
         - --etcd-servers=http://localhost:2379
         - --service-cluster-ip-range={{.FEDERATION_SERVICE_CIDR}}

--- a/federation/manifests/federation-controller-manager-deployment.yaml
+++ b/federation/manifests/federation-controller-manager-deployment.yaml
@@ -25,7 +25,8 @@ spec:
           mountPath: /etc/ssl/certs
         image: {{.FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO}}:{{.FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG}}
         command:
-        - /usr/local/bin/federation-controller-manager
+        - /usr/local/bin/hyperkube
+        - federation-controller-manager
         - --master=https://{{.FEDERATION_APISERVER_DEPLOYMENT_NAME}}:443
         - --dns-provider={{.FEDERATION_DNS_PROVIDER}}
         - --dns-provider-config={{.FEDERATION_DNS_PROVIDER_CONFIG}}

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -37,8 +37,6 @@ kube::golang::server_targets() {
     cmd/kubelet
     cmd/kubemark
     cmd/hyperkube
-    federation/cmd/federation-apiserver
-    federation/cmd/federation-controller-manager
     plugin/cmd/kube-scheduler
   )
   if [ -n "${KUBERNETES_CONTRIB:-}" ]; then
@@ -175,8 +173,6 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-scheduler
   kube-proxy
   kubectl
-  federation-apiserver
-  federation-controller-manager
 )
 
 kube::golang::is_statically_linked_library() {

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -197,8 +197,13 @@ kube::util::gen-docs() {
   "${genkubedocs}" "${dest}/docs/admin/" "kube-proxy"
   "${genkubedocs}" "${dest}/docs/admin/" "kube-scheduler"
   "${genkubedocs}" "${dest}/docs/admin/" "kubelet"
+
+  # We don't really need federation-apiserver and federation-controller-manager
+  # binaries to generate the docs. We just pass their names to decide which docs
+  # to generate. The actual binary for running federation is hyperkube.
   "${genfeddocs}" "${dest}/docs/admin/" "federation-apiserver"
   "${genfeddocs}" "${dest}/docs/admin/" "federation-controller-manager"
+
   mkdir -p "${dest}/docs/man/man1/"
   "${genman}" "${dest}/docs/man/man1/"
   mkdir -p "${dest}/docs/yaml/kubectl/"


### PR DESCRIPTION
Second attempt of PR #29632.

There are two things that this PR does:
1. It removes `federation-apiserver` and `federation-controller-manager` from binaries and docker_wrapped_binaries target lists.
2. Build the docker image for `hyperkube` on-the-fly while pushing the federation images. 

``` release-note
Federation binaries and their corresponding docker images - `federation-apiserver` and `federation-controller-manager` are now folded in to the `hyperkube` binary. If you were using one of these binaries or docker images, please switch to using the `hyperkube` version. Please refer to the federation manifests - `federation/manifests/federation-apiserver.yaml` and `federation/manifests/federation-controller-manager-deployment.yaml` for examples.
```

cc @kubernetes/sig-cluster-federation @colhom 

Fixes Issue #28633

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29929)

<!-- Reviewable:end -->
