### PR TITLE
use BASH_SOURCE to determine KUBE_ROOT in update-bindata.sh

### DIFF
--- a/hack/update-bindata.sh
+++ b/hack/update-bindata.sh
@@ -19,8 +19,8 @@ set -o pipefail
 set -o nounset
 
 if [[ -z "${KUBE_ROOT:-}" ]]; then
-	# Relative to test/e2e/generated/
-	KUBE_ROOT="../../../"
+    source $(dirname "${BASH_SOURCE[0]}")"/lib/init.sh"
+    KUBE_ROOT=$(kube::readlinkdashf $KUBE_ROOT)
 fi
 
 source "${KUBE_ROOT}/cluster/lib/logging.sh"


### PR DESCRIPTION
Fixes #30621

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30622)

<!-- Reviewable:end -->
