### PR TITLE
Fix TestPidOf {procfs} - Take #2

### DIFF
--- a/pkg/util/procfs/procfs.go
+++ b/pkg/util/procfs/procfs.go
@@ -66,7 +66,8 @@ func PidOf(name string) []int {
 	pids := []int{}
 	filepath.Walk("/proc", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// We should continue processing other directories/files
+			return nil
 		}
 		base := filepath.Base(path)
 		// Traverse only the directories we are interested in


### PR DESCRIPTION
We should not bailout when we get an error. We should continue
processing other files/directories. We were returning the
err passed in which was causing the processing to stop.

Fixes #30377

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30478)

<!-- Reviewable:end -->
