### PR TITLE
Endpoint controller logs errors during normal cluster behavior

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -487,7 +487,9 @@ func (e *EndpointController) syncService(key string) {
 	} else {
 		newEndpoints.Annotations[endpoints.PodHostnamesAnnotation] = serializedPodHostNames
 	}
-	if len(currentEndpoints.ResourceVersion) == 0 {
+
+	createEndpoints := len(currentEndpoints.ResourceVersion) == 0
+	if createEndpoints {
 		// No previous endpoints, create them
 		_, err = e.client.Endpoints(service.Namespace).Create(newEndpoints)
 	} else {
@@ -495,7 +497,15 @@ func (e *EndpointController) syncService(key string) {
 		_, err = e.client.Endpoints(service.Namespace).Update(newEndpoints)
 	}
 	if err != nil {
-		glog.Errorf("Error updating endpoints: %v", err)
+		if createEndpoints && errors.IsForbidden(err) {
+			// A request is forbidden primarily for two reasons:
+			// 1. namespace is terminating, endpoint creation is not allowed by default.
+			// 2. policy is misconfigured, in which case no service would function anywhere.
+			// Given the frequency of 1, we log at a lower level.
+			glog.V(5).Infof("Forbidden from creating endpoints: %v", err)
+		} else {
+			utilruntime.HandleError(err)
+		}
 		e.queue.Add(key) // Retry
 	}
 }


### PR DESCRIPTION
The endpoint controller logs an error when its forbidden from creating new endpoints during namespace termination.  This is normal cluster behavior, and therefore should not be logged.  This confuses operators administrating the cluster.

Updated to log at a lower level in response to a forbidden message when performing a create operation.  In case of an error on the API server side of the house, I continue to requeue the key.  It should be ignored in a future syncService call once the service is deleted as part of namespace termination.

See https://bugzilla.redhat.com/show_bug.cgi?id=1347425

/cc @kubernetes/rh-cluster-infra

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30510)

<!-- Reviewable:end -->
