### PR TITLE
AWS: Allow no-op kube-down to exit 0

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1439,7 +1439,9 @@ function kube-down {
     echo "If you are trying to delete a cluster in a shared VPC," >&2
     echo "please consider using one of the methods in the kube-deploy repo." >&2
     echo "See: https://github.com/kubernetes/kube-deploy/blob/master/docs/delete_cluster.md" >&2
-    exit 1
+    echo "" >&2
+    echo "Note: You may be seeing this message may be because the cluster was already deleted, or" >&2
+    echo "has a name other than '${CLUSTER_ID}'." >&2
   fi
 }
 


### PR DESCRIPTION
Not exactly sure why hack/e2e.go `IsUp()` is returning true right now,
but I can solve this a different way. This unifies with the GCE
behavior, which is that no-op kube-down returns 0.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30380)

<!-- Reviewable:end -->
