### PR TITLE
Add Time Series Data and Labels in Node density test

### DIFF
--- a/test/e2e/framework/perf_util.go
+++ b/test/e2e/framework/perf_util.go
@@ -57,56 +57,12 @@ const currentKubeletPerfMetricsVersion = "v1"
 // ResourceUsageToPerfData transforms ResourceUsagePerNode to PerfData. Notice that this function
 // only cares about memory usage, because cpu usage information will be extracted from NodesCPUSummary.
 func ResourceUsageToPerfData(usagePerNode ResourceUsagePerNode) *perftype.PerfData {
-	items := []perftype.DataItem{}
-	for node, usages := range usagePerNode {
-		for c, usage := range usages {
-			item := perftype.DataItem{
-				Data: map[string]float64{
-					"memory":     float64(usage.MemoryUsageInBytes) / (1024 * 1024),
-					"workingset": float64(usage.MemoryWorkingSetInBytes) / (1024 * 1024),
-					"rss":        float64(usage.MemoryRSSInBytes) / (1024 * 1024),
-				},
-				Unit: "MB",
-				Labels: map[string]string{
-					"node":      node,
-					"container": c,
-					"resource":  "memory",
-				},
-			}
-			items = append(items, item)
-		}
-	}
-	return &perftype.PerfData{
-		Version:   currentKubeletPerfMetricsVersion,
-		DataItems: items,
-	}
+	return ResourceUsageToPerfDataWithLabels(usagePerNode, nil)
 }
 
 // CPUUsageToPerfData transforms NodesCPUSummary to PerfData.
 func CPUUsageToPerfData(usagePerNode NodesCPUSummary) *perftype.PerfData {
-	items := []perftype.DataItem{}
-	for node, usages := range usagePerNode {
-		for c, usage := range usages {
-			data := map[string]float64{}
-			for perc, value := range usage {
-				data[fmt.Sprintf("Perc%02.0f", perc*100)] = value * 1000
-			}
-			item := perftype.DataItem{
-				Data: data,
-				Unit: "mCPU",
-				Labels: map[string]string{
-					"node":      node,
-					"container": c,
-					"resource":  "cpu",
-				},
-			}
-			items = append(items, item)
-		}
-	}
-	return &perftype.PerfData{
-		Version:   currentKubeletPerfMetricsVersion,
-		DataItems: items,
-	}
+	return CPUUsageToPerfDataWithLabels(usagePerNode, nil)
 }
 
 // PrintPerfData prints the perfdata in json format with PerfResultTag prefix.
@@ -115,5 +71,75 @@ func PrintPerfData(p *perftype.PerfData) {
 	// Notice that we must make sure the perftype.PerfResultEnd is in a new line.
 	if str := PrettyPrintJSON(p); str != "" {
 		Logf("%s %s\n%s", perftype.PerfResultTag, str, perftype.PerfResultEnd)
+	}
+}
+
+// ResourceUsageToPerfDataWithLabels transforms ResourceUsagePerNode to PerfData with additional labels.
+// Notice that this function only cares about memory usage, because cpu usage information will be extracted from NodesCPUSummary.
+func ResourceUsageToPerfDataWithLabels(usagePerNode ResourceUsagePerNode, labels map[string]string) *perftype.PerfData {
+	items := []perftype.DataItem{}
+	for node, usages := range usagePerNode {
+		for c, usage := range usages {
+			newLabels := map[string]string{
+				"node":      node,
+				"container": c,
+				"resource":  "memory",
+			}
+			if labels != nil {
+				for k, v := range labels {
+					newLabels[k] = v
+				}
+			}
+
+			item := perftype.DataItem{
+				Data: map[string]float64{
+					"memory":     float64(usage.MemoryUsageInBytes) / (1024 * 1024),
+					"workingset": float64(usage.MemoryWorkingSetInBytes) / (1024 * 1024),
+					"rss":        float64(usage.MemoryRSSInBytes) / (1024 * 1024),
+				},
+				Unit:   "MB",
+				Labels: newLabels,
+			}
+			items = append(items, item)
+		}
+	}
+	return &perftype.PerfData{
+		Version:   currentKubeletPerfMetricsVersion,
+		DataItems: items,
+	}
+}
+
+// CPUUsageToPerfDataWithLabels transforms NodesCPUSummary to PerfData with additional labels.
+func CPUUsageToPerfDataWithLabels(usagePerNode NodesCPUSummary, labels map[string]string) *perftype.PerfData {
+	items := []perftype.DataItem{}
+	for node, usages := range usagePerNode {
+		for c, usage := range usages {
+			newLabels := map[string]string{
+				"node":      node,
+				"container": c,
+				"resource":  "cpu",
+			}
+			if labels != nil {
+				for k, v := range labels {
+					newLabels[k] = v
+				}
+			}
+
+			data := map[string]float64{}
+			for perc, value := range usage {
+				data[fmt.Sprintf("Perc%02.0f", perc*100)] = value * 1000
+			}
+
+			item := perftype.DataItem{
+				Data:   data,
+				Unit:   "mCPU",
+				Labels: newLabels,
+			}
+			items = append(items, item)
+		}
+	}
+	return &perftype.PerfData{
+		Version:   currentKubeletPerfMetricsVersion,
+		DataItems: items,
 	}
 }

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -185,7 +185,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 				// verify resource
 				By("Verifying resource")
