### PR TITLE
Adding events to federation control plane

### DIFF
--- a/cmd/hyperkube/federation-apiserver.go
+++ b/cmd/hyperkube/federation-apiserver.go
@@ -18,13 +18,13 @@ package main
 
 import (
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 )
 
 // NewFederationAPIServer creates a new hyperkube Server object that includes the
 // description and flags.
 func NewFederationAPIServer() *Server {
-	s := genericoptions.NewServerRunOptions().WithEtcdOptions()
+	s := options.NewServerRunOptions()
 
 	hks := Server{
 		SimpleUsage: "federation-apiserver",
@@ -33,7 +33,6 @@ func NewFederationAPIServer() *Server {
 			return app.Run(s)
 		},
 	}
-	s.AddUniversalFlags(hks.Flags())
-	s.AddEtcdStorageFlags(hks.Flags())
+	s.AddFlags(hks.Flags())
 	return &hks
 }

--- a/federation/apis/core/install/install.go
+++ b/federation/apis/core/install/install.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const importPrefix = "k8s.io/kubernetes/federation/api"
+const importPrefix = "k8s.io/kubernetes/pkg/api"
 
 var accessor = meta.NewAccessor()
 
@@ -99,7 +99,7 @@ func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper 
 		"DeleteOptions",
 		"Status")
 
-	mapper := api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	mapper := api.NewDefaultRESTMapperFromScheme(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped, core.Scheme)
 	// setup aliases for groups of resources
 	mapper.AddResourceAlias("all", userResources...)
 

--- a/federation/apis/core/register.go
+++ b/federation/apis/core/register.go
@@ -70,6 +70,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&api.DeleteOptions{},
 		&api.Secret{},
 		&api.SecretList{},
+		&api.Event{},
+		&api.EventList{},
 	)
 
 	// Register Unversioned types under their own special group

--- a/federation/apis/core/v1/conversion.go
+++ b/federation/apis/core/v1/conversion.go
@@ -81,5 +81,14 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			return err
 		}
 	}
+	if err := v1.AddFieldLabelConversionsForEvent(scheme); err != nil {
+		return nil
+	}
+	if err := v1.AddFieldLabelConversionsForNamespace(scheme); err != nil {
+		return nil
+	}
+	if err := v1.AddFieldLabelConversionsForSecret(scheme); err != nil {
+		return nil
+	}
 	return nil
 }

--- a/federation/apis/core/v1/register.go
+++ b/federation/apis/core/v1/register.go
@@ -45,6 +45,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&v1.DeleteOptions{},
 		&v1.Secret{},
 		&v1.SecretList{},
+		&v1.Event{},
+		&v1.EventList{},
 	)
 
 	// Add common types

