### PR TITLE
[Scheduler] Improve pod log output debuggability

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -93,11 +93,11 @@ func (s *Scheduler) Run() {
 func (s *Scheduler) scheduleOne() {
 	pod := s.config.NextPod()
 
-	glog.V(3).Infof("Attempting to schedule: %+v", pod)
+	glog.V(3).Infof("Attempting to schedule pod: %v/%v", pod.Namespace, pod.Name)
 	start := time.Now()
 	dest, err := s.config.Algorithm.Schedule(pod, s.config.NodeLister)
 	if err != nil {
-		glog.V(1).Infof("Failed to schedule: %+v", pod)
+		glog.V(1).Infof("Failed to schedule pod: %v/%v", pod.Namespace, pod.Name)
 		s.config.Error(pod, err)
 		s.config.Recorder.Eventf(pod, api.EventTypeWarning, "FailedScheduling", "%v", err)
 		s.config.PodConditionUpdater.Update(pod, &api.PodCondition{


### PR DESCRIPTION
Address issue is #30675

The result of my expirments shows that both `glog.Infof("%v", pod)` and `glog.Infof("%+v", pod)` can't output useful information of a pod, it can only output `kind:"" apiVersion:""`. 

`%#v` can output the whole content of pod, but it seems too much!

So, my opinion is output pod info use the format of `%v` to print`pod.Namespace/pod.Name` instead of the pod **object** in both [here](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/scheduler.go#L96) and [here](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/scheduler.go#L100).

@wojtek-t 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30676)

<!-- Reviewable:end -->
