### PR TITLE
When parsing rackspace server metainformation, get ipv4 adresses first

### DIFF
--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -372,10 +372,10 @@ func getAddressByServer(srv *osservers.Server) (string, error) {
 		s = firstAddr(srv.Addresses["private"])
 	}
 	if s == "" {
-		s = firstAddr(srv.Addresses["public"])
+		s = srv.AccessIPv4
 	}
 	if s == "" {
-		s = srv.AccessIPv4
+		s = firstAddr(srv.Addresses["public"])
 	}
 	if s == "" {
 		s = srv.AccessIPv6


### PR DESCRIPTION
- release-note-none

Rackspace has no defined order for network information in the meta information.

| accessIPv4                           | 162.13.abc.xy
| accessIPv6                           | 2a00:1a48:7807:103:xxxx:yyyy:aaaa:bbbb
| public network                       | 2a00:1a48:7807:103:xxxx:yyyy:aaaa:bbbb, 162.13.abc.xy

The "public network" information somtimes has the ipv6 ip first, sometimes ipv4. This results in mixed results for the "HostAddresses" in the Node Registration. Afterwards some nodes are shown with their ipv4 ip, some with the ipv6 version (even if ipv6 is disabled in the linux).

This patch tries to get the ipv4 ips first, so - if present - ipv4 will be used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30288)

<!-- Reviewable:end -->
