### PR TITLE
Add cleanup addon pod to remove empty keys from etcd

### DIFF
--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-empty-dir-cleanup
+  namespace: kube-system
+  labels:
+    k8s-app: etcd-empty-dir-cleanup
+spec:
+  hostNetwork: true
+  dnsPolicy: Default
+  containers:
+  - name: etcd-empty-dir-cleanup
+    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.1

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gliderlabs/alpine
+MAINTAINER Mehdy Bohlool <mehdy@google.com>
+
+RUN apk-install bash
+ADD etcd-empty-dir-cleanup.sh etcd-empty-dir-cleanup.sh
+ADD etcdctl etcdctl
+ENV ETCDCTL /etcdctl
+ENV SLEEP_SECOND 3600
+RUN chmod +x etcd-empty-dir-cleanup.sh
+CMD bash /etcd-empty-dir-cleanup.sh

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY:	build push
+
+ETCD_VERSION = 2.2.1
+IMAGE = gcr.io/google_containers/etcd-empty-dir-cleanup
+TAG = 0.0.1
+
+clean:
+	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
+
+build: clean
+	curl -L -O https://github.com/coreos/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
+	tar xzvf etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
+	cp etcd-v$(ETCD_VERSION)-linux-amd64/etcdctl .
+	docker build -t $(IMAGE):$(TAG) .
+	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
+
+push: build
+	gcloud docker push $(IMAGE):$(TAG)

--- a/cluster/images/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.sh
+++ b/cluster/images/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Removing empty directories from etcd..."
+
+cleanup_empty_dirs () {
+  if [[ $(${ETCDCTL} ls $1) ]]; then
+    for SUBDIR in $(${ETCDCTL} ls -p $1 | grep "/$")
+    do
+      cleanup_empty_dirs ${SUBDIR}
+    done
+  else
+    echo "Removing empty key $1 ..."
+    ${ETCDCTL} rmdir $1
+  fi
+}
+
+while true
+do
+  echo "Starting cleanup..."
+  cleanup_empty_dirs "/registry"
+  echo "Done with cleanup."
+  sleep ${SLEEP_SECOND}
+done


### PR DESCRIPTION
namespace deletion will leave a trace of empty keys on etcd. This PR adds an addon pod to periodically check for those empty keys on etcd and remove them.

fixes #27307

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30319)

<!-- Reviewable:end -->
