### PR TITLE
Do not review: Try adding metrics support in pkg/kubelet/api/services.go

### DIFF
--- a/pkg/kubelet/api/services.go
+++ b/pkg/kubelet/api/services.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	statsApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 )
 
 // RuntimeService interface should be implemented by a container runtime.
@@ -68,4 +69,12 @@ type ImageManagerService interface {
 	PullImage(image *runtimeApi.ImageSpec, auth *runtimeApi.AuthConfig) error
 	// RemoveImage removes the image.
 	RemoveImage(image *runtimeApi.ImageSpec) error
+}
+
+// TODO: Replace statsApi with runtimeApi types.
+type ContainerMetricsService interface {
+	// GetAllContainerStats returns metrics for all containers.
+	GetAllContainerStats() ([]*statsApi.ContainerStats, error)
+	// GetContainerStats returns metrics for the given container ID.
+	GetContainerStats(id string) (*statsApi.ContainerStats, error)
 }

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/cadvisor/events"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	statsApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 )
 
 type cadvisorUnsupported struct {
@@ -76,3 +77,7 @@ func (cu *cadvisorUnsupported) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 func (cu *cadvisorUnsupported) WatchEvents(request *events.Request) (*events.EventChannel, error) {
 	return nil, unsupportedErr
 }
+
+func (cu *cadvisorUnsupported) GetAllContainerStats() ([]*statsApi.ContainerStats, error)
+
+func (cu *cadvisorUnsupported) GetContainerStats(id string) (*statsApi.ContainerStats, error)

--- a/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/cadvisor/events"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	statsApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 )
 
@@ -72,4 +73,12 @@ func (c *Fake) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 
 func (c *Fake) WatchEvents(request *events.Request) (*events.EventChannel, error) {
 	return new(events.EventChannel), nil
+}
+
+func (c *Fake) GetAllContainerStats() ([]*statsApi.ContainerStats, error) {
+	return []*statsApi.ContainerStats{}, nil
+}
+
+func (c *Fake) GetContainerStats(id string) (*statsApi.ContainerStats, error) {
+	return &statsApi.ContainerStats{}, nil
 }

--- a/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
@@ -21,6 +21,7 @@ import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/mock"
+	statsApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 )
 
@@ -82,4 +83,14 @@ func (c *Mock) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 func (c *Mock) WatchEvents(request *events.Request) (*events.EventChannel, error) {
 	args := c.Called()
 	return args.Get(0).(*events.EventChannel), args.Error(1)
+}
+
+func (c *Mock) GetAllContainerStats() ([]*statsApi.ContainerStats, error) {
+	args := c.Called()
+	return args.Get(0).([]*statsApi.ContainerStats), args.Error(1)
+}
+
+func (c *Mock) GetContainerStats(id string) (*statsApi.ContainerStats, error) {
+	args := c.Called()
+	return args.Get(0).(*statsApi.ContainerStats), args.Error(1)
 }

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/cadvisor/events"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	internalApi "k8s.io/kubernetes/pkg/kubelet/api"
 )
 
 // Interface is an abstract interface for testability.  It abstracts the interface to cAdvisor.
@@ -41,4 +42,7 @@ type Interface interface {
 
 	// Get events streamed through passedChannel that fit the request.
 	WatchEvents(request *events.Request) (*events.EventChannel, error)
+
+	// cadvisor implements the ContainerMetricsService.
+	internalApi.ContainerMetricsService
 }


### PR DESCRIPTION
NOTE: This is just a scratch PR to see the process of adding container metrics to CRI.

This commit does _not_ properly define the types for container metrics in proto/go
files, but rather just borrow the types in api/v1alpha/stats directly.

This commit moves most of the cadvisor container metrics related code from the
summaryBuilder in server/stats/summary.go to cadvisor, so that cadvisor can
implement the MetricsService interface.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29963)

<!-- Reviewable:end -->
