### PR TITLE
Add percentage of used resources to node metrics.

### DIFF
--- a/pkg/kubectl/cmd/top_test.go
+++ b/pkg/kubectl/cmd/top_test.go
@@ -24,9 +24,10 @@ import (
 	"time"
 
 	metrics_api "k8s.io/heapster/metrics/apis/metrics/v1alpha1"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	api "k8s.io/kubernetes/pkg/api/v1"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
 	"testing"
 )
 
@@ -56,93 +57,121 @@ func marshallBody(metrics interface{}) (io.ReadCloser, error) {
 	return ioutil.NopCloser(bytes.NewReader(result)), nil
 }
 
-func testNodeMetricsData() []metrics_api.NodeMetrics {
-	return []metrics_api.NodeMetrics{
+func testNodeMetricsData() ([]metrics_api.NodeMetrics, *api.NodeList) {
+	metrics := []metrics_api.NodeMetrics{
 		{
-			ObjectMeta: api.ObjectMeta{Name: "node1", ResourceVersion: "10"},
+			ObjectMeta: v1.ObjectMeta{Name: "node1", ResourceVersion: "10"},
 			Window:     unversioned.Duration{Duration: time.Minute},
-			Usage: api.ResourceList{
-				api.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
-				api.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
-				api.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+			Usage: v1.ResourceList{
+				v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+				v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
+				v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
 			},
 		},
 		{
-			ObjectMeta: api.ObjectMeta{Name: "node2", ResourceVersion: "11"},
+			ObjectMeta: v1.ObjectMeta{Name: "node2", ResourceVersion: "11"},
 			Window:     unversioned.Duration{Duration: time.Minute},
-			Usage: api.ResourceList{
-				api.ResourceCPU:     *resource.NewMilliQuantity(5, resource.DecimalSI),
-				api.ResourceMemory:  *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
-				api.ResourceStorage: *resource.NewQuantity(7*(1024*1024), resource.DecimalSI),
+			Usage: v1.ResourceList{
+				v1.ResourceCPU:     *resource.NewMilliQuantity(5, resource.DecimalSI),
+				v1.ResourceMemory:  *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
+				v1.ResourceStorage: *resource.NewQuantity(7*(1024*1024), resource.DecimalSI),
 			},
 		},
 	}
+	nodes := &api.NodeList{
+		ListMeta: unversioned.ListMeta{
+			ResourceVersion: "15",
+		},
+		Items: []api.Node{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "node1", ResourceVersion: "10"},
+				Status: api.NodeStatus{
+					Allocatable: api.ResourceList{
+						api.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
+						api.ResourceMemory:  *resource.NewQuantity(20*(1024*1024), resource.DecimalSI),
+						api.ResourceStorage: *resource.NewQuantity(30*(1024*1024), resource.DecimalSI),
+					},
+				},
+			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "node2", ResourceVersion: "11"},
+				Status: api.NodeStatus{
+					Allocatable: api.ResourceList{
+						api.ResourceCPU:     *resource.NewMilliQuantity(50, resource.DecimalSI),
+						api.ResourceMemory:  *resource.NewQuantity(60*(1024*1024), resource.DecimalSI),
+						api.ResourceStorage: *resource.NewQuantity(70*(1024*1024), resource.DecimalSI),
+					},
+				},
+			},
+		},
+	}
+	return metrics, nodes
 }
 
 func testPodMetricsData() []metrics_api.PodMetrics {
 	return []metrics_api.PodMetrics{
 		{
-			ObjectMeta: api.ObjectMeta{Name: "pod1", Namespace: "test", ResourceVersion: "10"},
+			ObjectMeta: v1.ObjectMeta{Name: "pod1", Namespace: "test", ResourceVersion: "10"},
 			Window:     unversioned.Duration{Duration: time.Minute},
 			Containers: []metrics_api.ContainerMetrics{
 				{
 					Name: "container1-1",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
 					},
 				},
 				{
 					Name: "container1-2",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(4, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
 					},
 				},
 			},
 		},
 		{
-			ObjectMeta: api.ObjectMeta{Name: "pod2", Namespace: "test", ResourceVersion: "11"},
+			ObjectMeta: v1.ObjectMeta{Name: "pod2", Namespace: "test", ResourceVersion: "11"},
 			Window:     unversioned.Duration{Duration: time.Minute},
 			Containers: []metrics_api.ContainerMetrics{
 				{
 					Name: "container2-1",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
 					},
 				},
 				{
 					Name: "container2-2",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(11*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(12*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(11*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(12*(1024*1024), resource.DecimalSI),
 					},
 				},
 				{
 					Name: "container2-3",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(13, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(14*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(15*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(13, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(14*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(15*(1024*1024), resource.DecimalSI),
 					},
 				},
 			},
 		},
 		{
-			ObjectMeta: api.ObjectMeta{Name: "pod3", Namespace: "test", ResourceVersion: "12"},
+			ObjectMeta: v1.ObjectMeta{Name: "pod3", Namespace: "test", ResourceVersion: "12"},
 			Window:     unversioned.Duration{Duration: time.Minute},
 			Containers: []metrics_api.ContainerMetrics{
 				{
 					Name: "container3-1",
-					Usage: api.ResourceList{
-						api.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
-						api.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
-						api.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
 					},
 				},
 			},

--- a/pkg/kubectl/metricsutil/metrics_client.go
+++ b/pkg/kubectl/metricsutil/metrics_client.go
@@ -45,7 +45,7 @@ var (
 )
 
 type HeapsterMetricsClient struct {
-	Client            *client.Client
+	*client.Client
 	HeapsterNamespace string
 	HeapsterScheme    string
 	HeapsterService   string
@@ -66,7 +66,7 @@ func DefaultHeapsterMetricsClient(client *client.Client) *HeapsterMetricsClient 
 	return NewHeapsterMetricsClient(client, DefaultHeapsterNamespace, DefaultHeapsterScheme, DefaultHeapsterService, DefaultHeapsterPort)
 }
 
-func PodMetricsUrl(namespace string, name string) (string, error) {
+func podMetricsUrl(namespace string, name string) (string, error) {
 	errs := validation.ValidateNamespaceName(namespace, false)
 	if len(errs) > 0 {
 		message := fmt.Sprintf("invalid namespace: %s - %v", namespace, errs)
@@ -82,7 +82,7 @@ func PodMetricsUrl(namespace string, name string) (string, error) {
 	return fmt.Sprintf("%s/namespaces/%s/pods/%s", MetricsRoot, namespace, name), nil
 }
 
-func NodeMetricsUrl(name string) (string, error) {
+func nodeMetricsUrl(name string) (string, error) {
 	if len(name) > 0 {
 		errs := validation.ValidateNodeName(name, false)
 		if len(errs) > 0 {
@@ -95,7 +95,7 @@ func NodeMetricsUrl(name string) (string, error) {
 
 func (cli *HeapsterMetricsClient) GetNodeMetrics(nodeName string, selector string) ([]metrics_api.NodeMetrics, error) {
 	params := map[string]string{"labelSelector": selector}
-	path, err := NodeMetricsUrl(nodeName)
+	path, err := nodeMetricsUrl(nodeName)
 	if err != nil {
 		return []metrics_api.NodeMetrics{}, err
 	}
@@ -139,7 +139,7 @@ func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string
 	params := map[string]string{"labelSelector": selector}
 	allMetrics := make([]metrics_api.PodMetrics, 0)
 	for _, ns := range namespaces {
-		path, err := PodMetricsUrl(ns, podName)
+		path, err := podMetricsUrl(ns, podName)
 		if err != nil {
 			return []metrics_api.PodMetrics{}, err
 		}
@@ -167,7 +167,7 @@ func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string
 }
 
 func GetHeapsterMetrics(cli *HeapsterMetricsClient, path string, params map[string]string) ([]byte, error) {
-	return cli.Client.Services(cli.HeapsterNamespace).
+	return cli.Services(cli.HeapsterNamespace).
 		ProxyGet(cli.HeapsterScheme, cli.HeapsterService, cli.HeapsterPort, path, params).
 		DoRaw()
 }


### PR DESCRIPTION
Show percentage along with resource usage in 'kubectl top node' command.

Remove Storage column. (#30782)

Sample output:

```
$ kubectl top node

NAME                           CPU(cores)   CPU%      MEMORY(bytes)   MEMORY%   
kubernetes-master              238m         23%       1982Mi          53%       
kubernetes-minion-group-xxxx   62m          3%        1576Mi          21%       
kubernetes-minion-group-yyyy   68m          3%        1638Mi          21%       
kubernetes-minion-group-zzzz   42m          2%        1568Mi          20%
```

**Release note**

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30767)

<!-- Reviewable:end -->
