### PR TITLE
make reousrce prefix assignment consistent

### DIFF
--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -46,7 +46,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 
 // NewREST returns a RESTStorage object that will work against clusters.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/clusters"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &federation.ClusterList{} }
 	storageInterface := opts.Decorator(

--- a/pkg/registry/certificates/etcd/etcd.go
+++ b/pkg/registry/certificates/etcd/etcd.go
@@ -37,7 +37,7 @@ type REST struct {
 
 // NewREST returns a registry which will store CertificateSigningRequest in the given helper
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *ApprovalREST) {
-	prefix := "/certificatesigningrequests"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &certificates.CertificateSigningRequestList{} }
 	storageInterface := opts.Decorator(


### PR DESCRIPTION
Make reousrce prefix assignment consistent with other registries

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30249)

<!-- Reviewable:end -->
