### PR TITLE
ExecHandlerName should be set default value when with incorrect name

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -160,6 +160,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		dockerExecHandler = &dockertools.NsenterExecHandler{}
 	default:
 		glog.Warningf("Unknown Docker exec handler %q; defaulting to native", s.DockerExecHandlerName)
+		s.DockerExecHandlerName = "native"
 		dockerExecHandler = &dockertools.NativeExecHandler{}
 	}
 


### PR DESCRIPTION
when ExecHandlerName  is incorrect, dockerExecHandler has been set NativeHandler, but ExecHandlerName  is incorrect yet, should be set "Native":

```
default:
    glog.Warningf("Unknown Docker exec handler %q; defaulting to native", s.DockerExecHandlerName)
    dockerExecHandler = &dockertools.NativeExecHandler{}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30434)

<!-- Reviewable:end -->
