### PR TITLE
add kubelet-enable-logserver control for kubelet

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -184,4 +184,5 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.EvictionMinimumReclaim, "eviction-minimum-reclaim", s.EvictionMinimumReclaim, "A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.")
 	fs.Int32Var(&s.PodsPerCore, "pods-per-core", s.PodsPerCore, "Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.")
 	fs.BoolVar(&s.ProtectKernelDefaults, "protect-kernel-defaults", s.ProtectKernelDefaults, "Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.")
+	fs.BoolVar(&s.EnableLogServer, "kubelet-enable-logserver", s.EnableLogServer, "Enable the Kubelet's logserver")
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -286,6 +286,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		EvictionConfig:        evictionConfig,
 		PodsPerCore:           int(s.PodsPerCore),
 		ProtectKernelDefaults: s.ProtectKernelDefaults,
+		EnableLogServer:       s.EnableLogServer,
 	}, nil
 }
 
@@ -639,6 +640,7 @@ func SimpleKubelet(client *clientset.Clientset,
 		EvictionConfig:               evictionConfig,
 		PodsPerCore:                  podsPerCore,
 		ProtectKernelDefaults:        false,
+		EnableLogServer:              true,
 	}
 	return &kcfg
 }
@@ -757,7 +759,15 @@ func RunKubelet(kcfg *KubeletConfig) error {
 
 func startKubelet(k KubeletBootstrap, podCfg *config.PodConfig, kc *KubeletConfig) {
 	// start the kubelet
-	go wait.Until(func() { k.Run(podCfg.Updates()) }, 0, wait.NeverStop)
+	go wait.Until(func() {
+		if kc.EnableLogServer {
+			kl, ok := k.(*Kubelet)
+			if ok && kl.logServer == nil {
+				kl.logServer = http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/")))
+			}
+		}
+		k.Run(podCfg.Updates())
+	}, 0, wait.NeverStop)
 
 	// start the kubelet server
 	if kc.EnableServer {
@@ -893,6 +903,7 @@ type KubeletConfig struct {
 	Options                    []kubelet.Option
 
 	ProtectKernelDefaults bool
+	EnableLogServer       bool
 }
 
 func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -274,6 +274,7 @@ kubelet-read-only-port
 kubelet-root-dir
 kubelet-sync-frequency
 kubelet-timeout
+kubelet-enable-logserver
 kubernetes-service-node-port
 label-columns
 last-release-pr

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -399,6 +399,10 @@ type KubeletConfiguration struct {
 	KubeReserved utilconfig.ConfigurationMap `json:"kubeReserved"`
 	// Default behaviour for kernel tuning
 	ProtectKernelDefaults bool `json:"protectKernelDefaults"`
+	// enableLogServer enables the logServer to startup,
+	// defaults to /logs/ from /var/log, and
+	// disables kubelet from exposing logs by http style
+	EnableLogServer bool `json:"enableLogServer"`
 }
 
 type KubeSchedulerConfiguration struct {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -944,9 +944,7 @@ func (kl *Kubelet) initializeRuntimeDependentModules() {
 
 // Run starts the kubelet reacting to config updates
 func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
-	if kl.logServer == nil {
-		kl.logServer = http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log/")))
-	}
+
 	if kl.kubeClient == nil {
 		glog.Warning("No api server defined - no node status update will be sent.")
 	}


### PR DESCRIPTION
As for kubelet, it startups a logserver which can be accessed bypass http to donwload any log file in /var/log,  in some case, maybe it should be limited, because the os logs or other sensitive logs still could download. then i add a param to control the log server startup

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30608)

<!-- Reviewable:end -->
