### PR TITLE
add delete strategy to certificates registry

### DIFF
--- a/pkg/registry/certificates/etcd/etcd.go
+++ b/pkg/registry/certificates/etcd/etcd.go
@@ -70,6 +70,7 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *ApprovalREST) {
 
 		CreateStrategy: csrregistry.Strategy,
 		UpdateStrategy: csrregistry.Strategy,
+		DeleteStrategy: csrregistry.Strategy,
 
 		Storage: storageInterface,
 	}


### PR DESCRIPTION
So that CSRs can be deleted.

cc @gtank 

``` console
$ kubectl delete certificatesigningrequest foo
error: error when deleting "foo": http: server closed connection
```

and on the apiserver:

```
E0806 00:11:53.791039       5 runtime.go:64] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:70
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:63
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:49
/usr/local/go/src/runtime/asm_amd64.s:472
/usr/local/go/src/runtime/panic.go:443
/usr/local/go/src/runtime/panic.go:62
/usr/local/go/src/runtime/sigpanic_unix.go:24
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/api/rest/create.go:115
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/api/rest/delete.go:50
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/registry/generic/registry/store.go:634
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go:799
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go:953
/usr/local/go/src/runtime/asm_amd64.s:1998
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0xa268ee]

goroutine 1161 [running]:
panic(0x2a00240, 0xc820014070)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
k8s.io/kubernetes/pkg/util/runtime.HandleCrash(0xc821ecbef8, 0x1, 0x1)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:56 +0x153
panic(0x2a00240, 0xc820014070)
        /usr/local/go/src/runtime/panic.go:443 +0x4e9
k8s.io/kubernetes/pkg/api/rest.objectMetaAndKind(0x0, 0x0, 0x7faf1332ee78, 0xc8220f0600, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/api/rest/create.go:115 +0x1ee
k8s.io/kubernetes/pkg/api/rest.BeforeDelete(0x0, 0x0, 0x7faf13188338, 0xc821e218f0, 0x7faf1332ee78, 0xc8220f0600, 0xc821eb11c0, 0x0, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/api/rest/delete.go:50 +0x94
k8s.io/kubernetes/pkg/registry/generic/registry.(*Store).Delete(0xc82013c9a0, 0x7faf13188338, 0xc821e218f0, 0xc821e0bdde, 0xa, 0xc821eb11c0, 0x0, 0x0, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/registry/generic/registry/store.go:634 +0x3b8
k8s.io/kubernetes/pkg/apiserver.DeleteResource.func1.1(0x0, 0x0, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go:799 +0xa4
k8s.io/kubernetes/pkg/apiserver.finishRequest.func1(0xc821e081e0, 0xc821eb12c0, 0xc821e08000, 0xc821e0bf80)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go:953 +0xd9
created by k8s.io/kubernetes/pkg/apiserver.finishRequest
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go:958 +0xf1
```
