### PR TITLE
fix nodeAffinity e2e file not exist failure

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -709,7 +710,8 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 
 		By("Trying to launch a pod that with NodeAffinity setting as embedded JSON string in the annotation value.")
 		labelPodName := "with-labels"
-		testPodPath := "test/e2e/testing-manifests/node-selection/pod-with-node-affinity.yaml"
+		nodeSelectionRoot := filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/node-selection")
+		testPodPath := filepath.Join(nodeSelectionRoot, "pod-with-node-affinity.yaml")
 		framework.RunKubectlOrDie("create", "-f", testPodPath, fmt.Sprintf("--namespace=%v", ns))
 
 		// check that pod got scheduled. We intentionally DO NOT check that the
@@ -1224,7 +1226,8 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 
 		By("Trying to launch a pod that with PodAffinity & PodAntiAffinity setting as embedded JSON string in the annotation value.")
 		labelPodName := "with-newlabels"
-		testPodPath := "test/e2e/testing-manifests/node-selection/pod-with-pod-affinity.yaml"
+		nodeSelectionRoot := filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/node-selection")
+		testPodPath := filepath.Join(nodeSelectionRoot, "pod-with-pod-affinity.yaml")
 		framework.RunKubectlOrDie("create", "-f", testPodPath, fmt.Sprintf("--namespace=%v", ns))
 
 		// check that pod got scheduled. We intentionally DO NOT check that the


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/pull/25584#discussion_r73464225 and https://github.com/kubernetes/kubernetes/issues/30018#issuecomment-237456707
#25584 removed repoRoot in scheduler_predicates e2e test.

Using relative path doesn't work. And I checked the filepath that currently `kubectl create -f` uses in `test\e2e\examples.go`, `test\e2e\ingress.go` and `test\e2e\petset.go`, they are still using repoRoot to generate make filepath. 

This PR is to revert the change that #25584 did in scheduler_predicates.go
