### PR TITLE
Add test for supplemental gid annotation to pv e2e test

### DIFF
--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -68,6 +68,8 @@ type VolumeTestConfig struct {
 	serverImage string
 	// Ports to export from the server pod. TCP only.
 	serverPorts []int
+	// Arguments to pass to the container image.
+	serverArgs []string
 	// Volumes needed to be mounted to the server container from the host
 	// map <host (source) path> -> <container (dst.) path>
 	volumes map[string]string
@@ -134,6 +136,7 @@ func startVolumeServer(client *client.Client, config VolumeTestConfig) *api.Pod 
 					SecurityContext: &api.SecurityContext{
 						Privileged: privileged,
 					},
+					Args:         config.serverArgs,
 					Ports:        serverPodPorts,
 					VolumeMounts: mounts,
 				},

--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -23,4 +23,5 @@ RUN chmod 644 /tmp/index.html
 # expose mountd 20048/tcp and nfsd 2049/tcp
 EXPOSE 2049/tcp 20048/tcp
 
-ENTRYPOINT ["/usr/local/bin/run_nfs.sh", "/exports", "/"]
+ENTRYPOINT ["/usr/local/bin/run_nfs.sh"]
+CMD ["/exports", "/"]

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.6
+TAG = 0.7
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/volumes-tester/nfs/README.md
+++ b/test/images/volumes-tester/nfs/README.md
@@ -2,6 +2,9 @@
 
 This container exports '/' directory with an index.html inside. NFSv4 only.
 
+Accepts a -G option for specifying a group id to give exported directories.
+Clients in the specified group will have full rwx permissions, others none.
+
 Inspired by https://github.com/cpuguy83/docker-nfs-server.
 
 Used by test/e2e/* to test NFSVolumeSource. Not for production use!

--- a/test/images/volumes-tester/nfs/run_nfs.sh
+++ b/test/images/volumes-tester/nfs/run_nfs.sh
@@ -17,10 +17,23 @@
 function start()
 {
 
+    unset gid
+    # accept "-G gid" option
+    while getopts "G:" opt; do
+        case ${opt} in
+            G) gid=${OPTARG};;
+        esac
+    done
+    shift $(($OPTIND - 1))
+
     # prepare /etc/exports
     for i in "$@"; do
         # fsid=0: needed for NFSv4
         echo "$i *(rw,fsid=0,insecure,no_root_squash)" >> /etc/exports
+        if [ -v gid ] ; then
+            chmod 070 $i
+            chgrp $gid $i
+        fi
         # move index.html to here
         /bin/cp /tmp/index.html $i/
         chmod 644 $i/index.html


### PR DESCRIPTION
Test for feature added in #29119. Adds the annotation to the pv in the PersistentVolumes e2e test. It tests it by checking the output of 'id -G.' Also tests the actual use case of an nfs server by using an nfs server image 'volume-nfs-gid', modified slightly from 'volume-nfs' to have some permissions set.

@pmorie

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30084)

<!-- Reviewable:end -->
