### PR TITLE
remove duplicate code in updatePodCIDR

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -281,11 +281,13 @@ func (kl *Kubelet) syncNetworkStatus() {
 // updatePodCIDR updates the pod CIDR in the runtime state if it is different
 // from the current CIDR.
 func (kl *Kubelet) updatePodCIDR(cidr string) {
-	if kl.runtimeState.podCIDR() == cidr {
+	podCIDR := kl.runtimeState.podCIDR()
+
+	if podCIDR == cidr {
 		return
 	}
 
-	glog.Infof("Setting Pod CIDR: %v -> %v", kl.runtimeState.podCIDR(), cidr)
+	glog.Infof("Setting Pod CIDR: %v -> %v", podCIDR, cidr)
 	kl.runtimeState.setPodCIDR(cidr)
 
 	if kl.networkPlugin != nil {


### PR DESCRIPTION
As kl.runtimeState.podCIDR() is a sync method, need fetch lock and release lock, so we only invoke once here

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/29969)

<!-- Reviewable:end -->
