### PR TITLE
[GarbageCollector] Increase log verbosity for Garbage collector tests

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -62,6 +62,7 @@ runTests() {
   make -C "${KUBE_ROOT}" test \
       WHAT="$(kube::test::find_integration_test_dirs | paste -sd' ' -)" \
       KUBE_GOFLAGS="${KUBE_GOFLAGS:-} -tags 'integration no-docker'" \
+      KUBE_TEST_ARGS="--vmodule=garbage*collector=6" \
       KUBE_RACE="" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_TEST_API_VERSIONS="$1"

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -504,7 +504,6 @@ func (gc *GarbageCollector) monitorFor(resource unversioned.GroupVersionResource
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				setObjectTypeMeta(newObj)
-				setObjectTypeMeta(oldObj)
 				event := &event{updateEvent, newObj, oldObj}
 				gc.propagator.eventQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: gc.clock.Now(), Object: event})
 			},

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	dto "github.com/prometheus/client_model/go"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
@@ -144,6 +145,8 @@ func setup(t *testing.T) (*httptest.Server, *garbagecollector.GarbageCollector, 
 
 // This test simulates the cascading deletion.
 func TestCascadingDeletion(t *testing.T) {
+	glog.V(6).Infof("TestCascadingDeletion starts")
+	defer glog.V(6).Infof("TestCascadingDeletion ends")
 	s, gc, clientSet := setup(t)
 	defer s.Close()
 
@@ -251,6 +254,8 @@ func TestCascadingDeletion(t *testing.T) {
 // This test simulates the case where an object is created with an owner that
 // doesn't exist. It verifies the GC will delete such an object.
 func TestCreateWithNonExistentOwner(t *testing.T) {
+	glog.V(6).Infof("TestCreateWithNonExistentOwner starts")
+	defer glog.V(6).Infof("TestCreateWithNonExistentOwner ends")
 	s, gc, clientSet := setup(t)
 	defer s.Close()
 


### PR DESCRIPTION
I cannot reproduce the flake of GC locally, see https://github.com/kubernetes/kubernetes/issues/28713#issuecomment-237842105, so I increased the log verbosity for Garbage collector tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30316)

<!-- Reviewable:end -->
