### PR TITLE
rbac integration tests: pin versions of API groups used in tests

### DIFF
--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -32,9 +32,11 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/batch"
 	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
@@ -275,6 +277,26 @@ var (
 		APIGroups: []string{"batch"},
 		Resources: []string{"*"},
 	}
+
+	// Pin API groups used for tests to a specific version because the default values for the
+	// testapi package may change. For example, if a new version of the batch API is enabled
+	// by default, the API path will differ from the "apiVerison" field of the object.
+	//
+	// See #30079
+	testGroups = map[string]testapi.TestGroup{
+		"": testapi.NewTestGroup(
+			unversioned.GroupVersion{Group: "", Version: "v1"},
+			unversioned.GroupVersion{Group: "", Version: "v1"},
+			api.Scheme.KnownTypes(api.SchemeGroupVersion),
+			api.Scheme.KnownTypes(unversioned.GroupVersion{Group: "", Version: "v1"}),
+		),
+		"batch": testapi.NewTestGroup(
+			unversioned.GroupVersion{Group: "batch", Version: "v1"},
+			batch.SchemeGroupVersion,
+			api.Scheme.KnownTypes(batch.SchemeGroupVersion),
+			api.Scheme.KnownTypes(unversioned.GroupVersion{Group: "batch", Version: "v1"}),
+		),
+	}
 )
 
 func TestRBAC(t *testing.T) {
@@ -391,7 +413,7 @@ func TestRBAC(t *testing.T) {
 		previousResourceVersion := make(map[string]float64)
 
 		for j, r := range tc.requests {
-			testGroup, ok := testapi.Groups[r.apiGroup]
+			testGroup, ok := testGroups[r.apiGroup]
 			if !ok {
 				t.Errorf("case %d %d: unknown api group %q, %s", i, j, r.apiGroup, r)
 				continue


### PR DESCRIPTION
This PR fixes the following failing test condition:

```
etcd &
KUBE_TEST_API="batch/v2alpha1" go test \
  --tags=integration \
  --run=TestRBAC \
   ./test/integration/auth
```

Enabling a new major version of batch overrides the values used in
tests, however the actual objects the test uses still have an
"apiVersion" of "batch/v1". Pin the testapi API groups used in test.
Particularly, always use "batch/v1" even when a newer version is
enabled.

Closes #30079

cc @soltysh @erictune

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30089)

<!-- Reviewable:end -->
