### PR TITLE
Fix subtle build breakage

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -348,6 +348,9 @@ kube::golang::setup_env() {
   subdir=$(kube::realpath . | sed "s|$KUBE_ROOT||")
   cd "${KUBE_GOPATH}/src/${KUBE_GO_PACKAGE}/${subdir}"
 
+  # Set GOROOT so binaries that parse code can work properly.
+  export GOROOT=$(go env GOROOT)
+
   # Unset GOBIN in case it already exists in the current session.
   unset GOBIN
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -612,18 +612,18 @@ kube::golang::build_binaries() {
     local use_go_build
     local -a targets=()
     local arg
-    
+
     # Add any files with those //generate annotations in the array below.
     readonly BINDATAS=( "${KUBE_ROOT}/test/e2e/framework/gobindata_util.go" )
     kube::log::status "Generating bindata:" "${BINDATAS[@]}"
     for bindata in ${BINDATAS[@]}; do
-	  # Only try to generate bindata if the file exists, since in some cases
-	  # one-off builds of individual directories may exclude some files.
+          # Only try to generate bindata if the file exists, since in some cases
+          # one-off builds of individual directories may exclude some files.
       if [[ -f $bindata ]]; then
           go generate "${bindata}"
       fi
     done
-    
+
     for arg; do
       if [[ "${arg}" == "--use_go_build" ]]; then
         use_go_build=true

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -45,7 +45,7 @@ gotoprotobuf=$(kube::util::find-binary "go-to-protobuf")
 # searches for the protoc-gen-gogo extension in the output directory
 # satisfies import of github.com/gogo/protobuf/gogoproto/gogo.proto and the
 # core Google protobuf types
-PATH="${KUBE_ROOT}/_output/local/go/bin:${PATH}" \
+PATH="${KUBE_ROOT}/_output/bin:${PATH}" \
   "${gotoprotobuf}" \
   --proto-import="${KUBE_ROOT}/vendor" \
   --proto-import="${KUBE_ROOT}/third_party/protobuf" \


### PR DESCRIPTION
Repro case:
$ make clean generated_files
$ hack/update-generated-protobuf.sh

This would complain about not finding `fmt`, and it was indicating the wrong
GOROOT.  The problem was that the first step built binaries for generating
code, which _embeds_ the value of GOROOT into the binary.  The whole tree was
bind-mounted into the build container and then JUST the dockerized dir was
mounted over it.  The in-container build tried to use the existing binaries,
but GOROOT is wrong.

This change whites-out the whole _output dir.

I first made just an anonymous volume for _output, but docker makes that as
root, which means I can't write to it from our non-root build.  So I just put
it in the data container.  This seems to work.  The biggest change this makes
is that the $GOPATH/bin/ and $GOPATH/pkg/ dirs will persist across dockerized
builds.

NB: this requires a `make clean` to activate.

@lavalamp @jbeda @quinton-hoole @david-mcmahon

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30546)

<!-- Reviewable:end -->
