### PR TITLE
Add annotations to the PodSecurityPolicy Provider interface

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -196,3 +196,4 @@ test/integration/openshift
 test/soak/cauldron
 test/soak/serve_hostnames
 third_party/forked/golang/expansion
+pkg/util/maps

--- a/pkg/security/podsecuritypolicy/provider_test.go
+++ b/pkg/security/podsecuritypolicy/provider_test.go
@@ -78,7 +78,7 @@ func TestCreatePodSecurityContextNonmutating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create provider %v", err)
 	}
-	sc, err := provider.CreatePodSecurityContext(pod)
+	sc, _, err := provider.CreatePodSecurityContext(pod)
 	if err != nil {
 		t.Fatalf("unable to create psc %v", err)
 	}
@@ -148,7 +148,7 @@ func TestCreateContainerSecurityContextNonmutating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create provider %v", err)
 	}
-	sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.Containers[0])
+	sc, _, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.Containers[0])
 	if err != nil {
 		t.Fatalf("unable to create container security context %v", err)
 	}
@@ -698,7 +698,7 @@ func TestGenerateContainerSecurityContextReadOnlyRootFS(t *testing.T) {
 			t.Errorf("%s unable to create provider %v", k, err)
 			continue
 		}
-		sc, err := provider.CreateContainerSecurityContext(v.pod, &v.pod.Spec.Containers[0])
+		sc, _, err := provider.CreateContainerSecurityContext(v.pod, &v.pod.Spec.Containers[0])
 		if err != nil {
 			t.Errorf("%s unable to create container security context %v", k, err)
 			continue

--- a/pkg/security/podsecuritypolicy/types.go
+++ b/pkg/security/podsecuritypolicy/types.go
@@ -29,10 +29,12 @@ import (
 // Provider provides the implementation to generate a new security
 // context based on constraints or validate an existing security context against constraints.
 type Provider interface {
-	// Create a PodSecurityContext based on the given constraints.
-	CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurityContext, error)
-	// Create a container SecurityContext based on the given constraints
-	CreateContainerSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error)
+	// Create a PodSecurityContext based on the given constraints. Also returns an updated set
+	// of Pod annotations for alpha feature support.
+	CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurityContext, map[string]string, error)
+	// Create a container SecurityContext based on the given constraints. Also returns an updated set
+	// of Pod annotations for alpha feature support.
+	CreateContainerSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, map[string]string, error)
 	// Ensure a pod's SecurityContext is in compliance with the given constraints.
 	ValidatePodSecurityContext(pod *api.Pod, fldPath *field.Path) field.ErrorList
 	// Ensure a container's SecurityContext is in compliance with the given constraints

--- a/pkg/util/maps/doc.go
+++ b/pkg/util/maps/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package maps has common methods for dealing with common map types.
+package maps

--- a/pkg/util/maps/string.go
+++ b/pkg/util/maps/string.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps
+
+// CopySS makes a shallow copy of a map.
+func CopySS(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	copy := make(map[string]string, len(m))
+	for k, v := range m {
+		copy[k] = v
+	}
+	return copy
+}


### PR DESCRIPTION
@pweil- is this what you were thinking in terms of API changes? I really like to avoid functions with more than 2 return values, but couldn't think of a cleaner approach in this case.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30257)

<!-- Reviewable:end -->
