### PR TITLE
Prevent panic in 'kubectl exec' when redirecting stdout

### DIFF
--- a/pkg/client/unversioned/remotecommand/v3.go
+++ b/pkg/client/unversioned/remotecommand/v3.go
@@ -63,7 +63,7 @@ func (p *streamProtocolV3) createStreams(conn streamCreator) error {
 }
 
 func (p *streamProtocolV3) handleResizes() {
-	if p.resizeStream == nil {
+	if p.resizeStream == nil || p.TerminalSizeQueue == nil {
 		return
 	}
 


### PR DESCRIPTION
Just add some nil checks to make sure we don't trip over when
we redirect output from exec to a file.

Fixes #30290

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30291)

<!-- Reviewable:end -->
