### PR TITLE
Extend the wait time to 2*time.Minute for liveness check test.

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -32,6 +32,8 @@ import (
 const (
 	probTestContainerName       = "test-webserver"
 	probTestInitialDelaySeconds = 15
+
+	defaultObservationTimeout = time.Minute * 2
 )
 
 var _ = framework.KubeDescribe("Probing container", func() {

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -39,10 +39,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	defaultObservationTimeout = time.Minute * 1
-)
-
 var (
 	buildBackOffDuration = time.Minute
 	syncLoopFrequency    = 10 * time.Second


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/30264.

https://github.com/kubernetes/kubernetes/pull/29814 changes the wait time to 1 minute, which is not enough. That's what causes the flake.

The test expected the container to be restarted, and the container was indeed restarted but it took about 1 minute:

```
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:02:35 -0700 PDT - event for liveness-exec: {default-scheduler } Scheduled: Successfully assigned liveness-exec to e2e-gce-agent-pr-38-0-minion-group-bv95
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:02:36 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Pulled: Container image "gcr.io/google_containers/busybox:1.24" already present on machine
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:02:36 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Created: Created container with docker id cf4e8e60535e
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:02:36 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Started: Started container with docker id cf4e8e60535e
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:02:55 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Unhealthy: Liveness probe failed: 
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:03:26 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Killing: Killing container with docker id cf4e8e60535e: pod "liveness-exec_e2e-tests-container-probe-b1wip(a1f856fc-5e07-11e6-a7e1-42010af00002)" container "liveness" is unhealthy, it will be killed and re-created.
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:03:26 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Created: Created container with docker id 0b18537dc794
Aug  9 01:03:40.696: INFO: At 2016-08-09 01:03:26 -0700 PDT - event for liveness-exec: {kubelet e2e-gce-agent-pr-38-0-minion-group-bv95} Started: Started container with docker id 0b18537dc794
```

This PR recovers the wait time to the original 2 \* time. Mark P0 to match the corresponding issue.

@fejta

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30488)

<!-- Reviewable:end -->
