### PR TITLE
Fix image verification when hostname is present in image

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -167,11 +167,20 @@ func matchImageTagOrSHA(inspected dockertypes.ImageInspect, image string) bool {
 		return true
 	}
 	if isTagged {
+		hostname, _ := dockerref.SplitHostname(named)
 		// Check the RepoTags for an exact match
 		for _, tag := range inspected.RepoTags {
-			if tag == image {
-				// We found a specific tag that we were looking for
-				return true
+			// Deal with image with hostname specified
+			if len(hostname) > 0 {
+				if strings.HasSuffix(image, tag) {
+					return true
+				}
+
+			} else {
+				if tag == image {
+					// We found a specific tag that we were looking for
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -174,6 +174,16 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			Output:    false,
 		},
 		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"colemickens/hyperkube-amd64:217.9beff63"}},
+			Image:     "colemickens/hyperkube-amd64:217.9beff63",
+			Output:    true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"colemickens/hyperkube-amd64:217.9beff63"}},
+			Image:     "docker.io/colemickens/hyperkube-amd64:217.9beff63",
+			Output:    true,
+		},
+		{
 			Inspected: dockertypes.ImageInspect{
 				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
 			},


### PR DESCRIPTION
Deal better with the situation where a image name contains
a hostname as well.

Fixes #30580

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30582)

<!-- Reviewable:end -->
