### PR TITLE
fix wrong path for all registries

### DIFF
--- a/docs/proposals/apiserver-watch.md
+++ b/docs/proposals/apiserver-watch.md
@@ -99,7 +99,7 @@ to implement the proposal.
 1. Since we want the watch in apiserver to be optional for different resource
 types, this needs to be self-contained and hidden behind a well defined API.
 This should be a layer very close to etcd - in particular all registries:
-"pkg/registry/generic/etcd" should be built on top of it.
+"pkg/registry/generic/registry" should be built on top of it.
 We will solve it by turning tools.EtcdHelper by extracting its interface
 and treating this interface as this API - the whole watch mechanisms in
 apiserver will be hidden behind that interface.


### PR DESCRIPTION
fix wrong path for all registries, registry path should be "pkg/registry/generic/registry", under this path, it is the package registry.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30623)

<!-- Reviewable:end -->
