### PR TITLE
[GarbageCollector] Fix 29992

### DIFF
--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -316,7 +316,6 @@ func TestUpdateSelectorToAdopt(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	go podInformer.Run(stopCh)
-	waitToObservePods(t, podInformer, 2)
 	go rm.Run(5, stopCh)
 	waitRSStable(t, clientSet, rs, ns.Name)
 
@@ -354,6 +353,7 @@ func TestUpdateSelectorToRemoveControllerRef(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	go podInformer.Run(stopCh)
+	waitToObservePods(t, podInformer, 2)
 	go rm.Run(5, stopCh)
 	waitRSStable(t, clientSet, rs, ns.Name)
 


### PR DESCRIPTION
Fix #29992.

I copied RC test code to the wrong place to the RS test in #29798. I took a look at the failure reports, they  were all failed on the RS test, so #29798 itself is correct.

Marked as P2 since it fixes a test flake that will block everyone.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30024)

<!-- Reviewable:end -->
