### PR TITLE
[WIP]implement first version of kube-proxy via ipvs

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/proxy/ipvs"
 )
 
 type ProxyServer struct {
@@ -68,6 +69,7 @@ type ProxyServer struct {
 const (
 	proxyModeUserspace              = "userspace"
 	proxyModeIptables               = "iptables"
+	proxyModeIPVS                   = "ipvs"
 	experimentalProxyModeAnnotation = options.ExperimentalProxyModeAnnotation
 	betaProxyModeAnnotation         = "net.beta.kubernetes.io/proxy-mode"
 )
@@ -214,6 +216,18 @@ func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, err
 		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
 		glog.V(0).Info("Tearing down userspace rules.")
 		userspace.CleanupLeftovers(iptInterface)
+	} else if proxyMode == proxyModeIPVS {
+		glog.V(0).Info("Using ipvs Proxier.")
+		proxierIpvs, err := ipvs.NewProxier(iptInterface, config.IPTablesSyncPeriod.Duration)
+		if err != nil {
+			glog.Fatalf("Unable to create proxier: %v", err)
+		}
+		proxier = proxierIpvs
+		endpointsHandler = proxierIpvs
+
+		// clean up all applied iptables and ipvs rules
+		ipvs.CleanupIptablesLeftovers(iptInterface)
+		ipvs.CleanupIpvsLeftover()
 	} else {
 		glog.V(0).Info("Using userspace Proxier.")
 		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
@@ -353,6 +367,8 @@ type nodeGetter interface {
 func getProxyMode(proxyMode string, client nodeGetter, hostname string, iptver iptables.IptablesVersioner, kcompat iptables.KernelCompatTester) string {
 	if proxyMode == proxyModeUserspace {
 		return proxyModeUserspace
+	} else if proxyMode == proxyModeIPVS {
+		return proxyModeIPVS
 	} else if proxyMode == proxyModeIptables {
 		return tryIptablesProxy(iptver, kcompat)
 	} else if proxyMode != "" {

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -88,6 +88,7 @@ type ProxyMode string
 const (
 	ProxyModeUserspace ProxyMode = "userspace"
 	ProxyModeIPTables  ProxyMode = "iptables"
+	ProxyModeIPVS      ProxyMode = "ipvs"
 )
 
 // HairpinMode denotes how the kubelet should configure networking to handle

--- a/pkg/proxy/ipvs/iptables.go
+++ b/pkg/proxy/ipvs/iptables.go
@@ -1,0 +1,473 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvs
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/proxy"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/iptables"
+
+	"github.com/golang/glog"
+)
+
+// See comments in the *PortalArgs() functions for some details about why we
+// use two chains for portals.
+var iptablesContainerPortalChain iptables.Chain = "KUBE-PORTALS-CONTAINER"
+var iptablesHostPortalChain iptables.Chain = "KUBE-PORTALS-HOST"
+
+// Chains for NodePort services
+var iptablesContainerNodePortChain iptables.Chain = "KUBE-NODEPORT-CONTAINER"
+var iptablesHostNodePortChain iptables.Chain = "KUBE-NODEPORT-HOST"
+var iptablesNonLocalNodePortChain iptables.Chain = "KUBE-NODEPORT-NON-LOCAL"
+
+// Ensure that the iptables infrastructure we use is set up.  This can safely be called periodically.
+func iptablesInit(ipt iptables.Interface) error {
+	// TODO: There is almost certainly room for optimization here.  E.g. If
+	// we knew the service-cluster-ip-range CIDR we could fast-track outbound packets not
+	// destined for a service. There's probably more, help wanted.
+
+	// Danger - order of these rules matters here:
+	//
+	// We match portal rules first, then NodePort rules.  For NodePort rules, we filter primarily on --dst-type LOCAL,
+	// because we want to listen on all local addresses, but don't match internet traffic with the same dst port number.
+	//
+	// There is one complication (per thockin):
+	// -m addrtype --dst-type LOCAL is what we want except that it is broken (by intent without foresight to our usecase)
+	// on at least GCE. Specifically, GCE machines have a daemon which learns what external IPs are forwarded to that
+	// machine, and configure a local route for that IP, making a match for --dst-type LOCAL when we don't want it to.
+	// Removing the route gives correct behavior until the daemon recreates it.
+	// Killing the daemon is an option, but means that any non-kubernetes use of the machine with external IP will be broken.
+	//
+	// This applies to IPs on GCE that are actually from a load-balancer; they will be categorized as LOCAL.
+	// _If_ the chains were in the wrong order, and the LB traffic had dst-port == a NodePort on some other service,
+	// the NodePort would take priority (incorrectly).
+	// This is unlikely (and would only affect outgoing traffic from the cluster to the load balancer, which seems
+	// doubly-unlikely), but we need to be careful to keep the rules in the right order.
+	args := []string{ /* service-cluster-ip-range matching could go here */ }
+	args = append(args, "-m", "comment", "--comment", "handle ClusterIPs; NOTE: this must be before the NodePort rules")
+	if _, err := ipt.EnsureChain(iptables.TableNAT, iptablesContainerPortalChain); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerPortalChain))...); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureChain(iptables.TableNAT, iptablesHostPortalChain); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostPortalChain))...); err != nil {
+		return err
+	}
+
+	// This set of rules matches broadly (addrtype & destination port), and therefore must come after the portal rules
+	args = []string{"-m", "addrtype", "--dst-type", "LOCAL"}
+	args = append(args, "-m", "comment", "--comment", "handle service NodePorts; NOTE: this must be the last rule in the chain")
+	if _, err := ipt.EnsureChain(iptables.TableNAT, iptablesContainerNodePortChain); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureRule(iptables.Append, iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerNodePortChain))...); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureChain(iptables.TableNAT, iptablesHostNodePortChain); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureRule(iptables.Append, iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostNodePortChain))...); err != nil {
+		return err
+	}
+
+	// Create a chain intended to explicitly allow non-local NodePort
+	// traffic to work around default-deny iptables configurations
+	// that would otherwise reject such traffic.
+	args = []string{"-m", "comment", "--comment", "Ensure that non-local NodePort traffic can flow"}
+	if _, err := ipt.EnsureChain(iptables.TableFilter, iptablesNonLocalNodePortChain); err != nil {
+		return err
+	}
+	if _, err := ipt.EnsureRule(iptables.Prepend, iptables.TableFilter, iptables.ChainInput, append(args, "-j", string(iptablesNonLocalNodePortChain))...); err != nil {
+		return err
+	}
+
+	// TODO: Verify order of rules.
+	return nil
+}
+
+// Flush all of our custom iptables rules.
+func iptablesFlush(ipt iptables.Interface) error {
+	el := []error{}
+	if err := ipt.FlushChain(iptables.TableNAT, iptablesContainerPortalChain); err != nil {
+		el = append(el, err)
+	}
+	if err := ipt.FlushChain(iptables.TableNAT, iptablesHostPortalChain); err != nil {
+		el = append(el, err)
+	}
+	if err := ipt.FlushChain(iptables.TableNAT, iptablesContainerNodePortChain); err != nil {
+		el = append(el, err)
+	}
+	if err := ipt.FlushChain(iptables.TableNAT, iptablesHostNodePortChain); err != nil {
+		el = append(el, err)
+	}
+	if err := ipt.FlushChain(iptables.TableFilter, iptablesNonLocalNodePortChain); err != nil {
+		el = append(el, err)
+	}
+	if len(el) != 0 {
+		glog.Errorf("Some errors flushing old iptables portals: %v", el)
+	}
+	return utilerrors.NewAggregate(el)
+}
+
+// Build a slice of iptables args that are common to from-container and from-host portal rules.
+func iptablesCommonPortalArgs(destIP net.IP, addPhysicalInterfaceMatch bool, addDstLocalMatch bool, destPort int, protocol api.Protocol, service proxy.ServicePortName) []string {
+	// This list needs to include all fields as they are eventually spit out
+	// by iptables-save.  This is because some systems do not support the
+	// 'iptables -C' arg, and so fall back on parsing iptables-save output.
+	// If this does not match, it will not pass the check.  For example:
+	// adding the /32 on the destination IP arg is not strictly required,
+	// but causes this list to not match the final iptables-save output.
+	// This is fragile and I hope one day we can stop supporting such old
+	// iptables versions.
+	args := []string{
+		"-m", "comment",
+		"--comment", service.String(),
+		"-p", strings.ToLower(string(protocol)),
+		"-m", strings.ToLower(string(protocol)),
+		"--dport", fmt.Sprintf("%d", destPort),
+	}
+
+	if destIP != nil {
+		args = append(args, "-d", fmt.Sprintf("%s/32", destIP.String()))
+	}
+
+	if addPhysicalInterfaceMatch {
+		args = append(args, "-m", "physdev", "!", "--physdev-is-in")
+	}
+
+	if addDstLocalMatch {
+		args = append(args, "-m", "addrtype", "--dst-type", "LOCAL")
+	}
+
+	return args
+}
+
+// Build a slice of iptables args for a from-container portal rule.
+func (proxier *Proxier) iptablesContainerPortalArgs(destIP net.IP, addPhysicalInterfaceMatch bool, addDstLocalMatch bool, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
+	args := iptablesCommonPortalArgs(destIP, addPhysicalInterfaceMatch, addDstLocalMatch, destPort, protocol, service)
+	// DNAT to ipvs vip:port
+	args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
+	return args
+}
+
+// Build a slice of iptables args for a from-host portal rule.
+func (proxier *Proxier) iptablesHostPortalArgs(destIP net.IP, addDstLocalMatch bool, destPort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
+	args := iptablesCommonPortalArgs(destIP, false, addDstLocalMatch, destPort, protocol, service)
+	// DNAT to ipvs vip:port
+	args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
+	return args
+}
+
+// Build a slice of iptables args for a from-container public-port rule.
+// See iptablesContainerPortalArgs
+// TODO: Should we just reuse iptablesContainerPortalArgs?
+func (proxier *Proxier) iptablesContainerNodePortArgs(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
+	args := iptablesCommonPortalArgs(nil, false, false, nodePort, protocol, service)
+	// DNAT to ipvs vip:port
+	args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
+
+	return args
+}
+
+// Build a slice of iptables args for a from-host public-port rule.
+// See iptablesHostPortalArgs
+// TODO: Should we just reuse iptablesHostPortalArgs?
+func (proxier *Proxier) iptablesHostNodePortArgs(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
+	args := iptablesCommonPortalArgs(nil, false, false, nodePort, protocol, service)
+	// // DNAT to ipvs vip:port
+	// TODO: Can we DNAT with IPv6?
+	args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))
+	return args
+}
+
+// Build a slice of iptables args for an from-non-local public-port rule.
+func (proxier *Proxier) iptablesNonLocalNodePortArgs(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
+	args := iptablesCommonPortalArgs(nil, false, false, proxyPort, protocol, service)
+	args = append(args, "-m", "comment", "--comment", service.String(), "-m", "state", "--state", "NEW", "-j", "ACCEPT")
+	return args
+}
+
+// CleanupIptablesLeftovers removes all iptables rules and chains created by the Proxier
+// It returns true if an error was encountered. Errors are logged.
+func CleanupIptablesLeftovers(ipt iptables.Interface) (encounteredError bool) {
+	// NOTE: Warning, this needs to be kept in sync with the userspace Proxier,
+	// we want to ensure we remove all of the iptables rules it creates.
+	// Currently they are all in iptablesInit()
+	// Delete Rules first, then Flush and Delete Chains
+	args := []string{"-m", "comment", "--comment", "handle ClusterIPs; NOTE: this must be before the NodePort rules"}
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostPortalChain))...); err != nil {
+		if !iptables.IsNotFoundError(err) {
+			glog.Errorf("Error removing userspace rule: %v", err)
+			encounteredError = true
+		}
+	}
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerPortalChain))...); err != nil {
+		if !iptables.IsNotFoundError(err) {
+			glog.Errorf("Error removing userspace rule: %v", err)
+			encounteredError = true
+		}
+	}
+	args = []string{"-m", "addrtype", "--dst-type", "LOCAL"}
+	args = append(args, "-m", "comment", "--comment", "handle service NodePorts; NOTE: this must be the last rule in the chain")
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainOutput, append(args, "-j", string(iptablesHostNodePortChain))...); err != nil {
+		if !iptables.IsNotFoundError(err) {
+			glog.Errorf("Error removing userspace rule: %v", err)
+			encounteredError = true
+		}
+	}
+	if err := ipt.DeleteRule(iptables.TableNAT, iptables.ChainPrerouting, append(args, "-j", string(iptablesContainerNodePortChain))...); err != nil {
+		if !iptables.IsNotFoundError(err) {
+			glog.Errorf("Error removing userspace rule: %v", err)
+			encounteredError = true
+		}
+	}
+	args = []string{"-m", "comment", "--comment", "Ensure that non-local NodePort traffic can flow"}
+	if err := ipt.DeleteRule(iptables.TableFilter, iptables.ChainInput, append(args, "-j", string(iptablesNonLocalNodePortChain))...); err != nil {
+		if !iptables.IsNotFoundError(err) {
+			glog.Errorf("Error removing userspace rule: %v", err)
+			encounteredError = true
+		}
+	}
+
+	// flush and delete chains.
+	tableChains := map[iptables.Table][]iptables.Chain{
+		iptables.TableNAT:    {iptablesContainerPortalChain, iptablesHostPortalChain, iptablesHostNodePortChain, iptablesContainerNodePortChain},
+		iptables.TableFilter: {iptablesNonLocalNodePortChain},
+	}
+	for table, chains := range tableChains {
+		for _, c := range chains {
+			// flush chain, then if successful delete, delete will fail if flush fails.
+			if err := ipt.FlushChain(table, c); err != nil {
+				if !iptables.IsNotFoundError(err) {
+					glog.Errorf("Error flushing userspace chain: %v", err)
+					encounteredError = true
+				}
+			} else {
+				if err = ipt.DeleteChain(table, c); err != nil {
+					if !iptables.IsNotFoundError(err) {
+						glog.Errorf("Error deleting userspace chain: %v", err)
+						encounteredError = true
+					}
+				}
+			}
+		}
+	}
+	return encounteredError
+}
+
+func (proxier *Proxier) AddIptablesRule(service proxy.ServicePortName, info *serviceInfo) (err error) {
+	for _, publicIP := range info.externalIPs {
+		err = proxier.AddOneIptablesRule(portal{net.ParseIP(publicIP), info.portal.port, true}, info.protocol, info.portal.ip, info.portal.port, service)
+		if err != nil {
+			return err
+		}
+	}
+	for _, ingress := range info.loadBalancerStatus.Ingress {
+		if ingress.IP != "" {
+			err = proxier.AddOneIptablesRule(portal{net.ParseIP(ingress.IP), info.portal.port, false}, info.protocol, info.portal.ip, info.portal.port, service)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if info.nodePort != 0 {
+		err = proxier.addNodeIptablesRule(info.nodePort, info.protocol, info.portal.ip, info.portal.port, service)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (proxier *Proxier) AddOneIptablesRule(portal portal, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) error {
+	// Handle traffic from containers.
+	args := proxier.iptablesContainerPortalArgs(portal.ip, portal.isExternal, false, portal.port, protocol, proxyIP, proxyPort, name)
+	existed, err := proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesContainerPortalChain, args...)
+	if err != nil {
+		glog.Errorf("Failed to install iptables %s rule for service %q, args:%v", iptablesContainerPortalChain, name, args)
+		return err
+	}
+	if !existed {
+		glog.V(3).Infof("Opened iptables from-containers portal for service %q on %s %s:%d", name, protocol, portal.ip, portal.port)
+	}
+	if portal.isExternal {
+		args := proxier.iptablesContainerPortalArgs(portal.ip, false, true, portal.port, protocol, proxyIP, proxyPort, name)
+		existed, err := proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesContainerPortalChain, args...)
+		if err != nil {
+			glog.Errorf("Failed to install iptables %s rule that opens service %q for local traffic, args:%v", iptablesContainerPortalChain, name, args)
+			return err
+		}
+		if !existed {
+			glog.V(3).Infof("Opened iptables from-containers portal for service %q on %s %s:%d for local traffic", name, protocol, portal.ip, portal.port)
+		}
+
+		args = proxier.iptablesHostPortalArgs(portal.ip, true, portal.port, protocol, proxyIP, proxyPort, name)
+		existed, err = proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesHostPortalChain, args...)
+		if err != nil {
+			glog.Errorf("Failed to install iptables %s rule for service %q for dst-local traffic", iptablesHostPortalChain, name)
+			return err
+		}
+		if !existed {
+			glog.V(3).Infof("Opened iptables from-host portal for service %q on %s %s:%d for dst-local traffic", name, protocol, portal.ip, portal.port)
+		}
+		return nil
+	}
+
+	// Handle traffic from the host.
+	args = proxier.iptablesHostPortalArgs(portal.ip, false, portal.port, protocol, proxyIP, proxyPort, name)
+	existed, err = proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesHostPortalChain, args...)
+	if err != nil {
+		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesHostPortalChain, name)
+		return err
+	}
+	if !existed {
+		glog.V(3).Infof("Opened iptables from-host portal for service %q on %s %s:%d", name, protocol, portal.ip, portal.port)
+	}
+	return nil
+}
+
+func (proxier *Proxier) addNodeIptablesRule(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) error {
+	// TODO: Do we want to allow containers to access public services?  Probably yes.
+	// TODO: We could refactor this to be the same code as portal, but with IP == nil
+
+	// Handle traffic from containers.
+	args := proxier.iptablesContainerNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	existed, err := proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesContainerNodePortChain, args...)
+	if err != nil {
+		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesContainerNodePortChain, name)
+		return err
+	}
+	if !existed {
+		glog.Infof("Opened iptables from-containers public port for service %q on %s port %d", name, protocol, nodePort)
+	}
+
+	// Handle traffic from the host.
+	args = proxier.iptablesHostNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	existed, err = proxier.iptables.EnsureRule(iptables.Append, iptables.TableNAT, iptablesHostNodePortChain, args...)
+	if err != nil {
+		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesHostNodePortChain, name)
+		return err
+	}
+	if !existed {
+		glog.Infof("Opened iptables from-host public port for service %q on %s port %d", name, protocol, nodePort)
+	}
+
+	args = proxier.iptablesNonLocalNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	existed, err = proxier.iptables.EnsureRule(iptables.Append, iptables.TableFilter, iptablesNonLocalNodePortChain, args...)
+	if err != nil {
+		glog.Errorf("Failed to install iptables %s rule for service %q", iptablesNonLocalNodePortChain, name)
+		return err
+	}
+	if !existed {
+		glog.Infof("Opened iptables from-non-local public port for service %q on %s port %d", name, protocol, nodePort)
+	}
+
+	return nil
+}
+
+func (proxier *Proxier) deleteIptablesRule(service proxy.ServicePortName, info *serviceInfo) error {
+	// Collect errors and report them all at the end.
+	el := proxier.deleteOneIptablesRule(info.portal, info.protocol, info.portal.ip, info.portal.port, service)
+	for _, publicIP := range info.externalIPs {
+		el = append(el, proxier.deleteOneIptablesRule(portal{net.ParseIP(publicIP), info.portal.port, true}, info.protocol, info.portal.ip, info.portal.port, service)...)
+	}
+	for _, ingress := range info.loadBalancerStatus.Ingress {
+		if ingress.IP != "" {
+			el = append(el, proxier.deleteOneIptablesRule(portal{net.ParseIP(ingress.IP), info.portal.port, false}, info.protocol, info.portal.ip, info.portal.port, service)...)
+		}
+	}
+	if info.nodePort != 0 {
+		el = append(el, proxier.deleteNodeIptablesRule(info.nodePort, info.protocol, info.portal.ip, info.portal.port, service)...)
+	}
+	if len(el) == 0 {
+		glog.V(3).Infof("Closed iptables portals for service %q", service)
+	} else {
+		glog.Errorf("Some errors closing iptables portals for service %q", service)
+	}
+	return utilerrors.NewAggregate(el)
+}
+
+func (proxier *Proxier) deleteOneIptablesRule(portal portal, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) []error {
+	el := []error{}
+	// Handle traffic from containers.
+	args := proxier.iptablesContainerPortalArgs(portal.ip, portal.isExternal, false, portal.port, protocol, proxyIP, proxyPort, name)
+	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesContainerPortalChain, args...); err != nil {
+		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesContainerPortalChain, name)
+		el = append(el, err)
+	}
+
+	if portal.isExternal {
+		args := proxier.iptablesContainerPortalArgs(portal.ip, false, true, portal.port, protocol, proxyIP, proxyPort, name)
+		if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesContainerPortalChain, args...); err != nil {
+			glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesContainerPortalChain, name)
+			el = append(el, err)
+		}
+
+		args = proxier.iptablesHostPortalArgs(portal.ip, true, portal.port, protocol, proxyIP, proxyPort, name)
+		if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesHostPortalChain, args...); err != nil {
+			glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesHostPortalChain, name)
+			el = append(el, err)
+		}
+		return el
+	}
+
+	// Handle traffic from the host (portalIP is not external).
+	args = proxier.iptablesHostPortalArgs(portal.ip, false, portal.port, protocol, proxyIP, proxyPort, name)
+	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesHostPortalChain, args...); err != nil {
+		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesHostPortalChain, name)
+		el = append(el, err)
+	}
+
+	return el
+}
+
+func (proxier *Proxier) deleteNodeIptablesRule(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) []error {
+	el := []error{}
+
+	// Handle traffic from containers.
+	args := proxier.iptablesContainerNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesContainerNodePortChain, args...); err != nil {
+		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesContainerNodePortChain, name)
+		el = append(el, err)
+	}
+
+	// Handle traffic from the host.
+	args = proxier.iptablesHostNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	if err := proxier.iptables.DeleteRule(iptables.TableNAT, iptablesHostNodePortChain, args...); err != nil {
+		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesHostNodePortChain, name)
+		el = append(el, err)
+	}
+
+	// Handle traffic not local to the host
+	args = proxier.iptablesNonLocalNodePortArgs(nodePort, protocol, proxyIP, proxyPort, name)
+	if err := proxier.iptables.DeleteRule(iptables.TableFilter, iptablesNonLocalNodePortChain, args...); err != nil {
+		glog.Errorf("Failed to delete iptables %s rule for service %q", iptablesNonLocalNodePortChain, name)
+		el = append(el, err)
+	}
+
+	return el
+}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1,0 +1,509 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvs
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/proxy"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/iptables"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/slice"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	"github.com/google/seesaw/ipvs"
+)
+
+const defaultScheduler = "rr"
+
+type portal struct {
+	ip         net.IP
+	port       int
+	isExternal bool
+}
+
+// internal struct for string service information
+type serviceInfo struct {
+	portal             portal
+	protocol           api.Protocol
+	nodePort           int
+	externalIPs        []string
+	loadBalancerStatus api.LoadBalancerStatus
+
+	sessionAffinityType api.ServiceAffinity
+	stickyMaxAgeSeconds int
+}
+
+// returns a new serviceInfo struct
+func newServiceInfo() *serviceInfo {
+	return &serviceInfo{
+		sessionAffinityType: api.ServiceAffinityNone, // default
+		// TODO: paramaterize this in the API. By now ipvs will use the default value(300s)
+		//stickyMaxAgeSeconds: 300,
+	}
+}
+
+type Proxier struct {
+	mu sync.Mutex
+
+	iptables   iptables.Interface
+	syncPeriod time.Duration
+
+	serviceMap                  map[proxy.ServicePortName]serviceInfo
+	endpointsMap                map[proxy.ServicePortName][]string
+	haveReceivedServiceUpdate   bool // true once we've seen an OnServiceUpdate event
+	haveReceivedEndpointsUpdate bool // true once we've seen an OnEndpointsUpdate event
+}
+
+// assert Proxier is a ProxyProvider
+var _ proxy.ProxyProvider = &Proxier{}
+
+func NewProxier(iptables iptables.Interface, syncPeriod time.Duration) (*Proxier, error) {
+	p := &Proxier{
+		iptables:     iptables,
+		syncPeriod:   syncPeriod,
+		serviceMap:   map[proxy.ServicePortName]serviceInfo{},
+		endpointsMap: map[proxy.ServicePortName][]string{},
+	}
+
+	// Set up the iptables foundations we need.
+	if err := iptablesInit(iptables); err != nil {
+		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
+	}
+	// Flush old iptables rules (since the bound ports will be invalid after a restart).
+	// When OnUpdate() is first called, the rules will be recreated.
+	if err := iptablesFlush(iptables); err != nil {
+		return nil, fmt.Errorf("failed to flush iptables: %v", err)
+	}
+
+	if err := ipvs.Init(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (proxier *Proxier) OnServiceUpdate(services []api.Service) {
+	proxier.mu.Lock()
+	defer proxier.mu.Unlock()
+	proxier.haveReceivedServiceUpdate = true
+
+	activeServices := make(map[proxy.ServicePortName]bool) // use a map as a set
+
+	for i := range services {
+		service := &services[i]
+		svcName := types.NamespacedName{
+			Namespace: service.Namespace,
+			Name:      service.Name,
+		}
+
+		// if ClusterIP is "None" or empty, skip proxying
+		if !api.IsServiceIPSet(service) {
+			glog.V(3).Infof("Skipping service %s due to clusterIP = %q", svcName, service.Spec.ClusterIP)
+			continue
+		}
+
+		for i := range service.Spec.Ports {
+			servicePort := &service.Spec.Ports[i]
+
+			serviceName := proxy.ServicePortName{
+				NamespacedName: svcName,
+				Port:           servicePort.Name,
+			}
+			activeServices[serviceName] = true
+			info, exists := proxier.serviceMap[serviceName]
+			if exists && proxier.sameConfig(&info, service, servicePort) {
+				// Nothing changed.
+				continue
+			}
+			if exists {
+				// Something changed.
+				glog.V(3).Infof("Something changed for service %q: removing it", serviceName)
+				err := proxier.deleteIptablesRule(serviceName, &info)
+				if err != nil {
+					glog.Errorf("Failed to delete iptables rule for %q: %v", serviceName, err)
+				}
+				delete(proxier.serviceMap, serviceName)
+			}
+			serviceIP := net.ParseIP(service.Spec.ClusterIP)
+			glog.V(1).Infof("Adding new service %q at %s:%d/%s", serviceName, serviceIP, servicePort.Port, servicePort.Protocol)
+
+			info = *newServiceInfo()
+			info.portal.ip = serviceIP
+			info.portal.port = int(servicePort.Port)
+			info.protocol = servicePort.Protocol
+			info.nodePort = int(servicePort.NodePort)
+			info.externalIPs = service.Spec.ExternalIPs
+			// Deep-copy in case the service instance changes
+			info.loadBalancerStatus = *api.LoadBalancerStatusDeepCopy(&service.Status.LoadBalancer)
+			info.sessionAffinityType = service.Spec.SessionAffinity
+			proxier.serviceMap[serviceName] = info
+
+			err := proxier.AddIptablesRule(serviceName, &info)
+			if err != nil {
+				glog.Errorf("Failed to add iptables rule for %q: %v", serviceName, err)
+			}
+
+			glog.V(4).Infof("added serviceInfo(%s): %s", serviceName, spew.Sdump(info))
+		}
+	}
+
+	// Remove services missing from the update.
+	for name, info := range proxier.serviceMap {
+		if !activeServices[name] {
+			glog.V(1).Infof("Removing service %q", name)
+			err := proxier.deleteIptablesRule(name, &info)
+			if err != nil {
+				glog.Errorf("Failed to delete iptables rule for %q: %v", name, err)
+			}
+			delete(proxier.serviceMap, name)
+		}
+	}
+
+	proxier.syncIpvsRules()
+}
+
+// OnEndpointsUpdate takes in a slice of updated endpoints.
+func (proxier *Proxier) OnEndpointsUpdate(allEndpoints []api.Endpoints) {
+	start := time.Now()
+	defer func() {
+		glog.V(4).Infof("OnEndpointsUpdate took %v for %d endpoints", time.Since(start), len(allEndpoints))
+	}()
+
+	proxier.mu.Lock()
+	defer proxier.mu.Unlock()
+	proxier.haveReceivedEndpointsUpdate = true
+
+	activeEndpoints := make(map[proxy.ServicePortName]bool) // use a map as a set
+
+	// Update endpoints for services.
+	for i := range allEndpoints {
+		svcEndpoints := &allEndpoints[i]
+
+		// We need to build a map of portname -> all ip:ports for that
+		// portname.  Explode Endpoints.Subsets[*] into this structure.
+		portsToEndpoints := map[string][]hostPortPair{}
+		for i := range svcEndpoints.Subsets {
+			ss := &svcEndpoints.Subsets[i]
+			for i := range ss.Ports {
+				port := &ss.Ports[i]
+				for i := range ss.Addresses {
+					addr := &ss.Addresses[i]
+					portsToEndpoints[port.Name] = append(portsToEndpoints[port.Name], hostPortPair{addr.IP, int(port.Port)})
+				}
+			}
+		}
+
+		for portname := range portsToEndpoints {
+			svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: svcEndpoints.Namespace, Name: svcEndpoints.Name}, Port: portname}
+			curEndpoints := proxier.endpointsMap[svcPort]
+			newEndpoints := flattenValidEndpoints(portsToEndpoints[portname])
+
+			if len(curEndpoints) != len(newEndpoints) || !slicesEquiv(slice.CopyStrings(curEndpoints), newEndpoints) {
+				glog.V(1).Infof("Setting endpoints for %q to %+v", svcPort, newEndpoints)
+				proxier.endpointsMap[svcPort] = newEndpoints
+			}
+			activeEndpoints[svcPort] = true
+		}
+	}
+
+	// Remove endpoints missing from the update.
+	for name := range proxier.endpointsMap {
+		if !activeEndpoints[name] {
+			glog.V(2).Infof("Removing endpoints for %q", name)
+			delete(proxier.endpointsMap, name)
+		}
+	}
+
+	proxier.syncIpvsRules()
+}
+
+func (proxier *Proxier) syncIpvsRules() {
+	start := time.Now()
+	defer func() {
+		glog.V(4).Infof("syncProxyRules took %v", time.Since(start))
+	}()
+	// don't sync rules till we've received services and endpoints
+	if !proxier.haveReceivedEndpointsUpdate || !proxier.haveReceivedServiceUpdate {
+		glog.V(2).Info("Not syncing iptables until Services and Endpoints have been received from master")
+		return
+	}
+	glog.V(3).Infof("Syncing ipvs rules")
+
+	// sync ipvs rules
+	type serviceKey struct {
+		ip       string
+		port     int
+		protocol api.Protocol
+	}
+	activeServices := make(map[serviceKey]bool)
+
+	for svcName, svcInfo := range proxier.serviceMap {
+		svcKey := serviceKey{
+			ip:       svcInfo.portal.ip.String(),
+			port:     svcInfo.portal.port,
+			protocol: svcInfo.protocol,
+		}
+		activeServices[svcKey] = true
+
+		// sync service
+		{
+			applied, err := ipvs.GetService(&ipvs.Service{
+				Address:  svcInfo.portal.ip,
+				Port:     uint16(svcInfo.portal.port),
+				Protocol: toProtoNum(svcInfo.protocol),
+			})
+			if err != nil || applied.Scheduler != defaultScheduler || (applied.Flags&ipvs.SFPersistent) == 0 {
+				if err == nil {
+					glog.V(4).Infof("Something changed for service %v: stopping it", svcName)
+					err = ipvs.DeleteService(ipvs.Service{
+						Address:  svcInfo.portal.ip,
+						Port:     uint16(svcInfo.portal.port),
+						Protocol: toProtoNum(svcInfo.protocol),
+					})
+					if err != nil {
+						glog.Errorf("Failed to remove Service for %v: %v", svcName, err)
+					}
+				}
+
+				glog.V(1).Infof("Adding new service %q at %s:%d/%s", svcName, svcInfo.portal.ip, svcInfo.portal.port, svcInfo.protocol)
+
+				var flags ipvs.ServiceFlags
+				if svcInfo.sessionAffinityType == api.ServiceAffinityClientIP {
+					flags |= ipvs.SFPersistent
+				}
+
+				err = ipvs.AddService(ipvs.Service{
+					Address:  svcInfo.portal.ip,
+					Port:     uint16(svcInfo.portal.port),
+					Protocol: toProtoNum(svcInfo.protocol),
+					Flags:    flags,
+				})
+				if err != nil {
+					glog.Errorf("Failed to add Service for %q: %v", svcName, err)
+				}
+			}
+		}
+		// sync endpoints
+		{
+			applied, err := ipvs.GetService(&ipvs.Service{
+				Address:  svcInfo.portal.ip,
+				Port:     uint16(svcInfo.portal.port),
+				Protocol: toProtoNum(svcInfo.protocol),
+			})
+			if err != nil {
+				continue
+			}
+
+			curEndpoints := sets.NewString()
+			newEndpoints := sets.NewString()
+			for _, des := range applied.Destinations {
+				curEndpoints.Insert([]string{net.JoinHostPort(des.Address.String(), fmt.Sprintf("%s", des.Port))}...)
+			}
+			for _, eps := range proxier.endpointsMap[svcName] {
+				newEndpoints.Insert(eps)
+			}
+			if !curEndpoints.Equal(newEndpoints) {
+				for _, ep := range newEndpoints.Difference(curEndpoints).List() {
+					ip, port := parseHostPort(ep)
+					ipvs.AddDestination(*applied, ipvs.Destination{
+						Address: net.ParseIP(ip),
+						Port:    uint16(port),
+					})
+				}
+				for _, ep := range curEndpoints.Difference(newEndpoints).List() {
+					ip, port := parseHostPort(ep)
+					ipvs.DeleteDestination(*applied, ipvs.Destination{
+						Address: net.ParseIP(ip),
+						Port:    uint16(port),
+					})
+				}
+			}
+		}
+	}
+
+	// reads all applied ipvs rules from the host
+	curServices, err := ipvs.GetServices()
+	if err != nil {
+		glog.Errorf("Failed to list all ipvs Service from host: %v", err)
+		return
+	}
+	for _, srv := range curServices {
+		svcKey := serviceKey{
+			ip:       srv.Address.String(),
+			port:     int(srv.Port),
+			protocol: toProtoType(srv.Protocol),
+		}
+
+		if !activeServices[svcKey] {
+			glog.V(1).Infof("Stopping service %q", srv)
+			err := ipvs.DeleteService(*srv)
+			if err != nil {
+				glog.Errorf("Failed to remove Service for %q: %v", srv, err)
+			}
+		}
+	}
+}
+
+func CleanupIpvsLeftover() error {
+	return ipvs.Flush()
+}
+
+// Sync is called to immediately synchronize the proxier state to iptables
+func (proxier *Proxier) Sync() {
+	if err := iptablesInit(proxier.iptables); err != nil {
+		glog.Errorf("Failed to ensure iptables: %v", err)
+	}
+	proxier.ensureIptablesRules()
+}
+
+// SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.
+func (proxier *Proxier) SyncLoop() {
+	t := time.NewTicker(proxier.syncPeriod)
+	defer t.Stop()
+	for {
+		<-t.C
+		glog.V(6).Infof("Periodic sync")
+		proxier.Sync()
+	}
+}
+
+// Ensure that portals exist for all services.
+func (proxier *Proxier) ensureIptablesRules() {
+	proxier.mu.Lock()
+	defer proxier.mu.Unlock()
+	// NB: This does not remove rules that should not be present.
+	for name, info := range proxier.serviceMap {
+		err := proxier.AddIptablesRule(name, &info)
+		if err != nil {
+			glog.Errorf("Failed to ensure portal for %q: %v", name, err)
+		}
+	}
+}
+
+func (proxier *Proxier) sameConfig(info *serviceInfo, service *api.Service, port *api.ServicePort) bool {
+	if info.protocol != port.Protocol || info.portal.port != int(port.Port) || info.nodePort != int(port.NodePort) {
+		return false
+	}
+	if !info.portal.ip.Equal(net.ParseIP(service.Spec.ClusterIP)) {
+		return false
+	}
+	if !ipsEqual(info.externalIPs, service.Spec.ExternalIPs) {
+		return false
+	}
+	if !api.LoadBalancerStatusEqual(&info.loadBalancerStatus, &service.Status.LoadBalancer) {
+		return false
+	}
+	if info.sessionAffinityType != service.Spec.SessionAffinity {
+		return false
+	}
+	return true
+}
+
+func ipsEqual(lhs, rhs []string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if lhs[i] != rhs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type endpointServicePair struct {
+	endpoint        string
+	servicePortName proxy.ServicePortName
+}
+
+// used in OnEndpointsUpdate
+type hostPortPair struct {
+	host string
+	port int
+}
+
+func isValidEndpoint(hpp *hostPortPair) bool {
+	return hpp.host != "" && hpp.port > 0
+}
+
+// Tests whether two slices are equivalent.  This sorts both slices in-place.
+func slicesEquiv(lhs, rhs []string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	if reflect.DeepEqual(slice.SortStrings(lhs), slice.SortStrings(rhs)) {
+		return true
+	}
+	return false
+}
+
+func flattenValidEndpoints(endpoints []hostPortPair) []string {
+	// Convert Endpoint objects into strings for easier use later.
+	var result []string
+	for i := range endpoints {
+		hpp := &endpoints[i]
+		if isValidEndpoint(hpp) {
+			result = append(result, net.JoinHostPort(hpp.host, strconv.Itoa(hpp.port)))
+		} else {
+			glog.Warningf("got invalid endpoint: %+v", *hpp)
+		}
+	}
+	return result
+}
+
+func toProtoNum(proto api.Protocol) ipvs.IPProto {
+	p := string(proto)
+	switch strings.ToLower(p) {
+	case "tcp":
+		return ipvs.IPProto(syscall.IPPROTO_TCP)
+	case "udp":
+		return ipvs.IPProto(syscall.IPPROTO_UDP)
+	}
+	return ipvs.IPProto(0)
+}
+
+func toProtoType(proto ipvs.IPProto) api.Protocol {
+	switch proto {
+	case syscall.IPPROTO_TCP:
+		return api.ProtocolTCP
+	case syscall.IPPROTO_UDP:
+		return api.ProtocolUDP
+	}
+	return api.ProtocolTCP
+}
+
+func parseHostPort(hostPort string) (string, int) {
+	host, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return hostPort, 0
+	}
+	intPort, err := strconv.Atoi(port)
+	if err != nil {
+		return hostPort, 0
+	}
+	return host, intPort
+}