--- a/federation/cmd/federation-apiserver/apiserver.go
+++ b/federation/cmd/federation-apiserver/apiserver.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"
@@ -36,9 +36,8 @@ import (
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	s := genericoptions.NewServerRunOptions().WithEtcdOptions()
-	s.AddUniversalFlags(pflag.CommandLine)
-	s.AddEtcdStorageFlags(pflag.CommandLine)
+	s := options.NewServerRunOptions()
+	s.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
 	logs.InitLogs()

--- a/federation/cmd/federation-apiserver/app/extensions.go
+++ b/federation/cmd/federation-apiserver/app/extensions.go
@@ -18,19 +18,18 @@ package app
 
 import (
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
-	"k8s.io/kubernetes/pkg/genericapiserver"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
-
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+	"k8s.io/kubernetes/pkg/genericapiserver"
 	ingressetcd "k8s.io/kubernetes/pkg/registry/ingress/etcd"
 	replicasetetcd "k8s.io/kubernetes/pkg/registry/replicaset/etcd"
 )
 
-func installExtensionsAPIs(s *genericoptions.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+func installExtensionsAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
 	replicaSetStorage := replicasetetcd.NewStorage(createRESTOptionsOrDie(s, g, f, extensions.Resource("replicasets")))
 	ingressStorage, ingressStatusStorage := ingressetcd.NewREST(createRESTOptionsOrDie(s, g, f, extensions.Resource("ingresses")))
 	extensionsResources := map[string]rest.Storage{

--- a/federation/cmd/federation-apiserver/app/federation.go
+++ b/federation/cmd/federation-apiserver/app/federation.go
@@ -20,17 +20,17 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/genericapiserver"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 
 	_ "k8s.io/kubernetes/federation/apis/federation/install"
 	clusteretcd "k8s.io/kubernetes/federation/registry/cluster/etcd"
 )
 
-func installFederationAPIs(s *genericoptions.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+func installFederationAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
 	clusterStorage, clusterStatusStorage := clusteretcd.NewREST(createRESTOptionsOrDie(s, g, f, federation.Resource("clusters")))
 	federationResources := map[string]rest.Storage{
 		"clusters":        clusterStorage,

--- a/federation/cmd/federation-apiserver/app/options/options.go
+++ b/federation/cmd/federation-apiserver/app/options/options.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package options contains flags and options for initializing federation-apiserver.
+package options
+
+import (
+	"time"
+
+	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+
+	"github.com/spf13/pflag"
+)
+
+// Runtime options for the federation-apiserver.
+type ServerRunOptions struct {
+	*genericoptions.ServerRunOptions
+	EventTTL time.Duration
+}
+
+// NewServerRunOptions creates a new ServerRunOptions object with default values.
+func NewServerRunOptions() *ServerRunOptions {
+	s := ServerRunOptions{
+		ServerRunOptions: genericoptions.NewServerRunOptions().WithEtcdOptions(),
+		EventTTL:         1 * time.Hour,
+	}
+	return &s
+}
+
+// AddFlags adds flags for ServerRunOptions fields to be specified via FlagSet.
+func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
+	// Add the generic flags.
+	s.ServerRunOptions.AddUniversalFlags(fs)
+	//Add etcd specific flags.
+	s.ServerRunOptions.AddEtcdStorageFlags(fs)
+
+	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
+		"Amount of time to retain events. Default is 1h.")
+}

--- a/federation/cmd/federation-apiserver/app/server_test.go
+++ b/federation/cmd/federation-apiserver/app/server_test.go
@@ -29,14 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fed_v1b1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	ext_v1b1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	"k8s.io/kubernetes/pkg/genericapiserver/options"
 )
 
 func TestLongRunningRequestRegexp(t *testing.T) {
-	regexp := regexp.MustCompile(options.NewServerRunOptions().WithEtcdOptions().LongRunningRequestRE)
+	regexp := regexp.MustCompile(options.NewServerRunOptions().LongRunningRequestRE)
 	dontMatch := []string{
 		"/api/v1/watch-namespace/",
 		"/api/v1/namespace-proxy/",
@@ -84,7 +84,7 @@ var groupVersions = []unversioned.GroupVersion{
 }
 
 func TestRun(t *testing.T) {
-	s := options.NewServerRunOptions().WithEtcdOptions()
+	s := options.NewServerRunOptions()
 	s.InsecurePort = insecurePort
 	_, ipNet, _ := net.ParseCIDR("10.10.10.0/24")
 	s.ServiceClusterIPRange = *ipNet
@@ -258,6 +258,8 @@ func testFederationResourceList(t *testing.T) {
 	}
 	assert.Equal(t, "v1", apiResourceList.APIVersion)
 	assert.Equal(t, fed_v1b1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
+	// Assert that there are exactly 2 resources.
+	assert.Equal(t, 2, len(apiResourceList.APIResources))
 
 	found := findResource(apiResourceList.APIResources, "clusters")
 	assert.NotNil(t, found)
@@ -280,11 +282,32 @@ func testCoreResourceList(t *testing.T) {
 	}
 	assert.Equal(t, "", apiResourceList.APIVersion)
 	assert.Equal(t, v1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
+	// Assert that there are exactly 6 resources.
+	assert.Equal(t, 6, len(apiResourceList.APIResources))
 
+	// Verify services.
 	found := findResource(apiResourceList.APIResources, "services")
 	assert.NotNil(t, found)
 	assert.True(t, found.Namespaced)
 	found = findResource(apiResourceList.APIResources, "services/status")
+	assert.NotNil(t, found)
+	assert.True(t, found.Namespaced)
+
+	// Verify namespaces.
+	found = findResource(apiResourceList.APIResources, "namespaces")
+	assert.NotNil(t, found)
+	assert.True(t, found.Namespaced)
+	found = findResource(apiResourceList.APIResources, "namespaces/status")
+	assert.NotNil(t, found)
+	assert.True(t, found.Namespaced)
+
+	// Verify events.
+	found = findResource(apiResourceList.APIResources, "events")
+	assert.NotNil(t, found)
+	assert.True(t, found.Namespaced)
+
+	// Verify secrets.
+	found = findResource(apiResourceList.APIResources, "secrets")
 	assert.NotNil(t, found)
 	assert.True(t, found.Namespaced)
 }
@@ -303,6 +326,8 @@ func testExtensionsResourceList(t *testing.T) {
 	// empty APIVersion for extensions group
 	assert.Equal(t, "", apiResourceList.APIVersion)
 	assert.Equal(t, ext_v1b1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
+	// Assert that there are exactly 5 resources.
+	assert.Equal(t, 5, len(apiResourceList.APIResources))
 
 	// Verify replicasets.
 	found := findResource(apiResourceList.APIResources, "replicasets")

--- a/pkg/api/mapper.go
+++ b/pkg/api/mapper.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -34,14 +35,21 @@ func RegisterRESTMapper(m meta.RESTMapper) {
 	RESTMapper = append(RESTMapper.(meta.MultiRESTMapper), m)
 }
 
+// Instantiates a DefaultRESTMapper based on types registered in api.Scheme
 func NewDefaultRESTMapper(defaultGroupVersions []unversioned.GroupVersion, interfacesFunc meta.VersionInterfacesFunc,
 	importPathPrefix string, ignoredKinds, rootScoped sets.String) *meta.DefaultRESTMapper {
+	return NewDefaultRESTMapperFromScheme(defaultGroupVersions, interfacesFunc, importPathPrefix, ignoredKinds, rootScoped, Scheme)
+}
+
+// Instantiates a DefaultRESTMapper based on types registered in the given scheme.
+func NewDefaultRESTMapperFromScheme(defaultGroupVersions []unversioned.GroupVersion, interfacesFunc meta.VersionInterfacesFunc,
+	importPathPrefix string, ignoredKinds, rootScoped sets.String, scheme *runtime.Scheme) *meta.DefaultRESTMapper {
 
 	mapper := meta.NewDefaultRESTMapper(defaultGroupVersions, interfacesFunc)
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address
 	// our resources.
 	for _, gv := range defaultGroupVersions {
-		for kind, oType := range Scheme.KnownTypes(gv) {
+		for kind, oType := range scheme.KnownTypes(gv) {
 			gvk := gv.WithKind(kind)
 			// TODO: Remove import path check.
 			// We check the import path because we currently stuff both "api" and "extensions" objects

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -172,7 +172,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		"ServiceAccount",
 		"ConfigMap",
 	} {
-		err = api.Scheme.AddFieldLabelConversionFunc("v1", kind,
+		err = scheme.AddFieldLabelConversionFunc("v1", kind,
 			func(label, value string) (string, string, error) {
 				switch label {
 				case "metadata.namespace",
@@ -189,7 +189,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	// Add field conversion funcs.
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Pod",
+	err = scheme.AddFieldLabelConversionFunc("v1", "Pod",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -212,7 +212,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err != nil {
 		return err
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Node",
+	err = scheme.AddFieldLabelConversionFunc("v1", "Node",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -227,7 +227,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err != nil {
 		return err
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ReplicationController",
+	err = scheme.AddFieldLabelConversionFunc("v1", "ReplicationController",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
@@ -241,45 +241,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err != nil {
 		return err
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Event",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "involvedObject.kind",
-				"involvedObject.namespace",
-				"involvedObject.name",
-				"involvedObject.uid",
-				"involvedObject.apiVersion",
-				"involvedObject.resourceVersion",
-				"involvedObject.fieldPath",
-				"reason",
-				"source",
-				"type",
-				"metadata.namespace",
-				"metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		},
-	)
-	if err != nil {
-		return err
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Namespace",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "status.phase",
-				"metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		},
-	)
-	if err != nil {
-		return err
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "PersistentVolume",
+	err = scheme.AddFieldLabelConversionFunc("v1", "PersistentVolume",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name":
@@ -292,19 +254,13 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err != nil {
 		return err
 	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Secret",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "type",
-				"metadata.namespace",
-				"metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		},
-	)
-	if err != nil {
+	if err := AddFieldLabelConversionsForEvent(scheme); err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForNamespace(scheme); err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForSecret(scheme); err != nil {
 		return err
 	}
 	return nil
@@ -768,4 +724,54 @@ func Convert_v1_ResourceList_To_api_ResourceList(in *ResourceList, out *api.Reso
 		(*out)[api.ResourceName(key)] = val
 	}
 	return nil
+}
+
+func AddFieldLabelConversionsForEvent(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc("v1", "Event",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "involvedObject.kind",
+				"involvedObject.namespace",
+				"involvedObject.name",
+				"involvedObject.uid",
+				"involvedObject.apiVersion",
+				"involvedObject.resourceVersion",
+				"involvedObject.fieldPath",
+				"reason",
+				"source",
+				"type",
+				"metadata.namespace",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}
+
+func AddFieldLabelConversionsForNamespace(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc("v1", "Namespace",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.phase",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}
+
+func AddFieldLabelConversionsForSecret(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc("v1", "Secret",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "type",
+				"metadata.namespace",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
 }


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/29744

Adding events to federation control plane.

Apart from the standard changes to add a resource to `federation/apis/core/v1`, other changes are:
- Adding a new `federationoptions.ServerRunOptions` which includes `genericoptions.ServerRunOptions` and EventsTTL. 
- Added a new method in `pkg/api/mapper` to build a RestMapper based on the passed Scheme rather than using `api.Scheme`. Updated `federation/apis/core/install` to use this new method. Without this change, if `federation/apis/core/install.init()` is called before `pkg/api/install.init()` then the registered RESTMapper in `pkg/apimachinery/registered` will have no resources. This second problem will be fixed once we have instances of `pkg/apimachinery/registered` instead of a single global singleton (generated clientset which imports `pkg/api/install` will have a different instance of registered, than federation-apiserver which imports `federation/apis/core/install`).

cc @kubernetes/sig-cluster-federation @lavalamp

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30421)

<!-- Reviewable:end -->
