### PR TITLE
Use report-dir in test framework instead.

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -107,6 +107,7 @@ func RegisterCommonFlags() {
 	flag.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
 	flag.StringVar(&TestContext.Host, "host", "http://127.0.0.1:8080", "The host, or apiserver, to connect to")
 	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 }
 
 // Register flags specific to the cluster e2e test suite.
@@ -123,7 +124,6 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
 	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 	flag.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
-	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
 	flag.StringVar(&TestContext.ContainerRuntime, "container-runtime", "docker", "The container runtime of cluster VM instances (docker or rkt).")
 	flag.StringVar(&TestContext.MasterOSDistro, "master-os-distro", "debian", "The OS distribution of cluster master (debian, trusty, or coreos).")

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -83,14 +83,15 @@ func TestE2eNode(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	RegisterFailHandler(Fail)
 	reporters := []Reporter{}
-	if *reportDir != "" {
+	reportDir := framework.TestContext.ReportDir
+	if reportDir != "" {
 		// Create the directory if it doesn't already exists
-		if err := os.MkdirAll(*reportDir, 0755); err != nil {
+		if err := os.MkdirAll(reportDir, 0755); err != nil {
 			glog.Errorf("Failed creating report directory: %v", err)
 		} else {
 			// Configure a junit reporter to write to the directory
 			junitFile := fmt.Sprintf("junit_%s%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode)
-			junitPath := path.Join(*reportDir, junitFile)
+			junitPath := path.Join(reportDir, junitFile)
 			reporters = append(reporters, more_reporters.NewJUnitReporter(junitPath))
 		}
 	}

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -33,10 +33,11 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var serverStartTimeout = flag.Duration("server-start-timeout", time.Second*120, "Time to wait for each server to become healthy.")
-var reportDir = flag.String("report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 
 type e2eService struct {
 	killCmds []*killCmd
@@ -111,12 +112,12 @@ func (es *e2eService) start() error {
 // Since we scp files from the remote directory, symlinks will be treated as normal files and file contents will be copied over.
 func (es *e2eService) getLogFiles() {
 	// Nothing to do if report dir is not specified.
-	if *reportDir == "" {
+	if framework.TestContext.ReportDir == "" {
 		return
 	}
 	journaldFound := isJournaldAvailable()
 	for targetFileName, logFileData := range es.logFiles {
-		targetLink := path.Join(*reportDir, targetFileName)
+		targetLink := path.Join(framework.TestContext.ReportDir, targetFileName)
 		if journaldFound {
 			// Skip log files that do not have an equivalent in journald based machines.
 			if len(logFileData.journalctlCommand) == 0 {
@@ -287,7 +288,7 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 		defer close(cmdErrorChan)
 
 		// Create the output filename
-		outPath := path.Join(*reportDir, cmd.outputFilename)
+		outPath := path.Join(framework.TestContext.ReportDir, cmd.outputFilename)
 		outfile, err := os.Create(outPath)
 		if err != nil {
 			cmdErrorChan <- fmt.Errorf("Failed to create file %s for `%s` %v.", outPath, cmd, err)


### PR DESCRIPTION
We already have `report-dir` option in framework test context.
The node e2e framework should use it as well.

/cc @ronnielai 
