### PR TITLE
pkg/apiserver/authenticator: reorder oidc plugin to auth after service accounts

### DIFF
--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -80,20 +80,26 @@ func New(config AuthenticatorConfig) (authenticator.Request, error) {
 		authenticators = append(authenticators, tokenAuth)
 	}
 
-	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
-		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCGroupsClaim)
-		if err != nil {
-			return nil, err
-		}
-		authenticators = append(authenticators, oidcAuth)
-	}
-
 	if len(config.ServiceAccountKeyFile) > 0 {
 		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountKeyFile, config.ServiceAccountLookup, config.ServiceAccountTokenGetter)
 		if err != nil {
 			return nil, err
 		}
 		authenticators = append(authenticators, serviceAccountAuth)
+	}
+
+	// NOTE(ericchiang): Keep the OpenID Connect after Service Accounts.
+	//
+	// Because both plugins verify JWTs whichever comes first in the union experiences
+	// cache misses for all requests using the other. While the service account plugin
+	// simply returns an error, the OpenID Connect plugin may query the provider to
+	// update the keys, causing performance hits.
+	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
+		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCGroupsClaim)
+		if err != nil {
+			return nil, err
+		}
+		authenticators = append(authenticators, oidcAuth)
 	}
 
 	if len(config.KeystoneURL) > 0 {


### PR DESCRIPTION
Both plugins verify JWTs, but the OpenID Connect plugin performs
much worse when faced with cache misses. Reorder the plugins so
the service account plugin tries to authenticate a bearer token
first.

I had a fun time with this by writing an OpenID Connect provider that stores its data in third party resources. When it's running in the cluster it uses a service account and caused some interesting behavior when the keys expired.

Our OpenID Connect plugin needs a more sophisticated caching model to avoid continuously re-requesting keys when seeing a lot of tokens it doesn't recognize. However, I feel this reordering is generally useful since service accounts will be more common than OpenID Connect tokens.

cc @kubernetes/sig-auth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30457)

<!-- Reviewable:end -->
