### PR TITLE
syncBatch should not use RLock as deleting apiStatusVersions is not threadsafe

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -364,8 +364,8 @@ func (m *manager) syncBatch() {
 	var updatedStatuses []podStatusSyncRequest
 	podToMirror, mirrorToPod := m.podManager.GetUIDTranslations()
 	func() { // Critical section
-		m.podStatusesLock.RLock()
-		defer m.podStatusesLock.RUnlock()
+		m.podStatusesLock.Lock()
+		defer m.podStatusesLock.Unlock()
 
 		// Clean up orphaned versions.
 		for uid := range m.apiStatusVersions {


### PR DESCRIPTION
syncBatch should not use RLock as deleting apiStatusVersions is not threadsafe, apiStatusVersions must only be accessed from the sync thread.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30123)

<!-- Reviewable:end -->
