### PR TITLE
get workers length shoud use RLock

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -234,8 +234,8 @@ func (m *manager) removeWorker(podUID types.UID, containerName string, probeType
 
 // workerCount returns the total number of probe workers. For testing.
 func (m *manager) workerCount() int {
-	m.workerLock.Lock()
-	defer m.workerLock.Unlock()
+	m.workerLock.RLock()
+	defer m.workerLock.RUnlock()
 	return len(m.workers)
 }
 


### PR DESCRIPTION
get workers length shoud use RLock properly

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30128)

<!-- Reviewable:end -->
