### PR TITLE
In AddOrUpdateTaintOnNode create annotation map if its nil

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2914,6 +2914,10 @@ func AddOrUpdateTaintOnNode(c *client.Client, nodeName string, taint api.Taint) 
 
 	taintsData, err := json.Marshal(newTaints)
 	ExpectNoError(err)
+
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
 	node.Annotations[api.TaintsAnnotationKey] = string(taintsData)
 	_, err = c.Nodes().Update(node)
 	ExpectNoError(err)


### PR DESCRIPTION
If node didn't have annotations both SchedulerPredicates taints-toleration tests were failing.

@gmarek PTAL

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30234)

<!-- Reviewable:end -->
