### PR TITLE
[GarbageCollector] Let kubectl delete rc and rs with DeleteOptions.OrphanDependents=false

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -202,7 +202,9 @@ func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout 
 			return err
 		}
 	}
-	return rc.Delete(name, nil)
+	falseVar := false
+	deleteOptions := &api.DeleteOptions{OrphanDependents: &falseVar}
+	return rc.Delete(name, deleteOptions)
 }
 
 // TODO(madhusudancs): Implement it when controllerRef is implemented - https://github.com/kubernetes/kubernetes/issues/2210
@@ -274,10 +276,9 @@ func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Durati
 		}
 	}
 
-	if err := rsc.Delete(name, nil); err != nil {
-		return err
-	}
-	return nil
+	falseVar := false
+	deleteOptions := &api.DeleteOptions{OrphanDependents: &falseVar}
+	return rsc.Delete(name, deleteOptions)
 }
 
 func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *api.DeleteOptions) error {


### PR DESCRIPTION
so that when the garbage collector is enabled, RC and RS are deleted immediately without waiting for the garbage collector to orphan the pods.

There is no user visible changes, so we don't need a release note.

cc @fabioy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30461)

<!-- Reviewable:end -->
