### PR TITLE
Don't bind pre-bound pvc & pv if size request not satisfied

### DIFF
--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -119,11 +119,11 @@ func (pvIndex *persistentVolumeOrderedIndex) findByClaim(claim *api.PersistentVo
 			if isVolumeBoundToClaim(volume, claim) {
 				// this claim and volume are pre-bound; return
 				// the volume if the size request is satisfied,
-				// otherwise leave the claim pending
+				// otherwise continue searching for a match
 				volumeQty := volume.Spec.Capacity[api.ResourceStorage]
 				volumeSize := volumeQty.Value()
 				if volumeSize < requestedSize {
-					return nil, nil
+					continue
 				}
 				return volume, nil
 			}

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -117,9 +117,14 @@ func (pvIndex *persistentVolumeOrderedIndex) findByClaim(claim *api.PersistentVo
 		//   the claim.
 		for _, volume := range volumes {
 			if isVolumeBoundToClaim(volume, claim) {
-				// this claim and volume are bound; return it,
-				// whether the claim is prebound or for volumes
-				// intended for dynamic provisioning v1
+				// this claim and volume are pre-bound; return
+				// the volume if the size request is satisfied,
+				// otherwise leave the claim pending
+				volumeQty := volume.Spec.Capacity[api.ResourceStorage]
+				volumeSize := volumeQty.Value()
+				if volumeSize < requestedSize {
+					return nil, nil
+				}
 				return volume, nil
 			}
 

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -610,11 +610,16 @@ func TestFindingPreboundVolumes(t *testing.T) {
 	pv1 := testVolume("pv1", "1Gi")
 	pv5 := testVolume("pv5", "5Gi")
 	pv8 := testVolume("pv8", "8Gi")
+	pvBadSize := testVolume("pvBadSize", "1Mi")
+	pvBadMode := testVolume("pvBadMode", "1Gi")
+	pvBadMode.Spec.AccessModes = []api.PersistentVolumeAccessMode{api.ReadOnlyMany}
 
 	index := newPersistentVolumeOrderedIndex()
 	index.store.Add(pv1)
 	index.store.Add(pv5)
 	index.store.Add(pv8)
+	index.store.Add(pvBadSize)
+	index.store.Add(pvBadMode)
 
 	// expected exact match on size
 	volume, _ := index.findBestMatchForClaim(claim)
@@ -635,6 +640,22 @@ func TestFindingPreboundVolumes(t *testing.T) {
 	volume, _ = index.findBestMatchForClaim(claim)
 	if volume.Name != pv8.Name {
 		t.Errorf("Expected %s but got volume %s instead", pv8.Name, volume.Name)
+	}
+
+	// pretend the volume with too small a size is pre-bound to the claim. should get the exact match.
+	pv8.Spec.ClaimRef = nil
+	pvBadSize.Spec.ClaimRef = claimRef
+	volume, _ = index.findBestMatchForClaim(claim)
+	if volume.Name != pv1.Name {
+		t.Errorf("Expected %s but got volume %s instead", pv1.Name, volume.Name)
+	}
+
+	// pretend the volume without the right access mode is pre-bound to the claim. should get the exact match.
+	pvBadSize.Spec.ClaimRef = nil
+	pvBadMode.Spec.ClaimRef = claimRef
+	volume, _ = index.findBestMatchForClaim(claim)
+	if volume.Name != pv1.Name {
+		t.Errorf("Expected %s but got volume %s instead", pv1.Name, volume.Name)
 	}
 }
 


### PR DESCRIPTION
as discussed briefly here https://github.com/kubernetes/kubernetes/pull/30522 , volume size ought to be verified before binding a pv & pvc regardless of what's in the pv's claimRef. @thockin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30690)

<!-- Reviewable:end -->
