### PR TITLE
[GarbageCollector] when GC deletes an object, it's always a cascading deletion.

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -611,7 +611,9 @@ func (gc *GarbageCollector) deleteObject(item objectReference) error {
 	}
 	uid := item.UID
 	preconditions := v1.Preconditions{UID: &uid}
-	deleteOptions := v1.DeleteOptions{Preconditions: &preconditions}
+	// when GC deletes an object, it's always a cascading deletion.
+	falseVar := false
+	deleteOptions := v1.DeleteOptions{Preconditions: &preconditions, OrphanDependents: &falseVar}
 	return client.Resource(resource, item.Namespace).Delete(item.Name, &deleteOptions)
 }
 


### PR DESCRIPTION
This saves the orphaning finalizer from processing the deletion issued by the garbage collector itself.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30697)

<!-- Reviewable:end -->
