### PR TITLE
Avoid unnecessary copies on GCI initialization.

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -157,10 +157,8 @@ function install-kube-binary-config {
     rm -f "${KUBE_HOME}/${cni_tar}"
   fi
 
-  cp "${KUBE_HOME}/kubernetes/LICENSES" "${KUBE_HOME}"
-  cp "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz" "${KUBE_HOME}"
-  chmod a+r "${KUBE_HOME}/kubernetes/LICENSES"
-  chmod a+r "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz"
+  mv "${KUBE_HOME}/kubernetes/LICENSES" "${KUBE_HOME}"
+  mv "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz" "${KUBE_HOME}"
 
   # Put kube-system pods manifests in ${KUBE_HOME}/kube-manifests/.
   dst_dir="${KUBE_HOME}/kube-manifests"


### PR DESCRIPTION
The issue I faced was that when starting a cluster I was getting:

```
Aug 12 11:12:46 e2e-test-wojtekt-master configure.sh[1079]: cp: error writing '/home/kubernetes/kubernetes-src.tar.gz': No space left on device
```

This PR reduces amount of space that is needed on startup, as well as this speeds up starting cluster.

@lavalamp @dchen1107

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30503)

<!-- Reviewable:end -->
