### PR TITLE
POC: etcd2 -> etcd3 migration

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -161,7 +161,7 @@ KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}
 TEST_CLUSTER="${TEST_CLUSTER:-true}"
 
 # Storage backend. 'etcd2' supported, 'etcd3' experimental.
-STORAGE_BACKEND=${STORAGE_BACKEND:-etcd2}
+STORAGE_BACKEND=${STORAGE_BACKEND:-etcd3}
 
 # OpenContrail networking plugin specific settings
 NETWORK_PROVIDER="${NETWORK_PROVIDER:-kubenet}" # none, opencontrail, flannel, kubenet

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -15,6 +15,8 @@
 {% set etcd_cluster = vars.etcd_cluster -%}
 {% set cluster_state = vars.cluster_state -%}
 
+{% set migrate = 'false' -%}
+
 {
 "apiVersion": "v1",
 "kind": "Pod",
@@ -36,7 +38,7 @@
     "command": [
               "/bin/sh",
               "-c",
-              "/usr/local/bin/etcd --name etcd-{{ hostname }} --listen-peer-urls http://{{ hostname }}:{{ server_port }} --initial-advertise-peer-urls http://{{ hostname }}:{{ server_port }} --advertise-client-urls http://127.0.0.1:{{ port }} --listen-client-urls http://127.0.0.1:{{ port }} --data-dir /var/etcd/data{{ suffix }} --initial-cluster-state {{ cluster_state }} --initial-cluster {{ etcd_cluster }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
+              "if true; then /usr/local/bin/etcdctl migrate --data-dir=var/etcd/data{{ suffix }}; fi; /usr/local/bin/etcd --name etcd-{{ hostname }} --listen-peer-urls http://{{ hostname }}:{{ server_port }} --initial-advertise-peer-urls http://{{ hostname }}:{{ server_port }} --advertise-client-urls http://127.0.0.1:{{ port }} --listen-client-urls http://127.0.0.1:{{ port }} --data-dir /var/etcd/data{{ suffix }} --initial-cluster-state {{ cluster_state }} --initial-cluster {{ etcd_cluster }} 1>>/var/log/etcd{{ suffix }}.log 2>&1; if true; then sleep 10; /usr/local/bin/etcdctl rm /registry --recursive; fi"
             ],
     "livenessProbe": {
       "httpGet": {
@@ -47,6 +49,11 @@
       "initialDelaySeconds": 15,
       "timeoutSeconds": 15
     },
+    "env": [
+      { "name": "ETCDCTL_API",
+        "value": "3"
+      }
+        ],
     "ports":[
       { "name": "serverport",
         "containerPort": {{ server_port }},


### PR DESCRIPTION
Ref #20504

@lavalamp @smarterclayton @timothysc @xiang90 @hongchaodeng 

This is obviously far from being ready PR, but here are my few thoughts about it:
- if we proceed with such approach, we won't be forced to change any our update scripts - it should just work out of the box
- it seems that when we don't have etcd2 data, doing anyther migration is no-op (I did some experiments to check it), which makes this approach just work
- this is so local change, that even if it appeared to be broken, we would be able to easily revert this change

I think that missing things in this PR are:
- figure out what to do with events (but this should be just a matter of passing appropriate transformer)
- backup data
- some error handling?

Please let me know if I'm completely missing something with this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30447)

<!-- Reviewable:end -->
