### PR TITLE
ClusterAutoscaler-friendly scheduler priority function that promotes well-used nodes

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
@@ -411,6 +411,161 @@ func TestLeastRequested(t *testing.T) {
 	}
 }
 
+func TestMostRequested(t *testing.T) {
+	labels1 := map[string]string{
+		"foo": "bar",
+		"baz": "blah",
+	}
+	labels2 := map[string]string{
+		"bar": "foo",
+		"baz": "blah",
+	}
+	noResources := api.PodSpec{
+		Containers: []api.Container{},
+	}
+	cpuOnly := api.PodSpec{
+		NodeName: "machine1",
+		Containers: []api.Container{
+			{
+				Resources: api.ResourceRequirements{
+					Requests: api.ResourceList{
+						"cpu":    resource.MustParse("1000m"),
+						"memory": resource.MustParse("0"),
+					},
+				},
+			},
+			{
+				Resources: api.ResourceRequirements{
+					Requests: api.ResourceList{
+						"cpu":    resource.MustParse("2000m"),
+						"memory": resource.MustParse("0"),
+					},
+				},
+			},
+		},
+	}
+	cpuOnly2 := cpuOnly
+	cpuOnly2.NodeName = "machine2"
+	cpuAndMemory := api.PodSpec{
+		NodeName: "machine2",
+		Containers: []api.Container{
+			{
+				Resources: api.ResourceRequirements{
+					Requests: api.ResourceList{
+						"cpu":    resource.MustParse("1000m"),
+						"memory": resource.MustParse("2000"),
+					},
+				},
+			},
+			{
+				Resources: api.ResourceRequirements{
+					Requests: api.ResourceList{
+						"cpu":    resource.MustParse("2000m"),
+						"memory": resource.MustParse("3000"),
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		pod          *api.Pod
+		pods         []*api.Pod
+		nodes        []*api.Node
+		expectedList schedulerapi.HostPriorityList
+		test         string
+	}{
+		{
+			/*
+				Node1 scores (used resources) on 0-10 scale
+				CPU Score: (0 * 10  / 4000 = 0
+				Memory Score: (0 * 10) / 10000 = 0
+				Node1 Score: (0 + 0) / 2 = 0
+
+				Node2 scores (used resources) on 0-10 scale
+				CPU Score: (0 * 10 / 4000 = 0
+				Memory Score: (0 * 10 / 10000 = 0
+				Node2 Score: (0 + 0) / 2 = 0
+			*/
+			pod:          &api.Pod{Spec: noResources},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			expectedList: []schedulerapi.HostPriority{{"machine1", 0}, {"machine2", 0}},
+			test:         "nothing scheduled, nothing requested",
+		},
+		{
+			/*
+				Node1 scores on 0-10 scale
+				CPU Score: (3000 * 10 / 4000 = 7.5
+				Memory Score: (5000 * 10) / 10000 = 5
+				Node1 Score: (7.5 + 5) / 2 = 6
+
+				Node2 scores on 0-10 scale
+				CPU Score: (3000 * 10 / 6000 = 5
+				Memory Score: (5000 * 10 / 10000 = 5
+				Node2 Score: (5 + 5) / 2 = 5
+			*/
+			pod:          &api.Pod{Spec: cpuAndMemory},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
+			expectedList: []schedulerapi.HostPriority{{"machine1", 6}, {"machine2", 5}},
+			test:         "nothing scheduled, resources requested, differently sized machines",
+		},
+		{
+			/*
+				Node1 scores on 0-10 scale
+				CPU Score: (6000 * 10) / 10000 = 6
+				Memory Score: (0 * 10) / 20000 = 10
+				Node1 Score: (6 + 0) / 2 = 3
+
+				Node2 scores on 0-10 scale
+				CPU Score: (6000 * 10) / 10000 = 6
+				Memory Score: (5000 * 10) / 20000 = 2.5
+				Node2 Score: (6 + 2.5) / 2 = 4
+			*/
+			pod:          &api.Pod{Spec: noResources},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			expectedList: []schedulerapi.HostPriority{{"machine1", 3}, {"machine2", 4}},
+			test:         "no resources requested, pods scheduled with resources",
+			pods: []*api.Pod{
+				{Spec: cpuOnly, ObjectMeta: api.ObjectMeta{Labels: labels2}},
+				{Spec: cpuOnly, ObjectMeta: api.ObjectMeta{Labels: labels1}},
+				{Spec: cpuOnly2, ObjectMeta: api.ObjectMeta{Labels: labels1}},
+				{Spec: cpuAndMemory, ObjectMeta: api.ObjectMeta{Labels: labels1}},
+			},
+		},
+		{
+			/*
+				Node1 scores on 0-10 scale
+				CPU Score: (6000 * 10) / 10000 = 6
+				Memory Score: (5000 * 10) / 20000 = 2.5
+				Node1 Score: (6 + 2.5) / 2 = 4
+
+				Node2 scores on 0-10 scale
+				CPU Score: (6000 * 10) / 10000 = 6
+				Memory Score: (10000 * 10) / 20000 = 5
+				Node2 Score: (6 + 5) / 2 = 5
+			*/
+			pod:          &api.Pod{Spec: cpuAndMemory},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			expectedList: []schedulerapi.HostPriority{{"machine1", 4}, {"machine2", 5}},
+			test:         "resources requested, pods scheduled with resources",
+			pods: []*api.Pod{
+				{Spec: cpuOnly},
+				{Spec: cpuAndMemory},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+		list, err := MostRequestedPriority(test.pod, nodeNameToInfo, test.nodes)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(test.expectedList, list) {
+			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
+		}
+	}
+}
+
 func TestNewNodeLabelPriority(t *testing.T) {
 	label1 := map[string]string{"foo": "bar"}
 	label2 := map[string]string{"bar": "foo"}

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -93,6 +93,8 @@ func init() {
 	factory.RegisterFitPredicate("HostName", predicates.PodFitsHost)
 	// Fit is determined by node selector query.
 	factory.RegisterFitPredicate("MatchNodeSelector", predicates.PodSelectorMatches)
+	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
+	factory.RegisterPriorityFunction("MostRequestedPriority", priorities.MostRequestedPriority, 1)
 }
 
 func defaultPredicates() sets.String {


### PR DESCRIPTION
It will help cluster autoscaler to put pods on nodes that are unlikely to be deleted soon due to low usage. Otherwise a pod may be frequently kicked from one node to another. A flag that enables it when CA is on will be added in a separate PR.

Fixes: #28842

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30274)

<!-- Reviewable:end -->
