### PR TITLE
Add a short `-n` for `kubectl --namespace`

### DIFF
--- a/docs/devel/kubectl-conventions.md
+++ b/docs/devel/kubectl-conventions.md
@@ -142,6 +142,7 @@ list when adding new short flags
 
   * `-f`: Resource file
     * also used for `--follow` in `logs`, but should be deprecated in favor of `-F`
+  * `-n`: Namespace scope
   * `-l`: Label selector
     * also used for `--labels` in `expose`, but should be deprecated
   * `-L`: Label columns

--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1349,6 +1349,8 @@ __EOF__
   kubectl create "${kube_flags[@]}" --namespace=other -f docs/admin/limitrange/valid-pod.yaml
   # Post-condition: valid-pod POD is created
   kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
+  # Post-condition: verify shorthand `-n other` has the same results as `--namespace=other`
+  kube::test::get_object_assert 'pods -n other' "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
 
   ### Delete POD valid-pod in specific namespace
   # Pre-condition: valid-pod POD exists

--- a/pkg/client/unversioned/clientcmd/overrides.go
+++ b/pkg/client/unversioned/clientcmd/overrides.go
@@ -158,7 +158,7 @@ func RecommendedContextOverrideFlags(prefix string) ContextOverrideFlags {
 	return ContextOverrideFlags{
 		ClusterName:  FlagInfo{prefix + FlagClusterName, "", "", "The name of the kubeconfig cluster to use"},
 		AuthInfoName: FlagInfo{prefix + FlagAuthInfoName, "", "", "The name of the kubeconfig user to use"},
-		Namespace:    FlagInfo{prefix + FlagNamespace, "", "", "If present, the namespace scope for this CLI request"},
+		Namespace:    FlagInfo{prefix + FlagNamespace, "n", "", "If present, the namespace scope for this CLI request"},
 	}
 }
 


### PR DESCRIPTION
fixes #24078

 `--namespace` is a very common flag for nearly every `kubectl` command we have. We should claim `-n` for it.  

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30630)

<!-- Reviewable:end -->
