### PR TITLE
Node E2E: Move the node name initialization to first function of SynchronizedBeforeEach

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -28,5 +28,6 @@ var startServices = flag.Bool("start-services", true, "If true, start local node
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
 
 type SharedContext struct {
+	NodeName      string
 	PodConfigPath string
 }


### PR DESCRIPTION
Currently, we start e2e services in the first function of `SynchronizedBeforeEach` to make sure that we only start them once even we are running test in parallel test nodes.

However, e2e services require `NodeName`, but we initialize `NodeName` in the second function.

This PR moved the initialization logic into the first function, and shared the node name with all test nodes via the `SharedContext`.
