### PR TITLE
kubectl run add pull-policy flag to control image pull policy

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -105,6 +105,7 @@ func addRunFlags(cmd *cobra.Command) {
 	cmd.Flags().String("generator", "", "The name of the API generator to use.  Default is 'deployment/v1beta1' if --restart=Always, 'job/v1' for OnFailure and 'run-pod/v1' for Never.  This will happen only for cluster version at least 1.3, for 1.2 we will fallback to 'deployment/v1beta1' for --restart=Always, 'job/v1' for others, for olders we will fallback to 'run/v1' for --restart=Always, 'run-pod/v1' for others.")
 	cmd.Flags().String("image", "", "The image for the container to run.")
 	cmd.MarkFlagRequired("image")
+	cmd.Flags().String("image-pull-policy", "", "The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server")
 	cmd.Flags().IntP("replicas", "r", 1, "Number of replicas to create for this container. Default is 1.")
 	cmd.Flags().Bool("rm", false, "If true, delete resources created in this command for attached containers.")
 	cmd.Flags().String("overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")
@@ -165,6 +166,10 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 	}
 	if restartPolicy != api.RestartPolicyAlways && replicas != 1 {
 		return cmdutil.UsageError(cmd, fmt.Sprintf("--restart=%s requires that --replicas=1, found %d", restartPolicy, replicas))
+	}
+
+	if err := verifyImagePullPolicy(cmd); err != nil {
+		return err
 	}
 
 	generatorName := cmdutil.GetFlagString(cmd, "generator")
@@ -414,6 +419,18 @@ func getRestartPolicy(cmd *cobra.Command, interactive bool) (api.RestartPolicy, 
 		return api.RestartPolicyNever, nil
 	default:
 		return "", cmdutil.UsageError(cmd, fmt.Sprintf("invalid restart policy: %s", restart))
+	}
+}
+
+func verifyImagePullPolicy(cmd *cobra.Command) error {
+	pullPolicy := cmdutil.GetFlagString(cmd, "image-pull-policy")
+	switch api.PullPolicy(pullPolicy) {
+	case api.PullAlways, api.PullIfNotPresent, api.PullNever:
+		return nil
+	case "":
+		return nil
+	default:
+		return cmdutil.UsageError(cmd, fmt.Sprintf("invalid image pull policy: %s", pullPolicy))
 	}
 }
 

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -35,10 +35,11 @@ func TestGenerate(t *testing.T) {
 	}{
 		{
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "-1",
+				"name":              "foo",
+				"image":             "someimage",
+				"image-pull-policy": "Always",
+				"replicas":          "1",
+				"port":              "-1",
 			},
 			expected: &api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{
@@ -55,8 +56,9 @@ func TestGenerate(t *testing.T) {
 						Spec: api.PodSpec{
 							Containers: []api.Container{
 								{
-									Name:  "foo",
-									Image: "someimage",
+									Name:            "foo",
+									Image:           "someimage",
+									ImagePullPolicy: api.PullAlways,
 								},
 							},
 						},
@@ -110,11 +112,12 @@ func TestGenerate(t *testing.T) {
 
 		{
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "-1",
-				"args":     []string{"bar", "baz", "blah"},
+				"name":              "foo",
+				"image":             "someimage",
+				"image-pull-policy": "Never",
+				"replicas":          "1",
+				"port":              "-1",
+				"args":              []string{"bar", "baz", "blah"},
 			},
 			expected: &api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{
@@ -131,9 +134,10 @@ func TestGenerate(t *testing.T) {
 						Spec: api.PodSpec{
 							Containers: []api.Container{
 								{
-									Name:  "foo",
-									Image: "someimage",
-									Args:  []string{"bar", "baz", "blah"},
+									Name:            "foo",
+									Image:           "someimage",
+									ImagePullPolicy: api.PullNever,
+									Args:            []string{"bar", "baz", "blah"},
 								},
 							},
 						},
@@ -213,11 +217,12 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "80",
-				"hostport": "80",
+				"name":              "foo",
+				"image":             "someimage",
+				"image-pull-policy": "IfNotPresent",
+				"replicas":          "1",
+				"port":              "80",
+				"hostport":          "80",
 			},
 			expected: &api.ReplicationController{
 				ObjectMeta: api.ObjectMeta{
@@ -234,8 +239,9 @@ func TestGenerate(t *testing.T) {
 						Spec: api.PodSpec{
 							Containers: []api.Container{
 								{
-									Name:  "foo",
-									Image: "someimage",
+									Name:            "foo",
+									Image:           "someimage",
+									ImagePullPolicy: api.PullIfNotPresent,
 									Ports: []api.ContainerPort{
 										{
 											ContainerPort: 80,
@@ -435,9 +441,10 @@ func TestGeneratePod(t *testing.T) {
 		},
 		{
 			params: map[string]interface{}{
-				"name":  "foo",
-				"image": "someimage",
-				"env":   []string{"a=b", "c=d"},
+				"name":              "foo",
+				"image":             "someimage",
+				"image-pull-policy": "Always",
+				"env":               []string{"a=b", "c=d"},
 			},
 			expected: &api.Pod{
 				ObjectMeta: api.ObjectMeta{
@@ -448,7 +455,7 @@ func TestGeneratePod(t *testing.T) {
 						{
 							Name:            "foo",
 							Image:           "someimage",
-							ImagePullPolicy: api.PullIfNotPresent,
+							ImagePullPolicy: api.PullAlways,
 							Env: []api.EnvVar{
 								{
 									Name:  "a",
@@ -639,18 +646,19 @@ func TestGenerateDeployment(t *testing.T) {
 	}{
 		{
 			params: map[string]interface{}{
-				"labels":   "foo=bar,baz=blah",
-				"name":     "foo",
-				"replicas": "3",
-				"image":    "someimage",
-				"port":     "80",
-				"hostport": "80",
-				"stdin":    "true",
-				"command":  "true",
-				"args":     []string{"bar", "baz", "blah"},
-				"env":      []string{"a=b", "c=d"},
-				"requests": "cpu=100m,memory=100Mi",
-				"limits":   "cpu=400m,memory=200Mi",
+				"labels":            "foo=bar,baz=blah",
+				"name":              "foo",
+				"replicas":          "3",
+				"image":             "someimage",
+				"image-pull-policy": "Always",
+				"port":              "80",
+				"hostport":          "80",
+				"stdin":             "true",
+				"command":           "true",
+				"args":              []string{"bar", "baz", "blah"},
+				"env":               []string{"a=b", "c=d"},
+				"requests":          "cpu=100m,memory=100Mi",
+				"limits":            "cpu=400m,memory=200Mi",
 			},
 			expected: &extensions.Deployment{
 				ObjectMeta: api.ObjectMeta{
@@ -667,9 +675,10 @@ func TestGenerateDeployment(t *testing.T) {
 						Spec: api.PodSpec{
 							Containers: []api.Container{
 								{
-									Name:  "foo",
-									Image: "someimage",
-									Stdin: true,
+									Name:            "foo",
+									Image:           "someimage",
+									ImagePullPolicy: api.PullAlways,
+									Stdin:           true,
 									Ports: []api.ContainerPort{
 										{
 											ContainerPort: 80,


### PR DESCRIPTION
``` release-note
Add support for --image-pull-policy to 'kubectl run'
```

Fix #30493 
@pwittrock @thockin ptal

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30614)

<!-- Reviewable:end -->
