### PR TITLE
Remove kubelet dependency on pidof

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -22,10 +22,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +40,7 @@ import (
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/oom"
+	"k8s.io/kubernetes/pkg/util/procfs"
 	"k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
@@ -526,22 +525,7 @@ func getPidsForProcess(name, pidFile string) ([]int, error) {
 			runtime.HandleError(err)
 		}
 	}
-
-	out, err := exec.Command("pidof", name).Output()
-	if err != nil {
-		return []int{}, fmt.Errorf("failed to find pid of %q: %v", name, err)
-	}
-
-	// The output of pidof is a list of pids.
-	pids := []int{}
-	for _, pidStr := range strings.Split(strings.TrimSpace(string(out)), " ") {
-		pid, err := strconv.Atoi(pidStr)
-		if err != nil {
-			continue
-		}
-		pids = append(pids, pid)
-	}
-	return pids, nil
+	return procfs.PidOf(name), nil
 }
 
 // Ensures that the Docker daemon is in the desired container.

--- a/pkg/util/procfs/procfs_test.go
+++ b/pkg/util/procfs/procfs_test.go
@@ -18,7 +18,12 @@ package procfs
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func verifyContainerName(procCgroupText, expectedName string, expectedErr bool, t *testing.T) {
@@ -55,4 +60,13 @@ func TestContainerNameFromProcCgroup(t *testing.T) {
 
 	procCgroupInvalid := "devices:docker/kubelet\ncpuacct:pkg/kubectl"
 	verifyContainerName(procCgroupInvalid, "", true, t)
+}
+
+func TestPidOf(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
+	}
+	pids := PidOf(filepath.Base(os.Args[0]))
+	assert.NotZero(t, pids)
+	assert.Contains(t, pids, os.Getpid())
 }


### PR DESCRIPTION
Issue #26093 identified pidof as one of the dependencies of kublet
which could be worked around. In this PR, we just look at /proc
to construct the list of pids we need for a specified process
instead of running "pidof" executable

Related to #26093

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30002)

<!-- Reviewable:end -->
