### PR TITLE
Correctly pipe USE_KUBEMARK in e2e-runner

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -389,6 +389,10 @@ if [[ "${E2E_UPGRADE_TEST:-}" == "true" ]]; then
   e2e_go_args+=(--upgrade_args="${GINKGO_UPGRADE_TEST_ARGS}")
 fi
 
+if [[ "${USE_KUBEMARK:-}" == "true" ]]; then
+  e2e_go_args+=("--kubemark=true")
+fi
+
 go run ./hack/e2e.go \
   ${E2E_OPT:-} \
   "${e2e_go_args[@]}"


### PR DESCRIPTION
cc @fejta

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30347)

<!-- Reviewable:end -->
