### PR TITLE
implmentation of federation ingress controller

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	clustercontroller "k8s.io/kubernetes/federation/pkg/federation-controller/cluster"
+	ingresscontroller "k8s.io/kubernetes/federation/pkg/federation-controller/ingress"
 	servicecontroller "k8s.io/kubernetes/federation/pkg/federation-controller/service"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -142,6 +143,11 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 	scClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, servicecontroller.UserAgentName))
 	servicecontroller := servicecontroller.New(scClientset, dns, s.FederationName, s.ZoneName)
 	if err := servicecontroller.Run(s.ConcurrentServiceSyncs, wait.NeverStop); err != nil {
+		glog.Errorf("Failed to start service controller: %v", err)
+	}
+	icClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, ingresscontroller.UserAgentName))
+	ingresscontroller := ingresscontroller.New(icClientset, dns, s.FederationName, s.ZoneName)
+	if err := ingresscontroller.Run(s.ConcurrentIngressSyncs, wait.NeverStop); err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)
 	}
 	select {}

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -47,6 +47,10 @@ type ControllerManagerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive service
 	// management, but more CPU (and network) load.
 	ConcurrentServiceSyncs int `json:"concurrentServiceSyncs"`
+	// concurrentIngressSyncs is the number of ingresses that are
+	// allowed to sync concurrently. Larger number = more responsive service
+	// management, but more CPU (and network) load.
+	ConcurrentIngressSyncs int `json:"concurrentIngressSyncs"`
 	// clusterMonitorPeriod is the period for syncing ClusterStatus in cluster controller.
 	ClusterMonitorPeriod unversioned.Duration `json:"clusterMonitorPeriod"`
 	// APIServerQPS is the QPS to use while talking with federation apiserver.
@@ -81,6 +85,7 @@ func NewCMServer() *CMServer {
 			Port:                   FederatedControllerManagerPort,
 			Address:                "0.0.0.0",
 			ConcurrentServiceSyncs: 10,
+			ConcurrentIngressSyncs: 10,
 			ClusterMonitorPeriod:   unversioned.Duration{Duration: 40 * time.Second},
 			APIServerQPS:           20.0,
 			APIServerBurst:         30,
@@ -97,6 +102,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.FederationName, "federation-name", s.FederationName, "Federation name.")
 	fs.StringVar(&s.ZoneName, "zone-name", s.ZoneName, "Zone name, like example.com.")
 	fs.IntVar(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
+	fs.IntVar(&s.ConcurrentIngressSyncs, "concurrent-ingress-syncs", s.ConcurrentIngressSyncs, "The number of ingress syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.DurationVar(&s.ClusterMonitorPeriod.Duration, "cluster-monitor-period", s.ClusterMonitorPeriod.Duration, "The period for syncing ClusterStatus in ClusterController.")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the federation API server (overrides any value in kubeconfig)")

--- a/federation/pkg/federation-controller/ingress/cluster_helper.go
+++ b/federation/pkg/federation-controller/ingress/cluster_helper.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"sync"
+
+	v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/api"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
+	"reflect"
+)
+
+type clusterCache struct {
+	clientset *release_1_4.Clientset
+	cluster   *v1beta1.Cluster
+	// A store of services, populated by the serviceController
+	ingressStore cache.StoreToIngressLister
+	// Watches changes to all services
+	ingressController *framework.Controller
+	// A store of endpoint, populated by the serviceController
+	endpointStore cache.StoreToEndpointsLister
+	// Watches changes to all endpoints
+	endpointController *framework.Controller
+	// services that need to be synced
+	ingressQueue *workqueue.Type
+	// endpoints that need to be synced
+	endpointQueue *workqueue.Type
+}
+
+type clusterClientCache struct {
+	rwlock    sync.Mutex // protects serviceMap
+	clientMap map[string]*clusterCache
+}
+
+func (cc *clusterClientCache) startClusterLW(cluster *v1beta1.Cluster, clusterName string) {
+	cachedClusterClient, ok := cc.clientMap[clusterName]
+	// only create when no existing cachedClusterClient
+	if ok {
+		if !reflect.DeepEqual(cachedClusterClient.cluster.Spec, cluster.Spec) {
+			//rebuild clientset when cluster spec is changed
+			clientset, err := newClusterClientset(cluster)
+			if err != nil || clientset == nil {
+				glog.Errorf("Failed to create corresponding restclient of kubernetes cluster: %v", err)
+			}
+			glog.V(4).Infof("Cluster spec changed, rebuild clientset for cluster %s", clusterName)
+			cachedClusterClient.clientset = clientset
+			go cachedClusterClient.ingressController.Run(wait.NeverStop)
+			go cachedClusterClient.endpointController.Run(wait.NeverStop)
+			glog.V(2).Infof("Start watching services and endpoints on cluster %s", clusterName)
+		} else {
+			// do nothing when there is no spec change
+			glog.V(4).Infof("Keep clientset for cluster %s", clusterName)
+			return
+		}
+	} else {
+		glog.V(4).Infof("No client cache for cluster %s, building new", clusterName)
+		clientset, err := newClusterClientset(cluster)
+		if err != nil || clientset == nil {
+			glog.Errorf("Failed to create corresponding restclient of kubernetes cluster: %v", err)
+		}
+		cachedClusterClient = &clusterCache{
+			cluster:       cluster,
+			clientset:     clientset,
+			ingressQueue:  workqueue.New(),
+			endpointQueue: workqueue.New(),
+		}
+		cachedClusterClient.endpointStore.Store, cachedClusterClient.endpointController = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+					return clientset.Core().Endpoints(v1.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return clientset.Core().Endpoints(v1.NamespaceAll).Watch(options)
+				},
+			},
+			&v1.Endpoints{},
+			serviceSyncPeriod,
+			framework.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					cc.enqueueEndpoint(obj, clusterName)
+				},
+				UpdateFunc: func(old, cur interface{}) {
+					cc.enqueueEndpoint(cur, clusterName)
+				},
+				DeleteFunc: func(obj interface{}) {
+					cc.enqueueEndpoint(obj, clusterName)
+				},
+			},
+		)
+
+		cachedClusterClient.ingressStore.Store, cachedClusterClient.ingressController = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+					return clientset.Core().Services(v1.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return clientset.Core().Services(v1.NamespaceAll).Watch(options)
+				},
+			},
+			&v1.Service{},
+			serviceSyncPeriod,
+			framework.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					cc.enqueueService(obj, clusterName)
+				},
+				UpdateFunc: func(old, cur interface{}) {
+					oldService, ok := old.(*v1.Service)
+
+					if !ok {
+						return
+					}
+					curService, ok := cur.(*v1.Service)
+					if !ok {
+						return
+					}
+					if !reflect.DeepEqual(oldService.Status.LoadBalancer, curService.Status.LoadBalancer) {
+						cc.enqueueService(cur, clusterName)
+					}
+				},
+				DeleteFunc: func(obj interface{}) {
+					service, _ := obj.(*v1.Service)
+					cc.enqueueService(obj, clusterName)
+					glog.V(2).Infof("Service %s/%s deletion found and enque to service store %s", service.Namespace, service.Name, clusterName)
+				},
+			},
+		)
+		cc.clientMap[clusterName] = cachedClusterClient
+		go cachedClusterClient.ingressController.Run(wait.NeverStop)
+		go cachedClusterClient.endpointController.Run(wait.NeverStop)
+		glog.V(2).Infof("Start watching services and endpoints on cluster %s", clusterName)
+	}
+
+}
+
+//TODO: copied from cluster controller, to make this as common function in pass 2
+// delFromClusterSet delete a cluster from clusterSet and
+// delete the corresponding restclient from the map clusterKubeClientMap
+func (cc *clusterClientCache) delFromClusterSet(obj interface{}) {
+	cluster, ok := obj.(*v1beta1.Cluster)
+	cc.rwlock.Lock()
+	defer cc.rwlock.Unlock()
+	if ok {
+		delete(cc.clientMap, cluster.Name)
+	} else {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Infof("Object contained wasn't a cluster or a deleted key: %+v", obj)
+			return
+		}
+		glog.Infof("Found tombstone for %v", obj)
+		delete(cc.clientMap, tombstone.Key)
+	}
+}
+
+// addToClusterSet inserts the new cluster to clusterSet and creates a corresponding
+// restclient to map clusterKubeClientMap
+func (cc *clusterClientCache) addToClientMap(obj interface{}) {
+	cluster := obj.(*v1beta1.Cluster)
+	cc.rwlock.Lock()
+	defer cc.rwlock.Unlock()
+	cluster, ok := obj.(*v1beta1.Cluster)
+	if !ok {
+		return
+	}
+	pred := getClusterConditionPredicate()
+	// check status
+	// skip if not ready
+	if pred(*cluster) {
+		cc.startClusterLW(cluster, cluster.Name)
+	}
+}
+
+func newClusterClientset(c *v1beta1.Cluster) (*release_1_4.Clientset, error) {
+	clusterConfig, err := util.BuildClusterConfig(c)
+	if clusterConfig != nil {
+		clientset := release_1_4.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, UserAgentName))
+		return clientset, nil
+	}
+	return nil, err
+}

