### PR TITLE
Recombine the condition for the "shouldScale" function

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -355,19 +355,19 @@ func shouldScale(hpa *autoscaling.HorizontalPodAutoscaler, currentReplicas, desi
 		return false
 	}
 
+	if hpa.Status.LastScaleTime == nil {
+		return true
+	}
+
 	// Going down only if the usageRatio dropped significantly below the target
 	// and there was no rescaling in the last downscaleForbiddenWindow.
-	if desiredReplicas < currentReplicas &&
-		(hpa.Status.LastScaleTime == nil ||
-			hpa.Status.LastScaleTime.Add(downscaleForbiddenWindow).Before(timestamp)) {
+	if desiredReplicas < currentReplicas && hpa.Status.LastScaleTime.Add(downscaleForbiddenWindow).Before(timestamp) {
 		return true
 	}
 
 	// Going up only if the usage ratio increased significantly above the target
 	// and there was no rescaling in the last upscaleForbiddenWindow.
-	if desiredReplicas > currentReplicas &&
-		(hpa.Status.LastScaleTime == nil ||
-			hpa.Status.LastScaleTime.Add(upscaleForbiddenWindow).Before(timestamp)) {
+	if desiredReplicas > currentReplicas && hpa.Status.LastScaleTime.Add(upscaleForbiddenWindow).Before(timestamp) {
 		return true
 	}
 	return false


### PR DESCRIPTION
The PR recombine the condition for the "shouldScale" function, abstract the common condition(hpa.Status.LastScaleTime == nil).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30678)

<!-- Reviewable:end -->
