### PR TITLE
Seperate out container process label and mount label for SELinux

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -1254,10 +1254,12 @@ type LinuxContainerConfig struct {
 	Resources *LinuxContainerResources `protobuf:"bytes,1,opt,name=resources" json:"resources,omitempty"`
 	// Capabilities to add or drop.
 	Capabilities *Capability `protobuf:"bytes,2,opt,name=capabilities" json:"capabilities,omitempty"`
-	// Optional SELinux context to be applied.
-	SelinuxOptions *SELinuxOption `protobuf:"bytes,3,opt,name=selinux_options,json=selinuxOptions" json:"selinux_options,omitempty"`
+	// Optional SELinux label for container processes
+	SelinuxProcessLabel *SELinuxOption `protobuf:"bytes,3,opt,name=selinux_process_label" json:"selinux_process_label,omitempty"`
+	// Optional SELinux mount label for container mount points
+	SelinuxMountLabel *SELinuxOption `protobuf:"bytes,4,opt,name=selinux_mount_label" json:"selinux_mount_label,omitempty"`
 	// User contains the user for the container process.
-	User             *LinuxUser `protobuf:"bytes,4,opt,name=user" json:"user,omitempty"`
+	User             *LinuxUser `protobuf:"bytes,5,opt,name=user" json:"user,omitempty"`
 	XXX_unrecognized []byte     `json:"-"`
 }
 
@@ -1280,9 +1282,16 @@ func (m *LinuxContainerConfig) GetCapabilities() *Capability {
 	return nil
 }
 
-func (m *LinuxContainerConfig) GetSelinuxOptions() *SELinuxOption {
+func (m *LinuxContainerConfig) GetSelinuxProcessLabel() *SELinuxOption {
 	if m != nil {
-		return m.SelinuxOptions
+		return m.SelinuxProcessLabel
+	}
+	return nil
+}
+
+func (m *LinuxContainerConfig) GetSelinuxMountLabel() *SELinuxOption {
+	if m != nil {
+		return m.SelinuxMountLabel
 	}
 	return nil
 }

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -370,10 +370,12 @@ message LinuxContainerConfig {
     optional LinuxContainerResources resources = 1;
     // Capabilities to add or drop.
     optional Capability capabilities = 2;
-    // Optional SELinux context to be applied.
-    optional SELinuxOption selinux_options = 3;
+    // Optional SELinux label for container processes
+    optional SELinuxOption selinux_process_label = 3;
+    // Optional SELinux mount label for container mount points
+    optional SELinuxOption selinux_mount_label = 4;
     // User contains the user for the container process.
-    optional LinuxUser user = 4;
+    optional LinuxUser user = 5;
 }
 
 message LinuxUser {


### PR DESCRIPTION
We need a seperate SELinux label for the container processes and the container mounts like in the OCI runtime spec. 

@vishh @yujuhong @dchen1107 PTAL

cc: @euank @feiskyer 
Signed-off-by: Mrunal Patel mpatel@redhat.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30295)

<!-- Reviewable:end -->
