### PR TITLE
make reousrce prefix consistent with other registries

### DIFF
--- a/pkg/registry/storageclass/etcd/etcd.go
+++ b/pkg/registry/storageclass/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/storageclasses"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.StorageClassList{} }
 	storageInterface := opts.Decorator(


### PR DESCRIPTION
Storage class registry was added recently in #29694.
In other registries, resource prefix was changed to a more generic way using RESTOptions.ResourcePrefix.

This PR is an attempt to make both consistent.
