### PR TITLE
Remove the ethtool kubelet dependency; use ip link instead of ethtool to determine pair interface.

### DIFF
--- a/pkg/kubelet/network/hairpin/hairpin.go
+++ b/pkg/kubelet/network/hairpin/hairpin.go
@@ -36,10 +36,6 @@ const (
 	hairpinEnable           = "1"
 )
 
-var (
-	ethtoolOutputRegex = regexp.MustCompile("peer_ifindex: (\\d+)")
-)
-
 func SetUpContainerPid(containerPid int, containerInterfaceName string) error {
 	pidStr := fmt.Sprintf("%d", containerPid)
 	nsenterArgs := []string{"-t", pidStr, "-n"}
@@ -69,24 +65,22 @@ func findPairInterfaceOfContainerInterface(e exec.Interface, containerInterfaceN
 	if err != nil {
 		return "", err
 	}
-	ethtoolPath, err := e.LookPath("ethtool")
-	if err != nil {
-		return "", err
-	}
 
-	nsenterArgs = append(nsenterArgs, "-F", "--", ethtoolPath, "--statistics", containerInterfaceName)
+	ipLinkOutputRegex := regexp.MustCompile(containerInterfaceName + "@if(\\d+)")
+
+	nsenterArgs = append(nsenterArgs, "-F", "--", "ip", "link", "show", containerInterfaceName)
 	output, err := e.Command(nsenterPath, nsenterArgs...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("Unable to query interface %s of container %s: %v: %s", containerInterfaceName, containerDesc, err, string(output))
 	}
-	// look for peer_ifindex
-	match := ethtoolOutputRegex.FindSubmatch(output)
+	// look for the interface name which is named eth0@if{pair_interface}
+	match := ipLinkOutputRegex.FindSubmatch(output)
 	if match == nil {
-		return "", fmt.Errorf("No peer_ifindex in interface statistics for %s of container %s", containerInterfaceName, containerDesc)
+		return "", fmt.Errorf("No pair interface returned from container output %s. Description: %s", containerInterfaceName, containerDesc)
 	}
 	peerIfIndex, err := strconv.Atoi(string(match[1]))
 	if err != nil { // seems impossible (\d+ not numeric)
-		return "", fmt.Errorf("peer_ifindex wasn't numeric: %s: %v", match[1], err)
+		return "", fmt.Errorf("Pair interface wasn't numeric: %s: %v", match[1], err)
 	}
 	iface, err := net.InterfaceByIndex(peerIfIndex)
 	if err != nil {

--- a/pkg/kubelet/network/hairpin/hairpin_test.go
+++ b/pkg/kubelet/network/hairpin/hairpin_test.go
@@ -30,8 +30,9 @@ import (
 func TestFindPairInterfaceOfContainerInterface(t *testing.T) {
 	// there should be at least "lo" on any system
 	interfaces, _ := net.Interfaces()
-	validOutput := fmt.Sprintf("garbage\n   peer_ifindex: %d", interfaces[0].Index)
-	invalidOutput := fmt.Sprintf("garbage\n   unknown: %d", interfaces[0].Index)
+	// let's imagine eth0 in a container connects to iface index 1 on the host system (=localhost)
+	validOutput := fmt.Sprintf("2: eth0@if1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000")
+	invalidOutput := fmt.Sprintf("2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000")
 
 	tests := []struct {
 		output       string


### PR DESCRIPTION
@kubernetes/sig-network does this seem worthwhile?
I noticed that the `ip link` inside a container is named `eth0@if{host_pair_interface}`. This PR removes the dependency on ethtool that does that lookup as well.

Can you reproduce and verify?
ref #26093

``` bash
$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether f0:76:1c:62:f1:36 brd ff:ff:ff:ff:ff:ff
3: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DORMANT group default qlen 1000
    link/ether d0:53:49:0a:a9:8f brd ff:ff:ff:ff:ff:ff
209: flannel0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1472 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default qlen 500
    link/none 
210: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1472 qdisc noqueue state UP mode DEFAULT group default 
    link/ether 02:42:5a:c2:48:48 brd ff:ff:ff:ff:ff:ff
212: vethb860bf4@if211: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1472 qdisc noqueue master docker0 state UP mode DEFAULT group default 
    link/ether f6:e0:1a:a4:a6:ec brd ff:ff:ff:ff:ff:ff link-netnsid 1
214: veth345cf11@if213: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1472 qdisc noqueue master docker0 state UP mode DEFAULT group default 
    link/ether c6:55:3a:33:89:71 brd ff:ff:ff:ff:ff:ff link-netnsid 0
$ sudo nsenter -t 22525 -n -- ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
211: eth0@if212: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1472 qdisc noqueue state UP mode DEFAULT group default 
    link/ether 02:42:0a:01:56:02 brd ff:ff:ff:ff:ff:ff link-netnsid 0
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30356)

<!-- Reviewable:end -->