--- a/federation/pkg/federation-controller/ingress/dns.go
+++ b/federation/pkg/federation-controller/ingress/dns.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+const (
+	// minDnsTtl is the minimum safe DNS TTL value to use (in seconds).  We use this as the TTL for all DNS records.
+	minDnsTtl = 180
+)
+
+// getHealthyEndpoints returns the hostnames and/or IP addresses of healthy endpoints for the service, at a zone, region and global level (or an error)
+func (s *ServiceController) getHealthyEndpoints(clusterName string, cachedService *cachedService) (zoneEndpoints, regionEndpoints, globalEndpoints []string, err error) {
+	var (
+		zoneNames  []string
+		regionName string
+	)
+	if zoneNames, regionName, err = s.getClusterZoneNames(clusterName); err != nil {
+		return nil, nil, nil, err
+	}
+	for lbClusterName, lbStatus := range cachedService.serviceStatusMap {
+		lbZoneNames, lbRegionName, err := s.getClusterZoneNames(lbClusterName)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for _, ingress := range lbStatus.Ingress {
+			readyEndpoints, ok := cachedService.endpointMap[lbClusterName]
+			if !ok || readyEndpoints == 0 {
+				continue
+			}
+			var address string
+			// We should get either an IP address or a hostname - use whichever one we get
+			if ingress.IP != "" {
+				address = ingress.IP
+			} else if ingress.Hostname != "" {
+				address = ingress.Hostname
+			}
+			if len(address) <= 0 {
+				return nil, nil, nil, fmt.Errorf("Service %s/%s in cluster %s has neither LoadBalancerStatus.ingress.ip nor LoadBalancerStatus.ingress.hostname. Cannot use it as endpoint for federated service.",
+					cachedService.lastState.Name, cachedService.lastState.Namespace, clusterName)
+			}
+			for _, lbZoneName := range lbZoneNames {
+				for _, zoneName := range zoneNames {
+					if lbZoneName == zoneName {
+						zoneEndpoints = append(zoneEndpoints, address)
+					}
+				}
+			}
+			if lbRegionName == regionName {
+				regionEndpoints = append(regionEndpoints, address)
+			}
+			globalEndpoints = append(globalEndpoints, address)
+		}
+	}
+	return zoneEndpoints, regionEndpoints, globalEndpoints, nil
+}
+
+// getClusterZoneNames returns the name of the zones (and the region) where the specified cluster exists (e.g. zones "us-east1-c" on GCE, or "us-east-1b" on AWS)
+func (s *ServiceController) getClusterZoneNames(clusterName string) (zones []string, region string, err error) {
+	client, ok := s.clusterCache.clientMap[clusterName]
+	if !ok {
+		return nil, "", fmt.Errorf("Cluster cache does not contain entry for cluster %s", clusterName)
+	}
+	if client.cluster == nil {
+		return nil, "", fmt.Errorf("Cluster cache entry for cluster %s is nil", clusterName)
+	}
+	return client.cluster.Status.Zones, client.cluster.Status.Region, nil
+}
+
+// getFederationDNSZoneName returns the name of the managed DNS Zone configured for this federation
+func (s *ServiceController) getFederationDNSZoneName() (string, error) {
+	return s.zoneName, nil
+}
+
+// getDnsZone is a hack around the fact that dnsprovider does not yet support a Get() method, only a List() method.  TODO:  Fix that.
+func getDnsZone(dnsZoneName string, dnsZonesInterface dnsprovider.Zones) (dnsprovider.Zone, error) {
+	dnsZones, err := dnsZonesInterface.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, dnsZone := range dnsZones {
+		if dnsZone.Name() == dnsZoneName {
+			return dnsZone, nil
+		}
+	}
+	return nil, fmt.Errorf("DNS zone %s not found.", dnsZoneName)
+}
+
+/* getRrset is a hack around the fact that dnsprovider.ResourceRecordSets interface does not yet include a Get() method, only a List() method.  TODO:  Fix that.
+   Note that if the named resource record set does not exist, but no error occurred, the returned set, and error, are both nil
+*/
+func getRrset(dnsName string, rrsetsInterface dnsprovider.ResourceRecordSets) (dnsprovider.ResourceRecordSet, error) {
+	var returnVal dnsprovider.ResourceRecordSet
+	rrsets, err := rrsetsInterface.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, rrset := range rrsets {
+		if rrset.Name() == dnsName {
+			returnVal = rrset
+			break
+		}
+	}
+	return returnVal, nil
+}
+
+/* getResolvedEndpoints perfoms DNS resolution on the provided slice of endpoints (which might be DNS names or IPv4 addresses)
+   and returns a list of IPv4 addresses.  If any of the endpoints are neither valid IPv4 addresses nor resolvable DNS names,
+   non-nil error is also returned (possibly along with a partially complete list of resolved endpoints.
+*/
+func getResolvedEndpoints(endpoints []string) ([]string, error) {
+	resolvedEndpoints := make([]string, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if net.ParseIP(endpoint) == nil {
+			// It's not a valid IP address, so assume it's a DNS name, and try to resolve it,
+			// replacing it's DNS name with it's IP addresses in expandedEndpoints
+			ipAddrs, err := net.LookupHost(endpoint)
+			if err != nil {
+				return resolvedEndpoints, err
+			}
+			resolvedEndpoints = append(resolvedEndpoints, ipAddrs...)
+
+		} else {
+			resolvedEndpoints = append(resolvedEndpoints, endpoint)
+		}
+	}
+	return resolvedEndpoints, nil
+}
+
+/* ensureDnsRrsets ensures (idempotently, and with minimum mutations) that all of the DNS resource record sets for dnsName are consistent with endpoints.
+   if endpoints is nil or empty, a CNAME record to uplevelCname is ensured.
+*/
+func (s *ServiceController) ensureDnsRrsets(dnsZoneName, dnsName string, endpoints []string, uplevelCname string) error {
+	dnsZone, err := getDnsZone(dnsZoneName, s.dnsZones)
+	if err != nil {
+		return err
+	}
+	rrsets, supported := dnsZone.ResourceRecordSets()
+	if !supported {
+		return fmt.Errorf("Failed to ensure DNS records for %s. DNS provider does not support the ResourceRecordSets interface.", dnsName)
+	}
+	rrset, err := getRrset(dnsName, rrsets) // TODO: rrsets.Get(dnsName)
+	if err != nil {
+		return err
+	}
+	if rrset == nil {
+		glog.V(4).Infof("No recordsets found for DNS name %q.  Need to add either A records (if we have healthy endpoints), or a CNAME record to %q", dnsName, uplevelCname)
+		if len(endpoints) < 1 {
+			glog.V(4).Infof("There are no healthy endpoint addresses at level %q, so CNAME to %q, if provided", dnsName, uplevelCname)
+			if uplevelCname != "" {
+				glog.V(4).Infof("Creating CNAME to %q for %q", uplevelCname, dnsName)
+				newRrset := rrsets.New(dnsName, []string{uplevelCname}, minDnsTtl, rrstype.CNAME)
+				glog.V(4).Infof("Adding recordset %v", newRrset)
+				err = rrsets.StartChangeset().Add(newRrset).Apply()
+				if err != nil {
+					return err
+				}
+				glog.V(4).Infof("Successfully created CNAME to %q for %q", uplevelCname, dnsName)
+			} else {
+				glog.V(4).Infof("We want no record for %q, and we have no record, so we're all good.", dnsName)
+			}
+		} else {
+			// We have valid endpoint addresses, so just add them as A records.
+			// But first resolve DNS names, as some cloud providers (like AWS) expose
+			// load balancers behind DNS names, not IP addresses.
+			glog.V(4).Infof("We have valid endpoint addresses %v at level %q, so add them as A records, after resolving DNS names", endpoints, dnsName)
+			resolvedEndpoints, err := getResolvedEndpoints(endpoints)
+			if err != nil {
+				return err // TODO: We could potentially add the ones we did get back, even if some of them failed to resolve.
+			}
+			newRrset := rrsets.New(dnsName, resolvedEndpoints, minDnsTtl, rrstype.A)
+			glog.V(4).Infof("Adding recordset %v", newRrset)
+			err = rrsets.StartChangeset().Add(newRrset).Apply()
+			if err != nil {
+				return err
+			}
+			glog.V(4).Infof("Successfully added recordset %v", newRrset)
+		}
+	} else {
+		// the rrset already exists, so make it right.
+		glog.V(4).Infof("Recordset %v already exists.  Ensuring that it is correct.", rrset)
+		if len(endpoints) < 1 {
+			// Need an appropriate CNAME record.  Check that we have it.
+			newRrset := rrsets.New(dnsName, []string{uplevelCname}, minDnsTtl, rrstype.CNAME)
+			glog.V(4).Infof("No healthy endpoints for %s.  Have recordset %v. Need recordset %v", dnsName, rrset, newRrset)
+			if dnsprovider.ResourceRecordSetsEquivalent(rrset, newRrset) {
+				// The existing rrset is equivalent to the required one - our work is done here
+				glog.V(4).Infof("Existing recordset %v is equivalent to needed recordset %v, our work is done here.", rrset, newRrset)
+				return nil
+			} else {
+				// Need to replace the existing one with a better one (or just remove it if we have no healthy endpoints).
+				glog.V(4).Infof("Existing recordset %v not equivalent to needed recordset %v removing existing and adding needed.", rrset, newRrset)
+				changeSet := rrsets.StartChangeset()
+				changeSet.Remove(rrset)
+				if uplevelCname != "" {
+					changeSet.Add(newRrset)
+					if err := changeSet.Apply(); err != nil {
+						return err
+					}
+					glog.V(4).Infof("Successfully replaced needed recordset %v -> %v", rrset, newRrset)
+				} else {
+					if err := changeSet.Apply(); err != nil {
+						return err
+					}
+					glog.V(4).Infof("Successfully removed existing recordset %v", rrset)
+					glog.V(4).Infof("Uplevel CNAME is empty string. Not adding recordset %v", newRrset)
+				}
+			}
+		} else {
+			// We have an rrset in DNS, possibly with some missing addresses and some unwanted addresses.
+			// And we have healthy endpoints.  Just replace what's there with the healthy endpoints, if it's not already correct.
+			glog.V(4).Infof("%s: Healthy endpoints %v exist.  Recordset %v exists.  Reconciling.", dnsName, endpoints, rrset)
+			resolvedEndpoints, err := getResolvedEndpoints(endpoints)
+			if err != nil { // Some invalid addresses or otherwise unresolvable DNS names.
+				return err // TODO: We could potentially add the ones we did get back, even if some of them failed to resolve.
+			}
+			newRrset := rrsets.New(dnsName, resolvedEndpoints, minDnsTtl, rrstype.A)
+			glog.V(4).Infof("Have recordset %v. Need recordset %v", rrset, newRrset)
+			if dnsprovider.ResourceRecordSetsEquivalent(rrset, newRrset) {
+				glog.V(4).Infof("Existing recordset %v is equivalent to needed recordset %v, our work is done here.", rrset, newRrset)
+				// TODO: We could be more thorough about checking for equivalence to avoid unnecessary updates, but in the
+				//       worst case we'll just replace what's there with an equivalent, if not exactly identical record set.
+				return nil
+			} else {
+				// Need to replace the existing one with a better one
+				glog.V(4).Infof("Existing recordset %v is not equivalent to needed recordset %v, removing existing and adding needed.", rrset, newRrset)
+				if err = rrsets.StartChangeset().Remove(rrset).Add(newRrset).Apply(); err != nil {
+					return err
+				}
+				glog.V(4).Infof("Successfully replaced recordset %v -> %v", rrset, newRrset)
+			}
+		}
+	}
+	return nil
+}
+
+/* ensureDnsRecords ensures (idempotently, and with minimum mutations) that all of the DNS records for a service in a given cluster are correct, given the current state of that service in that cluster.  This should be called every time the state of a service might have changed (either w.r.t. it's loadblancer address, or if the number of healthy backend endpoints for that service transitioned from zero to non-zero (or vice verse).  Only shards of the service which have both a loadbalancer ingress IP address or hostname AND at least one healthy backend endpoint are included in DNS records for that service (at all of zone, region and global levels). All other addresses are removed.  Also, if no shards exist in the zone or region of the cluster, a CNAME reference to the next higher level is ensured to exist.
+ */
+func (s *ServiceController) ensureDnsRecords(clusterName string, cachedService *cachedService) error {
+	// Quinton: Pseudocode....
+	// See https://github.com/kubernetes/kubernetes/pull/25107#issuecomment-218026648
+	// For each service we need the following DNS names:
+	// mysvc.myns.myfed.svc.z1.r1.mydomain.com  (for zone z1 in region r1)
+	//         - an A record to IP address of specific shard in that zone (if that shard exists and has healthy endpoints)
+	//         - OR a CNAME record to the next level up, i.e. mysvc.myns.myfed.svc.r1.mydomain.com  (if a healthy shard does not exist in zone z1)
+	// mysvc.myns.myfed.svc.r1.federation
+	//         - a set of A records to IP addresses of all healthy shards in region r1, if one or more of these exist
+	//         - OR a CNAME record to the next level up, i.e. mysvc.myns.myfed.svc.mydomain.com (if no healthy shards exist in region r1)
+	// mysvc.myns.myfed.svc.federation
+	//         - a set of A records to IP addresses of all healthy shards in all regions, if one or more of these exist.
+	//         - no record (NXRECORD response) if no healthy shards exist in any regions)
+	//
+	// For each cached service, cachedService.lastState tracks the current known state of the service, while cachedService.appliedState contains
+	// the state of the service when we last successfully sync'd it's DNS records.
+	// So this time around we only need to patch that (add new records, remove deleted records, and update changed records.
+	//
+	if s == nil {
+		return fmt.Errorf("nil ServiceController passed to ServiceController.ensureDnsRecords(clusterName: %s, cachedService: %v)", clusterName, cachedService)
+	}
+	if s.dns == nil {
+		return nil
+	}
+	if cachedService == nil {
+		return fmt.Errorf("nil cachedService passed to ServiceController.ensureDnsRecords(clusterName: %s, cachedService: %v)", clusterName, cachedService)
+	}
+	serviceName := cachedService.lastState.Name
+	namespaceName := cachedService.lastState.Namespace
+	zoneNames, regionName, err := s.getClusterZoneNames(clusterName)
+	if err != nil {
+		return err
+	}
+	if zoneNames == nil {
+		return fmt.Errorf("failed to get cluster zone names")
+	}
+	dnsZoneName, err := s.getFederationDNSZoneName()
+	if err != nil {
+		return err
+	}
+	zoneEndpoints, regionEndpoints, globalEndpoints, err := s.getHealthyEndpoints(clusterName, cachedService)
+	if err != nil {
+		return err
+	}
+	commonPrefix := serviceName + "." + namespaceName + "." + s.federationName + ".svc"
+	// dnsNames is the path up the DNS search tree, starting at the leaf
+	dnsNames := []string{
+		commonPrefix + "." + zoneNames[0] + "." + regionName + "." + dnsZoneName, // zone level - TODO might need other zone names for multi-zone clusters
+		commonPrefix + "." + regionName + "." + dnsZoneName,                      // region level, one up from zone level
+		commonPrefix + "." + dnsZoneName,                                         // global level, one up from region level
+		"", // nowhere to go up from global level
+	}
+
+	endpoints := [][]string{zoneEndpoints, regionEndpoints, globalEndpoints}
+
+	for i, endpoint := range endpoints {
+		if err = s.ensureDnsRrsets(dnsZoneName, dnsNames[i], endpoint, dnsNames[i+1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/federation/pkg/federation-controller/ingress/doc.go
+++ b/federation/pkg/federation-controller/ingress/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package service contains code for syncing Kubernetes services,
+// and cloud DNS servers with the federated service registry.
+package ingress // import "k8s.io/kubernetes/federation/pkg/federation-controller/ingress"

--- a/federation/pkg/federation-controller/ingress/ingress_helper.go
+++ b/federation/pkg/federation-controller/ingress/ingress_helper.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"time"
+
+	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	"k8s.io/kubernetes/pkg/api/errors"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+
+	"reflect"
+	"sort"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (i *IngressController) clusterIngressWorker() {
+	fedClient := i.federationClient
+	for clusterName, cache := range i.clusterCache.clientMap {
+		go func(cache *clusterCache, clusterName string) {
+			for {
+				func() {
+					key, quit := cache.ingressQueue.Get()
+					defer cache.ingressQueue.Done(key)
+					if quit {
+						return
+					}
+					err := i.clusterCache.syncIngress(key.(string), clusterName, cache, i.ingressCache, fedClient, i)
+					if err != nil {
+						glog.Errorf("Failed to sync ingress: %+v", err)
+					}
+				}()
+			}
+		}(cache, clusterName)
+	}
+}
+
+// Whenever there is change on ingress, the federation ingress should be updated
+func (cc *clusterClientCache) syncIngress(key, clusterName string, clusterCache *clusterCache, ingressCache *ingressCache, fedClient federation_release_1_4.Interface, ic *IngressController) error {
+	// obj holds the latest ingress info from apiserver, return if there is no federation cache for the ingress
+	cachedIngress, ok := ingressCache.get(key)
+	if !ok {
+		// if ingressCache does not exists, that means the ingress is not created by federation, we should skip it
+		return nil
+	}
+	ingressInterface, exists, err := clusterCache.ingressStore.GetByKey(key)
+	if err != nil {
+		glog.Infof("Did not successfully get %v from store: %v, will retry later", key, err)
+		clusterCache.ingressQueue.Add(key)
+		return err
+	}
+	var needUpdate, isDeletion bool
+	if exists {
+		ingress, ok := ingressInterface.(*extensions.Ingress)
+		if ok {
+			glog.V(4).Infof("Found ingress for federation ingress %s/%s from cluster %s", ingress.Namespace, ingress.Name, clusterName)
+			needUpdate = cc.processIngressUpdate(cachedIngress, ingress, clusterName)
+		} else {
+			_, ok := ingressInterface.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("Object contained wasn't a ingress or a deleted key: %+v", ingressInterface)
+			}
+			glog.Infof("Found tombstone for %v", key)
+			needUpdate = cc.processIngressDeletion(cachedIngress, clusterName)
+			isDeletion = true
+		}
+	} else {
+		glog.Infof("Can not get ingress %v for cluster %s from ingressStore", key, clusterName)
+		needUpdate = cc.processIngressDeletion(cachedIngress, clusterName)
+		isDeletion = true
+	}
+
+	if needUpdate {
+		for i := 0; i < clientRetryCount; i++ {
+			err := ic.ensureDnsRecords(clusterName, cachedIngress)
+			if err == nil {
+				break
+			}
+			glog.V(4).Infof("Error ensuring DNS Records for ingress %s on cluster %s: %v", key, clusterName, err)
+			time.Sleep(cachedIngress.nextDNSUpdateDelay())
+			clusterCache.ingressQueue.Add(key)
+			// did not retry here as we still want to persist federation apiserver even ensure dns records fails
+		}
+		err := cc.persistFedIngressUpdate(cachedIngress, fedClient)
+		if err == nil {
+			cachedIngress.appliedState = cachedIngress.lastState
+			cachedIngress.resetFedUpdateDelay()
+		} else {
+			if err != nil {
+				glog.Errorf("Failed to sync ingress: %+v, put back to ingress queue", err)
+				clusterCache.ingressQueue.Add(key)
+			}
+		}
+	}
+	if isDeletion {
+		// cachedIngress is not reliable here as
+		// deleting cache is the last step of federation ingress deletion
+		// TODO
+		//_, err := fedClient.Extensions().Ingresses(cachedIngress.lastState.Namespace).Get(cachedIngress.lastState.Name)
+		// rebuild ingress if federation ingress still exists
+		//if err == nil || !errors.IsNotFound(err) {
+		//	return ic.ensureClusterIngress(cachedIngress, clusterName, cachedIngress.appliedState, clusterCache.clientset)
+		//}
+	}
+	return nil
+}
+
+// processIngressDeletion is triggered when a ingress is delete from underlying k8s cluster
+// the deletion function will wip out the cached ingress info of the ingress from federation ingress ingress
+// the function returns a bool to indicate if actual update happened on federation ingress cache
+// and if the federation ingress cache is updated, the updated info should be post to federation apiserver
+func (cc *clusterClientCache) processIngressDeletion(cachedIngress *cachedIngress, clusterName string) bool {
+	cachedIngress.rwlock.Lock()
+	defer cachedIngress.rwlock.Unlock()
+	cachedStatus, ok := cachedIngress.ingressStatusMap[clusterName]
+	// cached status found, remove ingress info from federation ingress cache
+	if ok {
+		cachedFedIngressStatus := cachedIngress.lastState.Status.LoadBalancer
+		removeIndexes := []int{}
+		for i, fed := range cachedFedIngressStatus.Ingress {
+			for _, new := range cachedStatus.LoadBalancer {
+				// remove if same ingress record found
+				if new.IP == fed.IP && new.Hostname == fed.Hostname {
+					removeIndexes = append(removeIndexes, i)
+				}
+			}
+		}
+		sort.Ints(removeIndexes)
+		for i := len(removeIndexes) - 1; i >= 0; i-- {
+			cachedFedIngressStatus.Ingress = append(cachedFedIngressStatus.Ingress[:removeIndexes[i]], cachedFedIngressStatus.Ingress[removeIndexes[i]+1:]...)
+			glog.V(4).Infof("Remove old ingress %d for ingress %s/%s", removeIndexes[i], cachedIngress.lastState.Namespace, cachedIngress.lastState.Name)
+		}
+		delete(cachedIngress.ingressStatusMap, clusterName)
+		delete(cachedIngress.endpointMap, clusterName)
+		cachedIngress.lastState.Status.LoadBalancer = cachedFedIngressStatus
+		return true
+	} else {
+		glog.V(4).Infof("Ingress removal %s/%s from cluster %s observed.", cachedIngress.lastState.Namespace, cachedIngress.lastState.Name, clusterName)
+	}
+	return false
+}
+
+// processIngressUpdate Update ingress info when ingress updated
+// the function returns a bool to indicate if actual update happened on federation ingress cache
+// and if the federation ingress cache is updated, the updated info should be post to federation apiserver
+func (cc *clusterClientCache) processIngressUpdate(cachedIngress *cachedIngress, ingress *v1.Ingress, clusterName string) bool {
+	glog.V(4).Infof("Processing ingress update for %s/%s, cluster %s", ingress.Namespace, ingress.Name, clusterName)
+	cachedIngress.rwlock.Lock()
+	defer cachedIngress.rwlock.Unlock()
+	var needUpdate bool
+	newIngressLB := ingress.Status.LoadBalancer
+	cachedFedIngressStatus := cachedIngress.lastState.Status.LoadBalancer
+	if len(newIngressLB.Ingress) == 0 {
+		// not yet get LB IP
+		return false
+	}
+
+	cachedStatus, ok := cachedIngress.ingressStatusMap[clusterName]
+	if ok {
+		if reflect.DeepEqual(cachedStatus, newIngressLB) {
+			glog.V(4).Infof("Same ingress info observed for ingress %s/%s: %+v ", ingress.Namespace, ingress.Name, cachedStatus.Ingress)
+		} else {
+			glog.V(4).Infof("Ingress info was changed for ingress %s/%s: cache: %+v, new: %+v ",
+				ingress.Namespace, ingress.Name, cachedStatus.Ingress, newIngressLB)
+			needUpdate = true
+		}
+	} else {
+		glog.V(4).Infof("Cached ingress status was not found for %s/%s, cluster %s, building one", ingress.Namespace, ingress.Name, clusterName)
+
+		// cache is not always reliable(cache will be cleaned when ingress controller restart)
+		// two cases will run into this branch:
+		// 1. new ingress loadbalancer info received -> no info in cache, and no in federation ingress
+		// 2. ingress controller being restarted -> no info in cache, but it is in federation ingress
+
+		// check if the lb info is already in federation ingress
+
+		cachedIngress.ingressStatusMap[clusterName] = newIngressLB
+		needUpdate = false
+		// iterate ingress ingress info
+		for _, new := range newIngressLB.Ingress {
+			var found bool
+			// if it is known by federation ingress
+			for _, fed := range cachedFedIngressStatus.Ingress {
+				if new.IP == fed.IP && new.Hostname == fed.Hostname {
+					found = true
+				}
+			}
+			if !found {
+				needUpdate = true
+				break
+			}
+		}
+	}
+
+	if needUpdate {
+		// new status = cached federation status - cached status + new status from k8s cluster
+
+		removeIndexes := []int{}
+		for i, fed := range cachedFedIngressStatus.Ingress {
+			for _, new := range cachedStatus.Ingress {
+				// remove if same ingress record found
+				if new.IP == fed.IP && new.Hostname == fed.Hostname {
+					removeIndexes = append(removeIndexes, i)
+				}
+			}
+		}
+		sort.Ints(removeIndexes)
+		for i := len(removeIndexes) - 1; i >= 0; i-- {
+			cachedFedIngressStatus.Ingress = append(cachedFedIngressStatus.Ingress[:removeIndexes[i]], cachedFedIngressStatus.Ingress[removeIndexes[i]+1:]...)
+		}
+		cachedFedIngressStatus.Ingress = append(cachedFedIngressStatus.Ingress, ingress.Status.LoadBalancer.Ingress...)
+		cachedIngress.lastState.Status.LoadBalancer = cachedFedIngressStatus
+		glog.V(4).Infof("Add new ingress info %+v for ingress %s/%s", ingress.Status.LoadBalancer, ingress.Namespace, ingress.Name)
+	} else {
+		glog.V(4).Infof("Same ingress info found for %s/%s, cluster %s", ingress.Namespace, ingress.Name, clusterName)
+	}
+	return needUpdate
+}
+
+func (cc *clusterClientCache) persistFedIngressUpdate(cachedIngress *cachedIngress, fedClient federation_release_1_4.Interface) error {
+	ingress := cachedIngress.lastState
+	glog.V(5).Infof("Persist federation ingress status %s/%s", ingress.Namespace, ingress.Name)
+	var err error
+	for i := 0; i < clientRetryCount; i++ {
+		_, err := fedClient.Core().Ingresss(ingress.Namespace).Get(ingress.Name)
+		if errors.IsNotFound(err) {
+			glog.Infof("Not persisting update to ingress '%s/%s' that no longer exists: %v",
+				ingress.Namespace, ingress.Name, err)
+			return nil
+		}
+		_, err = fedClient.Core().Ingresss(ingress.Namespace).UpdateStatus(ingress)
+		if err == nil {
+			glog.V(2).Infof("Successfully update ingress %s/%s to federation apiserver", ingress.Namespace, ingress.Name)
+			return nil
+		}
+		if errors.IsNotFound(err) {
+			glog.Infof("Not persisting update to ingress '%s/%s' that no longer exists: %v",
+				ingress.Namespace, ingress.Name, err)
+			return nil
+		}
+		if errors.IsConflict(err) {
+			glog.V(4).Infof("Not persisting update to ingress '%s/%s' that has been changed since we received it: %v",
+				ingress.Namespace, ingress.Name, err)
+			return err
+		}
+		time.Sleep(cachedIngress.nextFedUpdateDelay())
+	}
+	return err
+}
+
+// obj could be an *api.Ingress, or a DeletionFinalStateUnknown marker item.
+func (cc *clusterClientCache) enqueueIngress(obj interface{}, clusterName string) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	_, ok := cc.clientMap[clusterName]
+	if ok {
+		cc.clientMap[clusterName].ingressQueue.Add(key)
+	}
+}

--- a/federation/pkg/federation-controller/ingress/ingress_helper_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_helper_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func buildServiceStatus(ingresses [][]string) v1.LoadBalancerStatus {
+	status := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{},
+	}
+	for _, element := range ingresses {
+		ingress := v1.LoadBalancerIngress{IP: element[0], Hostname: element[1]}
+		status.Ingress = append(status.Ingress, ingress)
+	}
+	return status
+}
+
+func TestProcessServiceUpdate(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap: make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name             string
+		cachedService    *cachedService
+		service          *v1.Service
+		clusterName      string
+		expectNeedUpdate bool
+		expectStatus     v1.LoadBalancerStatus
+	}{
+		{
+			"no-cache",
+			&cachedService{
+				lastState:        &v1.Service{},
+				serviceStatusMap: make(map[string]v1.LoadBalancerStatus),
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+			"foo",
+			true,
+			buildServiceStatus([][]string{{"ip1", ""}}),
+		},
+		{
+			"same-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1": {Ingress: []v1.LoadBalancerIngress{{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+			"foo1",
+			false,
+			buildServiceStatus([][]string{{"ip1", ""}}),
+		},
+		{
+			"diff-cluster",
+			&cachedService{
+				lastState: &v1.Service{
+					ObjectMeta: v1.ObjectMeta{Name: "bar1"},
+				},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo2": {Ingress: []v1.LoadBalancerIngress{{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip1", ""}}),
+		},
+		{
+			"diff-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip4", ""}, {"ip1", ""}, {"ip2", ""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1": buildServiceStatus([][]string{{"ip4", ""}, {"ip1", ""}, {"ip2", ""}}),
+				},
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip2", ""}, {"ip3", ""}, {"ip5", ""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip2", ""}, {"ip3", ""}, {"ip5", ""}}),
+		},
+	}
+	for _, test := range tests {
+		result := cc.processServiceUpdate(test.cachedService, test.service, test.clusterName)
+		if test.expectNeedUpdate != result {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectNeedUpdate, result)
+		}
+		if !reflect.DeepEqual(test.expectStatus, test.cachedService.lastState.Status.LoadBalancer) {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectStatus, test.cachedService.lastState.Status.LoadBalancer)
+		}
+	}
+}
+
+func TestProcessServiceDeletion(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap: make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name             string
+		cachedService    *cachedService
+		service          *v1.Service
+		clusterName      string
+		expectNeedUpdate bool
+		expectStatus     v1.LoadBalancerStatus
+	}{
+		{
+			"same-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1": {Ingress: []v1.LoadBalancerIngress{{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{}),
+		},
+		{
+			"diff-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip4", ""}, {"ip1", ""}, {"ip2", ""}, {"ip3", ""}, {"ip5", ""}, {"ip6", ""}, {"ip8", ""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1": buildServiceStatus([][]string{{"ip1", ""}, {"ip2", ""}, {"ip3", ""}}),
+					"foo2": buildServiceStatus([][]string{{"ip5", ""}, {"ip6", ""}, {"ip8", ""}}),
+				},
+			},
+			&v1.Service{Status: v1.ServiceStatus{LoadBalancer: buildServiceStatus([][]string{{"ip1", ""}, {"ip2", ""}, {"ip3", ""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip4", ""}, {"ip5", ""}, {"ip6", ""}, {"ip8", ""}}),
+		},
+	}
+	for _, test := range tests {
+		result := cc.processServiceDeletion(test.cachedService, test.clusterName)
+		if test.expectNeedUpdate != result {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectNeedUpdate, result)
+		}
+		if !reflect.DeepEqual(test.expectStatus, test.cachedService.lastState.Status.LoadBalancer) {
+			t.Errorf("Test failed for %s, expected %+v, saw %+v", test.name, test.expectStatus, test.cachedService.lastState.Status.LoadBalancer)
+		}
+	}
+}

--- a/federation/pkg/federation-controller/ingress/ingresscontroller.go
+++ b/federation/pkg/federation-controller/ingress/ingresscontroller.go
@@ -1,0 +1,786 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"reflect"
+
+	"github.com/golang/glog"
+	v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	federationcache "k8s.io/kubernetes/federation/client/cache"
+	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/conversion"
+	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	ingressSyncPeriod = 10 * time.Minute
+	clusterSyncPeriod = 10 * time.Minute
+
+	// How long to wait before retrying the processing of a ingress change.
+	// If this changes, the sleep in hack/jenkins/e2e.sh before downing a cluster
+	// should be changed appropriately.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+
+	// client retry count and interval is when accessing a remote kube-apiserver or federation apiserver
+	// how many times should be attempted and how long it should sleep when failure occurs
+	// the retry should be in short time so no exponential backoff
+	clientRetryCount = 5
+
+	retryable = true
+
+	doNotRetry = time.Duration(0)
+
+	UserAgentName = "federation-ingress-controller"
+	KubeAPIQPS    = 20.0
+	KubeAPIBurst  = 30
+)
+
+type cachedIngress struct {
+	lastState *extensions.Ingress
+	// The state as successfully applied to the DNS server
+	appliedState *extensions.Ingress
+	// cluster endpoint map hold subset info from kubernetes clusters
+	// key clusterName
+	// value is a flag that if there is ready address, 1 means there is ready address
+	endpointMap map[string]int
+	// ingressStatusMap map holds ingress status info from kubernetes clusters, keyed on clusterName
+	ingressStatusMap map[string]extensions.IngressStatus
+	// Ensures only one goroutine can operate on this ingress at any given time.
+	rwlock sync.Mutex
+	// Controls error back-off for procceeding federation ingress to k8s clusters
+	lastRetryDelay time.Duration
+	// Controls error back-off for updating federation ingress back to federation apiserver
+	lastFedUpdateDelay time.Duration
+	// Controls error back-off for dns record update
+	lastDNSUpdateDelay time.Duration
+}
+
+type ingressCache struct {
+	rwlock sync.Mutex // protects ingressMap
+	// federation ingress map contains all ingress received from federation apiserver
+	// key ingressName
+	fedIngressMap map[string]*cachedIngress
+}
+
+type IngressController struct {
+	dns              dnsprovider.Interface
+	federationClient federation_release_1_4.Interface
+	federationName   string
+	zoneName         string
+	// each federation should be configured with a single zone (e.g. "mycompany.com")
+	dnsZones     dnsprovider.Zones
+	ingressCache *ingressCache
+	clusterCache *clusterClientCache
+	// A store of ingresss, populated by the ingressController
+	ingressStore cache.StoreToIngressLister
+	// Watches changes to all ingresss
+	ingressController *framework.Controller
+	// A store of ingresss, populated by the ingressController
+	clusterStore federationcache.StoreToClusterLister
+	// Watches changes to all ingresss
+	clusterController *framework.Controller
+	eventBroadcaster  record.EventBroadcaster
+	eventRecorder     record.EventRecorder
+	// ingresss that need to be synced
+	queue           *workqueue.Type
+	knownClusterSet sets.String
+}
+
+// New returns a new ingress controller to keep DNS provider ingress resources
+// (like Kubernetes Ingresses and DNS server records for ingress discovery) in sync with the registry.
+
+func New(federationClient federation_release_1_4.Interface, dns dnsprovider.Interface, federationName, zoneName string) *IngressController {
+	broadcaster := record.NewBroadcaster()
+	// federationClient event is not supported yet
+	// broadcaster.StartRecordingToSink(&unversioned_core.EventSinkImpl{Interface: kubeClient.Core().Events("")})
+	recorder := broadcaster.NewRecorder(api.EventSource{Component: UserAgentName})
+
+	s := &IngressController{
+		dns:              dns,
+		federationClient: federationClient,
+		federationName:   federationName,
+		zoneName:         zoneName,
+		ingressCache:     &ingressCache{fedIngressMap: make(map[string]*cachedIngress)},
+		clusterCache: &clusterClientCache{
+			rwlock:    sync.Mutex{},
+			clientMap: make(map[string]*clusterCache),
+		},
+		eventBroadcaster: broadcaster,
+		eventRecorder:    recorder,
+		queue:            workqueue.New(),
+		knownClusterSet:  make(sets.String),
+	}
+	s.ingressStore.Store, s.ingressController = framework.NewInformer(
+		&cache.ListWatch{
+			// TODO: wait for federationClient.Extensions.Ingress
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return nil, nil
+				//return s.federationClient.Extensions().Ingresses(extensions.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return nil, nil
+				//return s.federationClient.Extensions().Ingresses(extensions.NamespaceAll).Watch(options)
+			},
+		},
+		&extensions.Ingress{},
+		ingressSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: s.enqueueIngress,
+			UpdateFunc: func(old, cur interface{}) {
+				// there is case that old and new are equals but we still catch the event now.
+				if !reflect.DeepEqual(old, cur) {
+					s.enqueueIngress(cur)
+				}
+			},
+			DeleteFunc: s.enqueueIngress,
+		},
+	)
+	s.clusterStore.Store, s.clusterController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return s.federationClient.Federation().Clusters().List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return s.federationClient.Federation().Clusters().Watch(options)
+			},
+		},
+		&v1beta1.Cluster{},
+		clusterSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			DeleteFunc: s.clusterCache.delFromClusterSet,
+			AddFunc:    s.clusterCache.addToClientMap,
+			UpdateFunc: func(old, cur interface{}) {
+				oldCluster, ok := old.(*v1beta1.Cluster)
+				if !ok {
+					return
+				}
+				curCluster, ok := cur.(*v1beta1.Cluster)
+				if !ok {
+					return
+				}
+				if !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) {
+					// update when spec is changed
+					s.clusterCache.addToClientMap(cur)
+				}
+
+				pred := getClusterConditionPredicate()
+				// only update when condition changed to ready from not-ready
+				if !pred(*oldCluster) && pred(*curCluster) {
+					s.clusterCache.addToClientMap(cur)
+				}
+				// did not handle ready -> not-ready
+				// how could we stop a controller?
+			},
+		},
+	)
+	return s
+}
+
+// obj could be an *api.Ingress, or a DeletionFinalStateUnknown marker item.
+func (s *IngressController) enqueueIngress(obj interface{}) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	s.queue.Add(key)
+}
+
+// Run starts a background goroutine that watches for changes to federation ingresss
+// and ensures that they have Kubernetes ingresss created, updated or deleted appropriately.
+// federationSyncPeriod controls how often we check the federation's ingresss to
+// ensure that the correct Kubernetes ingresss (and associated DNS entries) exist.
+// This is only necessary to fudge over failed watches.
+// clusterSyncPeriod controls how often we check the federation's underlying clusters and
+// their Kubernetes ingresss to ensure that matching ingresss created independently of the Federation
+// (e.g. directly via the underlying cluster's API) are correctly accounted for.
+
+// It's an error to call Run() more than once for a given IngressController
+// object.
+func (s *IngressController) Run(workers int, stopCh <-chan struct{}) error {
+	if err := s.init(); err != nil {
+		return err
+	}
+	defer runtime.HandleCrash()
+	go s.ingressController.Run(stopCh)
+	go s.clusterController.Run(stopCh)
+	// main worker, to snyc up ingress spec to underlying k8s clusters
+	for i := 0; i < workers; i++ {
+		go wait.Until(s.fedIngressWorker, time.Second, stopCh)
+	}
+	// status work, to update ingress status to federation, we only care about ingress objects
+	// k8s ingress controller will handle the monitor of service, endpoint..
+	go wait.Until(s.clusterIngressWorker, time.Second, stopCh)
+	go wait.Until(s.clusterSyncLoop, time.Second, stopCh)
+	<-stopCh
+	glog.Infof("Shutting down Federation Ingress Controller")
+	s.queue.ShutDown()
+	return nil
+}
+
+// Suppose we would write dns record to global dns server for all ingress virtual ip
+func (s *IngressController) init() error {
+	if s.federationName == "" {
+		return fmt.Errorf("IngressController should not be run without federationName.")
+	}
+	if s.zoneName == "" {
+		return fmt.Errorf("IngressController should not be run without zoneName.")
+	}
+	if s.dns == nil {
+		return fmt.Errorf("IngressController should not be run without a dnsprovider.")
+	}
+	zones, ok := s.dns.Zones()
+	if !ok {
+		return fmt.Errorf("the dns provider does not support zone enumeration, which is required for creating dns records.")
+	}
+	s.dnsZones = zones
+	if _, err := getDnsZone(s.zoneName, s.dnsZones); err != nil {
+		glog.Infof("DNS zone %q not found.  Creating DNS zone %q.", s.zoneName, s.zoneName)
+		managedZone, err := s.dnsZones.New(s.zoneName)
+		if err != nil {
+			return err
+		}
+		zone, err := s.dnsZones.Add(managedZone)
+		if err != nil {
+			return err
+		}
+		glog.Infof("DNS zone %q successfully created.  Note that DNS resolution will not work until you have registered this name with "+
+			"a DNS registrar and they have changed the authoritative name servers for your domain to point to your DNS provider.", zone.Name())
+	}
+	return nil
+}
+
+// fedIngressWorker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncIngress is never invoked concurrently with the same key.
+func (s *IngressController) fedIngressWorker() {
+	for {
+		func() {
+			key, quit := s.queue.Get()
+			if quit {
+				return
+			}
+
+			defer s.queue.Done(key)
+			err := s.syncIngress(key.(string))
+			if err != nil {
+				glog.Errorf("Error syncing ingress: %v", err)
+			}
+		}()
+	}
+}
+
+// processIngressForCluster creates or updates ingress to all registered running clusters,
+// update DNS records and update the ingress info with DNS entries to federation apiserver.
+// the function returns any error caught
+func (s *IngressController) processIngressForCluster(cachedIngress *cachedIngress, clusterName string, ingress *extensions.Ingress, client *release_1_4.Clientset) error {
+	glog.V(4).Infof("Process ingress %s/%s for cluster %s", ingress.Namespace, ingress.Name, clusterName)
+	// Create or Update k8s Ingress
+	err := s.ensureClusterIngress(cachedIngress, clusterName, ingress, client)
+	if err != nil {
+		glog.V(4).Infof("Failed to process ingress %s/%s for cluster %s", ingress.Namespace, ingress.Name, clusterName)
+		return err
+	}
+	glog.V(4).Infof("Successfully process ingress %s/%s for cluster %s", ingress.Namespace, ingress.Name, clusterName)
+	return nil
+}
+
+// updateFederationIngress Returns whatever error occurred along with a boolean indicator of whether it
+// should be retried.
+func (s *IngressController) updateFederationIngress(key string, cachedIngress *cachedIngress) (error, bool) {
+	// Clone federation ingress, and create them in underlying k8s cluster
+	clone, err := conversion.NewCloner().DeepCopy(cachedIngress.lastState)
+	if err != nil {
+		return err, !retryable
+	}
+	ingress, ok := clone.(*extensions.Ingress)
+	if !ok {
+		return fmt.Errorf("Unexpected ingress cast error : %v\n", ingress), !retryable
+	}
+
+	// handle available clusters one by one
+	var hasErr bool
+	for clusterName, cache := range s.clusterCache.clientMap {
+		go func(cache *clusterCache, clusterName string) {
+			err = s.processIngressForCluster(cachedIngress, clusterName, ingress, cache.clientset)
+			if err != nil {
+				hasErr = true
+			}
+		}(cache, clusterName)
+	}
+	if hasErr {
+		// detail error has been dumpped inside the loop
+		return fmt.Errorf("Ingress %s/%s was not successfully updated to all clusters", ingress.Namespace, ingress.Name), retryable
+	}
+	return nil, !retryable
+}
+
+func (s *IngressController) deleteFederationIngress(cachedIngress *cachedIngress) (error, bool) {
+	// handle available clusters one by one
+	var hasErr bool
+	for clusterName, cluster := range s.clusterCache.clientMap {
+		err := s.deleteClusterIngress(clusterName, cachedIngress, cluster.clientset)
+		if err != nil {
+			hasErr = true
+		} else if err := s.ensureDnsRecords(clusterName, cachedIngress); err != nil {
+			hasErr = true
+		}
+	}
+	if hasErr {
+		// detail error has been dumpped inside the loop
+		return fmt.Errorf("Ingress %s/%s was not successfully updated to all clusters", cachedIngress.lastState.Namespace, cachedIngress.lastState.Name), retryable
+	}
+	return nil, !retryable
+}
+
+func (s *IngressController) deleteClusterIngress(clusterName string, cachedIngress *cachedIngress, clientset *release_1_4.Clientset) error {
+	ingress := cachedIngress.lastState
+	glog.V(4).Infof("Deleting ingress %s/%s from cluster %s", ingress.Namespace, ingress.Name, clusterName)
+	var err error
+	for i := 0; i < clientRetryCount; i++ {
+		err = clientset.Extensions().Ingresses(ingress.Namespace).Delete(ingress.Name, &api.DeleteOptions{})
+		if err == nil || errors.IsNotFound(err) {
+			glog.V(4).Infof("Ingress %s/%s deleted from cluster %s", ingress.Namespace, ingress.Name, clusterName)
+			delete(cachedIngress.endpointMap, clusterName)
+			return nil
+		}
+		time.Sleep(cachedIngress.nextRetryDelay())
+	}
+	glog.V(4).Infof("Failed to delete ingress %s/%s from cluster %s, %+v", ingress.Namespace, ingress.Name, clusterName, err)
+	return err
+}
+
+func (s *IngressController) ensureClusterIngress(cachedIngress *cachedIngress, clusterName string, ingress *extensions.Ingress, client *release_1_4.Clientset) error {
+	var err error
+	var needUpdate bool
+	for i := 0; i < clientRetryCount; i++ {
+		ing, err := client.Extensions().Ingresses(ingress.Namespace).Get(ingress.Name)
+		if err == nil {
+			// ingress exists
+			glog.V(5).Infof("Found ingress %s/%s from cluster %s", ingress.Namespace, ingress.Name, clusterName)
+			if !reflect.DeepEqual(ing, ingress) {
+				needUpdate = true
+			}
+
+			if needUpdate {
+				// we only apply spec update
+				ing.Spec = ingress.Spec
+				_, err = client.Extensions().Ingresses(ing.Namespace).Update(ing)
+				if err == nil {
+					glog.V(5).Infof("Ingress %s/%s successfully updated to cluster %s", ing.Namespace, ing.Name, clusterName)
+					return nil
+				} else {
+					glog.V(4).Infof("Failed to update %+v", err)
+				}
+			} else {
+				glog.V(5).Infof("Ingress %s/%s is not updated to cluster %s as the spec are identical", ing.Namespace, ing.Name, clusterName)
+				return nil
+			}
+		} else if errors.IsNotFound(err) {
+			// Create ingress if it is not found
+			glog.Infof("Ingress '%s/%s' is not found in cluster %s, trying to create new",
+				ingress.Namespace, ingress.Name, clusterName)
+			ingress.ResourceVersion = ""
+			_, err = client.Extensions().Ingresses(ingress.Namespace).Create(ingress)
+			if err == nil {
+				glog.V(5).Infof("Ingress %s/%s successfully created to cluster %s", ingress.Namespace, ingress.Name, clusterName)
+				return nil
+			}
+			glog.V(4).Infof("Failed to create %+v", err)
+			if errors.IsAlreadyExists(err) {
+				glog.V(5).Infof("ingress %s/%s already exists in cluster %s", ingress.Namespace, ingress.Name, clusterName)
+				return nil
+			}
+		}
+		if errors.IsConflict(err) {
+			glog.V(4).Infof("Not persisting update to ingress '%s/%s' that has been changed since we received it: %v",
+				ingress.Namespace, ingress.Name, err)
+		}
+		// should we reuse same retry delay for all clusters?
+		time.Sleep(cachedIngress.nextRetryDelay())
+	}
+	return err
+}
+
+func (s *ingressCache) allIngresses() []*cachedIngress {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	ingresss := make([]*cachedIngress, 0, len(s.fedIngressMap))
+	for _, v := range s.fedIngressMap {
+		ingresss = append(ingresss, v)
+	}
+	return ingresss
+}
+
+func (s *ingressCache) get(ingressName string) (*cachedIngress, bool) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	ingress, ok := s.fedIngressMap[ingressName]
+	return ingress, ok
+}
+
+func (s *ingressCache) getOrCreate(ingressName string) *cachedIngress {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	ingress, ok := s.fedIngressMap[ingressName]
+	if !ok {
+		ingress = &cachedIngress{
+			endpointMap:      make(map[string]int),
+			ingressStatusMap: make(map[string]extensions.IngressStatus),
+		}
+		s.fedIngressMap[ingressName] = ingress
+	}
+	return ingress
+}
+
+func (s *ingressCache) set(ingressName string, ingress *cachedIngress) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	s.fedIngressMap[ingressName] = ingress
+}
+
+func (s *ingressCache) delete(ingressName string) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	delete(s.fedIngressMap, ingressName)
+}
+
+// needsUpdateDNS check if the dns records of the given ingress should be updated
+func (s *IngressController) needsUpdateIngress(oldIngress *extensions.Ingress, newIngress *extensions.Ingress) bool {
+	return true
+}
+
+func clustersFromList(list *v1beta1.ClusterList) []string {
+	result := []string{}
+	for ix := range list.Items {
+		result = append(result, list.Items[ix].Name)
+	}
+	return result
+}
+
+// getClusterConditionPredicate filter all clusters meet condition of
+// condition.type=Ready and condition.status=true
+func getClusterConditionPredicate() federationcache.ClusterConditionPredicate {
+	return func(cluster v1beta1.Cluster) bool {
+		// If we have no info, don't accept
+		if len(cluster.Status.Conditions) == 0 {
+			return false
+		}
+		for _, cond := range cluster.Status.Conditions {
+			//We consider the cluster for load balancing only when its ClusterReady condition status
+			//is ConditionTrue
+			if cond.Type == v1beta1.ClusterReady && cond.Status != v1.ConditionTrue {
+				glog.V(4).Infof("Ignoring cluser %v with %v condition status %v", cluster.Name, cond.Type, cond.Status)
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// clusterSyncLoop observes running clusters changes, and apply all ingresss to new added cluster
+// and add dns records for the changes
+func (s *IngressController) clusterSyncLoop() {
+	var ingresssToUpdate []*cachedIngress
+	// should we remove cache for cluster from ready to not ready? should remove the condition predicate if no
+	clusters, err := s.clusterStore.ClusterCondition(getClusterConditionPredicate()).List()
+	if err != nil {
+		glog.Infof("Fail to get cluster list")
+		return
+	}
+	newClusters := clustersFromList(&clusters)
+	var newSet, increase sets.String
+	newSet = sets.NewString(newClusters...)
+	if newSet.Equal(s.knownClusterSet) {
+		// The set of cluster names in the ingresss in the federation hasn't changed, but we can retry
+		// updating any ingresss that we failed to update last time around.
+		ingresssToUpdate = s.updateDNSRecords(ingresssToUpdate, newClusters)
+		return
+	}
+	glog.Infof("Detected change in list of cluster names. New  set: %v, Old set: %v", newSet, s.knownClusterSet)
+	increase = newSet.Difference(s.knownClusterSet)
+	// do nothing when cluster is removed.
+	if increase != nil {
+		// Try updating all ingresss, and save the ones that fail to try again next
+		// round.
+		ingresssToUpdate = s.ingressCache.allIngresses()
+		numIngresses := len(ingresssToUpdate)
+		for newCluster := range increase {
+			glog.Infof("New cluster observed %s", newCluster)
+			s.updateAllIngressesToCluster(ingresssToUpdate, newCluster)
+		}
+		ingresssToUpdate = s.updateDNSRecords(ingresssToUpdate, newClusters)
+		glog.Infof("Successfully updated %d out of %d DNS records to direct traffic to the updated cluster",
+			numIngresses-len(ingresssToUpdate), numIngresses)
+	}
+	s.knownClusterSet = newSet
+}
+
+func (s *IngressController) updateAllIngressesToCluster(ingresss []*cachedIngress, clusterName string) {
+	cluster, ok := s.clusterCache.clientMap[clusterName]
+	if ok {
+		for _, cachedIngress := range ingresss {
+			appliedState := cachedIngress.lastState
+			s.processIngressForCluster(cachedIngress, clusterName, appliedState, cluster.clientset)
+		}
+	}
+}
+
+func (s *IngressController) removeAllIngressesFromCluster(ingresss []*cachedIngress, clusterName string) {
+	client, ok := s.clusterCache.clientMap[clusterName]
+	if ok {
+		for _, cachedIngress := range ingresss {
+			s.deleteClusterIngress(clusterName, cachedIngress, client.clientset)
+		}
+		glog.Infof("Synced all ingresss to cluster %s", clusterName)
+	}
+}
+
+// updateDNSRecords updates all existing federation ingress DNS Records so that
+// they will match the list of cluster names provided.
+// Returns the list of ingresss that couldn't be updated.
+func (s *IngressController) updateDNSRecords(ingresss []*cachedIngress, clusters []string) (ingresssToRetry []*cachedIngress) {
+	for _, ingress := range ingresss {
+		func() {
+			ingress.rwlock.Lock()
+			defer ingress.rwlock.Unlock()
+			// If the applied state is nil, that means it hasn't yet been successfully dealt
+			// with by the DNS Record reconciler. We can trust the DNS Record
+			// reconciler to ensure the federation ingress's DNS records are created to target
+			// the correct backend ingress IP's
+			if ingress.appliedState == nil {
+				return
+			}
+			if err := s.lockedUpdateDNSRecords(ingress, clusters); err != nil {
+				glog.Errorf("External error while updating DNS Records: %v.", err)
+				ingresssToRetry = append(ingresssToRetry, ingress)
+			}
+		}()
+	}
+	return ingresssToRetry
+}
+
+// lockedUpdateDNSRecords Updates the DNS records of a ingress, assuming we hold the mutex
+// associated with the ingress.
+func (s *IngressController) lockedUpdateDNSRecords(ingress *cachedIngress, clusterNames []string) error {
+	ensuredCount := 0
+	for key := range s.clusterCache.clientMap {
+		for _, clusterName := range clusterNames {
+			if key == clusterName {
+				s.ensureDnsRecords(clusterName, ingress)
+				ensuredCount += 1
+			}
+		}
+	}
+	if ensuredCount < len(clusterNames) {
+		return fmt.Errorf("Failed to update DNS records for %d of %d clusters for ingress %v due to missing clients for those clusters",
+			len(clusterNames)-ensuredCount, len(clusterNames), ingress)
+	}
+	return nil
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedIngress) nextRetryDelay() time.Duration {
+	s.lastRetryDelay = s.lastRetryDelay * 2
+	if s.lastRetryDelay < minRetryDelay {
+		s.lastRetryDelay = minRetryDelay
+	}
+	if s.lastRetryDelay > maxRetryDelay {
+		s.lastRetryDelay = maxRetryDelay
+	}
+	return s.lastRetryDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedIngress) resetRetryDelay() {
+	s.lastRetryDelay = time.Duration(0)
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedIngress) nextFedUpdateDelay() time.Duration {
+	s.lastFedUpdateDelay = s.lastFedUpdateDelay * 2
+	if s.lastFedUpdateDelay < minRetryDelay {
+		s.lastFedUpdateDelay = minRetryDelay
+	}
+	if s.lastFedUpdateDelay > maxRetryDelay {
+		s.lastFedUpdateDelay = maxRetryDelay
+	}
+	return s.lastFedUpdateDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedIngress) resetFedUpdateDelay() {
+	s.lastFedUpdateDelay = time.Duration(0)
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedIngress) nextDNSUpdateDelay() time.Duration {
+	s.lastDNSUpdateDelay = s.lastDNSUpdateDelay * 2
+	if s.lastDNSUpdateDelay < minRetryDelay {
+		s.lastDNSUpdateDelay = minRetryDelay
+	}
+	if s.lastDNSUpdateDelay > maxRetryDelay {
+		s.lastDNSUpdateDelay = maxRetryDelay
+	}
+	return s.lastDNSUpdateDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedIngress) resetDNSUpdateDelay() {
+	s.lastDNSUpdateDelay = time.Duration(0)
+}
+
+// syncIngress will sync the Ingress with the given key if it has had its expectations fulfilled,
+// meaning it did not expect to see any more of its pods created or deleted. This function is not meant to be
+// invoked concurrently with the same key.
+func (s *IngressController) syncIngress(key string) error {
+	startTime := time.Now()
+	var cachedIngress *cachedIngress
+	var retryDelay time.Duration
+	defer func() {
+		glog.V(4).Infof("Finished syncing ingress %q (%v)", key, time.Now().Sub(startTime))
+	}()
+	// obj holds the latest ingress info from apiserver
+	obj, exists, err := s.ingressStore.Store.GetByKey(key)
+	if err != nil {
+		glog.Infof("Unable to retrieve ingress %v from store: %v", key, err)
+		s.queue.Add(key)
+		return err
+	}
+
+	if !exists {
+		// ingress absence in store means watcher caught the deletion, ensure LB info is cleaned
+		glog.Infof("Ingress has been deleted %v", key)
+		err, retryDelay = s.processIngressDeletion(key)
+	}
+
+	if exists {
+		ingress, ok := obj.(*extensions.Ingress)
+		if ok {
+			cachedIngress = s.ingressCache.getOrCreate(key)
+			err, retryDelay = s.processIngressUpdate(cachedIngress, ingress, key)
+		} else {
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("Object contained wasn't a ingress or a deleted key: %+v", obj)
+			}
+			glog.Infof("Found tombstone for %v", key)
+			err, retryDelay = s.processIngressDeletion(tombstone.Key)
+		}
+	}
+
+	if retryDelay != 0 {
+		s.enqueueIngress(obj)
+	} else if err != nil {
+		runtime.HandleError(fmt.Errorf("Failed to process ingress. Not retrying: %v", err))
+	}
+	return nil
+}
+
+// processIngressUpdate returns an error if processing the ingress update failed, along with a time.Duration
+// indicating whether processing should be retried; zero means no-retry; otherwise
+// we should retry in that Duration.
+func (s *IngressController) processIngressUpdate(cachedIngress *cachedIngress, ingress *extensions.Ingress, key string) (error, time.Duration) {
+	// Ensure that no other goroutine will interfere with our processing of the
+	// ingress.
+	cachedIngress.rwlock.Lock()
+	defer cachedIngress.rwlock.Unlock()
+
+	// Update the cached ingress (used above for populating synthetic deletes)
+	// alway trust ingress, which is retrieve from ingressStore, which keeps the latest ingress info getting from apiserver
+	// if the same ingress is changed before this go routine finished, there will be another queue entry to handle that.
+	cachedIngress.lastState = ingress
+	err, retry := s.updateFederationIngress(key, cachedIngress)
+	if err != nil {
+		message := "Error occurs when updating ingress to all clusters"
+		if retry {
+			message += " (will retry): "
+		} else {
+			message += " (will not retry): "
+		}
+		message += err.Error()
+		s.eventRecorder.Event(ingress, v1.EventTypeWarning, "UpdateIngressFail", message)
+		return err, cachedIngress.nextRetryDelay()
+	}
+	// Always update the cache upon success.
+	// NOTE: Since we update the cached ingress if and only if we successfully
+	// processed it, a cached ingress being nil implies that it hasn't yet
+	// been successfully processed.
+
+	cachedIngress.appliedState = ingress
+	s.ingressCache.set(key, cachedIngress)
+	glog.V(4).Infof("Successfully procceeded ingresss %s", key)
+	cachedIngress.resetRetryDelay()
+	return nil, doNotRetry
+}
+
+// processIngressDeletion returns an error if processing the ingress deletion failed, along with a time.Duration
+// indicating whether processing should be retried; zero means no-retry; otherwise
+// we should retry in that Duration.
+func (s *IngressController) processIngressDeletion(key string) (error, time.Duration) {
+	glog.V(2).Infof("Process ingress deletion for %v", key)
+	cachedIngress, ok := s.ingressCache.get(key)
+	if !ok {
+		return fmt.Errorf("Ingress %s not in cache even though the watcher thought it was. Ignoring the deletion.", key), doNotRetry
+	}
+	ingress := cachedIngress.lastState
+	cachedIngress.rwlock.Lock()
+	defer cachedIngress.rwlock.Unlock()
+	s.eventRecorder.Event(ingress, v1.EventTypeNormal, "DeletingDNSRecord", "Deleting DNS Records")
+	// TODO should we delete dns info here or wait for endpoint changes? prefer here
+	// or we do nothing for ingress deletion
+	//err := s.dns.balancer.EnsureLoadBalancerDeleted(ingress)
+	err, retry := s.deleteFederationIngress(cachedIngress)
+	if err != nil {
+		message := "Error occurs when deleting federation ingress"
+		if retry {
+			message += " (will retry): "
+		} else {
+			message += " (will not retry): "
+		}
+		s.eventRecorder.Event(ingress, v1.EventTypeWarning, "DeletingDNSRecordFailed", message)
+		return err, cachedIngress.nextRetryDelay()
+	}
+	s.eventRecorder.Event(ingress, v1.EventTypeNormal, "DeletedDNSRecord", "Deleted DNS Records")
+	s.ingressCache.delete(key)
+
+	cachedIngress.resetRetryDelay()
+	return nil, doNotRetry
+}

--- a/federation/pkg/federation-controller/ingress/ingresscontroller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingresscontroller_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns" // Only for unit testing purposes.
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func TestGetClusterConditionPredicate(t *testing.T) {
+	fakedns, _ := clouddns.NewFakeInterface() // No need to check for unsupported interfaces, as the fake interface supports everything that's required.
+	serviceController := ServiceController{
+		dns:          fakedns,
+		serviceCache: &serviceCache{fedServiceMap: make(map[string]*cachedService)},
+		clusterCache: &clusterClientCache{
+			rwlock:    sync.Mutex{},
+			clientMap: make(map[string]*clusterCache),
+		},
+		knownClusterSet: make(sets.String),
+	}
+
+	tests := []struct {
+		cluster           v1beta1.Cluster
+		expectAccept      bool
+		name              string
+		serviceController *ServiceController
+	}{
+		{
+			cluster:           v1beta1.Cluster{},
+			expectAccept:      false,
+			name:              "empty",
+			serviceController: &serviceController,
+		},
+		{
+			cluster: v1beta1.Cluster{
+				Status: v1beta1.ClusterStatus{
+					Conditions: []v1beta1.ClusterCondition{
+						{Type: v1beta1.ClusterReady, Status: v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept:      true,
+			name:              "basic",
+			serviceController: &serviceController,
+		},
+		{
+			cluster: v1beta1.Cluster{
+				Status: v1beta1.ClusterStatus{
+					Conditions: []v1beta1.ClusterCondition{
+						{Type: v1beta1.ClusterReady, Status: v1.ConditionFalse},
+					},
+				},
+			},
+			expectAccept:      false,
+			name:              "notready",
+			serviceController: &serviceController,
+		},
+	}
+	pred := getClusterConditionPredicate()
+	for _, test := range tests {
+		accept := pred(test.cluster)
+		if accept != test.expectAccept {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectAccept, accept)
+		}
+	}
+}

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -453,6 +453,19 @@ func (s *StoreToDaemonSetLister) GetPodDaemonSets(pod *api.Pod) (daemonSets []ex
 	return
 }
 
+// StoreToIngressLister makes a Store that has the List method of the client.ServiceInterface
+// The Store must contain (only) Services.
+type StoreToIngressLister struct {
+	Store
+}
+
+func (s *StoreToIngressLister) List() (ingress extensions.IngressList, err error) {
+	for _, m := range s.Store.List() {
+		ingress.Items = append(ingress.Items, *(m.(*extensions.Ingress)))
+	}
+	return ingress, nil
+}
+
 // StoreToServiceLister makes a Store that has the List method of the client.ServiceInterface
 // The Store must contain (only) Services.
 type StoreToServiceLister struct {


### PR DESCRIPTION
Code skeleton which is not ready for review yet.

Ingress controller:
- Watch clusters and maintain cluster client cache(this should be extract to common function)
- Watch federation ingress object on federation apiserver
- Creates Ingress object in each cluster in the federation
- Watch all underlying k8s clusters for ingress info
- When IngressStatus update event being caught, update the federation ingress with aggregation of the ingress info (need to check code and confirm is endpoint watcher still required)
- What's the further behavior of federation ingress controller? Need to confirm, write global DNS records like service controller?

Each cluster-level Ingress Controller ("GLBC") creates Google L7 Load Balancer machinery (forwarding rules, target proxy, URL map, backend service, health check) which ensures that traffic to the Ingress (backed by a Service), is directed to one of the nodes in the cluster.
KubeProxy redirects to one of the backend Pods (currently round-robin, per KubeProxy instance)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30266)

<!-- Reviewable:end -->
