### PR TITLE
dockertools: Don't use network plugin if net=host

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -344,7 +344,11 @@ func (dm *DockerManager) determineContainerIP(podNamespace, podName string, cont
 		}
 	}
 
-	if dm.networkPlugin.Name() != network.DefaultPluginName {
+	networkMode := getDockerNetworkMode(container)
+	isHostNetwork := networkMode == namespaceModeHost
+
+	// For host networking or default network plugin, GetPodNetworkStatus doesn't work
+	if !isHostNetwork && dm.networkPlugin.Name() != network.DefaultPluginName {
 		netStatus, err := dm.networkPlugin.GetPodNetworkStatus(podNamespace, podName, kubecontainer.DockerID(container.ID).ContainerID())
 		if err != nil {
 			glog.Errorf("NetworkPlugin %s failed on the status hook for pod '%s' - %v", dm.networkPlugin.Name(), podName, err)


### PR DESCRIPTION
I'm pretty sure this was just an oversight the first time around.

Before: `E0815 18:06:17.627468     976 docker_manager.go:350] NetworkPlugin kubenet failed on the status hook for pod 'sleep' - Unexpected command output Device "eth0" does not exist.`

After: No such logline is printed

The pod IP reported in `describe` is the same either way

cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30668)

<!-- Reviewable:end -->
