### PR TITLE
Fix PVC.Status.Capacity and AccessModes after binding

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -93,7 +93,7 @@ func TestSync(t *testing.T) {
 				newVolume("volume1-5_2", "1Gi", "", "", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			},
 			newClaimArray("claim1-5", "uid1-5", "1Gi", "", api.ClaimPending),
-			newClaimArray("claim1-5", "uid1-5", "1Gi", "volume1-5_1", api.ClaimBound, annBoundByController, annBindCompleted),
+			withExpectedCapacity("10Gi", newClaimArray("claim1-5", "uid1-5", "1Gi", "volume1-5_1", api.ClaimBound, annBoundByController, annBindCompleted)),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -109,7 +109,7 @@ func TestSync(t *testing.T) {
 				newVolume("volume1-6_2", "1Gi", "", "", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			},
 			newClaimArray("claim1-6", "uid1-6", "1Gi", "", api.ClaimPending),
-			newClaimArray("claim1-6", "uid1-6", "1Gi", "volume1-6_1", api.ClaimBound, annBoundByController, annBindCompleted),
+			withExpectedCapacity("10Gi", newClaimArray("claim1-6", "uid1-6", "1Gi", "volume1-6_1", api.ClaimBound, annBoundByController, annBindCompleted)),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -199,8 +199,8 @@ func TestSync(t *testing.T) {
 			"2-3 - claim prebound to unbound volume",
 			newVolumeArray("volume2-3", "1Gi", "", "", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-3", "1Gi", "uid2-3", "claim2-3", api.VolumeBound, api.PersistentVolumeReclaimRetain, annBoundByController),
-			newClaimArray("claim2-3", "uid2-3", "10Gi", "volume2-3", api.ClaimPending),
-			newClaimArray("claim2-3", "uid2-3", "10Gi", "volume2-3", api.ClaimBound, annBindCompleted),
+			newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", api.ClaimPending),
+			newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", api.ClaimBound, annBindCompleted),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -209,8 +209,8 @@ func TestSync(t *testing.T) {
 			"2-4 - claim prebound to prebound volume by name",
 			newVolumeArray("volume2-4", "1Gi", "", "claim2-4", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-4", "1Gi", "uid2-4", "claim2-4", api.VolumeBound, api.PersistentVolumeReclaimRetain),
-			newClaimArray("claim2-4", "uid2-4", "10Gi", "volume2-4", api.ClaimPending),
-			newClaimArray("claim2-4", "uid2-4", "10Gi", "volume2-4", api.ClaimBound, annBindCompleted),
+			newClaimArray("claim2-4", "uid2-4", "1Gi", "volume2-4", api.ClaimPending),
+			newClaimArray("claim2-4", "uid2-4", "1Gi", "volume2-4", api.ClaimBound, annBindCompleted),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -220,8 +220,8 @@ func TestSync(t *testing.T) {
 			"2-5 - claim prebound to prebound volume by UID",
 			newVolumeArray("volume2-5", "1Gi", "uid2-5", "claim2-5", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-5", "1Gi", "uid2-5", "claim2-5", api.VolumeBound, api.PersistentVolumeReclaimRetain),
-			newClaimArray("claim2-5", "uid2-5", "10Gi", "volume2-5", api.ClaimPending),
-			newClaimArray("claim2-5", "uid2-5", "10Gi", "volume2-5", api.ClaimBound, annBindCompleted),
+			newClaimArray("claim2-5", "uid2-5", "1Gi", "volume2-5", api.ClaimPending),
+			newClaimArray("claim2-5", "uid2-5", "1Gi", "volume2-5", api.ClaimBound, annBindCompleted),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -230,8 +230,8 @@ func TestSync(t *testing.T) {
 			"2-6 - claim prebound to already bound volume",
 			newVolumeArray("volume2-6", "1Gi", "uid2-6_1", "claim2-6_1", api.VolumeBound, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-6", "1Gi", "uid2-6_1", "claim2-6_1", api.VolumeBound, api.PersistentVolumeReclaimRetain),
-			newClaimArray("claim2-6", "uid2-6", "10Gi", "volume2-6", api.ClaimBound),
-			newClaimArray("claim2-6", "uid2-6", "10Gi", "volume2-6", api.ClaimPending),
+			newClaimArray("claim2-6", "uid2-6", "1Gi", "volume2-6", api.ClaimBound),
+			newClaimArray("claim2-6", "uid2-6", "1Gi", "volume2-6", api.ClaimPending),
 			noevents, noerrors, testSyncClaim,
 		},
 		{
@@ -240,8 +240,8 @@ func TestSync(t *testing.T) {
 			"2-7 - claim bound by controller to already bound volume",
 			newVolumeArray("volume2-7", "1Gi", "uid2-7_1", "claim2-7_1", api.VolumeBound, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-7", "1Gi", "uid2-7_1", "claim2-7_1", api.VolumeBound, api.PersistentVolumeReclaimRetain),
-			newClaimArray("claim2-7", "uid2-7", "10Gi", "volume2-7", api.ClaimBound, annBoundByController),
-			newClaimArray("claim2-7", "uid2-7", "10Gi", "volume2-7", api.ClaimBound, annBoundByController),
+			newClaimArray("claim2-7", "uid2-7", "1Gi", "volume2-7", api.ClaimBound, annBoundByController),
+			newClaimArray("claim2-7", "uid2-7", "1Gi", "volume2-7", api.ClaimBound, annBoundByController),
 			noevents, noerrors, testSyncClaimError,
 		},
 		{
@@ -251,8 +251,8 @@ func TestSync(t *testing.T) {
 			"2-8 - claim prebound to unbound volume that does not match the selector",
 			newVolumeArray("volume2-3", "1Gi", "", "", api.VolumePending, api.PersistentVolumeReclaimRetain),
 			newVolumeArray("volume2-3", "1Gi", "uid2-3", "claim2-3", api.VolumeBound, api.PersistentVolumeReclaimRetain, annBoundByController),
-			withLabelSelector(labels, newClaimArray("claim2-3", "uid2-3", "10Gi", "volume2-3", api.ClaimPending)),
-			withLabelSelector(labels, newClaimArray("claim2-3", "uid2-3", "10Gi", "volume2-3", api.ClaimBound, annBindCompleted)),
+			withLabelSelector(labels, newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", api.ClaimPending)),
+			withLabelSelector(labels, newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", api.ClaimBound, annBindCompleted)),
 			noevents, noerrors, testSyncClaim,
 		},
 

--- a/pkg/controller/volume/persistentvolume/controller_test.go
+++ b/pkg/controller/volume/persistentvolume/controller_test.go
@@ -42,8 +42,8 @@ func TestControllerSync(t *testing.T) {
 		{
 			// addClaim gets a new claim. Check it's bound to a volume.
 			"5-2 - complete bind",
-			newVolumeArray("volume5-2", "10Gi", "", "", api.VolumeAvailable, api.PersistentVolumeReclaimRetain),
-			newVolumeArray("volume5-2", "10Gi", "uid5-2", "claim5-2", api.VolumeBound, api.PersistentVolumeReclaimRetain, annBoundByController),
+			newVolumeArray("volume5-2", "1Gi", "", "", api.VolumeAvailable, api.PersistentVolumeReclaimRetain),
+			newVolumeArray("volume5-2", "1Gi", "uid5-2", "claim5-2", api.VolumeBound, api.PersistentVolumeReclaimRetain, annBoundByController),
 			noclaims, /* added in testAddClaim5_2 */
 			newClaimArray("claim5-2", "uid5-2", "1Gi", "volume5-2", api.ClaimBound, annBoundByController, annBindCompleted),
 			noevents, noerrors,
@@ -73,7 +73,7 @@ func TestControllerSync(t *testing.T) {
 		{
 			// deleteVolume with a bound volume. Check the claim is Lost.
 			"5-4 - delete volume",
-			newVolumeArray("volume5-4", "10Gi", "uid5-4", "claim5-4", api.VolumeBound, api.PersistentVolumeReclaimRetain),
+			newVolumeArray("volume5-4", "1Gi", "uid5-4", "claim5-4", api.VolumeBound, api.PersistentVolumeReclaimRetain),
 			novolumes,
 			newClaimArray("claim5-4", "uid5-4", "1Gi", "volume5-4", api.ClaimBound, annBoundByController, annBindCompleted),
 			newClaimArray("claim5-4", "uid5-4", "1Gi", "volume5-4", api.ClaimLost, annBoundByController, annBindCompleted),
@@ -91,13 +91,13 @@ func TestControllerSync(t *testing.T) {
 			// is expected - it should stay bound.
 			"5-5 - add bound volume from 1.2",
 			novolumes,
-			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-5", "10Gi", "uid5-5", "claim5-5", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
+			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-5", "1Gi", "uid5-5", "claim5-5", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
 			newClaimArray("claim5-5", "uid5-5", "1Gi", "", api.ClaimPending),
 			newClaimArray("claim5-5", "uid5-5", "1Gi", "volume5-5", api.ClaimBound, annBindCompleted, annBoundByController),
 			noevents, noerrors,
 			// Custom test function that generates a add event
 			func(ctrl *PersistentVolumeController, reactor *volumeReactor, test controllerTest) error {
-				volume := newVolume("volume5-5", "10Gi", "uid5-5", "claim5-5", api.VolumeBound, api.PersistentVolumeReclaimDelete)
+				volume := newVolume("volume5-5", "1Gi", "uid5-5", "claim5-5", api.VolumeBound, api.PersistentVolumeReclaimDelete)
 				volume = addVolumeAnnotation(volume, pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)
 				reactor.addVolumeEvent(volume)
 				return nil
@@ -107,14 +107,14 @@ func TestControllerSync(t *testing.T) {
 			// updateVolume with provisioned volume from Kubernetes 1.2. No
 			// "action" is expected - it should stay bound.
 			"5-6 - update bound volume from 1.2",
-			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-6", "10Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
-			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-6", "10Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
+			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-6", "1Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
+			[]*api.PersistentVolume{addVolumeAnnotation(newVolume("volume5-6", "1Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete), pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)},
 			newClaimArray("claim5-6", "uid5-6", "1Gi", "volume5-6", api.ClaimBound),
 			newClaimArray("claim5-6", "uid5-6", "1Gi", "volume5-6", api.ClaimBound, annBindCompleted),
 			noevents, noerrors,
 			// Custom test function that generates a add event
 			func(ctrl *PersistentVolumeController, reactor *volumeReactor, test controllerTest) error {
-				volume := newVolume("volume5-6", "10Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete)
+				volume := newVolume("volume5-6", "1Gi", "uid5-6", "claim5-6", api.VolumeBound, api.PersistentVolumeReclaimDelete)
 				volume = addVolumeAnnotation(volume, pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue)
 				reactor.modifyVolumeEvent(volume)
 				return nil
@@ -131,7 +131,7 @@ func TestControllerSync(t *testing.T) {
 			noevents, noerrors,
 			// Custom test function that generates a add event
 			func(ctrl *PersistentVolumeController, reactor *volumeReactor, test controllerTest) error {
-				volume := newVolume("volume5-7", "10Gi", "uid5-7", "claim5-7", api.VolumeBound, api.PersistentVolumeReclaimDelete)
+				volume := newVolume("volume5-7", "1Gi", "uid5-7", "claim5-7", api.VolumeBound, api.PersistentVolumeReclaimDelete)
 				volume = addVolumeAnnotation(volume, pvProvisioningRequiredAnnotationKey, "yes")
 				reactor.addVolumeEvent(volume)
 				return nil
@@ -148,7 +148,7 @@ func TestControllerSync(t *testing.T) {
 			noevents, noerrors,
 			// Custom test function that generates a add event
 			func(ctrl *PersistentVolumeController, reactor *volumeReactor, test controllerTest) error {
-				volume := newVolume("volume5-8", "10Gi", "uid5-8", "claim5-8", api.VolumeBound, api.PersistentVolumeReclaimDelete)
+				volume := newVolume("volume5-8", "1Gi", "uid5-8", "claim5-8", api.VolumeBound, api.PersistentVolumeReclaimDelete)
 				volume = addVolumeAnnotation(volume, pvProvisioningRequiredAnnotationKey, "yes")
 				reactor.modifyVolumeEvent(volume)
 				return nil


### PR DESCRIPTION
Also, fix unit tests to have the same claim and volume sizes in most of the
tests where we don't test matching based on size and test for a specific size
when we do actually test the matching.

Fixes #29425
