### PR TITLE
When binding a pvc, Search for pv with a claimRef even if accessModes…

### DIFF
--- a/pkg/controller/volume/persistentvolume/controller_base.go
+++ b/pkg/controller/volume/persistentvolume/controller_base.go
@@ -116,7 +116,7 @@ func NewPersistentVolumeController(
 			UpdateFunc: controller.updateVolume,
 			DeleteFunc: controller.deleteVolume,
 		},
-		cache.Indexers{"accessmodes": accessModesIndexFunc},
+		cache.Indexers{"accessmodes": accessModesIndexFunc, "claimref": claimRefIndexFunc},
 	)
 	_, controller.claimController = framework.NewInformer(
 		claimSource,

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -624,6 +624,7 @@ func TestFindingPreboundVolumes(t *testing.T) {
 
 	// pretend the exact match is pre-bound.  should get the next size up.
 	pv1.Spec.ClaimRef = &api.ObjectReference{Name: "foo", Namespace: "bar"}
+	index.store.Update(pv1)
 	volume, _ = index.findBestMatchForClaim(claim)
 	if volume.Name != pv5.Name {
 		t.Errorf("Expected %s but got volume %s instead", pv5.Name, volume.Name)
@@ -631,7 +632,9 @@ func TestFindingPreboundVolumes(t *testing.T) {
 
 	// pretend the exact match is available but the largest volume is pre-bound to the claim.
 	pv1.Spec.ClaimRef = nil
+	index.store.Update(pv1)
 	pv8.Spec.ClaimRef = claimRef
+	index.store.Update(pv8)
 	volume, _ = index.findBestMatchForClaim(claim)
 	if volume.Name != pv8.Name {
 		t.Errorf("Expected %s but got volume %s instead", pv8.Name, volume.Name)


### PR DESCRIPTION
claimRef when specified is supposed to take precedence over all else, including accessModes. Currently only volumes with matching access modes are considered, this pr saves the unmatched ones and searches them for a pre-bound volume.

Originally reported here https://bugzilla.redhat.com/show_bug.cgi?id=1366500

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30522)

<!-- Reviewable:end -->
