### PR TITLE
Fix glog's --v in kubectl

### DIFF
--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/logs"
 )
 
 /*
@@ -28,6 +29,9 @@ WARNING: this logic is duplicated, with minor changes, in cmd/hyperkube/kubectl.
 Any salient changes here will need to be manually reflected in that file.
 */
 func Run() error {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
 	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()
 }


### PR DESCRIPTION
With https://github.com/kubernetes/kubernetes/pull/29147 kubectl lost its glog output to stderr because  the `init()` func did not run anymore which had set `logtostderr` to true before.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30440)

<!-- Reviewable:end -->
