### PR TITLE
Remove incorrect docs about unset fields in NetworkPolicyPeer

### DIFF
--- a/docs/proposals/network-policy.md
+++ b/docs/proposals/network-policy.md
@@ -207,14 +207,12 @@ type NetworkPolicyPeer struct {
 
 	// This is a label selector which selects Pods in this namespace.
 	// This field follows standard unversioned.LabelSelector semantics.
-	// If not provided, this selector selects no pods.
 	// If present but empty, this selector selects all pods in this namespace.
 	PodSelector *unversioned.LabelSelector `json:"podSelector,omitempty"`
 	
 	// Selects Namespaces using cluster scoped-labels.  This 
 	// matches all pods in all namespaces selected by this label selector. 
 	// This field follows standard unversioned.LabelSelector semantics.
-	// If omited, this selector selects no namespaces.
 	// If present but empty, this selector selects all namespaces.
 	NamespaceSelector *unversioned.LabelSelector `json:"namespaceSelector,omitempty"`
 }


### PR DESCRIPTION
While hammering out the semantics of not-present vs present-but-empty, we appear to have added incorrect clarifications to NetworkPolicyPeer, where the semantics of PodSelector not being present is supposed to be "do what NamespaceSelector" says, not "select no pods", and likewise with NamespaceSelector not being present.

I think it's clearest if we just don't say anything, since we already said "Exactly one of the following must be specified" above. Alternatively we could be redundant and say "(If not provided, then NamespaceSelector must be set.)" or something like that.

@caseydavenport @thockin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30511)

<!-- Reviewable:end -->
