### PR TITLE
Federation - common libs - small changes in delaying deliverer

### DIFF
--- a/federation/pkg/federation-controller/util/delaying_deliverer_test.go
+++ b/federation/pkg/federation-controller/util/delaying_deliverer_test.go
@@ -26,7 +26,8 @@ import (
 func TestDelayingDeliverer(t *testing.T) {
 	targetChannel := make(chan *DelayingDelivererItem)
 	now := time.Now()
-	d := NewDelayingDeliverer(targetChannel)
+	d := NewDelayingDelivererWithChannel(targetChannel)
+	d.Start()
 	defer d.Stop()
 	startupDelay := time.Second
 	d.DeliverAt("a", "aaa", now.Add(startupDelay+2*time.Millisecond))


### PR DESCRIPTION
No-arg constructor, start and option to start with a handler listening on the target channel.

cc: @quinton-hoole @wojtek-t @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30365)

<!-- Reviewable:end -->
