### PR TITLE
Use GetMasterAndWorkerNodesOrDie in scheduler predicates tests

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/kubernetes/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -198,17 +197,10 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 		c = f.Client
 		ns = f.Namespace.Name
 		nodeList = &api.NodeList{}
-		nodes, err := c.Nodes().List(api.ListOptions{})
-		masterNodes = sets.NewString()
-		for _, node := range nodes.Items {
-			if system.IsMasterNode(&node) {
-				masterNodes.Insert(node.Name)
-			} else {
-				nodeList.Items = append(nodeList.Items, node)
-			}
-		}
 
-		err = framework.CheckTestingNSDeletedExcept(c, ns)
+		masterNodes, nodeList = framework.GetMasterAndWorkerNodesOrDie(c)
+
+		err := framework.CheckTestingNSDeletedExcept(c, ns)
 		framework.ExpectNoError(err)
 
 		// Every test case in this suite assumes that cluster add-on pods stay stable and


### PR DESCRIPTION
fixes #28857
follow up to https://github.com/kubernetes/kubernetes/pull/28970

Makes sure that unschedulable node won't be count as worker node.
Its using [GetMasterAndWorkerNodesOrDie](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go#L4743) method which is used also in [density tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/density.go#L389).

@gmarek PTAL
