### PR TITLE
Replace with explicit kubernetes fork path

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -243,7 +243,7 @@ separate dependency updates from other changes._
 export KPATH=$HOME/code/kubernetes
 mkdir -p $KPATH/src/k8s.io
 cd $KPATH/src/k8s.io
-git clone https://path/to/your/kubernetes/fork # assumes your fork is 'kubernetes'
+git clone https://github.com/$YOUR_GITHUB_USERNAME/kubernetes.git # assumes your fork is 'kubernetes'
 # Or copy your existing local repo here. IMPORTANT: making a symlink doesn't work.
 ```
 


### PR DESCRIPTION
At other place in development.md, explicit kubernetes fork path has been existed:

```
mkdir -p $GOPATH/src/k8s.io
cd $GOPATH/src/k8s.io
# Replace "$YOUR_GITHUB_USERNAME" below with your github username
git clone https://github.com/$YOUR_GITHUB_USERNAME/kubernetes.git
```

the following is easy to be confused and can be replaced with same description:

```
git clone https://path/to/your/fork .
```
