### PR TITLE
Set GOOGLE_APPLICATION_CREDENTIALS after activating

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -258,6 +258,8 @@ fi
 if [[ -f "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
   echo 'Activating service account...'  # No harm in doing this multiple times.
   gcloud auth activate-service-account --key-file="${KUBEKINS_SERVICE_ACCOUNT_FILE}"
+  # https://developers.google.com/identity/protocols/application-default-credentials
+  export GOOGLE_APPLICATION_CREDENTIALS="${KUBEKINS_SERVICE_ACCOUNT_FILE}"
   unset KUBEKINS_SERVICE_ACCOUNT_FILE
 elif [[ -n "${KUBEKINS_SERVICE_ACCOUNT_FILE:-}" ]]; then
   echo "ERROR: cannot access service account file at: ${KUBEKINS_SERVICE_ACCOUNT_FILE}"


### PR DESCRIPTION
https://developers.google.com/identity/protocols/application-default-credentials

We should set this explicitly as https://golang.org/pkg/os/user/#User (which the oauth libraries use: [sdk.go](https://github.com/kubernetes/kubernetes/blob/fa95788e560de7575c851d87d76c664b3753a7a6/vendor/golang.org/x/oauth2/google/sdk.go#L165) - [default.go](https://github.com/kubernetes/kubernetes/blob/fa95788e560de7575c851d87d76c664b3753a7a6/vendor/golang.org/x/oauth2/google/default.go#L101) via [CreateGCECloud](https://github.com/kubernetes/kubernetes/blob/fa95788e560de7575c851d87d76c664b3753a7a6/test/e2e/e2e.go#L75)) will ignore any `$HOME` overrides.

Mitigates https://github.com/kubernetes/kubernetes/issues/28514 and related to https://github.com/kubernetes/test-infra/issues/266
