### PR TITLE
Read the federation controller manager kubeconfig from a filesystem path

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -52,10 +52,6 @@ import (
 )
 
 const (
-	// TODO(madhusudancs): Consider making this configurable via a flag.
-	// "federation-apiserver-kubeconfig" is a reserved secret name which
-	// stores the kubeconfig for federation-apiserver.
-	KubeconfigSecretName = "federation-apiserver-kubeconfig"
 	// "federation-apiserver-secret" was the old name we used to store
 	// Federation API server kubeconfig secret. Unfortunately, this name
 	// is very close to "federation-apiserver-secrets" and causes a lot
@@ -95,8 +91,7 @@ func Run(s *options.CMServer) error {
 		glog.Errorf("unable to register configz: %s", err)
 	}
 	// Create the config to talk to federation-apiserver.
-	kubeconfigGetter := util.KubeconfigGetterForSecret(KubeconfigSecretName)
-	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
+	restClientCfg, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil || restClientCfg == nil {
 		// Retry with the deprecated name in 1.4.
 		// TODO(madhusudancs): Remove this in 1.5.

--- a/federation/manifests/federation-controller-manager-deployment.yaml
+++ b/federation/manifests/federation-controller-manager-deployment.yaml
@@ -17,17 +17,24 @@ spec:
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs
+      - name: kubeconfig
+        secret:
+          secretName: federation-apiserver-kubeconfig
       containers:
       - name: controller-manager
         volumeMounts:
         - name: ssl-certs
           readOnly: true
           mountPath: /etc/ssl/certs
+        - name: kubeconfig
+          readOnly: true
+          mountPath: "/etc/federation/controller-manager",
         image: {{.FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO}}:{{.FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG}}
         command:
         - /usr/local/bin/hyperkube
         - federation-controller-manager
         - --master=https://{{.FEDERATION_APISERVER_DEPLOYMENT_NAME}}:443
+        - --kubeconfig=/etc/federation/controller-manager/kubeconfig
         - --dns-provider={{.FEDERATION_DNS_PROVIDER}}
         - --dns-provider-config={{.FEDERATION_DNS_PROVIDER_CONFIG}}
         - --federation-name={{.FEDERATION_NAME}}


### PR DESCRIPTION
This decoupling from the Kubernetes API allows admins to run federation control plane components wherever they like, even outside Kubernetes. This also makes the federation controller manager read its config from one single place in a uniform and/or consistent way, instead of spreading the config around command line flags and secrets.

``` release-note
Federation controller manager can consume the federation API server kubeconfig from a file configured via --kubeconfig flag.

If you are upgrading your Cluster Federation components from v1.4.x, please update your `federation-apiserver` and `federation-controller-manager` manifests to the new version:
```

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30601)

<!-- Reviewable:end -->
