### PR TITLE
kubelet/api: split RuntimeService interface

### DIFF
--- a/pkg/kubelet/api/services.go
+++ b/pkg/kubelet/api/services.go
@@ -47,12 +47,9 @@ type ContainerManager interface {
 	Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error
 }
 
-// RuntimeService interface should be implemented by a container runtime.
-// The methods should be thread-safe.
-type RuntimeService interface {
-	RuntimeVersioner
-	ContainerManager
-
+// PodSandboxManager contains methods for operating on PodSandboxes. The methods
+// are thread-safe.
+type PodSandboxManager interface {
 	// CreatePodSandbox creates a pod-level sandbox.
 	// The definition of PodSandbox is at https://github.com/kubernetes/kubernetes/pull/25899
 	CreatePodSandbox(config *runtimeApi.PodSandboxConfig) (string, error)
@@ -66,6 +63,14 @@ type RuntimeService interface {
 	PodSandboxStatus(podSandboxID string) (*runtimeApi.PodSandboxStatus, error)
 	// ListPodSandbox returns a list of Sandbox.
 	ListPodSandbox(filter *runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error)
+}
+
+// RuntimeService interface should be implemented by a container runtime.
+// The methods should be thread-safe.
+type RuntimeService interface {
+	RuntimeVersioner
+	ContainerManager
+	PodSandboxManager
 }
 
 // ImageManagerService interface should be implemented by a container image

--- a/pkg/kubelet/api/services.go
+++ b/pkg/kubelet/api/services.go
@@ -28,24 +28,9 @@ type RuntimeVersioner interface {
 	Version(apiVersion string) (*runtimeApi.VersionResponse, error)
 }
 
-// RuntimeService interface should be implemented by a container runtime.
-// The methods should be thread-safe.
-type RuntimeService interface {
-	RuntimeVersioner
-
-	// CreatePodSandbox creates a pod-level sandbox.
-	// The definition of PodSandbox is at https://github.com/kubernetes/kubernetes/pull/25899
-	CreatePodSandbox(config *runtimeApi.PodSandboxConfig) (string, error)
-	// StopPodSandbox stops the sandbox. If there are any running containers in the
-	// sandbox, they should be force terminated.
-	StopPodSandbox(podSandboxID string) error
-	// RemovePodSandbox removes the sandbox. If there are running containers in the
-	// sandbox, they should be forcibly removed.
-	RemovePodSandbox(podSandboxID string) error
-	// PodSandboxStatus returns the Status of the PodSandbox.
-	PodSandboxStatus(podSandboxID string) (*runtimeApi.PodSandboxStatus, error)
-	// ListPodSandbox returns a list of Sandbox.
-	ListPodSandbox(filter *runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error)
+// ContainerManager contains methods to manipulate containers managed by a
+// container runtime. The methods are thread-safe.
+type ContainerManager interface {
 	// CreateContainer creates a new container in specified PodSandbox.
 	CreateContainer(podSandboxID string, config *runtimeApi.ContainerConfig, sandboxConfig *runtimeApi.PodSandboxConfig) (string, error)
 	// StartContainer starts the container.
@@ -60,6 +45,27 @@ type RuntimeService interface {
 	ContainerStatus(containerID string) (*runtimeApi.ContainerStatus, error)
 	// Exec executes a command in the container.
 	Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error
+}
+
+// RuntimeService interface should be implemented by a container runtime.
+// The methods should be thread-safe.
+type RuntimeService interface {
+	RuntimeVersioner
+	ContainerManager
+
+	// CreatePodSandbox creates a pod-level sandbox.
+	// The definition of PodSandbox is at https://github.com/kubernetes/kubernetes/pull/25899
+	CreatePodSandbox(config *runtimeApi.PodSandboxConfig) (string, error)
+	// StopPodSandbox stops the sandbox. If there are any running containers in the
+	// sandbox, they should be force terminated.
+	StopPodSandbox(podSandboxID string) error
+	// RemovePodSandbox removes the sandbox. If there are running containers in the
+	// sandbox, they should be forcibly removed.
+	RemovePodSandbox(podSandboxID string) error
+	// PodSandboxStatus returns the Status of the PodSandbox.
+	PodSandboxStatus(podSandboxID string) (*runtimeApi.PodSandboxStatus, error)
+	// ListPodSandbox returns a list of Sandbox.
+	ListPodSandbox(filter *runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error)
 }
 
 // ImageManagerService interface should be implemented by a container image

--- a/pkg/kubelet/api/services.go
+++ b/pkg/kubelet/api/services.go
@@ -22,11 +22,17 @@ import (
 	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
+// RuntimeVersioner contains methods for runtime name, version and API version.
+type RuntimeVersioner interface {
+	// Version returns the runtime name, runtime version and runtime API version
+	Version(apiVersion string) (*runtimeApi.VersionResponse, error)
+}
+
 // RuntimeService interface should be implemented by a container runtime.
 // The methods should be thread-safe.
 type RuntimeService interface {
-	// Version returns the runtime name, runtime version and runtime API version
-	Version(apiVersion string) (*runtimeApi.VersionResponse, error)
+	RuntimeVersioner
+
 	// CreatePodSandbox creates a pod-level sandbox.
 	// The definition of PodSandbox is at https://github.com/kubernetes/kubernetes/pull/25899
 	CreatePodSandbox(config *runtimeApi.PodSandboxConfig) (string, error)


### PR DESCRIPTION
Splits `RuntimeService` interface into smaller interfaces
to make testing easier and delineate the responsibilities.

Its a non-breaking change to the previous users of `api.RuntimeService`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30619)

<!-- Reviewable:end -->
