### PR TITLE
Add back the original liveness check timeout.

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -223,6 +223,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 								},
 							},
 							InitialDelaySeconds: 15,
+							TimeoutSeconds:      5,
 							FailureThreshold:    1,
 						},
 					},


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/30342.
Fixes https://github.com/kubernetes/kubernetes/issues/30335.

When I moved the test into common directory, I removed the original 10s timeout - https://github.com/kubernetes/kubernetes/pull/29814/commits/0362789283d06c31b42e94ac7e81c1ba981a0b87#diff-0f856ff011970dca55a2cd916b9ddcf0L1128.

It turns out that the default 1s timeout is not enough. In all the flake, the probe request is cancelled on the kubelet side. This PR added back a 5s timeout to eliminate the flake.

Mark P0 to match the corresponding issue.

@freehan 
/cc @matchstick :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30641)

<!-- Reviewable:end -->
