### PR TITLE
Node controller deletePod return true if there are pods pending deletion

### DIFF
--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -82,7 +82,7 @@ func cleanupOrphanedPods(pods []*api.Pod, nodeStore cache.Store, forcefulDeleteP
 }
 
 // deletePods will delete all pods from master running on given node, and return true
-// if any pods were deleted.
+// if any pods were deleted, or were found pending deletion.
 func deletePods(kubeClient clientset.Interface, recorder record.EventRecorder, nodeName, nodeUID string, daemonStore cache.StoreToDaemonSetLister) (bool, error) {
 	remaining := false
 	selector := fields.OneTermEqualSelector(api.PodHostField, nodeName)
@@ -101,8 +101,9 @@ func deletePods(kubeClient clientset.Interface, recorder record.EventRecorder, n
 		if pod.Spec.NodeName != nodeName {
 			continue
 		}
-		// if the pod has already been deleted, ignore it
+		// if the pod has already been marked for deletion, we still return true that there are remaining pods.
 		if pod.DeletionGracePeriodSeconds != nil {
+			remaining = true
 			continue
 		}
 		// if the pod is managed by a daemonset, ignore it


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/30536

If a node had a single pod in terminating state, and that node no longer reported healthy, the pod was never deleted by the node controller because it believed there were no pods remaining.

@smarterclayton @ncdc

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30624)

<!-- Reviewable:end -->
