### PR TITLE
ResourceNames() should prohibit unnamed arguments

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -212,6 +212,10 @@ func (b *Builder) ResourceNames(resource string, names ...string) *Builder {
 			b.resourceTuples = append(b.resourceTuples, tuple)
 			continue
 		}
+		if len(resource) == 0 {
+			b.errs = append(b.errs, fmt.Errorf("the argument %q must be RESOURCE/NAME", name))
+			continue
+		}
 
 		// Use the given default type to create a resource tuple
 		b.resourceTuples = append(b.resourceTuples, resourceTuple{Resource: resource, Name: name})


### PR DESCRIPTION
resource.Builder should prohibit empty resource names (the error is from
the wrong place) so that commands that work on multiple resources but
not resource types can properly limit errors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30713)

<!-- Reviewable:end -->