--- a/vendor/github.com/google/seesaw/LICENSE
+++ b/vendor/github.com/google/seesaw/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/seesaw/ipvs/ipvs.go
+++ b/vendor/github.com/google/seesaw/ipvs/ipvs.go
@@ -1,0 +1,533 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: jsing@google.com (Joel Sing)
+
+// Package ipvs provides a Go interface to Linux IPVS.
+package ipvs
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+
+	"github.com/google/seesaw/netlink"
+)
+
+/*
+#include <linux/types.h>
+#include <linux/ip_vs.h>
+*/
+import "C"
+
+const familyName = "IPVS"
+
+var (
+	family int
+	info   ipvsInfo
+)
+
+type ipvsInfo struct {
+	Version       uint32 `netlink:"attr:1"`
+	ConnTableSize uint32 `netlink:"attr:2"`
+}
+
+type ipvsDestination struct {
+	Address        net.IP            `netlink:"attr:1"`
+	Port           uint16            `netlink:"attr:2,network"`
+	Flags          DestinationFlags  `netlink:"attr:3"`
+	Weight         uint32            `netlink:"attr:4"`
+	UpperThreshold uint32            `netlink:"attr:5"`
+	LowerThreshold uint32            `netlink:"attr:6"`
+	ActiveConns    uint32            `netlink:"attr:7,omitempty"`
+	InactiveConns  uint32            `netlink:"attr:8,omitempty"`
+	PersistConns   uint32            `netlink:"attr:9,omitempty"`
+	Stats          *DestinationStats `netlink:"attr:10,optional"`
+}
+
+type ipvsService struct {
+	AddrFamily        uint16        `netlink:"attr:1"`
+	Protocol          IPProto       `netlink:"attr:2,optional"`
+	Address           net.IP        `netlink:"attr:3,optional"`
+	Port              uint16        `netlink:"attr:4,network,optional"`
+	FirewallMark      uint32        `netlink:"attr:5,omitempty,optional"`
+	Scheduler         string        `netlink:"attr:6"`
+	Flags             ServiceFlags  `netlink:"attr:7"`
+	Timeout           uint32        `netlink:"attr:8"`
+	Netmask           uint32        `netlink:"attr:9"`
+	Stats             *ServiceStats `netlink:"attr:10,optional"`
+	PersistenceEngine string        `netlink:"attr:11,omitempty,optional"`
+}
+
+type ipvsCommand struct {
+	Service     *ipvsService     `netlink:"attr:1,omitempty,optional"`
+	Destination *ipvsDestination `netlink:"attr:2,omitempty,optional"`
+}
+
+// newIPVSService converts a service to its IPVS representation.
+func newIPVSService(svc *Service) *ipvsService {
+	ipvsSvc := &ipvsService{
+		Address:           svc.Address,
+		Protocol:          svc.Protocol,
+		Port:              svc.Port,
+		FirewallMark:      svc.FirewallMark,
+		Scheduler:         svc.Scheduler,
+		Flags:             svc.Flags,
+		Timeout:           svc.Timeout,
+		PersistenceEngine: svc.PersistenceEngine,
+	}
+
+	if ip4 := svc.Address.To4(); ip4 != nil {
+		ipvsSvc.AddrFamily = syscall.AF_INET
+		ipvsSvc.Netmask = 0xffffffff
+	} else {
+		ipvsSvc.AddrFamily = syscall.AF_INET6
+		ipvsSvc.Netmask = 128
+	}
+
+	return ipvsSvc
+}
+
+// newIPVSDestination converts a destination to its IPVS representation.
+func newIPVSDestination(dst *Destination) *ipvsDestination {
+	return &ipvsDestination{
+		Address:        dst.Address,
+		Port:           dst.Port,
+		Flags:          dst.Flags,
+		Weight:         uint32(dst.Weight),
+		UpperThreshold: dst.UpperThreshold,
+		LowerThreshold: dst.LowerThreshold,
+	}
+}
+
+// toService converts a service entry from its IPVS representation to the Go
+// equivalent Service structure.
+func (ipvsSvc ipvsService) toService() *Service {
+	svc := &Service{
+		Address:           ipvsSvc.Address,
+		Protocol:          ipvsSvc.Protocol,
+		Port:              ipvsSvc.Port,
+		FirewallMark:      ipvsSvc.FirewallMark,
+		Scheduler:         ipvsSvc.Scheduler,
+		Flags:             ipvsSvc.Flags,
+		Timeout:           ipvsSvc.Timeout,
+		PersistenceEngine: ipvsSvc.PersistenceEngine,
+		Statistics:        &ServiceStats{},
+	}
+
+	// Various callers of this package expect that a service will always
+	// have a non-nil address (all zero bytes if non-existent). At some
+	// point we may want to revisit this and return a nil address instead.
+	if svc.Address == nil {
+		if ipvsSvc.AddrFamily == syscall.AF_INET {
+			svc.Address = net.IPv4zero
+		} else {
+			svc.Address = net.IPv6zero
+		}
+	}
+
+	if ipvsSvc.Stats != nil {
+		*svc.Statistics = *ipvsSvc.Stats
+	}
+
+	return svc
+}
+
+// toDestination converts a destination entry from its IPVS representation
+// to the Go equivalent Destination structure.
+func (ipvsDst ipvsDestination) toDestination() *Destination {
+	dst := &Destination{
+		Address:        ipvsDst.Address,
+		Port:           ipvsDst.Port,
+		Weight:         int32(ipvsDst.Weight), // TODO(jsing): uint32?
+		Flags:          ipvsDst.Flags,
+		LowerThreshold: ipvsDst.LowerThreshold,
+		UpperThreshold: ipvsDst.UpperThreshold,
+		Statistics:     &DestinationStats{},
+	}
+
+	if ipvsDst.Stats != nil {
+		*dst.Statistics = *ipvsDst.Stats
+	}
+
+	dst.Statistics.ActiveConns = ipvsDst.ActiveConns
+	dst.Statistics.InactiveConns = ipvsDst.InactiveConns
+	dst.Statistics.PersistConns = ipvsDst.PersistConns
+
+	return dst
+}
+
+// IPProto specifies the protocol encapsulated within an IP datagram.
+type IPProto uint16
+
+// String returns the name for the given protocol value.
+func (proto IPProto) String() string {
+	switch proto {
+	case syscall.IPPROTO_TCP:
+		return "TCP"
+	case syscall.IPPROTO_UDP:
+		return "UDP"
+	}
+	return fmt.Sprintf("IP(%d)", proto)
+}
+
+// IPVSVersion represents a IPVS version as major, minor and patch values.
+type IPVSVersion struct {
+	Major uint
+	Minor uint
+	Patch uint
+}
+
+// String returns a string representation of the IPVS version number.
+func (v IPVSVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ServiceFlags specifies the flags for a IPVS service.
+type ServiceFlags uint32
+
+// Bytes returns the netlink representation of the service flags.
+func (f ServiceFlags) Bytes() []byte {
+	x := make([]byte, 8)
+	var b [4]byte
+	*(*uint32)(unsafe.Pointer(&b)) = uint32(f)
+	copy(x[:4], b[:])
+	*(*uint32)(unsafe.Pointer(&b)) = ^uint32(0)
+	copy(x[4:], b[:])
+	return x
+}
+
+// SetBytes sets the service flags from its netlink representation.
+func (f *ServiceFlags) SetBytes(x []byte) {
+	var b [4]byte
+	copy(b[:], x)
+	*f = ServiceFlags(*(*uint32)(unsafe.Pointer(&b)))
+}
+
+const (
+	SFPersistent ServiceFlags = ipvsSvcFlagPersist
+	SFHashed     ServiceFlags = ipvsSvcFlagHashed
+	SFOnePacket  ServiceFlags = ipvsSvcFlagOnePacket
+)
+
+// Service represents an IPVS service.
+type Service struct {
+	Address           net.IP
+	Protocol          IPProto
+	Port              uint16
+	FirewallMark      uint32
+	Scheduler         string
+	Flags             ServiceFlags
+	Timeout           uint32
+	PersistenceEngine string
+	Statistics        *ServiceStats
+	Destinations      []*Destination
+}
+
+// Equal returns true if two Services are the same.
+func (svc Service) Equal(other Service) bool {
+	return svc.Address.Equal(other.Address) &&
+		svc.Protocol == other.Protocol &&
+		svc.Port == other.Port &&
+		svc.FirewallMark == other.FirewallMark &&
+		svc.Scheduler == other.Scheduler &&
+		svc.Flags == other.Flags &&
+		svc.Timeout == other.Timeout &&
+		svc.PersistenceEngine == other.PersistenceEngine
+}
+
+// String returns a string representation of a Service.
+func (svc Service) String() string {
+	switch {
+	case svc.FirewallMark > 0:
+		return fmt.Sprintf("FWM %d (%s)", svc.FirewallMark, svc.Scheduler)
+	case svc.Address.To4() == nil:
+		return fmt.Sprintf("%v [%v]:%d (%s)", svc.Protocol, svc.Address, svc.Port, svc.Scheduler)
+	default:
+		return fmt.Sprintf("%v %v:%d (%s)", svc.Protocol, svc.Address, svc.Port, svc.Scheduler)
+	}
+}
+
+// DestinationFlags specifies the flags for a connection to an IPVS destination.
+type DestinationFlags uint32
+
+const (
+	DFForwardMask   DestinationFlags = ipvsDstFlagFwdMask
+	DFForwardMasq   DestinationFlags = ipvsDstFlagFwdMasq
+	DFForwardLocal  DestinationFlags = ipvsDstFlagFwdLocal
+	DFForwardRoute  DestinationFlags = ipvsDstFlagFwdRoute
+	DFForwardTunnel DestinationFlags = ipvsDstFlagFwdTunnel
+	DFForwardBypass DestinationFlags = ipvsDstFlagFwdBypass
+)
+
+// Destination represents an IPVS destination.
+type Destination struct {
+	Address        net.IP
+	Port           uint16
+	Weight         int32
+	Flags          DestinationFlags
+	LowerThreshold uint32
+	UpperThreshold uint32
+	Statistics     *DestinationStats
+}
+
+// Equal returns true if two Destinations are the same.
+func (dest Destination) Equal(other Destination) bool {
+	return dest.Address.Equal(other.Address) &&
+		dest.Port == other.Port &&
+		dest.Weight == other.Weight &&
+		dest.Flags == other.Flags &&
+		dest.LowerThreshold == other.LowerThreshold &&
+		dest.UpperThreshold == other.UpperThreshold
+}
+
+// String returns a string representation of a Destination.
+func (dest Destination) String() string {
+	addr := dest.Address.String()
+	if dest.Address.To4() == nil {
+		addr = fmt.Sprintf("[%s]", addr)
+	}
+	return fmt.Sprintf("%s:%d", addr, dest.Port)
+}
+
+type Stats struct {
+	Connections uint32 `netlink:"attr:1"`
+	PacketsIn   uint32 `netlink:"attr:2"`
+	PacketsOut  uint32 `netlink:"attr:3"`
+	BytesIn     uint64 `netlink:"attr:4"`
+	BytesOut    uint64 `netlink:"attr:5"`
+	CPS         uint32 `netlink:"attr:6"`
+	PPSIn       uint32 `netlink:"attr:7"`
+	PPSOut      uint32 `netlink:"attr:8"`
+	BPSIn       uint32 `netlink:"attr:9"`
+	BPSOut      uint32 `netlink:"attr:10"`
+}
+
+// ServiceStats encapsulates statistics for an IPVS service.
+type ServiceStats struct {
+	Stats
+}
+
+// DestinationStats encapsulates statistics for an IPVS destination.
+type DestinationStats struct {
+	Stats
+	ActiveConns   uint32
+	InactiveConns uint32
+	PersistConns  uint32
+}
+
+const (
+	ipvsSvcFlagPersist   = 0x1
+	ipvsSvcFlagHashed    = 0x2
+	ipvsSvcFlagOnePacket = 0x4
+
+	ipvsDstFlagFwdMask   = 0x7
+	ipvsDstFlagFwdMasq   = 0x0
+	ipvsDstFlagFwdLocal  = 0x1
+	ipvsDstFlagFwdTunnel = 0x2
+	ipvsDstFlagFwdRoute  = 0x3
+	ipvsDstFlagFwdBypass = 0x4
+	ipvsDstFlagSync      = 0x20
+	ipvsDstFlagHashed    = 0x40
+	ipvsDstFlagNoOutput  = 0x80
+	ipvsDstFlagInactive  = 0x100
+	ipvsDstFlagOutSeq    = 0x200
+	ipvsDstFlagInSeq     = 0x400
+	ipvsDstFlagSeqMask   = 0x600
+	ipvsDstFlagNoCPort   = 0x800
+	ipvsDstFlagTemplate  = 0x1000
+	ipvsDstFlagOnePacket = 0x2000
+)
+
+// Init intialises IPVS.
+func Init() error {
+	var err error
+	family, err = netlink.Family(familyName)
+	if err != nil {
+		return err
+	}
+
+	return netlink.SendMessageUnmarshal(C.IPVS_CMD_GET_INFO, family, 0, &info)
+}
+
+// Version returns the version number for IPVS.
+func Version() IPVSVersion {
+	v := uint(info.Version)
+	return IPVSVersion{
+		Major: (v >> 16) & 0xff,
+		Minor: (v >> 8) & 0xff,
+		Patch: v & 0xff,
+	}
+}
+
+// Flush flushes all services and destinations from the IPVS table.
+func Flush() error {
+	return netlink.SendMessage(C.IPVS_CMD_FLUSH, family, 0)
+}
+
+// AddService adds the specified service to the IPVS table. Any destinations
+// associated with the given service will also be added.
+func AddService(svc Service) error {
+	ic := &ipvsCommand{Service: newIPVSService(&svc)}
+	if err := netlink.SendMessageMarshalled(C.IPVS_CMD_NEW_SERVICE, family, 0, ic); err != nil {
+		return err
+	}
+	for _, dst := range svc.Destinations {
+		if err := AddDestination(svc, *dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateService updates the specified service in the IPVS table.
+func UpdateService(svc Service) error {
+	ic := &ipvsCommand{Service: newIPVSService(&svc)}
+	return netlink.SendMessageMarshalled(C.IPVS_CMD_SET_SERVICE, family, 0, ic)
+}
+
+// DeleteService deletes the specified service from the IPVS table.
+func DeleteService(svc Service) error {
+	ic := &ipvsCommand{Service: newIPVSService(&svc)}
+	return netlink.SendMessageMarshalled(C.IPVS_CMD_DEL_SERVICE, family, 0, ic)
+}
+
+// AddDestination adds the specified destination to the IPVS table.
+func AddDestination(svc Service, dst Destination) error {
+	ic := &ipvsCommand{
+		Service:     newIPVSService(&svc),
+		Destination: newIPVSDestination(&dst),
+	}
+	return netlink.SendMessageMarshalled(C.IPVS_CMD_NEW_DEST, family, 0, ic)
+}
+
+// UpdateDestination updates the specified destination in the IPVS table.
+func UpdateDestination(svc Service, dst Destination) error {
+	ic := &ipvsCommand{
+		Service:     newIPVSService(&svc),
+		Destination: newIPVSDestination(&dst),
+	}
+	return netlink.SendMessageMarshalled(C.IPVS_CMD_SET_DEST, family, 0, ic)
+}
+
+// DeleteDestination deletes the specified destination from the IPVS table.
+func DeleteDestination(svc Service, dst Destination) error {
+	ic := &ipvsCommand{
+		Service:     newIPVSService(&svc),
+		Destination: newIPVSDestination(&dst),
+	}
+	return netlink.SendMessageMarshalled(C.IPVS_CMD_DEL_DEST, family, 0, ic)
+}
+
+// destinations returns a list of destinations that are currently
+// configured in the kernel IPVS table for the specified service.
+func destinations(svc *Service) ([]*Destination, error) {
+	msg, err := netlink.NewMessage(C.IPVS_CMD_GET_DEST, family, netlink.MFDump)
+	if err != nil {
+		return nil, err
+	}
+	defer msg.Free()
+
+	ic := &ipvsCommand{Service: newIPVSService(svc)}
+	if err := msg.Marshal(ic); err != nil {
+		return nil, err
+	}
+
+	var dsts []*Destination
+	cb := func(msg *netlink.Message, arg interface{}) error {
+		ic := &ipvsCommand{}
+		if err := msg.Unmarshal(ic); err != nil {
+			return fmt.Errorf("failed to unmarshal service: %v", err)
+		}
+		if ic.Destination == nil {
+			return errors.New("no destination in unmarshalled message")
+		}
+		dsts = append(dsts, ic.Destination.toDestination())
+		return nil
+	}
+	if err := msg.SendCallback(cb, nil); err != nil {
+		return nil, err
+	}
+	return dsts, nil
+}
+
+// services returns a list of services that are currently configured in the
+// kernel IPVS table. If a specific service is given, an exact match will be
+// attempted and a single service will be returned if it is found.
+func services(svc *Service) ([]*Service, error) {
+	var flags int
+	if svc == nil {
+		flags = netlink.MFDump
+	}
+
+	msg, err := netlink.NewMessage(C.IPVS_CMD_GET_SERVICE, family, flags)
+	if err != nil {
+		return nil, err
+	}
+	defer msg.Free()
+
+	if svc != nil {
+		ic := &ipvsCommand{Service: newIPVSService(svc)}
+		if err := msg.Marshal(ic); err != nil {
+			return nil, err
+		}
+	}
+
+	var svcs []*Service
+	cb := func(msg *netlink.Message, arg interface{}) error {
+		ic := &ipvsCommand{}
+		if err := msg.Unmarshal(ic); err != nil {
+			return fmt.Errorf("failed to unmarshal service: %v", err)
+		}
+		if ic.Service == nil {
+			return errors.New("no service in unmarshalled message")
+		}
+		svcs = append(svcs, ic.Service.toService())
+		return nil
+	}
+	if err := msg.SendCallback(cb, nil); err != nil {
+		return nil, err
+	}
+
+	for _, svc := range svcs {
+		dsts, err := destinations(svc)
+		if err != nil {
+			return nil, err
+		}
+		svc.Destinations = dsts
+	}
+
+	return svcs, nil
+}
+
+// GetService returns the service entry that is currently configured in the
+// kernel IPVS table, which matches the specified service.
+func GetService(svc *Service) (*Service, error) {
+	svcs, err := services(svc)
+	if err != nil {
+		return nil, err
+	}
+	if len(svcs) == 0 {
+		return nil, errors.New("no service found")
+	}
+	return svcs[0], nil
+}
+
+// GetServices returns a list of service entries that are currently configured
+// in the kernel IPVS table.
+func GetServices() ([]*Service, error) {
+	return services(nil)
+}

--- a/vendor/github.com/google/seesaw/ipvs/ipvs_test.go
+++ b/vendor/github.com/google/seesaw/ipvs/ipvs_test.go
@@ -1,0 +1,604 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: jsing@google.com (Joel Sing)
+
+package ipvs
+
+import (
+	"bytes"
+	"net"
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/google/seesaw/netlink"
+)
+
+var testStats = Stats{
+	Connections: 1234,
+	PacketsIn:   100000,
+	PacketsOut:  200000,
+	BytesIn:     300000,
+	BytesOut:    400000,
+	CPS:         10,
+	PPSIn:       100,
+	PPSOut:      200,
+	BPSIn:       300,
+	BPSOut:      400,
+}
+
+var ipvsServiceTests = []struct {
+	desc        string
+	ipvsService ipvsService
+	want        Service
+}{
+	{
+		"Zeroed structs",
+		ipvsService{},
+		Service{
+			Address:    net.ParseIP("::0"),
+			Statistics: &ServiceStats{},
+		},
+	},
+	{
+		"IPv4 1.2.3.4 with TCP/80 using wlc",
+		ipvsService{
+			Protocol:          syscall.IPPROTO_TCP,
+			Port:              80,
+			FirewallMark:      0,
+			Scheduler:         "wlc",
+			Flags:             0,
+			Timeout:           0,
+			Netmask:           0xffffffff,
+			Stats:             &ServiceStats{Stats: testStats},
+			AddrFamily:        syscall.AF_INET,
+			Address:           net.ParseIP("1.2.3.4"),
+			PersistenceEngine: "",
+		},
+		Service{
+			Address:           net.ParseIP("1.2.3.4"),
+			Protocol:          syscall.IPPROTO_TCP,
+			Port:              80,
+			FirewallMark:      0,
+			Scheduler:         "wlc",
+			Flags:             0,
+			Timeout:           0,
+			PersistenceEngine: "",
+			Statistics:        &ServiceStats{Stats: testStats},
+		},
+	},
+	{
+		"IPv6 2012::beef with UDP/33434 using wlc",
+		ipvsService{
+			Protocol:          syscall.IPPROTO_UDP,
+			Port:              33434,
+			FirewallMark:      0,
+			Scheduler:         "wlc",
+			Flags:             1234,
+			Timeout:           100,
+			Netmask:           128,
+			Stats:             &ServiceStats{Stats: testStats},
+			AddrFamily:        syscall.AF_INET6,
+			Address:           net.ParseIP("2012::beef"),
+			PersistenceEngine: "",
+		},
+		Service{
+			Address:           net.ParseIP("2012::beef"),
+			Protocol:          syscall.IPPROTO_UDP,
+			Port:              33434,
+			FirewallMark:      0,
+			Scheduler:         "wlc",
+			Flags:             1234,
+			Timeout:           100,
+			PersistenceEngine: "",
+			Statistics:        &ServiceStats{Stats: testStats},
+		},
+	},
+	{
+		"IPv4 FWM 4 using lc",
+		ipvsService{
+			Protocol:          0,
+			Port:              0,
+			FirewallMark:      4,
+			Scheduler:         "lc",
+			Flags:             0,
+			Timeout:           0,
+			Netmask:           0xffffffff,
+			Stats:             &ServiceStats{Stats: testStats},
+			AddrFamily:        syscall.AF_INET,
+			Address:           nil,
+			PersistenceEngine: "",
+		},
+		Service{
+			Address:           net.ParseIP("0.0.0.0"),
+			Protocol:          0,
+			Port:              0,
+			FirewallMark:      4,
+			Scheduler:         "lc",
+			Flags:             0,
+			Timeout:           0,
+			PersistenceEngine: "",
+			Statistics:        &ServiceStats{Stats: testStats},
+		},
+	},
+	{
+		"IPv6 FWM 6 using wrr",
+		ipvsService{
+			Protocol:          0,
+			Port:              0,
+			FirewallMark:      6,
+			Scheduler:         "wrr",
+			Flags:             0,
+			Timeout:           0,
+			Netmask:           0xffffffff,
+			Stats:             &ServiceStats{Stats: testStats},
+			AddrFamily:        syscall.AF_INET6,
+			Address:           nil,
+			PersistenceEngine: "",
+		},
+		Service{
+			Address:           net.ParseIP("::0"),
+			Protocol:          0,
+			Port:              0,
+			FirewallMark:      6,
+			Scheduler:         "wrr",
+			Flags:             0,
+			Timeout:           0,
+			PersistenceEngine: "",
+			Statistics:        &ServiceStats{Stats: testStats},
+		},
+	},
+}
+
+func TestIPVSServiceToService(t *testing.T) {
+	for _, test := range ipvsServiceTests {
+		got := test.ipvsService.toService()
+		if !reflect.DeepEqual(*got, test.want) {
+			t.Errorf("toService() failed for %s - got %#v, want %#v",
+				test.desc, *got, test.want)
+		}
+	}
+}
+
+var ipvsDestinationTests = []struct {
+	desc            string
+	ipvsDestination ipvsDestination
+	want            Destination
+}{
+	{
+		"Zeroed structs",
+		ipvsDestination{},
+		Destination{
+			Statistics: &DestinationStats{},
+		},
+	},
+	{
+		"IPv4 1.2.4.4 with port 54321",
+		ipvsDestination{
+			Port:           54321,
+			Flags:          0,
+			Weight:         1,
+			UpperThreshold: 100000,
+			LowerThreshold: 10000,
+			ActiveConns:    12345678,
+			InactiveConns:  87654321,
+			PersistConns:   1234,
+			Stats:          &DestinationStats{Stats: testStats},
+			Address:        net.ParseIP("1.2.3.4"),
+		},
+		Destination{
+			Address:        net.ParseIP("1.2.3.4"),
+			Port:           54321,
+			Weight:         1,
+			Flags:          0,
+			LowerThreshold: 10000,
+			UpperThreshold: 100000,
+			Statistics: &DestinationStats{
+				Stats:         testStats,
+				ActiveConns:   12345678,
+				InactiveConns: 87654321,
+				PersistConns:  1234,
+			},
+		},
+	},
+	{
+		"IPv6 2002::cafe with port 53",
+		ipvsDestination{
+			Port:           53,
+			Flags:          0xf0f0f0f0,
+			Weight:         1,
+			UpperThreshold: 0,
+			LowerThreshold: 0,
+			ActiveConns:    12345678,
+			InactiveConns:  87654321,
+			PersistConns:   1234,
+			Stats:          &DestinationStats{Stats: testStats},
+			Address:        net.ParseIP("2002::cafe"),
+		},
+		Destination{
+			Address:        net.ParseIP("2002::cafe"),
+			Port:           53,
+			Weight:         1,
+			Flags:          0xf0f0f0f0,
+			LowerThreshold: 0,
+			UpperThreshold: 0,
+			Statistics: &DestinationStats{
+				Stats:         testStats,
+				ActiveConns:   12345678,
+				InactiveConns: 87654321,
+				PersistConns:  1234,
+			},
+		},
+	},
+}
+
+func TestIPVSDestinationToDestination(t *testing.T) {
+	for _, test := range ipvsDestinationTests {
+		got := test.ipvsDestination.toDestination()
+		if !reflect.DeepEqual(*got, test.want) {
+			t.Errorf("toDestination() failed for %s - got %#v, want %#v",
+				test.desc, *got, test.want)
+		}
+	}
+}
+
+var serviceTests = []struct {
+	desc    string
+	service Service
+	want    ipvsService
+}{
+	{
+		"Zeroed structs",
+		Service{},
+		ipvsService{
+			AddrFamily: syscall.AF_INET6,
+			Netmask:    128,
+		},
+	},
+	{
+		"IPv4 1.2.3.4 with TCP/54321 using wlc",
+		Service{
+			Address:      net.ParseIP("1.2.3.4"),
+			Protocol:     syscall.IPPROTO_TCP,
+			Port:         54321,
+			FirewallMark: 1,
+			Scheduler:    "wlc",
+			Flags:        0,
+			Timeout:      100000,
+		},
+		ipvsService{
+			Protocol:          syscall.IPPROTO_TCP,
+			Port:              54321,
+			FirewallMark:      1,
+			Scheduler:         "wlc",
+			Flags:             0,
+			Timeout:           100000,
+			Netmask:           0xffffffff,
+			AddrFamily:        syscall.AF_INET,
+			Address:           net.ParseIP("1.2.3.4"),
+			PersistenceEngine: "",
+		},
+	},
+	{
+		"IPv6 2002::cafe with UDP/53",
+		Service{
+			Address:      net.ParseIP("2002::cafe"),
+			Protocol:     syscall.IPPROTO_UDP,
+			Port:         53,
+			FirewallMark: 0,
+			Scheduler:    "xxxxxxxxxxxxxxxx",
+			Flags:        0xf0f0f0f0,
+			Timeout:      0,
+		},
+		ipvsService{
+			Protocol:          syscall.IPPROTO_UDP,
+			Port:              53,
+			FirewallMark:      0,
+			Scheduler:         "xxxxxxxxxxxxxxxx",
+			Flags:             0xf0f0f0f0,
+			Timeout:           0,
+			Netmask:           128,
+			AddrFamily:        syscall.AF_INET6,
+			Address:           net.ParseIP("2002::cafe"),
+			PersistenceEngine: "",
+		},
+	},
+}
+
+func TestServiceToIPVSService(t *testing.T) {
+	for _, test := range serviceTests {
+		got := newIPVSService(&test.service)
+		if !reflect.DeepEqual(*got, test.want) {
+			t.Errorf("toIPVSService() failed for %s - got %#v, want %#v)",
+				test.desc, *got, test.want)
+		}
+	}
+}
+
+var destinationTests = []struct {
+	desc        string
+	destination Destination
+	want        ipvsDestination
+}{
+	{
+		"Zeroed structs",
+		Destination{},
+		ipvsDestination{},
+	},
+	{
+		"IPv4 1.2.4.4 with port 54321",
+		Destination{
+			Address:        net.ParseIP("1.2.3.4"),
+			Port:           54321,
+			Weight:         2,
+			Flags:          0,
+			LowerThreshold: 10000,
+			UpperThreshold: 100000,
+		},
+		ipvsDestination{
+			Port:           54321,
+			Flags:          0,
+			Weight:         2,
+			UpperThreshold: 100000,
+			LowerThreshold: 10000,
+			Address:        net.ParseIP("1.2.3.4"),
+		},
+	},
+	{
+		"IPv6 2002::cafe with port 53",
+		Destination{
+			Address:        net.ParseIP("2002::cafe"),
+			Port:           53,
+			Weight:         3,
+			Flags:          0xf0f0f0f0,
+			LowerThreshold: 0,
+			UpperThreshold: 0,
+		},
+		ipvsDestination{
+			Port:           53,
+			Flags:          0xf0f0f0f0,
+			Weight:         3,
+			UpperThreshold: 0,
+			LowerThreshold: 0,
+			Address:        net.ParseIP("2002::cafe"),
+		},
+	},
+}
+
+func TestDestinationToIPVSDestination(t *testing.T) {
+	for _, test := range destinationTests {
+		got := newIPVSDestination(&test.destination)
+		if !reflect.DeepEqual(*got, test.want) {
+			t.Errorf("toIPVSDestination() failed for %s - got %#v, want %#v)",
+				test.desc, *got, test.want)
+		}
+	}
+}
+
+const (
+	nlTestCommand = 1
+	nlTestFamily  = 25
+)
+
+var (
+	nlmIPVSAddDestination = []byte{
+		0x6c, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x58, 0x00, 0x02, 0x00,
+		0x14, 0x00, 0x01, 0x00, 0x20, 0x02, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0xca, 0xfe, 0x06, 0x00, 0x02, 0x00,
+		0x00, 0x35, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+		0xf4, 0xf3, 0xf2, 0xf1, 0x08, 0x00, 0x04, 0x00,
+		0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x05, 0x00,
+		0xd0, 0x07, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0xe8, 0x03, 0x00, 0x00, 0x08, 0x00, 0x07, 0x00,
+		0x4e, 0x61, 0xbc, 0x00, 0x08, 0x00, 0x08, 0x00,
+		0xb1, 0x7f, 0x39, 0x05, 0x08, 0x00, 0x09, 0x00,
+		0xd2, 0x04, 0x00, 0x00,
+	}
+
+	nlmIPVSDestination = []byte{
+		0xc8, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0xb4, 0x00, 0x02, 0x00,
+		0x14, 0x00, 0x01, 0x00, 0x20, 0x02, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0xca, 0xfe, 0x06, 0x00, 0x02, 0x00,
+		0x00, 0x35, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+		0xf4, 0xf3, 0xf2, 0xf1, 0x08, 0x00, 0x04, 0x00,
+		0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x05, 0x00,
+		0xd0, 0x07, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0xe8, 0x03, 0x00, 0x00, 0x08, 0x00, 0x07, 0x00,
+		0x4e, 0x61, 0xbc, 0x00, 0x08, 0x00, 0x08, 0x00,
+		0xb1, 0x7f, 0x39, 0x05, 0x08, 0x00, 0x09, 0x00,
+		0xd2, 0x04, 0x00, 0x00, 0x5c, 0x00, 0x0a, 0x00,
+		0x08, 0x00, 0x01, 0x00, 0x03, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x02, 0x00, 0x0c, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x0c, 0x00, 0x04, 0x00, 0x1a, 0x04, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x05, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x09, 0x00, 0x54, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	nlmIPVSAddService = []byte{
+		0x68, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x54, 0x00, 0x01, 0x00,
+		0x06, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+		0x06, 0x00, 0x02, 0x00, 0x06, 0x00, 0x00, 0x00,
+		0x14, 0x00, 0x03, 0x00, 0x01, 0x01, 0x01, 0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x04, 0x00,
+		0x50, 0x00, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0x77, 0x6c, 0x63, 0x00, 0x0c, 0x00, 0x07, 0x00,
+		0xf4, 0xf3, 0xf2, 0xf1, 0xff, 0xff, 0xff, 0xff,
+		0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x09, 0x00, 0xff, 0xff, 0xff, 0xff,
+	}
+
+	nlmIPVSService = []byte{
+		0xc4, 0x00, 0x00, 0x00, 0x16, 0x00, 0x02, 0x00,
+		0xb0, 0xb3, 0xc8, 0x55, 0x79, 0x02, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0xb0, 0x00, 0x01, 0x00,
+		0x06, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+		0x06, 0x00, 0x02, 0x00, 0x06, 0x00, 0x00, 0x00,
+		0x14, 0x00, 0x03, 0x00, 0x01, 0x01, 0x01, 0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x04, 0x00,
+		0x50, 0x00, 0x00, 0x00, 0x07, 0x00, 0x06, 0x00,
+		0x77, 0x6c, 0x63, 0x00, 0x0c, 0x00, 0x07, 0x00,
+		0xf4, 0xf3, 0xf2, 0xf1, 0xff, 0xff, 0xff, 0xff,
+		0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x09, 0x00, 0xff, 0xff, 0xff, 0xff,
+		0x5c, 0x00, 0x0a, 0x00, 0x08, 0x00, 0x01, 0x00,
+		0x03, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 0x00,
+		0x0c, 0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x04, 0x00,
+		0x1a, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x0c, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x07, 0x00,
+		0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x09, 0x00,
+		0x54, 0x00, 0x00, 0x00, 0x08, 0x00, 0x0a, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	testIPVSDestination = &ipvsDestination{
+		Address:        net.ParseIP("2002::cafe"),
+		Port:           53,
+		Flags:          0xf1f2f3f4,
+		Weight:         1,
+		UpperThreshold: 2000,
+		LowerThreshold: 1000,
+		ActiveConns:    12345678,
+		InactiveConns:  87654321,
+		PersistConns:   1234,
+		Stats:          nil,
+	}
+
+	testIPVSService = &ipvsService{
+		AddrFamily:        syscall.AF_INET,
+		Protocol:          syscall.IPPROTO_TCP,
+		Address:           net.IPv4(1, 1, 1, 1),
+		Port:              0x5000,
+		FirewallMark:      0x0,
+		Scheduler:         "wlc",
+		Flags:             0xf1f2f3f4,
+		Timeout:           0x0,
+		Netmask:           0xffffffff,
+		Stats:             nil,
+		PersistenceEngine: "",
+	}
+
+	testIPVSStats = Stats{
+		Connections: 0x3,
+		PacketsIn:   0xc,
+		PacketsOut:  0x0,
+		BytesIn:     0x41a,
+		BytesOut:    0x0,
+		CPS:         0x0,
+		PPSIn:       0x1,
+		PPSOut:      0x0,
+		BPSIn:       0x54,
+		BPSOut:      0x0,
+	}
+)
+
+func TestDestinationNetlinkMarshal(t *testing.T) {
+	m, err := netlink.NewMessage(nlTestCommand, nlTestFamily, 0)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	ic := &ipvsCommand{Destination: testIPVSDestination}
+	if err := m.Marshal(ic); err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	got, err := m.Bytes()
+	if err != nil {
+		t.Fatalf("Failed to get message bytes: %v", err)
+	}
+	if want := nlmIPVSAddDestination; !bytes.Equal(got, want) {
+		t.Errorf("Got netlink bytes %#v, want %#v", got, want)
+	}
+}
+
+func TestDestinationNetlinkUnmarshal(t *testing.T) {
+	m, err := netlink.NewMessageFromBytes(nlmIPVSDestination)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	got := &ipvsCommand{}
+	if err := m.Unmarshal(got); err != nil {
+		t.Errorf("Failed to unmarshal message: %v", err)
+	}
+
+	want := *testIPVSDestination
+	want.Stats = &DestinationStats{Stats: testIPVSStats}
+	if !reflect.DeepEqual(got.Destination, &want) {
+		t.Errorf("Got IPVS destination %#v, want %#v", got.Destination, &want)
+	}
+}
+
+func TestServiceNetlinkMarshal(t *testing.T) {
+	m, err := netlink.NewMessage(nlTestCommand, nlTestFamily, 0)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	ic := &ipvsCommand{Service: testIPVSService}
+	if err := m.Marshal(ic); err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	got, err := m.Bytes()
+	if err != nil {
+		t.Fatalf("Failed to get message bytes: %v", err)
+	}
+	if want := nlmIPVSAddService; !bytes.Equal(got, want) {
+		t.Errorf("Got netlink bytes %#v, want %#v", got, want)
+	}
+}
+
+func TestServiceNetlinkUnmarshal(t *testing.T) {
+	m, err := netlink.NewMessageFromBytes(nlmIPVSService)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	got := &ipvsCommand{}
+	if err := m.Unmarshal(got); err != nil {
+		t.Fatalf("Failed to unmarshal message: %v", err)
+	}
+
+	want := *testIPVSService
+	want.Stats = &ServiceStats{Stats: testIPVSStats}
+	if !reflect.DeepEqual(got.Service, &want) {
+		t.Errorf("Got IPVS service %#v, want %#v", got.Service, &want)
+	}
+}

--- a/vendor/github.com/google/seesaw/netlink/cfuncs.go
+++ b/vendor/github.com/google/seesaw/netlink/cfuncs.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+/*
+#cgo CFLAGS: -I/usr/include/libnl3
+
+#include <netlink/netlink.h>
+
+int callback(struct nl_msg *msg, void *arg);
+
+int callbackGateway(struct nl_msg *msg, void *arg)
+{
+	return callback(msg, arg);
+}
+*/
+import "C"

--- a/vendor/github.com/google/seesaw/netlink/message.go
+++ b/vendor/github.com/google/seesaw/netlink/message.go
@@ -1,0 +1,295 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/libnl3
+#cgo LDFLAGS: -lnl-3 -lnl-genl-3
+
+#include <stdint.h>
+
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+
+int callbackGateway(struct nl_msg *msg, void *arg);
+*/
+import "C"
+
+// Netlink message flags.
+const (
+	MFRequest  = C.NLM_F_REQUEST
+	MFMulti    = C.NLM_F_MULTI
+	MFACK      = C.NLM_F_ACK
+	MFEcho     = C.NLM_F_ECHO
+	MFDumpIntr = C.NLM_F_DUMP_INTR
+	MFRoot     = C.NLM_F_ROOT
+	MFMatch    = C.NLM_F_MATCH
+	MFAtomic   = C.NLM_F_ATOMIC
+	MFDump     = C.NLM_F_DUMP
+	MFReplace  = C.NLM_F_REPLACE
+	MFExcl     = C.NLM_F_EXCL
+	MFCreate   = C.NLM_F_CREATE
+	MFAppend   = C.NLM_F_APPEND
+)
+
+// CallbackFunc is a netlink message callback function.
+type CallbackFunc func(*Message, interface{}) error
+
+// callbackArg contains information passed for libnl callbacks.
+type callbackArg struct {
+	id  uintptr
+	fn  CallbackFunc
+	arg interface{}
+	err error
+}
+
+var (
+	nextCallbackID uintptr
+	callbacks      = make(map[uintptr]*callbackArg)
+	callbacksLock  sync.RWMutex
+)
+
+// registerCallback registers a callback and returns the allocated callback ID.
+func registerCallback(cbArg *callbackArg) uintptr {
+	callbacksLock.Lock()
+	defer callbacksLock.Unlock()
+	cbArg.id = nextCallbackID
+	nextCallbackID++
+	if _, ok := callbacks[cbArg.id]; ok {
+		panic(fmt.Sprintf("Callback ID %d already in use", cbArg.id))
+	}
+	callbacks[cbArg.id] = cbArg
+	return cbArg.id
+}
+
+// unregisterCallback unregisters a callback.
+func unregisterCallback(cbArg *callbackArg) {
+	callbacksLock.Lock()
+	defer callbacksLock.Unlock()
+	if _, ok := callbacks[cbArg.id]; !ok {
+		panic(fmt.Sprintf("Callback ID %d not registered", cbArg.id))
+	}
+	delete(callbacks, cbArg.id)
+}
+
+// callback is the Go callback trampoline that is called from the
+// callbackGateway C function, which in turn gets called from libnl.
+//
+//export callback
+func callback(nlm *C.struct_nl_msg, nla unsafe.Pointer) C.int {
+	cbID := uintptr(nla)
+	callbacksLock.RLock()
+	cbArg := callbacks[cbID]
+	callbacksLock.RUnlock()
+
+	if cbArg == nil {
+		panic(fmt.Sprintf("No netlink callback with ID %d", cbID))
+	}
+
+	cbMsg := &Message{nlm: nlm}
+	if err := cbArg.fn(cbMsg, cbArg.arg); err != nil {
+		cbArg.err = err
+		return C.NL_STOP
+	}
+	return C.NL_OK
+}
+
+func callbackDefault(msg *Message, arg interface{}) error {
+	return nil
+}
+
+func callbackUnmarshal(msg *Message, arg interface{}) error {
+	return msg.Unmarshal(arg)
+}
+
+// Message represents a netlink message.
+type Message struct {
+	nlm *C.struct_nl_msg
+}
+
+// NewMessage returns an initialised netlink message.
+func NewMessage(command, family, flags int) (*Message, error) {
+	nlm := C.nlmsg_alloc()
+	if nlm == nil {
+		return nil, errors.New("failed to create netlink message")
+	}
+	C.genlmsg_put(nlm, C.NL_AUTO_PID, C.NL_AUTO_SEQ, C.int(family), 0, C.int(flags), C.uint8_t(command), genlVersion)
+	return &Message{nlm: nlm}, nil
+}
+
+// NewMessageFromBytes returns a netlink message that is initialised from the
+// given byte slice.
+func NewMessageFromBytes(nlb []byte) (*Message, error) {
+	nlm := C.nlmsg_alloc_size(C.size_t(len(nlb)))
+	if nlm == nil {
+		return nil, errors.New("failed to create netlink message")
+	}
+	nlh := C.nlmsg_hdr(nlm)
+	copy((*[1 << 20]byte)(unsafe.Pointer(nlh))[:len(nlb)], nlb)
+	return &Message{nlm: nlm}, nil
+}
+
+// Free frees resources associated with a netlink message.
+func (m *Message) Free() {
+	C.nlmsg_free(m.nlm)
+	m.nlm = nil
+}
+
+// Bytes returns the byte slice representation of a netlink message.
+func (m *Message) Bytes() ([]byte, error) {
+	if m.nlm == nil {
+		return nil, errors.New("no netlink message")
+	}
+	nlh := C.nlmsg_hdr(m.nlm)
+	nlb := make([]byte, nlh.nlmsg_len)
+	copy(nlb, (*[1 << 20]byte)(unsafe.Pointer(nlh))[:nlh.nlmsg_len])
+	return nlb, nil
+}
+
+// Marshal converts the given struct into a netlink message. Each field within
+// the struct is added as netlink data, with structs and pointers to structs
+// being recursively added as nested data.
+//
+// Supported data types and their netlink mappings are as follows:
+//
+//	uint8:		NLA_U8
+//	uint16:		NLA_U16
+//	uint32:		NLA_U32
+//	uint64:		NLA_U64
+//	string:		NLA_STRING
+//	byte array:	NLA_UNSPEC
+//	struct:		NLA_NESTED
+//	net.IP:		NLA_UNSPEC
+//
+// Each field must have a `netlink' tag, which can contain the following
+// comma separated options:
+//
+//	attr:x		specify the netlink attribute for this field (required)
+//	network		value will be converted to its network byte order
+//	omitempty	if the field has a zero value it will be omitted
+//	optional	mark the field as being an optional (for unmarshalling)
+//
+// Other Go data types are unsupported and an error will be returned if one
+// is encountered.
+func (m *Message) Marshal(v interface{}) error {
+	val := reflect.Indirect(reflect.ValueOf(v))
+	if val.Kind() != reflect.Struct {
+		return fmt.Errorf("%v is not a struct or a pointer to a struct", reflect.TypeOf(v))
+	}
+	return marshal(val, "", nil, m.nlm)
+}
+
+// Unmarshal parses the netlink message and fills the struct referenced by the
+// given pointer. The supported data types and netlink encodings are the same
+// as for Marshal.
+func (m *Message) Unmarshal(v interface{}) error {
+	val := reflect.Indirect(reflect.ValueOf(v))
+	if val.Kind() != reflect.Struct || !val.CanSet() {
+		return fmt.Errorf("%v is not a pointer to a struct", reflect.TypeOf(v))
+	}
+	maxAttrID, err := structMaxAttrID(val)
+	if err != nil {
+		return err
+	}
+	attrs, err := parseMessage(m.nlm, maxAttrID)
+	if err != nil {
+		return err
+	}
+	return unmarshal(val, "", nil, attrs)
+}
+
+// Send sends the netlink message.
+func (m *Message) Send() error {
+	return m.SendCallback(callbackDefault, nil)
+}
+
+// SendCallback sends the netlink message. The specified callback function
+// will be called for each message that is received in response.
+func (m *Message) SendCallback(fn CallbackFunc, arg interface{}) error {
+	s, err := newSocket()
+	if err != nil {
+		return err
+	}
+	defer s.free()
+
+	if errno := C.genl_connect(s.nls); errno != 0 {
+		return &Error{errno, "failed to connect to netlink"}
+	}
+	defer C.nl_close(s.nls)
+
+	cbArg := &callbackArg{fn: fn, arg: arg}
+	cbID := registerCallback(cbArg)
+	defer unregisterCallback(cbArg)
+
+	if errno := C.nl_socket_modify_cb(s.nls, C.NL_CB_VALID, C.NL_CB_CUSTOM, (C.nl_recvmsg_msg_cb_t)(unsafe.Pointer(C.callbackGateway)), unsafe.Pointer(cbID)); errno != 0 {
+		return &Error{errno, "failed to modify callback"}
+	}
+	// nl_send_auto_complete returns number of bytes sent or a negative
+	// errno on failure.
+	if errno := C.nl_send_auto_complete(s.nls, m.nlm); errno < 0 {
+		return &Error{errno, "failed to send netlink message"}
+	}
+	if errno := C.nl_recvmsgs_default(s.nls); errno != 0 {
+		return &Error{errno, "failed to receive messages"}
+	}
+	return nil
+}
+
+// SendMessage creates and sends a netlink message.
+func SendMessage(command, family, flags int) error {
+	return SendMessageCallback(command, family, flags, callbackDefault, nil)
+}
+
+// SendMessageCallback creates and sends a netlink message. The specified
+// callback function will be called for each message that is received in
+// response.
+func SendMessageCallback(command, family, flags int, cb CallbackFunc, arg interface{}) error {
+	msg, err := NewMessage(command, family, flags)
+	if err != nil {
+		return err
+	}
+	defer msg.Free()
+
+	return msg.SendCallback(cb, arg)
+}
+
+// SendMessageMarshalled creates a netlink message and marshals the given
+// struct into the message, before sending it.
+func SendMessageMarshalled(command, family, flags int, v interface{}) error {
+	msg, err := NewMessage(command, family, flags)
+	if err != nil {
+		return err
+	}
+	defer msg.Free()
+
+	if err := msg.Marshal(v); err != nil {
+		return err
+	}
+	return msg.Send()
+}
+
+// SendMessageUnmarshal creates and sends a netlink message. All messages
+// received in response will be unmarshalled into the given struct.
+func SendMessageUnmarshal(command, family, flags int, v interface{}) error {
+	return SendMessageCallback(command, family, flags, callbackUnmarshal, v)
+}

--- a/vendor/github.com/google/seesaw/netlink/message_test.go
+++ b/vendor/github.com/google/seesaw/netlink/message_test.go
@@ -1,0 +1,399 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+import (
+	"bytes"
+	"net"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+type ipvsInfo struct {
+	Version       uint32 `netlink:"attr:1"`
+	ConnTableSize uint32 `netlink:"attr:2"`
+}
+
+type ipvsStats struct {
+	Conns      uint32 `netlink:"attr:1"`
+	PacketsIn  uint32 `netlink:"attr:2"`
+	PacketsOut uint32 `netlink:"attr:3"`
+	BytesIn    uint64 `netlink:"attr:4"`
+	BytesOut   uint64 `netlink:"attr:5"`
+	CPS        uint32 `netlink:"attr:6"`
+	PPSIn      uint32 `netlink:"attr:7"`
+	PPSOut     uint32 `netlink:"attr:8"`
+	BPSIn      uint32 `netlink:"attr:9"`
+	BPSOut     uint32 `netlink:"attr:10"`
+}
+
+type ipvsServiceStats struct {
+	Ignore bool
+	ipvsStats
+}
+
+type ipvsService struct {
+	AddrFamily        uint16            `netlink:"attr:1"`
+	Protocol          uint16            `netlink:"attr:2,omitempty,optional"`
+	Address           net.IP            `netlink:"attr:3,omitempty,optional"`
+	Port              uint16            `netlink:"attr:4,network,omitempty,optional"`
+	FirewallMark      uint32            `netlink:"attr:5,omitempty,optional"`
+	Scheduler         string            `netlink:"attr:6"`
+	Flags             [8]byte           `netlink:"attr:7"`
+	Timeout           uint32            `netlink:"attr:8"`
+	Netmask           uint32            `netlink:"attr:9"`
+	Stats             *ipvsServiceStats `netlink:"attr:10,optional"`
+	PersistenceEngine string            `netlink:"attr:11,omitempty,optional"`
+}
+
+type ipvsCommand struct {
+	Service *ipvsService `netlink:"attr:1"`
+}
+
+type ipvsIPAddr struct {
+	IP net.IP `netlink:"attr:1"`
+}
+
+var (
+	nlmIPVSInfo = []byte{
+		0x24, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0xc6, 0x20, 0xc8, 0x55, 0x33, 0x28, 0x00, 0x00,
+		0x0e, 0x01, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00,
+		0x01, 0x02, 0x01, 0x00, 0x08, 0x00, 0x02, 0x00,
+		0x00, 0x10, 0x00, 0x00,
+	}
+
+	nlmIPVSAddService = []byte{
+		0x68, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x54, 0x00, 0x01, 0x00,
+		0x06, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+		0x06, 0x00, 0x02, 0x00, 0x06, 0x00, 0x00, 0x00,
+		0x14, 0x00, 0x03, 0x00, 0x01, 0x01, 0x01, 0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x04, 0x00,
+		0x50, 0x00, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0x77, 0x6c, 0x63, 0x00, 0x0c, 0x00, 0x07, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+		0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x09, 0x00, 0xff, 0xff, 0xff, 0xff,
+	}
+
+	nlmIPVSService = []byte{
+		0xc4, 0x00, 0x00, 0x00, 0x16, 0x00, 0x02, 0x00,
+		0xb0, 0xb3, 0xc8, 0x55, 0x79, 0x02, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0xb0, 0x00, 0x01, 0x00,
+		0x06, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+		0x06, 0x00, 0x02, 0x00, 0x11, 0x00, 0x00, 0x00,
+		0x14, 0x00, 0x03, 0x00, 0x01, 0x02, 0x03, 0x04,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x04, 0x00,
+		0x35, 0x00, 0x00, 0x00, 0x07, 0x00, 0x06, 0x00,
+		0x72, 0x72, 0x00, 0x00, 0x0c, 0x00, 0x07, 0x00,
+		0x02, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+		0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x09, 0x00, 0xff, 0xff, 0xff, 0xff,
+		0x5c, 0x00, 0x0a, 0x00, 0x08, 0x00, 0x01, 0x00,
+		0x03, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 0x00,
+		0x0c, 0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x04, 0x00,
+		0x1a, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x0c, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x06, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x07, 0x00,
+		0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x09, 0x00,
+		0x54, 0x00, 0x00, 0x00, 0x08, 0x00, 0x0a, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	nlmIPVSIPv4 = []byte{
+		0x28, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x14, 0x00, 0x01, 0x00,
+		0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	nlmIPVSIPv6 = []byte{
+		0x28, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x14, 0x00, 0x01, 0x00,
+		0x20, 0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xca, 0xfe,
+	}
+
+	ipvsIPTests = []struct {
+		ip         net.IP
+		nlm        []byte
+		bytesEqual bool
+	}{
+		{net.IPv4(1, 2, 3, 4), nlmIPVSIPv4, true},
+		{net.IP{1, 2, 3, 4}, nlmIPVSIPv4, false},
+		{net.ParseIP("2015::cafe"), nlmIPVSIPv6, true},
+	}
+)
+
+func TestMessageBytes(t *testing.T) {
+	m, err := NewMessageFromBytes(nlmIPVSInfo)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	got, err := m.Bytes()
+	if err != nil {
+		t.Fatalf("Failed to get netlink message bytes: %v", err)
+	}
+	if want := nlmIPVSInfo; !bytes.Equal(got, want) {
+		t.Errorf("Got netlink bytes %#v, want %#v", got, want)
+	}
+}
+
+func TestMessageMarshal(t *testing.T) {
+	m, err := NewMessage(1, 25, 0)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	service := &ipvsService{
+		AddrFamily:   syscall.AF_INET,
+		Protocol:     syscall.IPPROTO_TCP,
+		Address:      net.IPv4(1, 1, 1, 1),
+		Port:         0x5000,
+		FirewallMark: 0x0,
+		Scheduler:    "wlc",
+		Flags: [8]uint8{
+			0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff,
+		},
+		Timeout:           0x0,
+		Netmask:           0xffffffff,
+		Stats:             nil,
+		PersistenceEngine: "",
+	}
+	ic := &ipvsCommand{Service: service}
+	if err := m.Marshal(ic); err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	got, err := m.Bytes()
+	if err != nil {
+		t.Fatalf("Failed to get message bytes: %v", err)
+	}
+	if want := nlmIPVSAddService; !bytes.Equal(got, want) {
+		t.Fatalf("Got netlink bytes %#v, want %#v", got, want)
+	}
+}
+
+func TestMessageMarshalIP(t *testing.T) {
+	for _, test := range ipvsIPTests {
+		func() {
+			m, err := NewMessage(1, 25, 0)
+			if err != nil {
+				t.Fatalf("Failed to make netlink message: %v", err)
+			}
+			defer m.Free()
+			if err := m.Marshal(&ipvsIPAddr{test.ip}); err != nil {
+				t.Errorf("Failed to marshal: %v", err)
+				return
+			}
+			got, err := m.Bytes()
+			if err != nil {
+				t.Errorf("Failed to get message bytes: %v", err)
+				return
+			}
+			if want := test.nlm; !bytes.Equal(got, want) {
+				t.Errorf("Got netlink bytes %#v, want %#v", got, want)
+			}
+		}()
+	}
+}
+
+func TestMessageMarshalUnexported(t *testing.T) {
+	m, err := NewMessage(1, 25, 0)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	nes := &struct {
+		internal uint32 `netlink:"attr:x"`
+	}{}
+	if err := m.Marshal(nes); err == nil {
+		t.Fatal("Marshal message succeeded with unexported field")
+	}
+}
+
+func TestMesageMarshalNonStruct(t *testing.T) {
+	var info *ipvsInfo
+	var u int32
+	var s string
+
+	tests := []struct {
+		v interface{}
+	}{
+		{nil},
+		{info},
+		{u},
+		{&u},
+		{s},
+		{&s},
+	}
+
+	m, err := NewMessage(1, 25, 0)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	for _, test := range tests {
+		if err := m.Marshal(test.v); err == nil {
+			t.Errorf("Marshal message succeeded with %v", reflect.TypeOf(test.v))
+		}
+	}
+}
+
+func TestMessageUnmarshal(t *testing.T) {
+	m, err := NewMessageFromBytes(nlmIPVSInfo)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	got := &ipvsInfo{}
+	if err := m.Unmarshal(got); err != nil {
+		t.Fatalf("Failed to unmarshal message: %v", err)
+	}
+
+	want := &ipvsInfo{Version: 0x10201, ConnTableSize: 0x1000}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Got IPVS info %#v, want %#v", got, want)
+	}
+}
+
+func TestMessageUnmarshalIP(t *testing.T) {
+	for _, test := range ipvsIPTests {
+		func() {
+			m, err := NewMessageFromBytes(test.nlm)
+			if err != nil {
+				t.Fatalf("Failed to make netlink message: %v", err)
+			}
+			defer m.Free()
+			ipa := &ipvsIPAddr{}
+			if err := m.Unmarshal(ipa); err != nil {
+				t.Errorf("Failed to unmarshal: %v", err)
+				return
+			}
+			if test.bytesEqual && !bytes.Equal(test.ip, ipa.IP) {
+				t.Errorf("IP address bytes differ - got %#v, want %#v", ipa.IP, test.ip)
+				return
+			}
+			if !test.ip.Equal(ipa.IP) {
+				t.Errorf("IP addresses differ - got %#v, want %#v", ipa.IP, test.ip)
+			}
+		}()
+	}
+}
+
+func TestMessageUnmarshalUnexported(t *testing.T) {
+	m, err := NewMessageFromBytes(nlmIPVSInfo)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	nes := &struct {
+		internal uint32 `netlink:"attr:1"`
+	}{}
+	if err := m.Unmarshal(nes); err == nil {
+		t.Error("Unmarshal message succeeded with unexported field")
+	}
+}
+
+func TestMesageUnmarshalNonStructPtr(t *testing.T) {
+	var info *ipvsInfo
+	var u int32
+	var s string
+
+	tests := []struct {
+		v interface{}
+	}{
+		{nil},
+		{ipvsInfo{}},
+		{info},
+		{u},
+		{&u},
+		{s},
+		{&s},
+	}
+
+	m, err := NewMessageFromBytes(nlmIPVSInfo)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	for _, test := range tests {
+		if err := m.Unmarshal(test.v); err == nil {
+			t.Errorf("Unmarshal message succeeded with %v", reflect.TypeOf(test.v))
+		}
+	}
+}
+
+func TestMessageUnmarshalNested(t *testing.T) {
+	m, err := NewMessageFromBytes(nlmIPVSService)
+	if err != nil {
+		t.Fatalf("Failed to make netlink message: %v", err)
+	}
+	defer m.Free()
+
+	got := &ipvsCommand{}
+	if err := m.Unmarshal(got); err != nil {
+		t.Errorf("Failed to unmarshal message: %v", err)
+	}
+
+	want := &ipvsService{
+		AddrFamily:   0x2,
+		Protocol:     0x11,
+		Address:      net.IPv4(1, 2, 3, 4),
+		Port:         0x3500,
+		FirewallMark: 0x0,
+		Scheduler:    "rr",
+		Flags: [8]uint8{
+			0x02, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+		},
+		Timeout: 0x0,
+		Netmask: 0xffffffff,
+		Stats: &ipvsServiceStats{
+			ipvsStats: ipvsStats{
+				Conns:      0x3,
+				PacketsIn:  0xc,
+				PacketsOut: 0x0,
+				BytesIn:    0x41a,
+				BytesOut:   0x0,
+				CPS:        0x0,
+				PPSIn:      0x1,
+				PPSOut:     0x0,
+				BPSIn:      0x54,
+				BPSOut:     0x0,
+			},
+		},
+		PersistenceEngine: "",
+	}
+	if !reflect.DeepEqual(got.Service, want) {
+		t.Errorf("Got IPVS service %#v, want %#v", got.Service, want)
+	}
+}

--- a/vendor/github.com/google/seesaw/netlink/netlink.go
+++ b/vendor/github.com/google/seesaw/netlink/netlink.go
@@ -1,0 +1,580 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package netlink provides a Go interface to netlink via the libnl library.
+package netlink
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/libnl3
+#cgo LDFLAGS: -lnl-3 -lnl-genl-3
+
+#include <stdint.h>
+
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+*/
+import "C"
+
+const (
+	genlVersion = 1
+	nlMaxBytes  = 512
+)
+
+// uint16FromNetwork converts the given value from its network byte order.
+func uint16FromNetwork(u uint16) uint16 {
+	b := *(*[2]byte)(unsafe.Pointer(&u))
+	return binary.BigEndian.Uint16(b[:])
+}
+
+// uint16ToNetwork converts the given value to its network byte order.
+func uint16ToNetwork(u uint16) uint16 {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], u)
+	return *(*uint16)(unsafe.Pointer(&b))
+}
+
+// uint32FromNetwork converts the given value from its network byte order.
+func uint32FromNetwork(u uint32) uint32 {
+	b := *(*[4]byte)(unsafe.Pointer(&u))
+	return binary.BigEndian.Uint32(b[:])
+}
+
+// uint32ToNetwork converts the given value to its network byte order.
+func uint32ToNetwork(u uint32) uint32 {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], u)
+	return *(*uint32)(unsafe.Pointer(&b))
+}
+
+// uint64FromNetwork converts the given value from its network byte order.
+func uint64FromNetwork(u uint64) uint64 {
+	b := *(*[8]byte)(unsafe.Pointer(&u))
+	return binary.BigEndian.Uint64(b[:])
+}
+
+// uint64ToNetwork converts the given value to its network byte order.
+func uint64ToNetwork(u uint64) uint64 {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], u)
+	return *(*uint64)(unsafe.Pointer(&b))
+}
+
+type fieldParams struct {
+	attr      uint16
+	network   bool
+	omitempty bool
+	optional  bool
+}
+
+func parseFieldParams(params string) (*fieldParams, error) {
+	if params == "" {
+		return nil, nil
+	}
+	fp := &fieldParams{}
+	for _, param := range strings.Split(params, ",") {
+		parts := strings.Split(param, ":")
+		switch name := parts[0]; name {
+		case "attr":
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid field parameter %q", param)
+			}
+			val := parts[1]
+			n, err := strconv.ParseUint(val, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %q for field parameter %s", val, name)
+			}
+			fp.attr = uint16(n)
+
+		case "network":
+			fp.network = true
+
+		case "omitempty":
+			fp.omitempty = true
+
+		case "optional":
+			fp.optional = true
+
+		default:
+			return nil, fmt.Errorf("unknown field parameter %q", name)
+		}
+	}
+	return fp, nil
+}
+
+// structMaxAttrID returns the maximum attribute ID found on netlink tagged
+// fields within the given struct and any untagged structs it contains.
+func structMaxAttrID(v reflect.Value) (uint16, error) {
+	if v.Kind() != reflect.Struct {
+		return 0, fmt.Errorf("%v is not a struct", v.Type())
+	}
+	st := v.Type()
+
+	var maxAttrID uint16
+	for i := 0; i < st.NumField(); i++ {
+		ft, fv := st.Field(i), v.Field(i)
+		fp, err := parseFieldParams(ft.Tag.Get("netlink"))
+		if err != nil {
+			return 0, err
+		}
+		if fp != nil && fp.attr > maxAttrID {
+			maxAttrID = fp.attr
+		}
+		if fp == nil && fv.Kind() == reflect.Struct {
+			attrID, err := structMaxAttrID(fv)
+			if err != nil {
+				return 0, err
+			}
+			if attrID > maxAttrID {
+				maxAttrID = attrID
+			}
+		}
+	}
+	return maxAttrID, nil
+}
+
+func xcalloc(n, size uint) (unsafe.Pointer, error) {
+	if n < 1 || size < 1 {
+		return nil, errors.New("invalid allocation size")
+	}
+	// TODO(jsing): We should really use C.SIZE_MAX here, however that
+	// currently translates to -1 via cgo...
+	if ^C.size_t(0)/C.size_t(n) < C.size_t(size) {
+		return nil, errors.New("integer overflow")
+	}
+	m := C.calloc(C.size_t(n), C.size_t(size))
+	if m == nil {
+		return nil, errors.New("out of memory")
+	}
+	return m, nil
+}
+
+type attribute struct {
+	nla *C.struct_nlattr
+}
+
+type nlAttrs struct {
+	attrs **C.struct_nlattr
+	n     uint
+}
+
+func newNLAttrs(n uint) (*nlAttrs, error) {
+	size := unsafe.Sizeof(&C.struct_nlattr{})
+	m, err := xcalloc(n, uint(size))
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate netlink attributes: %v", err)
+	}
+	return &nlAttrs{attrs: (**C.struct_nlattr)(m), n: n}, nil
+}
+
+func (a nlAttrs) free() {
+	if a.attrs == nil {
+		return
+	}
+	C.free(unsafe.Pointer(a.attrs))
+	a.attrs = nil
+}
+
+func (a nlAttrs) attributes() map[uint16]*attribute {
+	if a.attrs == nil {
+		return nil
+	}
+	attrs := make(map[uint16]*attribute)
+	for _, nla := range (*[1 << 20]*C.struct_nlattr)(unsafe.Pointer(a.attrs))[:a.n] {
+		if nla == nil {
+			continue
+		}
+		attrs[uint16(nla.nla_type)] = &attribute{nla: nla}
+	}
+	return attrs
+}
+
+func parseMessage(nlm *C.struct_nl_msg, maxAttrID uint16) (map[uint16]*attribute, error) {
+	if nlm == nil {
+		return nil, errors.New("no netlink message")
+	}
+
+	nlas, err := newNLAttrs(uint(maxAttrID) + 1)
+	if err != nil {
+		return nil, err
+	}
+	defer nlas.free()
+
+	var nlaPolicy *C.struct_nla_policy
+	if errno := C.genlmsg_parse(C.nlmsg_hdr(nlm), 0, nlas.attrs, C.int(maxAttrID), nlaPolicy); errno != 0 {
+		return nil, &Error{errno, "failed to parse netlink message"}
+	}
+
+	return nlas.attributes(), nil
+}
+
+func parseNested(attr *attribute, maxAttrID uint16) (map[uint16]*attribute, error) {
+	nlas, err := newNLAttrs(uint(maxAttrID) + 1)
+	if err != nil {
+		return nil, err
+	}
+	defer nlas.free()
+
+	var nlaPolicy *C.struct_nla_policy
+	if errno := C.nla_parse_nested(nlas.attrs, C.int(maxAttrID), attr.nla, nlaPolicy); errno != 0 {
+		return nil, errors.New("failed to parse netlink nested attribute")
+	}
+
+	return nlas.attributes(), nil
+}
+
+var (
+	netIPType = reflect.TypeOf(net.IP{})
+)
+
+func marshal(v reflect.Value, field string, params *fieldParams, nlm *C.struct_nl_msg) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	if !v.CanInterface() {
+		return fmt.Errorf("field %s is unexported", field)
+	}
+
+	if params != nil && params.omitempty {
+		switch v.Kind() {
+		case reflect.Array, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.String:
+			if v.Interface() == reflect.Zero(v.Type()).Interface() {
+				return nil
+			}
+		}
+	}
+
+	if nl, ok := v.Interface().(Marshaler); ok {
+		b := nl.Bytes()
+		if len(b) > nlMaxBytes {
+			return fmt.Errorf("field %s is %d bytes - exceeds maximum of %d", field, len(b), nlMaxBytes)
+		}
+		var d [nlMaxBytes]byte
+		copy(d[:], b)
+		if errno := C.nla_put(nlm, C.int(params.attr), C.int(len(b)), unsafe.Pointer(&d)); errno != 0 {
+			return &Error{errno, "failed to put data"}
+		}
+		return nil
+	}
+
+	switch v.Type() {
+	case netIPType:
+		var d [net.IPv6len]byte
+		ip := net.IP(v.Bytes())
+		if ip4 := ip.To4(); ip4 != nil {
+			copy(d[:], ip4)
+		} else {
+			copy(d[:], ip)
+		}
+		if errno := C.nla_put(nlm, C.int(params.attr), C.int(len(d)), unsafe.Pointer(&d)); errno != 0 {
+			return &Error{errno, "failed to put IP address"}
+		}
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.Array:
+		if k := v.Type().Elem().Kind(); k != reflect.Uint8 {
+			return fmt.Errorf("field %s is an array of unsupported type %v", field, k)
+		}
+		// Passing down the array pointer directly can trip
+		// the cgo pointer checks if the array is part of a
+		// larger struct that contains pointers, since cgo
+		// can't tell that we are only passing the array.
+		// Avoid the checks by making a copy.
+		vl := v.Len()
+		b := make([]byte, vl)
+		for i := 0; i < vl; i++ {
+			b[i] = byte(v.Index(i).Uint())
+		}
+		if errno := C.nla_put(nlm, C.int(params.attr), C.int(vl), unsafe.Pointer(&b[0])); errno != 0 {
+			return &Error{errno, "failed to put data"}
+		}
+
+	case reflect.Uint8:
+		if errno := C.nla_put_u8(nlm, C.int(params.attr), C.uint8_t(v.Uint())); errno != 0 {
+			return &Error{errno, "failed to put u8"}
+		}
+
+	case reflect.Uint16:
+		uval := uint16(v.Uint())
+		if params.network {
+			uval = uint16ToNetwork(uval)
+		}
+		if errno := C.nla_put_u16(nlm, C.int(params.attr), C.uint16_t(uval)); errno != 0 {
+			return &Error{errno, "failed to put u16"}
+		}
+
+	case reflect.Uint32:
+		uval := uint32(v.Uint())
+		if params.network {
+			uval = uint32ToNetwork(uval)
+		}
+		if errno := C.nla_put_u32(nlm, C.int(params.attr), C.uint32_t(uval)); errno != 0 {
+			return &Error{errno, "failed to put u32"}
+		}
+
+	case reflect.Uint64:
+		uval := uint64(v.Uint())
+		if params.network {
+			uval = uint64ToNetwork(uval)
+		}
+		if errno := C.nla_put_u64(nlm, C.int(params.attr), C.uint64_t(uval)); errno != 0 {
+			return &Error{errno, "failed to put u64"}
+		}
+
+	case reflect.String:
+		cs := C.CString(v.String())
+		if cs == nil {
+			return errors.New("failed to allocate string")
+		}
+		defer C.free(unsafe.Pointer(cs))
+		if errno := C.nla_put_string(nlm, C.int(params.attr), cs); errno != 0 {
+			return &Error{errno, "failed to put string"}
+		}
+
+	case reflect.Struct:
+		var nla *C.struct_nlattr
+		if params != nil {
+			if nla = C.nla_nest_start(nlm, C.int(params.attr)); nla == nil {
+				return errors.New("failed to start nested attribute")
+			}
+		}
+		st := v.Type()
+		for i := 0; i < st.NumField(); i++ {
+			ft, fv := st.Field(i), v.Field(i)
+			fp, err := parseFieldParams(ft.Tag.Get("netlink"))
+			if err != nil {
+				return err
+			}
+			if fp == nil && fv.Kind() != reflect.Struct {
+				continue
+			}
+			if err := marshal(fv, ft.Name, fp, nlm); err != nil {
+				return err
+			}
+		}
+		if nla != nil {
+			C.nla_nest_end(nlm, nla)
+		}
+
+	default:
+		return fmt.Errorf("field %s has unsupported type %v (%v)", field, v.Type(), v.Kind())
+	}
+	return nil
+}
+
+func unmarshal(v reflect.Value, field string, params *fieldParams, attrs map[uint16]*attribute) error {
+	var attr *attribute
+	if params != nil {
+		attr = attrs[params.attr]
+		if attr == nil {
+			if !params.optional {
+				return fmt.Errorf("missing attribute for required field %s", field)
+			}
+			return nil
+		}
+	}
+
+	if v.Kind() != reflect.Struct && !v.CanSet() {
+		return fmt.Errorf("field %s is unsettable", field)
+	}
+
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	va := v.Addr()
+	var unmarshaler Unmarshaler
+	if va.Type().Implements(reflect.TypeOf(&unmarshaler).Elem()) {
+		if !v.CanSet() {
+			return fmt.Errorf("field %s implements Unmarshaler but is unsettable", field)
+		}
+		nl := va.Interface().(Unmarshaler)
+		b := C.GoBytes(unsafe.Pointer(C.nla_data(attr.nla)), C.int(attr.nla.nla_len))
+		nl.SetBytes(b)
+		return nil
+	}
+
+	switch v.Type() {
+	case netIPType:
+		ip := net.IP(C.GoBytes(unsafe.Pointer(C.nla_data(attr.nla)), C.int(attr.nla.nla_len)))
+		if len(ip) < net.IPv6len {
+			return fmt.Errorf("IP address attribute for field %s is %d bytes (want at least %d)", field, len(ip), net.IPv6len)
+		}
+		ip = ip[:net.IPv6len]
+		if bytes.Equal(ip[net.IPv4len:], make([]byte, net.IPv6len-net.IPv4len)) {
+			ip = net.IPv4(ip[0], ip[1], ip[2], ip[3])
+		}
+		v.SetBytes(ip)
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.Array:
+		if k := v.Type().Elem().Kind(); k != reflect.Uint8 {
+			return fmt.Errorf("field %s is an array of unsupported type %v", field, k)
+		}
+		b := (*[1 << 20]byte)(unsafe.Pointer(v.UnsafeAddr()))[:v.Len()]
+		d := C.GoBytes(unsafe.Pointer(C.nla_data(attr.nla)), C.int(attr.nla.nla_len))
+		copy(b, d)
+
+	case reflect.Uint8:
+		v.SetUint(uint64(C.nla_get_u8(attr.nla)))
+
+	case reflect.Uint16:
+		uval := uint16(C.nla_get_u16(attr.nla))
+		if params.network {
+			uval = uint16FromNetwork(uval)
+		}
+		v.SetUint(uint64(uval))
+
+	case reflect.Uint32:
+		uval := uint32(C.nla_get_u32(attr.nla))
+		if params.network {
+			uval = uint32FromNetwork(uval)
+		}
+		v.SetUint(uint64(uval))
+
+	case reflect.Uint64:
+		uval := uint64(C.nla_get_u64(attr.nla))
+		if params.network {
+			uval = uint64FromNetwork(uval)
+		}
+		v.SetUint(uint64(uval))
+
+	case reflect.String:
+		v.SetString(C.GoString(C.nla_get_string(attr.nla)))
+
+	case reflect.Struct:
+		if attr != nil {
+			maxAttrID, err := structMaxAttrID(v)
+			if err != nil {
+				return err
+			}
+			attrs, err = parseNested(attr, maxAttrID)
+			if err != nil {
+				return err
+			}
+		}
+
+		st := v.Type()
+		for i := 0; i < st.NumField(); i++ {
+			ft, fv := st.Field(i), v.Field(i)
+			fp, err := parseFieldParams(ft.Tag.Get("netlink"))
+			if err != nil {
+				return err
+			}
+			if fp == nil && fv.Kind() != reflect.Struct {
+				continue
+			}
+			if fv.Kind() == reflect.Ptr && fv.IsNil() && attrs[fp.attr] != nil {
+				fv.Set(reflect.New(ft.Type.Elem()))
+			}
+			if err := unmarshal(fv, ft.Name, fp, attrs); err != nil {
+				return err
+			}
+		}
+
+	default:
+		return fmt.Errorf("field %s has unsupported type %v (%v)", field, v.Type(), v.Kind())
+	}
+	return nil
+}
+
+type socket struct {
+	nls *C.struct_nl_sock
+}
+
+func newSocket() (*socket, error) {
+	nls := C.nl_socket_alloc()
+	if nls == nil {
+		return nil, errors.New("failed to allocate netlink socket")
+	}
+	return &socket{nls: nls}, nil
+}
+
+func (s *socket) free() {
+	C.nl_socket_free(s.nls)
+	s.nls = nil
+}
+
+// Error represents a netlink error.
+type Error struct {
+	errno C.int
+	msg   string
+}
+
+// Error returns the string representation of a netlink error.
+func (e *Error) Error() string {
+	nle := C.GoString(C.nl_geterror(e.errno))
+	return fmt.Sprintf("%s: %s", e.msg, strings.ToLower(nle))
+}
+
+// Family returns the family identifier for the specified family name.
+func Family(name string) (int, error) {
+	s, err := newSocket()
+	if err != nil {
+		return -1, err
+	}
+	defer s.free()
+
+	if errno := C.genl_connect(s.nls); errno != 0 {
+		return -1, &Error{errno, "failed to connect to netlink"}
+	}
+	defer C.nl_close((*C.struct_nl_sock)(s.nls))
+
+	cn := C.CString(name)
+	defer C.free(unsafe.Pointer(cn))
+	family := C.genl_ctrl_resolve(s.nls, cn)
+	if family < 0 {
+		return -1, errors.New("failed to resolve family name")
+	}
+	return int(family), nil
+}
+
+// Marshaler represents a type that is capable of marshaling itself into its
+// netlink representation.
+type Marshaler interface {
+	// Bytes returns a byte slice containing the netlink representation of
+	// the given type.
+	Bytes() []byte
+}
+
+// Unmarshaler represents a type that is capable of unmarshaling itself from
+// its netlink representation.
+type Unmarshaler interface {
+	// SetBytes sets the value of the given type from a byte slice that
+	// contains its netlink representation.
+	SetBytes([]byte)
+}

