### PR TITLE
Update etcd makefile to build 3.0.4

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -17,7 +17,7 @@
 # Usage:
 # 	[TAG=2.2.1] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 
-TAG?=3.0.3
+TAG?=3.0.4
 ARCH?=amd64
 REGISTRY?=gcr.io/google_containers
 GOLANG_VERSION?=1.6.3


### PR DESCRIPTION
Bumps the dependency, but we will also need someone to push to the google repos too.  

/cc @kubernetes/sig-scalability  

xref: #29235 #29399

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30309)

<!-- Reviewable:end -->
