### PR TITLE
Quota admission errors if usage is negative

### DIFF
--- a/pkg/quota/resources.go
+++ b/pkg/quota/resources.go
@@ -169,6 +169,18 @@ func IsZero(a api.ResourceList) bool {
 	return true
 }
 
+// IsNegative returns the set of resource names that have a negative value.
+func IsNegative(a api.ResourceList) []api.ResourceName {
+	results := []api.ResourceName{}
+	zero := resource.MustParse("0")
+	for k, v := range a {
+		if v.Cmp(zero) < 0 {
+			results = append(results, k)
+		}
+	}
+	return results
+}
+
 // ToSet takes a list of resource names and converts to a string set
 func ToSet(resourceNames []api.ResourceName) sets.String {
 	result := sets.NewString()

--- a/pkg/quota/resources_test.go
+++ b/pkg/quota/resources_test.go
@@ -256,3 +256,37 @@ func TestIsZero(t *testing.T) {
 		}
 	}
 }
+
+func TestIsNegative(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		expected []api.ResourceName
+	}{
+		"empty": {
+			a:        api.ResourceList{},
+			expected: []api.ResourceName{},
+		},
+		"some-negative": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("-10"),
+				api.ResourceMemory: resource.MustParse("0"),
+			},
+			expected: []api.ResourceName{api.ResourceCPU},
+		},
+		"all-negative": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("-200m"),
+				api.ResourceMemory: resource.MustParse("-1Gi"),
+			},
+			expected: []api.ResourceName{api.ResourceCPU, api.ResourceMemory},
+		},
+	}
+	for testName, testCase := range testCases {
+		actual := IsNegative(testCase.a)
+		actualSet := ToSet(actual)
+		expectedSet := ToSet(testCase.expected)
+		if !actualSet.Equal(expectedSet) {
+			t.Errorf("%s expected: %v, actual: %v", testName, expectedSet, actualSet)
+		}
+	}
+}


### PR DESCRIPTION
If quota observes negative usage for an artifact, that artifact could game the quota system.

This adds a global check in the quota system to catch this scenario for all evaluators.

/cc @deads2k

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30396)

<!-- Reviewable:end -->