--- a/vendor/github.com/google/seesaw/netlink/netlink_test.go
+++ b/vendor/github.com/google/seesaw/netlink/netlink_test.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFieldParams(t *testing.T) {
+	tests := []struct {
+		params  string
+		want    *fieldParams
+		wantErr bool
+	}{
+		{
+			"",
+			nil,
+			false,
+		},
+		{
+			"attr:123",
+			&fieldParams{attr: 123},
+			false,
+		},
+		{
+			"attr:-123",
+			nil,
+			true,
+		},
+		{
+			"attr:65536",
+			nil,
+			true,
+		},
+		{
+			"attr:123,omitempty,optional",
+			&fieldParams{attr: 123, omitempty: true, optional: true},
+			false,
+		},
+		{
+			"abcxyz",
+			nil,
+			true,
+		},
+	}
+	for _, test := range tests {
+		got, err := parseFieldParams(test.params)
+		switch {
+		case test.wantErr && err == nil:
+			t.Errorf("parseFieldParams(%q): got nil error, want error", test.params)
+		case !test.wantErr && err != nil:
+			t.Errorf("parseFieldParams(%q) returned error: %v", test.params, err)
+		case !test.wantErr && !reflect.DeepEqual(got, test.want):
+			t.Errorf("parseFieldParams(%q) = %#v, want %#v", test.params, got, test.want)
+		}
+	}
+}
+
+func TestMaxAttrID(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  uint16
+	}{
+		{
+			struct{}{},
+			0,
+		},
+		{
+			struct {
+				a uint32 `netlink:"attr:65535"`
+			}{},
+			65535,
+		},
+		{
+			struct {
+				a uint8  `netlink:"attr:1"`
+				b uint16 `netlink:"attr:2"`
+				c uint32 `netlink:"attr:3"`
+			}{},
+			3,
+		},
+		{
+			struct {
+				c uint32 `netlink:"attr:3"`
+				b uint16 `netlink:"attr:2"`
+				a uint8  `netlink:"attr:1"`
+			}{},
+			3,
+		},
+		{
+			struct {
+				a uint8  `netlink:"attr:1"`
+				b uint16 `netlink:"attr:2"`
+				c uint32 `netlink:"attr:3"`
+				x struct {
+					d string `netlink:"attr:5"`
+				}
+			}{},
+			5,
+		},
+		{
+			struct {
+				a uint8  `netlink:"attr:1"`
+				b uint16 `netlink:"attr:2"`
+				c uint32 `netlink:"attr:3"`
+				x struct {
+					d string `netlink:"attr:5"`
+				} `netlink:"attr:4"`
+			}{},
+			4,
+		},
+	}
+	for i, test := range tests {
+		got, err := structMaxAttrID(reflect.ValueOf(test.input))
+		if err != nil {
+			t.Errorf("%d: got error: %v", i, err)
+			continue
+		}
+		if got != test.want {
+			t.Errorf("%d: got %d, want %d", i, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
This implement the first version of ipvs based kube-proxy , using seesaw's [ipvs](https://github.com/google/seesaw/tree/master/ipvs) package to talk with ipvs.
### Requirements
- [libnl](https://www.infradead.org/~tgr/libnl/) - There is a compile and runtime dependency on libnl:

```
apt-get install libnl-3-dev libnl-genl-3-dev
```

kube-proxy also expects a few kernel modules to be loaded:
- ip_vs - IP Virtual Server module. Used to handle transport layer switching within the Linux kernel.
- nf_conntrack_ipv4 - Used by the Linux kernel to maintain the state of all logical network connections and relate packets to the sessions.

BTW, Is there any scripts I should update to install [libnl](https://www.infradead.org/~tgr/libnl/) and the ip_vs kernel modules on each node?

@bprashanth Mind to spend some time to take a look and give some instruction?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30134)

<!-- Reviewable:end -->
