### PR TITLE
fix path handling in hack/lib/init.sh

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -110,6 +110,7 @@ else
 endif
 
 	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
+	rm -rf "${TEMP_DIR}"
 
 push: build
 	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}

--- a/hack/dev-push-hyperkube.sh
+++ b/hack/dev-push-hyperkube.sh
@@ -27,7 +27,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
 source "${KUBE_ROOT}/build/common.sh"
 
 if [[ -z "${KUBE_DOCKER_REGISTRY:-}" ]]; then

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 # The root of the build/dist directory
-KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd -P)"
 
 KUBE_OUTPUT_SUBPATH="${KUBE_OUTPUT_SUBPATH:-_output/local}"
 KUBE_OUTPUT="${KUBE_ROOT}/${KUBE_OUTPUT_SUBPATH}"


### PR DESCRIPTION
Jenkinsfile pipeline jobs get cloned into "<project> (<branch>)". As a result, I can't use certain things in `hack/lib/init.sh`.

This is a small fix for that problem.

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30583)

<!-- Reviewable:end -->
