### PR TITLE
pkg/storage: remove Codec() from interface

### DIFF
--- a/pkg/registry/generic/registry/storage_factory.go
+++ b/pkg/registry/generic/registry/storage_factory.go
@@ -45,6 +45,7 @@ func StorageWithCacher(
 		ResourcePrefix:       resourcePrefix,
 		NewListFunc:          newListFunc,
 		TriggerPublisherFunc: triggerFunc,
+		Codec:                storageConfig.Codec,
 	}
 	if scopeStrategy.NamespaceScoped() {
 		cacherConfig.KeyFunc = func(obj runtime.Object) (string, error) {

--- a/pkg/registry/generic/registry/store_test.go
+++ b/pkg/registry/generic/registry/store_test.go
@@ -1015,7 +1015,8 @@ func newTestGenericStoreRegistry(t *testing.T, hasCacheEnabled bool) (*etcdtesti
 	podPrefix := "/pods"
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	strategy := &testRESTStrategy{api.Scheme, api.SimpleNameGenerator, true, false, true}
-	s := etcdstorage.NewEtcdStorage(server.Client, testapi.Default.StorageCodec(), etcdtest.PathPrefix(), false, etcdtest.DeserializationCacheSize)
+	codec := testapi.Default.StorageCodec()
+	s := etcdstorage.NewEtcdStorage(server.Client, codec, etcdtest.PathPrefix(), false, etcdtest.DeserializationCacheSize)
 	if hasCacheEnabled {
 		config := storage.CacherConfig{
 			CacheCapacity:  10,
@@ -1025,6 +1026,7 @@ func newTestGenericStoreRegistry(t *testing.T, hasCacheEnabled bool) (*etcdtesti
 			ResourcePrefix: podPrefix,
 			KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NoNamespaceKeyFunc(podPrefix, obj) },
 			NewListFunc:    func() runtime.Object { return &api.PodList{} },
+			Codec:          codec,
 		}
 		s = storage.NewCacherFromConfig(config)
 	}

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -65,6 +65,8 @@ type CacherConfig struct {
 	// NewList is a function that creates new empty object storing a list of
 	// objects of type Type.
 	NewListFunc func() runtime.Object
+
+	Codec runtime.Codec
 }
 
 type watchersMap map[int]*cacheWatcher
@@ -176,7 +178,7 @@ func NewCacherFromConfig(config CacherConfig) *Cacher {
 	// Give this error when it is constructed rather than when you get the
 	// first watch item, because it's much easier to track down that way.
 	if obj, ok := config.Type.(runtime.Object); ok {
-		if err := runtime.CheckCodec(config.Storage.Codec(), obj); err != nil {
+		if err := runtime.CheckCodec(config.Codec, obj); err != nil {
 			panic("storage codec doesn't seem to match given type: " + err.Error())
 		}
 	}
@@ -373,11 +375,6 @@ func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, f
 // Implements storage.Interface.
 func (c *Cacher) GuaranteedUpdate(ctx context.Context, key string, ptrToType runtime.Object, ignoreNotFound bool, preconditions *Preconditions, tryUpdate UpdateFunc) error {
 	return c.storage.GuaranteedUpdate(ctx, key, ptrToType, ignoreNotFound, preconditions, tryUpdate)
-}
-
-// Implements storage.Interface.
-func (c *Cacher) Codec() runtime.Codec {
-	return c.storage.Codec()
 }
 
 func (c *Cacher) triggerValues(event *watchCacheEvent) ([]string, bool) {

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -59,6 +59,7 @@ func newTestCacher(s storage.Interface) *storage.Cacher {
 		ResourcePrefix: prefix,
 		KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) },
 		NewListFunc:    func() runtime.Object { return &api.PodList{} },
+		Codec:          testapi.Default.Codec(),
 	}
 	return storage.NewCacherFromConfig(config)
 }

--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -85,11 +85,6 @@ func init() {
 	metrics.Register()
 }
 
-// Codec provides access to the underlying codec being used by the implementation.
-func (h *etcdHelper) Codec() runtime.Codec {
-	return h.codec
-}
-
 // Implements storage.Interface.
 func (h *etcdHelper) Versioner() storage.Versioner {
 	return h.versioner

--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -73,11 +73,6 @@ func newStore(c *clientv3.Client, codec runtime.Codec, prefix string) *store {
 	}
 }
 
-// Codec implements storage.Interface.Codec.
-func (s *store) Codec() runtime.Codec {
-	return s.codec
-}
-
 // Versioner implements storage.Interface.Versioner.
 func (s *store) Versioner() storage.Versioner {
 	return s.versioner

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -182,9 +182,6 @@ type Interface interface {
 	//    }
 	// })
 	GuaranteedUpdate(ctx context.Context, key string, ptrToType runtime.Object, ignoreNotFound bool, precondtions *Preconditions, tryUpdate UpdateFunc) error
-
-	// Codec provides access to the underlying codec being used by the implementation.
-	Codec() runtime.Codec
 }
 
 // Config interface allows storage tiers to generate the proper storage.interface


### PR DESCRIPTION
What?
Removes Codec() from storage.Interface.

Why?
- storage interface doesn't need to expose Codec().
- Codec() isn't used anywhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30664)

<!-- Reviewable:end -->
