### PR TITLE
check validation with no apps client in kubectl util factory

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -1080,7 +1080,7 @@ func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
 	}
 	if gvk.Group == apps.GroupName {
 		if c.c.AppsClient == nil {
-			return errors.New("unable to validate: no autoscaling client")
+			return errors.New("unable to validate: no apps client")
 		}
 		return getSchemaAndValidate(c.c.AppsClient.RESTClient, data, "apis/", gvk.GroupVersion().String(), c.cacheDir, c)
 	}


### PR DESCRIPTION
autoscaling client already exist:

```
    if c.c.AutoscalingClient == nil {
        return errors.New("unable to validate: no autoscaling client")
```

so following autoscaling client should be apps client:

```
    if c.c.AppsClient == nil {
        return errors.New("unable to validate: no autoscaling client")
    }
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30362)

<!-- Reviewable:end -->
