### PR TITLE
Marked NodePhase deprecated.

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -16736,7 +16736,7 @@
      },
      "phase": {
       "type": "string",
-      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase"
+      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase The field is never populated, and now is deprecated."
      },
      "conditions": {
       "type": "array",

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -4715,7 +4715,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NodePhase is the recently observed lifecycle phase of the node. More info: <a href="http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase">http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NodePhase is the recently observed lifecycle phase of the node. More info: <a href="http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase">http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase</a> The field is never populated, and now is deprecated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -8160,7 +8160,7 @@ The resulting set of endpoints can be viewed as:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-06-29 05:55:28 UTC
+Last updated 2016-08-11 00:53:51 UTC
 </div>
 </div>
 </body>

--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -1301,6 +1301,7 @@ message NodeStatus {
 
   // NodePhase is the recently observed lifecycle phase of the node.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase
+  // The field is never populated, and now is deprecated.
   optional string phase = 3;
 
   // Conditions is an array of current observed node conditions.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2376,6 +2376,7 @@ type NodeStatus struct {
 	Allocatable ResourceList `json:"allocatable,omitempty" protobuf:"bytes,2,rep,name=allocatable,casttype=ResourceList,castkey=ResourceName"`
 	// NodePhase is the recently observed lifecycle phase of the node.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase
+	// The field is never populated, and now is deprecated.
 	Phase NodePhase `json:"phase,omitempty" protobuf:"bytes,3,opt,name=phase,casttype=NodePhase"`
 	// Conditions is an array of current observed node conditions.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -893,7 +893,7 @@ var map_NodeStatus = map[string]string{
 	"":                "NodeStatus is information about the current status of a node.",
 	"capacity":        "Capacity represents the total resources of a node. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity for more details.",
 	"allocatable":     "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
-	"phase":           "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase",
+	"phase":           "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase The field is never populated, and now is deprecated.",
 	"conditions":      "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition",
 	"addresses":       "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses",
 	"daemonEndpoints": "Endpoints of daemons running on the Node.",


### PR DESCRIPTION
cc/ @lavalamp 

Even Kubernetes stops set NodePhase for a while, the user might patch NodeStatus with NodePhase. Marked the field deprecated and documented first. 

xref: https://github.com/kubernetes/kubernetes.github.io/pull/549

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30005)

<!-- Reviewable:end -->
