### PR TITLE
Documented second arg to create-flanneld-opts in cluster/ubuntu/util.sh

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -318,6 +318,7 @@ EOF
 
 # Create ~/kube/default/flanneld with proper contents.
 # $1: The one hostname or IP address at which the etcd leader listens.
+# $2: The IP address or network interface for the local Flannel daemon to use
 function create-flanneld-opts() {
   cat <<EOF > ~/kube/default/flanneld
 FLANNEL_OPTS="--etcd-endpoints=http://${1}:4001 \


### PR DESCRIPTION
This is a bug fix, no release note needed.

Fixes #29546
