### PR TITLE
Node Conformance Test: Move namespace controller to services

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -31,12 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/client/typed/dynamic"
-	namespacecontroller "k8s.io/kubernetes/pkg/controller/namespace"
-	"k8s.io/kubernetes/pkg/util/wait"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -124,10 +118,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		glog.Infof("Running tests without starting services.")
 	}
 
-	glog.Infof("Starting namespace controller")
-	// TODO(random-liu): Move namespace controller into namespace services.
-	startNamespaceController()
-
 	// Reference common test to make the import valid.
 	commontest.CurrentSuite = commontest.NodeE2E
 
@@ -169,23 +159,4 @@ func maskLocksmithdOnCoreos() {
 		}
 		glog.Infof("Locksmithd is masked successfully")
 	}
-}
-
-const (
-	// ncResyncPeriod is resync period of the namespace controller
-	ncResyncPeriod = 5 * time.Minute
-	// ncConcurrency is concurrency of the namespace controller
-	ncConcurrency = 2
-)
-
-func startNamespaceController() {
-	// Use the default QPS
-	config := restclient.AddUserAgent(&restclient.Config{Host: framework.TestContext.Host}, "node-e2e-namespace-controller")
-	client, err := clientset.NewForConfig(config)
-	Expect(err).NotTo(HaveOccurred())
-	clientPool := dynamic.NewClientPool(config, dynamic.LegacyAPIPathResolverFunc)
-	resources, err := client.Discovery().ServerPreferredNamespacedResources()
-	Expect(err).NotTo(HaveOccurred())
-	nc := namespacecontroller.NewNamespaceController(client, clientPool, resources, ncResyncPeriod, api.FinalizerKubernetes)
-	go nc.Run(ncConcurrency, wait.NeverStop)
 }

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -150,7 +150,8 @@ type e2eService struct {
 	logFiles map[string]logFileData
 
 	// All statically linked e2e services
-	etcdServer *EtcdServer
+	etcdServer   *EtcdServer
+	nsController *NamespaceController
 }
 
 type logFileData struct {
@@ -219,6 +220,11 @@ func (es *e2eService) start() error {
 	}
 	es.services = append(es.services, s)
 
+	err = es.startNamespaceController()
+	if err != nil {
+		return nil
+	}
+
 	return nil
 }
 
@@ -279,14 +285,23 @@ func isJournaldAvailable() bool {
 
 func (es *e2eService) stop() {
 	es.getLogFiles()
+	// TODO(random-liu): Use a loop to stop all services after introducing service interface.
+	// Stop namespace controller
+	if es.nsController != nil {
+		if err := es.nsController.Stop(); err != nil {
+			glog.Errorf("Failed to stop %q: %v", es.nsController.Name(), err)
+		}
+	}
 	for _, s := range es.services {
 		if err := s.kill(); err != nil {
 			glog.Errorf("Failed to stop %v: %v", s.name, err)
 		}
 	}
-	// TODO(random-liu): Use a loop to stop all services after introducing service interface.
-	if err := es.etcdServer.Stop(); err != nil {
-		glog.Errorf("Failed to stop %q: %v", es.etcdServer.Name(), err)
+	// Stop etcd
+	if es.etcdServer != nil {
+		if err := es.etcdServer.Stop(); err != nil {
+			glog.Errorf("Failed to stop %q: %v", es.etcdServer.Name(), err)
+		}
 	}
 	for _, d := range es.rmDirs {
 		err := os.RemoveAll(d)
@@ -323,6 +338,11 @@ func (es *e2eService) startApiServer() (*server, error) {
 		[]string{apiserverHealthCheckURL},
 		"kube-apiserver.log")
 	return server, server.start()
+}
+
+func (es *e2eService) startNamespaceController() error {
+	es.nsController = NewNamespaceController()
+	return es.nsController.Start()
 }
 
 func (es *e2eService) startKubeletServer() (*server, error) {

--- a/test/e2e_node/namespace_controller.go
+++ b/test/e2e_node/namespace_controller.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
+	namespacecontroller "k8s.io/kubernetes/pkg/controller/namespace"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// ncName is the name of namespace controller
+	ncName = "namespace-controller"
+	// ncResyncPeriod is resync period of the namespace controller
+	ncResyncPeriod = 5 * time.Minute
+	// ncConcurrency is concurrency of the namespace controller
+	ncConcurrency = 2
+)
+
+// NamespaceController is a server which manages namespace controller.
+type NamespaceController struct {
+	stopCh chan struct{}
+}
+
+// NewNamespaceController creates a new namespace controller.
+func NewNamespaceController() *NamespaceController {
+	return &NamespaceController{stopCh: make(chan struct{})}
+}
+
+// Start starts the namespace controller.
+func (n *NamespaceController) Start() error {
+	// Use the default QPS
+	config := restclient.AddUserAgent(&restclient.Config{Host: framework.TestContext.Host}, ncName)
+	client, err := clientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	clientPool := dynamic.NewClientPool(config, dynamic.LegacyAPIPathResolverFunc)
+	resources, err := client.Discovery().ServerPreferredNamespacedResources()
+	if err != nil {
+		return err
+	}
+	nc := namespacecontroller.NewNamespaceController(client, clientPool, resources, ncResyncPeriod, api.FinalizerKubernetes)
+	go nc.Run(ncConcurrency, n.stopCh)
+	return nil
+}
+
+// Stop stops the namespace controller.
+func (n *NamespaceController) Stop() error {
+	close(n.stopCh)
+	return nil
+}
+
+// Name returns the name of namespace controller.
+func (n *NamespaceController) Name() string {
+	return ncName
+}


### PR DESCRIPTION
For #30122, #30174.
Based on #30116, #30198.

**Please only review the 3rd PR.**

This PR is part of our roadmap to package node conformance test.
The 1st commit is from #30116, which started e2e services in a separate process.
The 2nd commit is from #30198, it statically linked etcd into the node e2e framework.

The 3rd commit is new, it moved namespace controller into e2e services.

@dchen1107 @vishh 
/cc @kubernetes/sig-node @kubernetes/sig-testing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30200)

<!-- Reviewable:end -->
