### PR TITLE
Fixing the error in registering /v1 api

### DIFF
--- a/federation/apis/core/install/install.go
+++ b/federation/apis/core/install/install.go
@@ -91,7 +91,9 @@ var userResources = []string{"svc"}
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString()
+	rootScoped := sets.NewString(
+		"Namespace",
+	)
 
 	// these kinds should be excluded from the list of resources
 	ignoredKinds := sets.NewString(

--- a/federation/cmd/federation-apiserver/app/core.go
+++ b/federation/cmd/federation-apiserver/app/core.go
@@ -18,6 +18,14 @@ package app
 
 import (
 	"github.com/golang/glog"
+
+	// HACK to ensure that rest mapper from pkg/api is registered for groupName="".
+	// This is required because both pkg/api/install and federation/apis/core/install
+	// are installing their respective groupMeta at the same groupName.
+	// federation/apis/core/install has only a subset of resources and hence if it gets registered first, then installation of v1 API fails in pkg/master.
+	// TODO(nikhiljindal): Fix this by ensuring that pkg/api/install and federation/apis/core/install do not conflict with each other.
+	_ "k8s.io/kubernetes/pkg/api/install"
+
 	"k8s.io/kubernetes/federation/apis/core"
 	_ "k8s.io/kubernetes/federation/apis/core/install"
 	"k8s.io/kubernetes/federation/apis/core/v1"

--- a/federation/cmd/federation-apiserver/app/server_test.go
+++ b/federation/cmd/federation-apiserver/app/server_test.go
@@ -296,10 +296,10 @@ func testCoreResourceList(t *testing.T) {
 	// Verify namespaces.
 	found = findResource(apiResourceList.APIResources, "namespaces")
 	assert.NotNil(t, found)
-	assert.True(t, found.Namespaced)
+	assert.False(t, found.Namespaced)
 	found = findResource(apiResourceList.APIResources, "namespaces/status")
 	assert.NotNil(t, found)
-	assert.True(t, found.Namespaced)
+	assert.False(t, found.Namespaced)
 
 	// Verify events.
 	found = findResource(apiResourceList.APIResources, "events")


### PR DESCRIPTION
Temporary fix for https://github.com/kubernetes/kubernetes/issues/30635.

Am working on a proper fix, but its much bigger.
Would be good to unblock devs in the meantime.

cc @lavalamp @kubernetes/sig-api-machinery

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30655)

<!-- Reviewable:end -->
