### PR TITLE
Federation - common libs - get clientset for cluster

### DIFF
--- a/federation/pkg/federation-controller/util/cluster_util.go
+++ b/federation/pkg/federation-controller/util/cluster_util.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -129,4 +130,14 @@ var KubeconfigGetterForSecret = func(secretName string) clientcmd.KubeconfigGett
 		}
 		return clientcmd.Load(data)
 	}
+}
+
+// Retruns Clientset for the given cluster.
+func GetClientsetForCluster(cluster *federation_v1beta1.Cluster) (*federation_release_1_4.Clientset, error) {
+	clusterConfig, err := BuildClusterConfig(cluster)
+	if err != nil && clusterConfig != nil {
+		clientset := federation_release_1_4.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, userAgentName))
+		return clientset, nil
+	}
+	return nil, err
 }


### PR DESCRIPTION
Get clientset method builds a clientset for a federated cluster.

cc: @quinton-hoole @wojtek-t @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30439)

<!-- Reviewable:end -->
