### PR TITLE
Change kubectl create to use dynamic client

### DIFF
--- a/pkg/api/meta/unstructured.go
+++ b/pkg/api/meta/unstructured.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// InterfacesForUnstructured returns VersionInterfaces suitable for
+// dealing with runtime.Unstructured objects.
+func InterfacesForUnstructured(unversioned.GroupVersion) (*VersionInterfaces, error) {
+	return &VersionInterfaces{
+		ObjectConvertor:  &runtime.UnstructuredObjectConverter{},
+		MetadataAccessor: NewAccessor(),
+	}, nil
+}

--- a/pkg/client/typed/discovery/restmapper.go
+++ b/pkg/client/typed/discovery/restmapper.go
@@ -80,6 +80,8 @@ func NewRESTMapper(groupResources []*APIGroupResources, versionInterfaces meta.V
 				// TODO only do this if it supports listing
 				versionMapper.Add(gv.WithKind(resource.Kind+"List"), scope)
 			}
+			// TODO why is this type not in discovery (at least for "v1")
+			versionMapper.Add(gv.WithKind("List"), meta.RESTScopeRoot)
 			unionMapper = append(unionMapper, versionMapper)
 		}
 	}

--- a/pkg/client/typed/discovery/unstructured.go
+++ b/pkg/client/typed/discovery/unstructured.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// UnstructuredObjectTyper provides a runtime.ObjectTyper implmentation for
+// runtime.Unstructured object based on discovery information.
+type UnstructuredObjectTyper struct {
+	registered map[unversioned.GroupVersionKind]bool
+}
+
+// NewUnstructuredObjectTyper returns a runtime.ObjectTyper for
+// unstructred objects based on discovery information.
+func NewUnstructuredObjectTyper(groupResources []*APIGroupResources) *UnstructuredObjectTyper {
+	dot := &UnstructuredObjectTyper{registered: make(map[unversioned.GroupVersionKind]bool)}
+	for _, group := range groupResources {
+		for _, discoveryVersion := range group.Group.Versions {
+			resources, ok := group.VersionedResources[discoveryVersion.Version]
+			if !ok {
+				continue
+			}
+
+			gv := unversioned.GroupVersion{Group: group.Group.Name, Version: discoveryVersion.Version}
+			for _, resource := range resources {
+				dot.registered[gv.WithKind(resource.Kind)] = true
+			}
+		}
+	}
+	return dot
+}
+
+// ObjectKind returns the group,version,kind of the provided object, or an error
+// if the object in not *runtime.Unstructured or has no group,version,kind
+// information.
+func (d *UnstructuredObjectTyper) ObjectKind(obj runtime.Object) (unversioned.GroupVersionKind, error) {
+	if _, ok := obj.(*runtime.Unstructured); !ok {
+		return unversioned.GroupVersionKind{}, fmt.Errorf("type %T is invalid for dynamic object typer", obj)
+	}
+
+	return obj.GetObjectKind().GroupVersionKind(), nil
+}
+
+// ObjectKinds returns a slice of one element with the group,version,kind of the
+// provided object, or an error if the object is not *runtime.Unstructured or
+// has no group,version,kind information. unversionedType will always be false
+// because runtime.Unstructured object should always have group,version,kind
+// information set.
+func (d *UnstructuredObjectTyper) ObjectKinds(obj runtime.Object) (gvks []unversioned.GroupVersionKind, unversionedType bool, err error) {
+	gvk, err := d.ObjectKind(obj)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return []unversioned.GroupVersionKind{gvk}, false, nil
+}
+
+// Recognizes returns true if the provided group,version,kind was in the
+// discovery information.
+func (d *UnstructuredObjectTyper) Recognizes(gvk unversioned.GroupVersionKind) bool {
+	return d.registered[gvk]
+}
+
+// IsUnversioned returns false always because *runtime.Unstructured objects
+// should always have group,version,kind information set. ok will be true if the
+// object's group,version,kind is registered.
+func (d *UnstructuredObjectTyper) IsUnversioned(obj runtime.Object) (unversioned bool, ok bool) {
+	gvk, err := d.ObjectKind(obj)
+	if err != nil {
+		return false, false
+	}
+
+	return false, d.registered[gvk]
+}
+
+var _ runtime.ObjectTyper = &UnstructuredObjectTyper{}

