### PR TITLE
Remove implicit Prometheus metrics from client

### DIFF
--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -23,6 +23,8 @@ package main
 
 import (
 	"os"
+
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 )
 
 func main() {

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"

--- a/cmd/kube-dns/dns.go
+++ b/cmd/kube-dns/dns.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/cmd/kube-dns/app"
 	"k8s.io/kubernetes/cmd/kube-dns/app/options"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"

--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -19,6 +19,7 @@ package app
 import (
 	"os"
 
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	clientset "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"

--- a/contrib/mesos/cmd/km/km.go
+++ b/contrib/mesos/cmd/km/km.go
@@ -19,6 +19,8 @@ package main
 
 import (
 	"os"
+
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 )
 
 func main() {

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -74,6 +74,8 @@ pkg/apis/imagepolicy/install
 pkg/api/v1
 pkg/auth/authenticator
 pkg/auth/authorizer/union
+pkg/client/metrics
+pkg/client/metrics/prometheus
 pkg/client/testing/core
 pkg/client/unversioned
 pkg/client/unversioned/adapters/internalclientset

--- a/pkg/client/metrics/prometheus/prometheus.go
+++ b/pkg/client/metrics/prometheus/prometheus.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package prometheus creates and registers prometheus metrics with
+// rest clients. To use this package, you just have to import it.
+package prometheus
+
+import (
+	"net/url"
+	"time"
+
+	"k8s.io/kubernetes/pkg/client/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const restClientSubsystem = "rest_client"
+
+var (
+	// requestLatency is a Prometheus Summary metric type partitioned by
+	// "verb" and "url" labels. It is used for the rest client latency metrics.
+	requestLatency = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Subsystem: restClientSubsystem,
+			Name:      "request_latency_microseconds",
+			Help:      "Request latency in microseconds. Broken down by verb and URL",
+			MaxAge:    time.Hour,
+		},
+		[]string{"verb", "url"},
+	)
+
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: restClientSubsystem,
+			Name:      "request_status_codes",
+			Help:      "Number of http requests, partitioned by metadata",
+		},
+		[]string{"code", "method", "host"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(requestLatency)
+	prometheus.MustRegister(requestResult)
+	metrics.Register(&latencyAdapter{requestLatency}, &resultAdapter{requestResult})
+}
+
+type latencyAdapter struct {
+	m *prometheus.SummaryVec
+}
+
+func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
+	microseconds := float64(latency) / float64(time.Microsecond)
+	l.m.WithLabelValues(verb, u.String()).Observe(microseconds)
+}
+
+type resultAdapter struct {
+	m *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(code, method, host string) {
+	r.m.WithLabelValues(code, method, host).Inc()
+}

--- a/pkg/client/restclient/request_test.go
+++ b/pkg/client/restclient/request_test.go
@@ -331,7 +331,8 @@ func TestURLTemplate(t *testing.T) {
 	if full.String() != "http://localhost/pre1/namespaces/ns/r1/nm?p0=v0" {
 		t.Errorf("unexpected initial URL: %s", full)
 	}
-	actual := r.finalURLTemplate()
+	actualURL := r.finalURLTemplate()
+	actual := actualURL.String()
 	expected := "http://localhost/pre1/namespaces/%7Bnamespace%7D/r1/%7Bname%7D?p0=%7Bvalue%7D"
 	if actual != expected {
 		t.Errorf("unexpected URL template: %s %s", actual, expected)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR starts to cut away at dependencies that the client has.

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
The implicit registration of Prometheus metrics for request count and latency have been removed, and a plug-able interface was added. If you were using our client libraries in your own binaries and want these metrics, add the following to your imports in the main package: "k8s.io/pkg/client/metrics/prometheus". 
```

cc: @kubernetes/sig-api-machinery @kubernetes/sig-instrumentation @fgrzadkowski  @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30638)

<!-- Reviewable:end -->
