### PR TITLE
Remove 'dir-named-kubernetes' check.

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -64,19 +64,6 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	flag.Parse()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("Could not get pwd: %v", err)
-	}
-	acwd, err := filepath.Abs(cwd)
-	if err != nil {
-		log.Fatalf("Failed to convert to an absolute path: %v", err)
-	}
-	if !strings.Contains(filepath.Base(acwd), "kubernetes") {
-		// TODO(fejta): cd up into  the kubernetes directory
-		log.Fatalf("Must run from kubernetes directory: %v", cwd)
-	}
-
 	if *isup {
 		status := 1
 		if IsUp() {


### PR DESCRIPTION
This check it too restrictive.  Rather than looking for an alternative, #30640 might just make this obsolete anyway.

cc @fejta

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30662)

<!-- Reviewable:end -->
