### PR TITLE
cluster/gke: reword package docs

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -16,8 +16,7 @@
 
 # A library of helper functions and constant for the local config.
 
-# Use the config file specified in $KUBE_CONFIG_FILE, or default to
-# config-default.sh.
+# Uses the config file specified in $KUBE_CONFIG_FILE, or defaults to config-default.sh
 
 KUBE_PROMPT_FOR_UPDATE=y
 KUBE_SKIP_UPDATE=${KUBE_SKIP_UPDATE-"n"}


### PR DESCRIPTION
Rewords the package docs and removes the confusing dot trailing the file name

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30595)

<!-- Reviewable:end -->
