### PR TITLE
Start etcd-empty-dir-cleanup pod automatically on master

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -549,6 +549,10 @@ function prepare-etcd-manifest {
   mv "${temp_file}" /etc/kubernetes/manifests
 }
 
+function start-etcd-empty-dir-cleanup-pod {
+  cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml" "/etc/kubernetes/manifests"
+}
+
 # Starts etcd server pod (and etcd-events pod if needed).
 # More specifically, it prepares dirs and files, sets the variable value
 # in the manifests, and copies them to /etc/kubernetes/manifests.
@@ -1038,6 +1042,7 @@ start-kubelet
 if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
   compute-master-manifest-variables
   start-etcd-servers
+  start-etcd-empty-dir-cleanup-pod
   start-kube-apiserver
   start-kube-controller-manager
   start-kube-scheduler


### PR DESCRIPTION
etcd-empty-dir-cleanup removes empty directories from etcd every hour. This PR runs the pod automatically on GCI masters.

related #30319 
fixes #27307

Workaround for non-gci systems:

ssh to master and:

sudo cp /home/kubernetes/kube-manifests/kubernetes/gci-trusty/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml /etc/kubernetes/manifests/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30393)

<!-- Reviewable:end -->
