### PR TITLE
Remove usage of brctl as a kubelet dependency

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -45,6 +45,12 @@ const (
 
 	// kubernetes firewall rules
 	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
+
+	// The bridge kubelet is responsible for managing when --configure-cbr0 is enabled
+	BridgeName = "cbr0"
+
+	// The MTU a kubelet-managed bridge should have
+	BridgeMTU = 1460
 )
 
 // effectiveHairpinMode determines the effective hairpin mode given the
@@ -232,7 +238,7 @@ func (kl *Kubelet) cleanupBandwidthLimits(allPods []*api.Pod) error {
 // NOTE!!! if you make changes here, also make them to kubenet
 func (kl *Kubelet) reconcileCBR0(podCIDR string) error {
 	if podCIDR == "" {
-		glog.V(5).Info("PodCIDR not set. Will not configure cbr0.")
+		glog.V(5).Infof("PodCIDR not set. Will not configure bridge %s.", BridgeName)
 		return nil
 	}
 	glog.V(5).Infof("PodCIDR is set to %q", podCIDR)
@@ -242,13 +248,13 @@ func (kl *Kubelet) reconcileCBR0(podCIDR string) error {
 	}
 	// Set cbr0 interface address to first address in IPNet
 	cidr.IP.To4()[3] += 1
-	if err := ensureCbr0(cidr, kl.hairpinMode == componentconfig.PromiscuousBridge, kl.babysitDaemons); err != nil {
+	if err := ensureBridge(BridgeName, BridgeMTU, cidr, kl.hairpinMode == componentconfig.PromiscuousBridge, kl.babysitDaemons); err != nil {
 		return err
 	}
 	if kl.shapingEnabled() {
 		if kl.shaper == nil {
 			glog.V(5).Info("Shaper is nil, creating")
-			kl.shaper = bandwidth.NewTCShaper("cbr0")
+			kl.shaper = bandwidth.NewTCShaper(BridgeName)
 		}
 		return kl.shaper.ReconcileInterface()
 	}

--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -33,6 +33,8 @@ import (
 	"github.com/golang/glog"
 )
 
+// TODO: Remove dependency on tc, use vishvanada/netlink instead
+
 // tcShaper provides an implementation of the BandwidthShaper interface on Linux using the 'tc' tool.
 // In general, using this requires that the caller posses the NET_CAP_ADMIN capability, though if you
 // do this within an container, it only requires the NS_CAPABLE capability for manipulations to that


### PR DESCRIPTION
Also removed some ip exec calls in favor for netlink, and added a todo for `tc` and reordered the functions.

Related to #26093

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30056)

<!-- Reviewable:end -->
