### PR TITLE
update comment info for scheduler binding fails

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -111,12 +111,8 @@ func (s *Scheduler) scheduleOne() {
 
 	// Optimistically assume that the binding will succeed and send it to apiserver
 	// in the background.
-	// The only risk in this approach is that if the binding fails because of some
-	// reason, scheduler will be assuming that it succeeded while scheduling next
-	// pods, until the assumption in the internal cache expire (expiration is
-	// defined as "didn't read the binding via watch within a given timeout",
-	// timeout is currently set to 30s). However, after this timeout, the situation
-	// will self-repair.
+	// If the binding fails, scheduler will release resources allocated to assumed pod
+	// immediately.
 	assumed := *pod
 	assumed.Spec.NodeName = dest
 	if err := s.config.SchedulerCache.AssumePod(&assumed); err != nil {


### PR DESCRIPTION
Since the process logic for scheduler binding failed has changed, I think we should update the comment information to avoid make people confused :)

The related issue is #30611.

@wojtek-t What do you think about it ?

Thanks!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30609)

<!-- Reviewable:end -->
