### PR TITLE
remove logging to t.lofg

### DIFF
--- a/pkg/client/record/event_test.go
+++ b/pkg/client/record/event_test.go
@@ -350,8 +350,7 @@ func TestEventf(t *testing.T) {
 	recorder := recorderWithFakeClock(api.EventSource{Component: "eventTest"}, eventBroadcaster, clock)
 	for index, item := range table {
 		clock.Step(1 * time.Second)
-		logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
-		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+		logWatcher := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
 			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
@@ -369,8 +368,7 @@ func TestEventf(t *testing.T) {
 			actualEvent := <-createEvent
 			validateEvent(strconv.Itoa(index), actualEvent, item.expect, t)
 		}
-		logWatcher1.Stop()
-		logWatcher2.Stop()
+		logWatcher.Stop()
 	}
 	sinkWatcher.Stop()
 }
@@ -597,8 +595,7 @@ func TestEventfNoNamespace(t *testing.T) {
 
 	for index, item := range table {
 		clock.Step(1 * time.Second)
-		logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
-		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+		logWatcher := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
 			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
@@ -617,8 +614,7 @@ func TestEventfNoNamespace(t *testing.T) {
 			validateEvent(strconv.Itoa(index), actualEvent, item.expect, t)
 		}
 
-		logWatcher1.Stop()
-		logWatcher2.Stop()
+		logWatcher.Stop()
 	}
 	sinkWatcher.Stop()
 }


### PR DESCRIPTION
Until release 1.6, golang's t.report() doesn't protect t.output with a read lock: https://github.com/golang/go/blob/release-branch.go1.6/src/testing/testing.go#L536-L538. It leads to the data race in https://github.com/kubernetes/kubernetes/issues/29975.

I think we can just remove the offending lines:

```
logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
```

It looks like the code just prints event to test log for human. The line is originally added by @lavalamp in https://github.com/kubernetes/kubernetes/pull/5535. (Thanks to @saad-ali for digging the history of the file)

Fix #29975. Marked as P0 because it fixes a P0 flake that blocks everyone.
