### PR TITLE
remove duplicated nodeinfo.pods assignment

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -133,10 +133,8 @@ func (n *NodeInfo) AllocatableResource() Resource {
 }
 
 func (n *NodeInfo) Clone() *NodeInfo {
-	pods := append([]*api.Pod(nil), n.pods...)
 	clone := &NodeInfo{
 		node:                n.node,
-		pods:                pods,
 		requestedResource:   &(*n.requestedResource),
 		nonzeroRequest:      &(*n.nonzeroRequest),
 		allocatableResource: &(*n.allocatableResource),


### PR DESCRIPTION
There are duplicated assignments for nodeinfo.pods, one place is [here](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/schedulercache/node_info.go#L139) and the other one is [here](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/schedulercache/node_info.go#L147). 

I think we can remove one.

The related issue is #30610

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30585)

<!-- Reviewable:end -->
