### PR TITLE
node_e2e: Use upstream CoreOS image directly

### DIFF
--- a/test/e2e_node/jenkins/coreos-init.yaml
+++ b/test/e2e_node/jenkins/coreos-init.yaml
@@ -1,0 +1,36 @@
+#cloud-config
+
+users:
+  - name: "jenkins"
+    groups: 
+      - "docker"
+      - "sudo"
+
+
+coreos:
+  units:
+    - name: "docker.service"
+      enable: true
+      drop-ins:
+        - name: 10-disable-systemd-cgroup-driver.conf
+          content: |
+            [Service]
+            CPUAccounting=yes
+            MemoryAccounting=yes
+            # Temporary, remove after https://github.com/coreos/bugs/issues/1435 is resolved
+            Environment="DOCKER_CGROUPS="
+    - name: "update-engine.service"
+      mask: true
+    - name: "locksmithd.service"
+      mask: true
+    - name: "node-e2e-test-setup.service"
+      command: "start"
+      content: |
+        [Unit]
+        Description=Setup a vanilla CoreOS image for use by Node e2e
+        WantedBy=multi-user.target
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        # chain `ExecStartPre`'s here to do any setup
+        ExecStart=/bin/true

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -8,9 +8,10 @@ images:
   ubuntu-docker10:
     image: e2e-node-ubuntu-trusty-docker10-v1-image
     project: kubernetes-node-e2e-images
-  coreos-stable:
-    image: e2e-node-coreos-alpha-1068-20160707-image
-    project: kubernetes-node-e2e-images
+  coreos-alpha:
+    image: coreos-alpha-1122-0-0-v20160727
+    project: coreos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/coreos-init.yaml"
   containervm:
     image: e2e-node-containervm-v20160321-image
     project: kubernetes-node-e2e-images


### PR DESCRIPTION
.. and update it to the latest alpha

This will make updating the CoreOS image in the future much simpler since it won't involve project-copying, manual-baking, or so on.

cc @pwittrock @vishh @bboreham @yifan-gu 
