### PR TITLE
Update dnsprovider multi-type support test to test for an A-record and an AAAA-record.

### DIFF
--- a/federation/pkg/dnsprovider/rrstype/rrstype.go
+++ b/federation/pkg/dnsprovider/rrstype/rrstype.go
@@ -22,6 +22,7 @@ type (
 
 const (
 	A     = RrsType("A")
+	AAAA  = RrsType("AAAA")
 	CNAME = RrsType("CNAME")
 	// TODO:  Add other types as required
 )

--- a/federation/pkg/dnsprovider/tests/commontests.go
+++ b/federation/pkg/dnsprovider/tests/commontests.go
@@ -84,17 +84,17 @@ func CommonTestResourceRecordSetsDifferentTypes(t *testing.T, zone dnsprovider.Z
 	defer sets.StartChangeset().Remove(rrset).Apply()
 	t.Logf("Successfully added resource record set: %v", rrset)
 
-	cnameRrset := rrsets.New("alpha.test.com", []string{"cname.test.com"}, 80, rrstype.CNAME)
+	aaaaRrset := rrsets.New("alpha.test.com", []string{"2001:4860:4860::8888"}, 80, rrstype.AAAA)
 
 	// Add the resource with the same name but different type
-	err := sets.StartChangeset().Add(cnameRrset).Apply()
+	err := sets.StartChangeset().Add(aaaaRrset).Apply()
 	if err != nil {
-		t.Errorf("Failed to add resource record set %v: %v", cnameRrset, err)
+		t.Errorf("Failed to add resource record set %v: %v", aaaaRrset, err)
 	}
-	defer sets.StartChangeset().Remove(cnameRrset).Apply()
+	defer sets.StartChangeset().Remove(aaaaRrset).Apply()
 
 	// Check that both records exist
-	assertHasRecord(t, sets, cnameRrset)
+	assertHasRecord(t, sets, aaaaRrset)
 	assertHasRecord(t, sets, rrset)
 }
 


### PR DESCRIPTION
Having an A-record and a CNAME-record in the tests led to a confusion
that dns providers support such configurations. This change avoids
that confusion by putting only compatible records for the same domain
name in the tests.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30433)

<!-- Reviewable:end -->
