### PR TITLE
fix build/common.sh gcloud active account discovery

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -1086,7 +1086,7 @@ function kube::release::gcs::verify_prereqs() {
   fi
 
   if [[ -z "${GCLOUD_ACCOUNT-}" ]]; then
-    GCLOUD_ACCOUNT=$(gcloud auth list 2>/dev/null | awk '/(active)/ { print $2 }')
+    GCLOUD_ACCOUNT=$(gcloud auth list 2>/dev/null | awk '/(active)|(ACTIVE)/ { print $2 }')
   fi
   if [[ -z "${GCLOUD_ACCOUNT-}" ]]; then
     echo "No account authorized through gcloud.  Please fix with:"


### PR DESCRIPTION
gcloud tags active account with capital 'ACTIVE' but build/common.sh expect lowercase 'active'

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30418)

<!-- Reviewable:end -->