--- a/pkg/client/typed/dynamic/client.go
+++ b/pkg/client/typed/dynamic/client.go
@@ -40,11 +40,7 @@ import (
 // Client is a Kubernetes client that allows you to access metadata
 // and manipulate metadata of a Kubernetes API group.
 type Client struct {
-	cl *restclient.RESTClient
-}
-
-type ClientWithParameterCodec struct {
-	client         *Client
+	cl             *restclient.RESTClient
 	parameterCodec runtime.ParameterCodec
 }
 
@@ -85,32 +81,21 @@ func (c *Client) GetRateLimiter() flowcontrol.RateLimiter {
 
 // Resource returns an API interface to the specified resource for this client's
 // group and version. If resource is not a namespaced resource, then namespace
-// is ignored.
+// is ignored. The ResourceClient inherits the parameter codec of c.
 func (c *Client) Resource(resource *unversioned.APIResource, namespace string) *ResourceClient {
 	return &ResourceClient{
-		cl:       c.cl,
-		resource: resource,
-		ns:       namespace,
-	}
-}
-
-// ParameterCodec wraps a parameterCodec around the Client.
-func (c *Client) ParameterCodec(parameterCodec runtime.ParameterCodec) *ClientWithParameterCodec {
-	return &ClientWithParameterCodec{
-		client:         c,
-		parameterCodec: parameterCodec,
-	}
-}
-
-// Resource returns an API interface to the specified resource for this client's
-// group and version. If resource is not a namespaced resource, then namespace
-// is ignored. The ResourceClient inherits the parameter codec of c.
-func (c *ClientWithParameterCodec) Resource(resource *unversioned.APIResource, namespace string) *ResourceClient {
-	return &ResourceClient{
-		cl:             c.client.cl,
+		cl:             c.cl,
 		resource:       resource,
 		ns:             namespace,
 		parameterCodec: c.parameterCodec,
+	}
+}
+
+// ParameterCodec returns a client with the provided parameter codec.
+func (c *Client) ParameterCodec(parameterCodec runtime.ParameterCodec) *Client {
+	return &Client{
+		cl:             c.cl,
+		parameterCodec: parameterCodec,
 	}
 }
 

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -275,6 +276,13 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec, runtime.Neg
 		Object: func(discovery bool) (meta.RESTMapper, runtime.ObjectTyper) {
 			return testapi.Default.RESTMapper(), api.Scheme
 		},
+		UnstructuredObject: func() (meta.RESTMapper, runtime.ObjectTyper, error) {
+			groupResources := testDynamicResources()
+			mapper := discovery.NewRESTMapper(groupResources, meta.InterfacesForUnstructured)
+			typer := discovery.NewUnstructuredObjectTyper(groupResources)
+
+			return kubectl.ShortcutExpander{RESTMapper: mapper}, typer, nil
+		},
 		Client: func() (*client.Client, error) {
 			// Swap out the HTTP client out of the client with the fake's version.
 			fakeClient := t.Client.(*fake.RESTClient)
@@ -284,6 +292,9 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec, runtime.Neg
 			return c, t.Err
 		},
 		ClientForMapping: func(*meta.RESTMapping) (resource.RESTClient, error) {
+			return t.Client, t.Err
+		},
+		UnstructuredClientForMapping: func(*meta.RESTMapping) (resource.RESTClient, error) {
 			return t.Client, t.Err
 		},
 		Decoder: func(bool) runtime.Decoder {

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
 )
 
 // CreateOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -107,8 +108,11 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		return err
 	}
 
-	mapper, typer := f.Object(cmdutil.GetIncludeThirdPartyAPIs(cmd))
-	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), runtime.UnstructuredJSONScheme).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/create_test.go
+++ b/pkg/kubectl/cmd/create_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 )
 
@@ -40,14 +41,15 @@ func TestCreateObject(t *testing.T) {
 	_, _, rc := testData()
 	rc.Items[0].Name = "redis-master-controller"
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, _ := NewAPIFactory()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
+			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -72,16 +74,17 @@ func TestCreateMultipleObject(t *testing.T) {
 	initTestErrorHandler(t)
 	_, svc, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, _ := NewAPIFactory()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, &svc.Items[0])}, nil
-			case p == "/namespaces/test/replicationcontrollers" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
+			case p == "/namespaces/test/services" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &svc.Items[0])}, nil
+			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -108,14 +111,15 @@ func TestCreateDirectory(t *testing.T) {
 	_, _, rc := testData()
 	rc.Items[0].Name = "name"
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, _ := NewAPIFactory()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
+			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -33,6 +33,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer"
@@ -87,6 +88,26 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 		},
 	}
 	return pods, svc, rc
