### PR TITLE
remove useless value copy

### DIFF
--- a/plugin/pkg/scheduler/testing/pods_to_cache.go
+++ b/plugin/pkg/scheduler/testing/pods_to_cache.go
@@ -42,7 +42,6 @@ func (p PodsToCache) UpdateNode(oldNode, newNode *api.Node) error { return nil }
 func (p PodsToCache) RemoveNode(node *api.Node) error { return nil }
 
 func (p PodsToCache) UpdateNodeNameToInfoMap(infoMap map[string]*schedulercache.NodeInfo) error {
-	infoMap = schedulercache.CreateNodeNameToInfoMap(p, nil)
 	return nil
 }
 


### PR DESCRIPTION
Copy something to values in parameters won't change them in go. So, remove it to avoid making people confused.
