### PR TITLE
Update core etcd references to use 3.0.4

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir $TMPDIR \
             github.com/jteeuwen/go-bindata/go-bindata
 
 # Download and symlink etcd. We need this for our integration tests.
-RUN export ETCD_VERSION=v3.0.3; \
+RUN export ETCD_VERSION=v3.0.4; \
   mkdir -p /usr/local/src/etcd \
   && cd /usr/local/src/etcd \
   && curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | tar -xz \

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -23,7 +23,7 @@ RELEASES_DIR=${RELEASES_DIR:-/tmp/downloads}
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 
 # Define etcd version to use.
-ETCD_VERSION=${ETCD_VERSION:-"3.0.3"}
+ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
 # Define k8s version to use.
 K8S_VERSION=${K8S_VERSION:-"1.1.1"}

--- a/cluster/gce/coreos/kube-manifests/etcd-events.yaml
+++ b/cluster/gce/coreos/kube-manifests/etcd-events.yaml
@@ -14,7 +14,7 @@ spec:
       --listen-client-urls=http://127.0.0.1:4002
       --data-dir=/var/etcd/data-events
       1>>/var/log/etcd-events.log 2>&1
-    image: gcr.io/google_containers/etcd:3.0.3
+    image: gcr.io/google_containers/etcd:3.0.4
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:

--- a/cluster/gce/coreos/kube-manifests/etcd.yaml
+++ b/cluster/gce/coreos/kube-manifests/etcd.yaml
@@ -14,7 +14,7 @@ spec:
       --listen-client-urls=http://127.0.0.1:4001
       --data-dir=/var/etcd/data
       1>>/var/log/etcd.log 2>&1
-    image: gcr.io/google_containers/etcd:3.0.3
+    image: gcr.io/google_containers/etcd:3.0.4
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:

--- a/cluster/images/hyperkube/static-pods/etcd.json
+++ b/cluster/images/hyperkube/static-pods/etcd.json
@@ -10,7 +10,7 @@
     "containers": [
       {
         "name": "etcd",
-        "image": "gcr.io/google_containers/etcd-ARCH:3.0.3",
+        "image": "gcr.io/google_containers/etcd-ARCH:3.0.4",
         "command": [
                 "/usr/local/bin/etcd",
                 "--listen-client-urls=http://127.0.0.1:4001",

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -27,7 +27,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "gcr.io/google_containers/etcd:3.0.3",
+    "image": "gcr.io/google_containers/etcd:3.0.4",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}

--- a/cluster/saltbase/salt/flannel-server/flannel-server.manifest
+++ b/cluster/saltbase/salt/flannel-server/flannel-server.manifest
@@ -75,7 +75,7 @@
             },
             {
                 "name": "etcd-container",
-                "image": "gcr.io/google_containers/etcd:3.0.3",
+                "image": "gcr.io/google_containers/etcd:3.0.4",
                 "command": [
                     "/bin/sh",
                     "-c",

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.0.3}
+ETCD_VERSION=${ETCD_VERSION:-3.0.4}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-4001}
 

--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -55,11 +55,11 @@ fi
 # Install etcd
 hash etcd 2>/dev/null
 if [ $? -ne 0 ]; then
-  curl -L  https://github.com/coreos/etcd/releases/download/v3.0.3/etcd-v3.0.3-linux-amd64.tar.gz -o etcd-v3.0.3-linux-amd64.tar.gz
-  tar xzvf etcd-v3.0.3-linux-amd64.tar.gz
-  sudo mv etcd-v3.0.3-linux-amd64/etcd* /usr/local/bin/
+  curl -L  https://github.com/coreos/etcd/releases/download/v3.0.4/etcd-v3.0.4-linux-amd64.tar.gz -o etcd-v3.0.4-linux-amd64.tar.gz
+  tar xzvf etcd-v3.0.4-linux-amd64.tar.gz
+  sudo mv etcd-v3.0.4-linux-amd64/etcd* /usr/local/bin/
   sudo chown root:root /usr/local/bin/etcd*
-  rm -r etcd-v3.0.3-linux-amd64*
+  rm -r etcd-v3.0.4-linux-amd64*
 fi
 
 # Install nsenter for ubuntu images

--- a/test/kubemark/start-kubemark-master.sh
+++ b/test/kubemark/start-kubemark-master.sh
@@ -21,7 +21,7 @@ EVENT_STORE_URL="http://${EVENT_STORE_IP}:4002"
 NUM_NODES=$2
 if [ "${EVENT_STORE_IP}" == "127.0.0.1" ]; then
 	sudo docker run --net=host -v /var/etcd/data-events:/var/etcd/data -d \
-		gcr.io/google_containers/etcd:3.0.3 /usr/local/bin/etcd \
+		gcr.io/google_containers/etcd:3.0.4 /usr/local/bin/etcd \
 		--listen-peer-urls http://127.0.0.1:2381 \
 		--advertise-client-urls=http://127.0.0.1:4002 \
 		--listen-client-urls=http://0.0.0.0:4002 \
@@ -29,7 +29,7 @@ if [ "${EVENT_STORE_IP}" == "127.0.0.1" ]; then
 fi
 
 sudo docker run --net=host -v /var/etcd/data:/var/etcd/data -d \
-	gcr.io/google_containers/etcd:3.0.3 /usr/local/bin/etcd \
+	gcr.io/google_containers/etcd:3.0.4 /usr/local/bin/etcd \
 	--listen-peer-urls http://127.0.0.1:2380 \
 	--advertise-client-urls=http://127.0.0.1:4001 \
 	--listen-client-urls=http://0.0.0.0:4001 \

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -140,7 +140,7 @@ if [ "${SEPARATE_EVENT_MACHINE:-false}" == "true" ]; then
   done
 
   gcloud compute ssh "${EVENT_STORE_NAME}" --zone="${ZONE}" --project="${PROJECT}" \
-    --command="sudo docker run --net=host -d gcr.io/google_containers/etcd:2.0.12 /usr/local/bin/etcd \
+    --command="sudo docker run --net=host -d gcr.io/google_containers/etcd:3.0.4 /usr/local/bin/etcd \
       --listen-peer-urls http://127.0.0.1:2380 \
       --advertise-client-urls=http://127.0.0.1:4002 \
       --listen-client-urls=http://0.0.0.0:4002 \


### PR DESCRIPTION
This updates the core references to use 3.0.4. 

There are still legacy references in the code base that should be cleaned, or just removed but I'm reluctant to purge.  

/cc @kubernetes/sig-scalability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30508)

<!-- Reviewable:end -->
