### PR TITLE
cluster/log-dump scp shouldn't check host keys for aws

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -46,7 +46,7 @@ function copy-logs-from-node() {
 
     if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
         local ip=$(get_ssh_hostname "${node}")
-        scp -i "${AWS_SSH_KEY}" "${SSH_USER}@${ip}:${scp_files}" "${dir}" > /dev/null || true
+        scp -oLogLevel=quiet -oConnectTimeout=30 -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" "${SSH_USER}@${ip}:${scp_files}" "${dir}" > /dev/null || true
     else
         gcloud compute copy-files --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
     fi


### PR DESCRIPTION
parity with cluster/aws/util.sh:ssh-to-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30472)

<!-- Reviewable:end -->
