### PR TITLE
Do make release in hack/jenkins/build.sh instead of e2e.go.

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -62,7 +62,11 @@ git clean -fdx
 # docker images -q | xargs -r docker rmi
 
 # Build
-go run ./hack/e2e.go -v --build
+if [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
+    make quick-release
+else
+    make release
+fi
 
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then


### PR DESCRIPTION
#30384 and https://github.com/kubernetes/test-infra/issues/393

This will start building on other architectures again, which will break the build. Lets fix the PPC issue first.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30640)

<!-- Reviewable:end -->
