### PR TITLE
Minor fixes in federated controller libraries

### DIFF
--- a/federation/pkg/federation-controller/util/delaying_deliverer.go
+++ b/federation/pkg/federation-controller/util/delaying_deliverer.go
@@ -153,3 +153,8 @@ func (d *DelayingDeliverer) DeliverAt(key string, value interface{}, deliveryTim
 func (d *DelayingDeliverer) DeliverAfter(key string, value interface{}, delay time.Duration) {
 	d.DeliverAt(key, value, time.Now().Add(delay))
 }
+
+// Gets target chanel of the deliverer.
+func (d *DelayingDeliverer) GetTargetChannel() chan *DelayingDelivererItem {
+	return d.targetChannel
+}

--- a/federation/pkg/federation-controller/util/federated_informer.go
+++ b/federation/pkg/federation-controller/util/federated_informer.go
@@ -116,7 +116,7 @@ type ClusterLifecycleHandlerFuncs struct {
 func NewFederatedInformer(
 	federationClient federation_release_1_4.Interface,
 	targetInformerFactory TargetInformerFactory,
-	clusterLifecycle ClusterLifecycleHandlerFuncs) FederatedInformer {
+	clusterLifecycle *ClusterLifecycleHandlerFuncs) FederatedInformer {
 
 	federatedInformer := &federatedInformerImpl{
 		targetInformerFactory: targetInformerFactory,

--- a/federation/pkg/federation-controller/util/federated_informer_test.go
+++ b/federation/pkg/federation-controller/util/federated_informer_test.go
@@ -105,7 +105,7 @@ func TestFederatedInformer(t *testing.T) {
 		},
 	}
 
-	informer := NewFederatedInformer(fakeClient, targetInformerFactory, lifecycle).(*federatedInformerImpl)
+	informer := NewFederatedInformer(fakeClient, targetInformerFactory, &lifecycle).(*federatedInformerImpl)
 	informer.clientFactory = func(cluster *federation_api.Cluster) (federation_release_1_4.Interface, error) {
 		return fakeClient, nil
 	}


### PR DESCRIPTION
Arg change in federated informer + get channel func in delaying deliverer.

cc: @quinton-hoole @wojtek-t @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30359)

<!-- Reviewable:end -->
