### PR TITLE
Node Conformance Test: Statically link apiserver

### DIFF
--- a/test/e2e_node/apiserver.go
+++ b/test/e2e_node/apiserver.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import (
+	"fmt"
+	"net"
+
+	apiserver "k8s.io/kubernetes/cmd/kube-apiserver/app"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+)
+
+const (
+	clusterIPRange          = "10.0.0.1/24"
+	apiserverClientURL      = "http://localhost:8080"
+	apiserverHealthCheckURL = apiserverClientURL + "/healthz"
+)
+
+// APIServer is a server which manages apiserver.
+type APIServer struct{}
+
+// NewAPIServer creates an apiserver.
+func NewAPIServer() *APIServer {
+	return &APIServer{}
+}
+
+// Start starts the apiserver, returns when apiserver is ready.
+func (a *APIServer) Start() error {
+	config := options.NewAPIServer()
+	config.StorageConfig.ServerList = []string{getEtcdClientURL()}
+	_, ipnet, err := net.ParseCIDR(clusterIPRange)
+	if err != nil {
+		return err
+	}
+	config.ServiceClusterIPRange = *ipnet
+	config.AllowPrivileged = true
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		err := apiserver.Run(config)
+		if err != nil {
+			errCh <- fmt.Errorf("run apiserver error: %v", err)
+		}
+	}()
+
+	err = readinessCheck([]string{apiserverHealthCheckURL}, errCh)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Stop stops the apiserver. Currently, there is no way to stop the apiserver.
+// The function is here only for completion.
+func (a *APIServer) Stop() error {
+	return nil
+}
+
+const apiserverName = "apiserver"
+
+func (a *APIServer) Name() string {
+	return apiserverName
+}
+
+func getAPIServerClientURL() string {
+	return apiserverClientURL
+}
+
+func getAPIServerHealthCheckURL() string {
+	return apiserverHealthCheckURL
+}


### PR DESCRIPTION
For #30122, #30174.
Based on #30116, #30198, #30200.

**Please only review the 4th PR.**

This PR is part of our roadmap to package node conformance test.
The 1st commit is from #30116, which started e2e services in a separate process.
The 2nd commit is from #30198, it statically linked etcd into the node e2e framework.
The 3rd commit is from #30200, it moved namespace controller into e2e services.

The 4th commit is new, it statically linked apiserver into the node e2e framework.

@dchen1107 @vishh 
/cc @kubernetes/sig-node @kubernetes/sig-testing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30211)

<!-- Reviewable:end -->