-				verifyResource(f, testArg, rc)
+				verifyResource(f, itArg, rc)
 			})
 		}
 	})
@@ -242,7 +242,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 				// verify resource
 				By("Verifying resource")
-				verifyResource(f, testArg, rc)
+				verifyResource(f, itArg, rc)
 			})
 		}
 	})

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -73,6 +73,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 	})
 
 	Context("create a batch of pods", func() {
+		// Zhou(ToDo): add more tests and the values are generous, set more precise limits after benchmark
 		densityTests := []DensityTest{
 			{
 				podsNr:   10,
@@ -87,8 +88,8 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				},
 				// percentile limit of single pod startup latency
 				podStartupLimits: framework.LatencyMetric{
-					Perc50: 10 * time.Second,
-					Perc90: 15 * time.Second,
+					Perc50: 16 * time.Second,
+					Perc90: 18 * time.Second,
 					Perc99: 20 * time.Second,
 				},
 				// upbound of startup latency of a batch of pods
@@ -191,6 +192,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 	})
 
 	Context("create a sequence of pods", func() {
+		// Zhou(ToDo): add more tests and the values are generous, set more precise limits after benchmark
 		densityTests := []DensityTest{
 			{
 				podsNr:   10,

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -73,8 +73,8 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 	})
 
 	Context("create a batch of pods", func() {
-		// Zhou(ToDo): add more tests and the values are generous, set more precise limits after benchmark
-		densityTests := []DensityTest{
+		// TODO(coufon): add more tests and the values are generous, set more precise limits after benchmark
+		dTests := []densityTest{
 			{
 				podsNr:   10,
 				interval: 0 * time.Millisecond,
@@ -97,7 +97,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			},
 		}
 
-		for _, testArg := range densityTests {
+		for _, testArg := range dTests {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval",
 				itArg.podsNr, itArg.interval), func() {
@@ -186,14 +186,14 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 				// verify resource
 				By("Verifying resource")
-				verifyResource(f, itArg, rc)
+				verifyResource(f, itArg.cpuLimits, itArg.memLimits, rc)
 			})
 		}
 	})
 
 	Context("create a sequence of pods", func() {
-		// Zhou(ToDo): add more tests and the values are generous, set more precise limits after benchmark
-		densityTests := []DensityTest{
+		// TODO(coufon): add more tests and the values are generous, set more precise limits after benchmark
+		dTests := []densityTest{
 			{
 				podsNr:   10,
 				bgPodsNr: 10,
@@ -213,7 +213,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			},
 		}
 
-		for _, testArg := range densityTests {
+		for _, testArg := range dTests {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %d background pods",
 				itArg.podsNr, itArg.bgPodsNr), func() {
@@ -244,13 +244,13 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 				// verify resource
 				By("Verifying resource")
-				verifyResource(f, itArg, rc)
+				verifyResource(f, itArg.cpuLimits, itArg.memLimits, rc)
 			})
 		}
 	})
 })
 
-type DensityTest struct {
+type densityTest struct {
 	// number of pods
 	podsNr int
 	// number of background pods
@@ -276,6 +276,7 @@ func createBatchPodWithRateControl(f *framework.Framework, pods []*api.Pod, inte
 	return createTimes
 }
 
+// checkPodDeleted checks whether a pod has been successfully deleted
 func checkPodDeleted(f *framework.Framework, podName string) error {
 	ns := f.Namespace.Name
 	_, err := f.Client.Pods(ns).Get(podName)
@@ -306,7 +307,7 @@ func getPodStartLatency(node string) (framework.KubeletLatencyMetrics, error) {
 	return latencyMetrics, nil
 }
 
-// Verifies whether 50, 90 and 99th percentiles of PodStartupLatency are
+// verifyPodStartupLatency verifies whether 50, 90 and 99th percentiles of PodStartupLatency are
 // within the threshold.
 func verifyPodStartupLatency(expect, actual framework.LatencyMetric) error {
 	if actual.Perc50 > expect.Perc50 {
@@ -321,6 +322,7 @@ func verifyPodStartupLatency(expect, actual framework.LatencyMetric) error {
 	return nil
 }
 
+// newInformerWatchPod creates an informer to check whether all pods are running.
 func newInformerWatchPod(f *framework.Framework, mutex *sync.Mutex, watchTimes map[string]unversioned.Time,
 	podType string) *controllerframework.Controller {
 	ns := f.Namespace.Name
@@ -365,7 +367,8 @@ func newInformerWatchPod(f *framework.Framework, mutex *sync.Mutex, watchTimes m
 	return controller
 }
 
-func verifyLatency(batchLag time.Duration, e2eLags []framework.PodLatencyData, testArg DensityTest) {
+// verifyLatency verifies that whether pod creation latency satisfies the limit.
+func verifyLatency(batchLag time.Duration, e2eLags []framework.PodLatencyData, testArg densityTest) {
 	framework.PrintLatencies(e2eLags, "worst client e2e total latencies")
 
 	// Zhou: do not trust `kubelet' metrics since they are not reset!
@@ -390,35 +393,7 @@ func verifyLatency(batchLag time.Duration, e2eLags []framework.PodLatencyData, t
 	framework.Logf("Sequential creation throughput is %.1f pods/min", throughputSequential)
 }
 
-func verifyResource(f *framework.Framework, testArg DensityTest, rc *ResourceCollector) {
-	nodeName := framework.TestContext.NodeName
-
-	// verify and log memory
-	usagePerContainer, err := rc.GetLatest()
-	Expect(err).NotTo(HaveOccurred())
-	framework.Logf("%s", formatResourceUsageStats(usagePerContainer))
-
-	usagePerNode := make(framework.ResourceUsagePerNode)
-	usagePerNode[nodeName] = usagePerContainer
-
-	memPerfData := framework.ResourceUsageToPerfData(usagePerNode)
-	framework.PrintPerfData(memPerfData)
-
-	verifyMemoryLimits(f.Client, testArg.memLimits, usagePerNode)
-
-	// verify and log cpu
-	cpuSummary := rc.GetCPUSummary()
-	framework.Logf("%s", formatCPUSummary(cpuSummary))
-
-	cpuSummaryPerNode := make(framework.NodesCPUSummary)
-	cpuSummaryPerNode[nodeName] = cpuSummary
-
-	cpuPerfData := framework.CPUUsageToPerfData(cpuSummaryPerNode)
-	framework.PrintPerfData(cpuPerfData)
-
-	verifyCPULimits(testArg.cpuLimits, cpuSummaryPerNode)
-}
-
+// createBatchPodSequential creats pods back-to-back in sequence.
 func createBatchPodSequential(f *framework.Framework, pods []*api.Pod) (time.Duration, []framework.PodLatencyData) {
 	batchStartTime := unversioned.Now()
 	e2eLags := make([]framework.PodLatencyData, 0)

--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -203,7 +203,11 @@ func (r *ResourceCollector) GetBasicCPUStats(containerName string) map[float64]f
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	result := make(map[float64]float64, len(percentiles))
-	usages := r.buffers[containerName]
+	usages := make([]*framework.ContainerResourceUsage, len(r.buffers[containerName]))
+	// must make a copy of array, otherwise the timeseries order is changed
+	for i, usage := range r.buffers[containerName] {
+		usages[i] = usage
+	}
 	sort.Sort(resourceUsageByCPU(usages))
 	for _, q := range percentiles {
 		index := int(float64(len(usages))*q) - 1


### PR DESCRIPTION
This pull requests contain:
1. Increase the pod creation latency limit according to test results;
2. Add 'GetResourceSeriesWithLabels' in 'resource_collector.go' to provide resource usage time series data;
3. Modify 'GetBasicCPUStats' in 'resource_collector.go' to make a copy of CPU usage array before sorting (otherwise time series data is disordered);
4. Add 'ResourceUsageToPerfDataWithLabels' and 'CPUUsageToPerfDataWithLabels' to attach labels to 'PerfData' for benchmark dashboard;

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30333)

<!-- Reviewable:end -->
