### PR TITLE
Add zsh compatibility note `completion` cmd help

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -42,10 +42,11 @@ $ brew install bash-completion
 $ source $(brew --prefix)/etc/bash_completion
 $ source <(kubectl completion bash)
 
-If you use zsh, the following will load kubectl zsh completion:
+If you use zsh*, the following will load kubectl zsh completion:
 
 $ source <(kubectl completion zsh)
-`
+
+* zsh completions are only supported in versions of zsh >= 5.2`
 )
 
 var (


### PR DESCRIPTION
zsh completions are not supported on zsh versions < 5.2.

This patch advices user on supported versions of zsh when using the `completion`
command to avoid potential UX failure.
##### After

`$ kubectl completion -h`

```
Output shell completion code for the given shell (bash or zsh).

This command prints shell code which must be evaluation to provide interactive
completion of kubectl commands.

Examples:

$ source <(kubectl completion bash)

will load the kubectl completion code for bash. Note that this depends on the
bash-completion framework. It must be sourced before sourcing the kubectl
completion, e.g. on the Mac:

$ brew install bash-completion
$ source $(brew --prefix)/etc/bash_completion
$ source <(kubectl completion bash)

If you use zsh*, the following will load kubectl zsh completion:

$ source <(kubectl completion zsh)

* zsh completions are only supported in versions of zsh >= 5.2
```

``` release-note
release-note-none
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30460)

<!-- Reviewable:end -->
