### PR TITLE
return err on `kubectl run --image` with invalid value

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1066,6 +1066,18 @@ __EOF__
   # teardown
   kubectl delete thirdpartyresources foo.company.com "${kube_flags[@]}"
 
+  #################
+  # Run cmd w img #
+  #################
+
+  # Test that a valid image reference value is provided as the value of --image in `kubectl run <name> --image`
+  output_message=$(kubectl run test1 --image=validname)
+  kube::test::if_has_string "${output_message}" 'deployment "test1" created'
+  # test invalid image name
+  output_message=$(! kubectl run test2 --image=InvalidImageName 2>&1)
+  kube::test::if_has_string "${output_message}" 'error: Invalid image name "InvalidImageName": invalid reference format'
+
+
   #####################################
   # Recursive Resources via directory #
   #####################################

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/distribution/reference"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -133,6 +136,13 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 	// Let kubectl run follow rules for `--`, see #13004 issue
 	if len(args) == 0 || argsLenAtDash == 0 {
 		return cmdutil.UsageError(cmd, "NAME is required for run")
+	}
+
+	// validate image name
+	imageName := cmdutil.GetFlagString(cmd, "image")
+	validImageRef := reference.ReferenceRegexp.MatchString(imageName)
+	if !validImageRef {
+		return fmt.Errorf("Invalid image name %q: %v", imageName, reference.ErrReferenceInvalidFormat)
 	}
 
 	interactive := cmdutil.GetFlagBool(cmd, "stdin")


### PR DESCRIPTION
When running `kubectl run <configname> --image="Invalid$$%ImageValue%%__"`, a configuration is successfully created with an image name that is not a valid value for an image reference.

This patch validates that the image name is a valid image reference, and returns an error before creating a config if an invalid value is passed.

`$ kubectl run test --image="Invalid__%imagename"`

```
error: Invalid image name "Invalid__%imagename": invalid reference format
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30162)

<!-- Reviewable:end -->
