### PR TITLE
Move UTs that block on apiserver to integration tests. 

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -200,3 +200,6 @@ test/soak/serve_hostnames
 third_party/forked/golang/expansion
 pkg/util/maps
 pkg/volume/quobyte
+test/integration/discoverysummarizer
+test/integration/examples
+test/integration/federation

--- a/test/integration/discoverysummarizer/discoverysummarizer_test.go
+++ b/test/integration/discoverysummarizer/discoverysummarizer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kubernetes/cmd/kubernetes-discovery/discoverysummarizer"
 	"k8s.io/kubernetes/examples/apiserver"
 )
 
@@ -46,10 +47,10 @@ func testResponse(t *testing.T, serverURL, path string, expectedStatusCode int) 
 }
 
 func runDiscoverySummarizer(t *testing.T) string {
-	configFilePath := "../config.json"
+	configFilePath := "../../../cmd/kubernetes-discovery/config.json"
 	port := "9090"
 	serverURL := "http://localhost:" + port
-	s, err := NewDiscoverySummarizer(configFilePath)
+	s, err := discoverysummarizer.NewDiscoverySummarizer(configFilePath)
 	if err != nil {
 		t.Errorf("unexpected error: %v\n", err)
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -27,10 +27,11 @@ import (
 	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup.k8s.io/v1"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/examples/apiserver"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-var serverIP = fmt.Sprintf("http://localhost:%d", InsecurePort)
+var serverIP = fmt.Sprintf("http://localhost:%d", apiserver.InsecurePort)
 
 var groupVersion = v1.SchemeGroupVersion
 
@@ -41,7 +42,7 @@ var groupVersionForDiscovery = unversioned.GroupVersionForDiscovery{
 
 func TestRun(t *testing.T) {
 	go func() {
-		if err := Run(NewServerRunOptions()); err != nil {
+		if err := apiserver.Run(apiserver.NewServerRunOptions()); err != nil {
 			t.Fatalf("Error in bringing up the server: %v", err)
 		}
 	}()

--- a/test/integration/federation/server_test.go
+++ b/test/integration/federation/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fed_v1b1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -90,7 +91,7 @@ func TestRun(t *testing.T) {
 	s.ServiceClusterIPRange = *ipNet
 	s.StorageConfig.ServerList = []string{"http://localhost:2379"}
 	go func() {
-		if err := Run(s); err != nil {
+		if err := app.Run(s); err != nil {
 			t.Fatalf("Error in bringing up the server: %v", err)
 		}
 	}()


### PR DESCRIPTION
In validating etcd.v3client we had uncovered that a change in the behavior of the client https://github.com/coreos/etcd/issues/6162 , caused a number of unit tests to fail.  These test failures were due to the fact that the unit tests were trying to standup a apiserver even though there was no etcd backend stood up.  

This PR simply shuffles those tests to integration tests, which is where they should be. 

/cc @kubernetes/sig-scalability @wojtek-t @hongchaodeng @xiang90

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30634)

<!-- Reviewable:end -->
