### PR TITLE
pkg/util/exec: don't specify paths for echo

### DIFF
--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -64,7 +64,7 @@ func TestExecutorNoArgs(t *testing.T) {
 func TestExecutorWithArgs(t *testing.T) {
 	ex := New()
 
-	cmd := ex.Command("/bin/echo", "stdout")
+	cmd := ex.Command("echo", "stdout")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Errorf("expected success, got %+v", err)


### PR DESCRIPTION
`ex.Command()` already searches the binary in PATH, no need to manually
specify it as `/bin/echo`. `pkg/util/exec` tests fail in non-conventional environments
due to this (e.g. NixOS).
