### PR TITLE
Add note: kubelet manages only k8s containers.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -101,7 +101,8 @@ func NewKubeletCommand() *cobra.Command {
 node. The kubelet works in terms of a PodSpec. A PodSpec is a YAML or JSON object
 that describes a pod. The kubelet takes a set of PodSpecs that are provided through
 various mechanisms (primarily through the apiserver) and ensures that the containers
-described in those PodSpecs are running and healthy.
+described in those PodSpecs are running and healthy. The kubelet doesn't manage
+containers which were not created by Kubernetes.
 
 Other than from an PodSpec from the apiserver, there are three ways that a container
 manifest can be provided to the Kubelet.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -396,7 +396,7 @@ func GetKubeletDockerContainers(client DockerInterface, allContainers bool) ([]*
 		// Skip containers that we didn't create to allow users to manually
 		// spin up their own containers if they want.
 		if !strings.HasPrefix(container.Names[0], "/"+containerNamePrefix+"_") {
-			glog.V(3).Infof("Docker Container: %s is not managed by kubelet.", container.Names[0])
+			glog.V(5).Infof("Docker Container: %s is not managed by kubelet.", container.Names[0])
 			continue
 		}
 		result = append(result, container)


### PR DESCRIPTION
Kubelet wrote log when accesing container which was not created in k8s, what could confuse users. That's why we added note about it in documentation and lowered log level of the message to 5.

Here is example of the message: 

```
> Apr 19 11:50:32 openshift-114.lab.sjc.redhat.com atomic-openshift-node[9551]: 
I0419 11:50:32.194020    9600 docker.go:363] 
Docker Container: /tiny_babbage is not managed by kubelet.
```

bug 1328441
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1328441

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30435)

<!-- Reviewable:end -->
