### PR TITLE
Node Conformance Test: Remove unnecessary binary copy

### DIFF
--- a/test/e2e_node/e2e_build.go
+++ b/test/e2e_node/e2e_build.go
@@ -28,11 +28,10 @@ import (
 	"github.com/golang/glog"
 )
 
-var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet and kube-apiserver binaries.")
+var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet binaries.")
 
 var buildTargets = []string{
 	"cmd/kubelet",
-	"cmd/kube-apiserver",
 	"test/e2e_node/e2e_node.test",
 	"vendor/github.com/onsi/ginkgo/ginkgo",
 }
@@ -114,30 +113,10 @@ func getK8sBuildOutputDir() (string, error) {
 	return buildOutputDir, nil
 }
 
-func getK8sNodeTestDir() (string, error) {
-	k8sRoot, err := getK8sRootDir()
-	if err != nil {
-		return "", err
-	}
-	buildOutputDir := filepath.Join(k8sRoot, "test/e2e_node")
-	if _, err := os.Stat(buildOutputDir); err != nil {
-		return "", err
-	}
-	return buildOutputDir, nil
-}
-
 func getKubeletServerBin() string {
 	bin, err := getK8sBin("kubelet")
 	if err != nil {
 		glog.Fatalf("Could not locate kubelet binary %v.", err)
-	}
-	return bin
-}
-
-func getApiServerBin() string {
-	bin, err := getK8sBin("kube-apiserver")
-	if err != nil {
-		glog.Fatalf("Could not locate kube-apiserver binary %v.", err)
 	}
 	return bin
 }

--- a/test/e2e_node/e2e_remote.go
+++ b/test/e2e_node/e2e_remote.go
@@ -91,23 +91,6 @@ func CreateTestArchive() (string, error) {
 		return "", fmt.Errorf("failed to locate kubernetes build output directory %v", err)
 	}
 
-	ginkgoTest := filepath.Join(buildOutputDir, "e2e_node.test")
-	if _, err := os.Stat(ginkgoTest); err != nil {
-		return "", fmt.Errorf("failed to locate test binary %s", ginkgoTest)
-	}
-	kubelet := filepath.Join(buildOutputDir, "kubelet")
-	if _, err := os.Stat(kubelet); err != nil {
-		return "", fmt.Errorf("failed to locate binary %s", kubelet)
-	}
-	apiserver := filepath.Join(buildOutputDir, "kube-apiserver")
-	if _, err := os.Stat(apiserver); err != nil {
-		return "", fmt.Errorf("failed to locate binary %s", apiserver)
-	}
-	ginkgo := filepath.Join(buildOutputDir, "ginkgo")
-	if _, err := os.Stat(apiserver); err != nil {
-		return "", fmt.Errorf("failed to locate binary %s", ginkgo)
-	}
-
 	glog.Infof("Building archive...")
 	tardir, err := ioutil.TempDir("", "node-e2e-archive")
 	if err != nil {
@@ -116,25 +99,20 @@ func CreateTestArchive() (string, error) {
 	defer os.RemoveAll(tardir)
 
 	// Copy binaries
-	out, err := exec.Command("cp", ginkgoTest, filepath.Join(tardir, "e2e_node.test")).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to copy e2e_node.test %v.", err)
-	}
-	out, err = exec.Command("cp", kubelet, filepath.Join(tardir, "kubelet")).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to copy kubelet %v.", err)
-	}
-	out, err = exec.Command("cp", apiserver, filepath.Join(tardir, "kube-apiserver")).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to copy kube-apiserver %v.", err)
-	}
-	out, err = exec.Command("cp", ginkgo, filepath.Join(tardir, "ginkgo")).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to copy ginkgo %v.", err)
+	requiredBins := []string{"kubelet", "e2e_node.test", "ginkgo"}
+	for _, bin := range requiredBins {
+		source := filepath.Join(buildOutputDir, bin)
+		if _, err := os.Stat(source); err != nil {
+			return "", fmt.Errorf("failed to locate test binary %s: %v", bin, err)
+		}
+		out, err := exec.Command("cp", source, filepath.Join(tardir, bin)).CombinedOutput()
+		if err != nil {
+			return "", fmt.Errorf("failed to copy %q: %v Output: %q", bin, err, out)
+		}
 	}
 
 	// Build the tar
-	out, err = exec.Command("tar", "-zcvf", archiveName, "-C", tardir, ".").CombinedOutput()
+	out, err := exec.Command("tar", "-zcvf", archiveName, "-C", tardir, ".").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to build tar %v.  Output:\n%s", err, out)
 	}

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -162,8 +162,6 @@ type logFileData struct {
 const (
 	// This is consistent with the level used in a cluster e2e test.
 	LOG_VERBOSITY_LEVEL = "4"
-	// Etcd binary is expected to either be available via PATH, or at this location.
-	defaultEtcdPath = "/tmp/etcd"
 )
 
 func newE2EService() *e2eService {

--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -52,16 +52,6 @@ if [ $? -ne 0 ] ; then
   sudo sed -i 's/Defaults    requiretty/# Defaults    requiretty/' /etc/sudoers
 fi
 
-# Install etcd
-hash etcd 2>/dev/null
-if [ $? -ne 0 ]; then
-  curl -L  https://github.com/coreos/etcd/releases/download/v3.0.4/etcd-v3.0.4-linux-amd64.tar.gz -o etcd-v3.0.4-linux-amd64.tar.gz
-  tar xzvf etcd-v3.0.4-linux-amd64.tar.gz
-  sudo mv etcd-v3.0.4-linux-amd64/etcd* /usr/local/bin/
-  sudo chown root:root /usr/local/bin/etcd*
-  rm -r etcd-v3.0.4-linux-amd64*
-fi
-
 # Install nsenter for ubuntu images
 cat /etc/*-release | grep "ID=ubuntu"
 if [ $? -eq 0 ]; then

--- a/test/e2e_node/jenkins/gci-init.yaml
+++ b/test/e2e_node/jenkins/gci-init.yaml
@@ -2,8 +2,4 @@
 
 runcmd:
   - mount /tmp /tmp -o remount,exec,suid
-  - etcd_version=v2.2.5
-  - curl -L https://github.com/coreos/etcd/releases/download/${etcd_version}/etcd-${etcd_version}-linux-amd64.tar.gz -o /tmp/etcd.tar.gz
-  - tar xzvf /tmp/etcd.tar.gz -C /tmp
-  - cp  /tmp/etcd-${etcd_version}-linux-amd64/etcd* /tmp/
-  - rm -rf /tmp/etcd-${etcd_version}-linux-amd64/
+  - usermod -a -G docker jenkins


### PR DESCRIPTION
For #30122, #30174.

This PR removed unnecessary dependencies in the node e2e test framework, because we've statically linked these dependencies.

@dchen1107 @vishh 
/cc @kubernetes/sig-node @kubernetes/sig-testing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30348)

<!-- Reviewable:end -->