+}
+
+func testDynamicResources() []*discovery.APIGroupResources {
+	return []*discovery.APIGroupResources{
+		{
+			Group: unversioned.APIGroup{
+				Versions: []unversioned.GroupVersionForDiscovery{
+					{Version: "v1"},
+				},
+				PreferredVersion: unversioned.GroupVersionForDiscovery{Version: "v1"},
+			},
+			VersionedResources: map[string][]unversioned.APIResource{
+				"v1": {
+					{Name: "pods", Namespaced: true, Kind: "Pod"},
+					{Name: "services", Namespaced: true, Kind: "Service"},
+					{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+				},
+			},
+		},
+	}
 }
 
 func testComponentStatusData() *api.ComponentStatusList {

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
 )
 
 // ReplaceOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -187,8 +188,11 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 		}
 	}
 
-	mapper, typer := f.Object(cmdutil.GetIncludeThirdPartyAPIs(cmd))
-	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), runtime.UnstructuredJSONScheme).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
@@ -212,7 +216,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 		return err
 	}
 
-	r = resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r = resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), runtime.UnstructuredJSONScheme).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -54,20 +53,8 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode %q: %v", source, err)
 	}
-	var obj runtime.Object
-	var versioned runtime.Object
-	if isThirdParty, gvkOut, err := thirdpartyresourcedata.IsThirdPartyObject(data, gvk); err != nil {
-		return nil, err
-	} else if isThirdParty {
-		obj, err = runtime.Decode(thirdpartyresourcedata.NewDecoder(nil, gvkOut.Kind), data)
-		versioned = obj
-		gvk = gvkOut
-	} else {
-		obj, versioned = versions.Last(), versions.First()
-	}
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode %q: %v [%v]", source, err, gvk)
-	}
+
+	obj, versioned := versions.Last(), versions.First()
 	mapping, err := m.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %q: %v", source, err)

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -618,13 +618,7 @@ func RetrieveLatest(info *Info, err error) error {
 	if info.Namespaced() && len(info.Namespace) == 0 {
 		return fmt.Errorf("no namespace set on resource %s %q", info.Mapping.Resource, info.Name)
 	}
-	obj, err := NewHelper(info.Client, info.Mapping).Get(info.Namespace, info.Name, info.Export)
-	if err != nil {
-		return err
-	}
-	info.Object = obj
-	info.ResourceVersion, _ = info.Mapping.MetadataAccessor.ResourceVersion(obj)
-	return nil
+	return info.Get()
 }
 
 // RetrieveLazy updates the object if it has not been loaded yet.

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runtime
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -136,6 +137,21 @@ type Unstructured struct {
 	// Object is a JSON compatible map with string, float, int, []interface{}, or map[string]interface{}
 	// children.
 	Object map[string]interface{}
+}
+
+// MarshalJSON ensures that the unstructured object produces proper
+// JSON when passed to Go's standard JSON library.
+func (u *Unstructured) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	err := UnstructuredJSONScheme.Encode(u, &buf)
+	return buf.Bytes(), err
+}
+
+// UnmarshalJSON ensures that the unstructured object properly decodes
+// JSON when passed to Go's standard JSON library.
+func (u *Unstructured) UnmarshalJSON(b []byte) error {
+	_, _, err := UnstructuredJSONScheme.Decode(b, nil, u)
+	return err
 }
 
 func getNestedField(obj map[string]interface{}, fields ...string) interface{} {
@@ -448,6 +464,21 @@ type UnstructuredList struct {
 
 	// Items is a list of unstructured objects.
 	Items []*Unstructured `json:"items"`
+}
+
+// MarshalJSON ensures that the unstructured list object produces proper
+// JSON when passed to Go's standard JSON library.
+func (u *UnstructuredList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	err := UnstructuredJSONScheme.Encode(u, &buf)
+	return buf.Bytes(), err
+}
+
+// UnmarshalJSON ensures that the unstructured list object properly
+// decodes JSON when passed to Go's standard JSON library.
+func (u *UnstructuredList) UnmarshalJSON(b []byte) error {
+	_, _, err := UnstructuredJSONScheme.Decode(b, nil, u)
+	return err
 }
 
 func (u *UnstructuredList) setNestedField(value interface{}, fields ...string) {

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -103,10 +103,9 @@ func (s unstructuredJSONScheme) decodeInto(data []byte, obj Object) error {
 	case *UnstructuredList:
 		return s.decodeToList(data, x)
 	case *VersionedObjects:
-		u := new(Unstructured)
-		err := s.decodeToUnstructured(data, u)
+		o, err := s.decode(data)
 		if err == nil {
-			x.Objects = []Object{u}
+			x.Objects = []Object{o}
 		}
 		return err
 	default:


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/16764 https://github.com/kubernetes/kubernetes/issues/3955

This is a series of changes to allow kubectl create to use discovery-based REST mapping and dynamic clients.

cc @kubernetes/sig-api-machinery

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
kubectl will no longer do client-side defaulting on create and replace.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30250)

<!-- Reviewable:end -->
