### PR TITLE
Avoid duplicated contrib/ sources

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -485,11 +485,6 @@ function kube::build::source_targets() {
           \( -path ./_\* -o -path ./.git\* \) -prune  \
         \))
   )
-  if [ -n "${KUBERNETES_CONTRIB:-}" ]; then
-    for contrib in "${KUBERNETES_CONTRIB}"; do
-      targets+=($(eval "kube::contrib::${contrib}::source_targets"))
-    done
-  fi
   echo "${targets[@]}"
 }
 


### PR DESCRIPTION
This commit removes a part of common.sh script which copied contrib/ sources for enabled contribs, which resulted in the duplicated files inside tarball.

Fixes #30150

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30276)

<!-- Reviewable:end -->
