### PR TITLE
Add logging time series to benchmark test

### DIFF
--- a/test/e2e/perftype/perftype.go
+++ b/test/e2e/perftype/perftype.go
@@ -31,7 +31,7 @@ type DataItem struct {
 	// should have the same unit.
 	Unit string `json:"unit"`
 	// Labels is the labels of the data item.
-	Labels map[string]string `json:"labels"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // PerfData contains all data items generated in current test.
@@ -40,6 +40,8 @@ type PerfData struct {
 	// to detect metrics version change and decide what version to support.
 	Version   string     `json:"version"`
 	DataItems []DataItem `json:"dataItems"`
+	// Labels is the labels of the dataset.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // PerfResultTag is the prefix of generated perfdata. Analyzing tools can find the perf result

--- a/test/e2e_node/benchmark_util.go
+++ b/test/e2e_node/benchmark_util.go
@@ -1,0 +1,103 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import (
+	"sort"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/perftype"
+)
+
+const (
+	// TODO(coufon): be consistent with perf_util.go version (not exposed)
+	currentTimeSeriesVersion = "v1"
+	TimeSeriesTag            = "[Result:TimeSeries]"
+	TimeSeriesEnd            = "[Finish:TimeSeries]"
+)
+
+type NodeTimeSeries struct {
+	// value in OperationData is an array of timestamps
+	OperationData map[string][]int64         `json:"op_data,omitempty"`
+	ResourceData  map[string]*ResourceSeries `json:"resource_data,omitempty"`
+	Labels        map[string]string          `json:"labels"`
+	Version       string                     `json:"version"`
+}
+
+// logDensityTimeSeries logs the time series data of operation and resource usage
+func logDensityTimeSeries(rc *ResourceCollector, create, watch map[string]unversioned.Time, testName string) {
+	timeSeries := &NodeTimeSeries{
+		Labels: map[string]string{
+			"node":     framework.TestContext.NodeName,
+			"datatype": "timeseries",
+			"test":     testName,
+		},
+		Version: currentTimeSeriesVersion,
+	}
+	// Attach operation time series.
+	timeSeries.OperationData = map[string][]int64{
+		"create":  getCumulatedPodTimeSeries(create),
+		"running": getCumulatedPodTimeSeries(watch),
+	}
+	// Attach resource time series.
+	timeSeries.ResourceData = rc.GetResourceTimeSeries()
+	// Log time series with tags
+	framework.Logf("%s %s\n%s", TimeSeriesTag, framework.PrettyPrintJSON(timeSeries), TimeSeriesEnd)
+}
+
+type int64arr []int64
+
+func (a int64arr) Len() int           { return len(a) }
+func (a int64arr) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a int64arr) Less(i, j int) bool { return a[i] < a[j] }
+
+// getCumulatedPodTimeSeries gets the cumulative pod number time series.
+func getCumulatedPodTimeSeries(timePerPod map[string]unversioned.Time) []int64 {
+	timeSeries := make(int64arr, 0)
+	for _, ts := range timePerPod {
+		timeSeries = append(timeSeries, ts.Time.UnixNano())
+	}
+	// Sort all timestamps.
+	sort.Sort(timeSeries)
+	return timeSeries
+}
+
+// getLatencyPerfData returns perf data from latency
+func getLatencyPerfData(latency framework.LatencyMetric, testName string) *perftype.PerfData {
+	return &perftype.PerfData{
+		Version: "v1",
+		DataItems: []perftype.DataItem{
+			{
+				Data: map[string]float64{
+					"Perc50": float64(latency.Perc50) / 1000000,
+					"Perc90": float64(latency.Perc90) / 1000000,
+					"Perc99": float64(latency.Perc99) / 1000000,
+				},
+				Unit: "ms",
+				Labels: map[string]string{
+					"datatype":    "latency",
+					"latencytype": "test-e2e",
+					"node":        framework.TestContext.NodeName,
+					"test":        testName,
+				},
+			},
+		},
+	}
+}

--- a/test/e2e_node/benchmark_util.go
+++ b/test/e2e_node/benchmark_util.go
@@ -45,9 +45,8 @@ type NodeTimeSeries struct {
 func logDensityTimeSeries(rc *ResourceCollector, create, watch map[string]unversioned.Time, testName string) {
 	timeSeries := &NodeTimeSeries{
 		Labels: map[string]string{
-			"node":     framework.TestContext.NodeName,
-			"datatype": "timeseries",
-			"test":     testName,
+			"node": framework.TestContext.NodeName,
+			"test": testName,
 		},
 		Version: currentTimeSeriesVersion,
 	}
@@ -94,10 +93,12 @@ func getLatencyPerfData(latency framework.LatencyMetric, testName string) *perft
 				Labels: map[string]string{
 					"datatype":    "latency",
 					"latencytype": "test-e2e",
-					"node":        framework.TestContext.NodeName,
-					"test":        testName,
 				},
 			},
+		},
+		Labels: map[string]string{
+			"node": framework.TestContext.NodeName,
+			"test": testName,
 		},
 	}
 }

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -119,7 +119,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 		}
 	})
 
-	Context("create a batch of pods [Benchmark]", func() {
+	Context("create a batch of pods", func() {
 		dTests := []densityTest{
 			{
 				podsNr:   10,
@@ -137,7 +137,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 		for _, testArg := range dTests {
 			itArg := testArg
-			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval",
+			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval [Benchmark]",
 				itArg.podsNr, itArg.interval), func() {
 				itArg.createMethod = "batch"
 				testName := itArg.getTestName()
@@ -190,7 +190,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 		}
 	})
 
-	Context("create a sequence of pods [Benchmark]", func() {
+	Context("create a sequence of pods", func() {
 		dTests := []densityTest{
 			{
 				podsNr:   10,
@@ -208,7 +208,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 
 		for _, testArg := range dTests {
 			itArg := testArg
-			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %d background pods",
+			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %d background pods [Benchmark]",
 				itArg.podsNr, itArg.bgPodsNr), func() {
 				itArg.createMethod = "sequence"
 				testName := itArg.getTestName()

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -241,7 +241,7 @@ type densityTest struct {
 }
 
 func (dt *densityTest) getTestName() string {
-	return fmt.Sprintf("create_%s_%d_%d_%d", dt.createMethod, dt.podsNr, dt.bgPodsNr, dt.interval.Nanoseconds()/1000000)
+	return fmt.Sprintf("density_create_%s_%d_%d_%d", dt.createMethod, dt.podsNr, dt.bgPodsNr, dt.interval.Nanoseconds()/1000000)
 }
 
 // runDensityBatchTest runs the density batch pod creation test

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -106,14 +106,15 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval",
 				itArg.podsNr, itArg.interval), func() {
-
-				batchLag, e2eLags := runDensityBatchTest(f, rc, itArg)
+				itArg.createMethod = "batch"
+				testName := itArg.getTestName()
+				batchLag, e2eLags := runDensityBatchTest(f, rc, itArg, false)
 
 				By("Verifying latency")
-				printAndVerifyLatency(batchLag, e2eLags, itArg, true)
+				logAndVerifyLatency(batchLag, e2eLags, itArg.podStartupLimits, itArg.podBatchStartupLimit, testName, true)
 
 				By("Verifying resource")
-				printAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, true)
+				logAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, testName, true)
 			})
 		}
 	})
@@ -138,14 +139,15 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval",
 				itArg.podsNr, itArg.interval), func() {
-
-				batchLag, e2eLags := runDensityBatchTest(f, rc, itArg)
+				itArg.createMethod = "batch"
+				testName := itArg.getTestName()
+				batchLag, e2eLags := runDensityBatchTest(f, rc, itArg, true)
 
 				By("Verifying latency")
-				printAndVerifyLatency(batchLag, e2eLags, itArg, false)
+				logAndVerifyLatency(batchLag, e2eLags, itArg.podStartupLimits, itArg.podBatchStartupLimit, testName, false)
 
 				By("Verifying resource")
-				printAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, false)
+				logAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, testName, false)
 			})
 		}
 	})
@@ -175,14 +177,15 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %d background pods",
 				itArg.podsNr, itArg.bgPodsNr), func() {
-
+				itArg.createMethod = "sequence"
+				testName := itArg.getTestName()
 				batchlag, e2eLags := runDensitySeqTest(f, rc, itArg)
 
 				By("Verifying latency")
-				printAndVerifyLatency(batchlag, e2eLags, itArg, true)
+				logAndVerifyLatency(batchlag, e2eLags, itArg.podStartupLimits, itArg.podBatchStartupLimit, testName, true)
 
 				By("Verifying resource")
-				printAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, true)
+				logAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, testName, true)
 			})
 		}
 	})
@@ -207,14 +210,15 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 			itArg := testArg
 			It(fmt.Sprintf("latency/resource should be within limit when create %d pods with %d background pods",
 				itArg.podsNr, itArg.bgPodsNr), func() {
-
+				itArg.createMethod = "sequence"
+				testName := itArg.getTestName()
 				batchlag, e2eLags := runDensitySeqTest(f, rc, itArg)
 
 				By("Verifying latency")
-				printAndVerifyLatency(batchlag, e2eLags, itArg, false)
+				logAndVerifyLatency(batchlag, e2eLags, itArg.podStartupLimits, itArg.podBatchStartupLimit, testName, false)
 
 				By("Verifying resource")
-				printAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, false)
+				logAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, testName, false)
 			})
 		}
 	})
@@ -227,6 +231,8 @@ type densityTest struct {
 	bgPodsNr int
 	// interval between creating pod (rate control)
 	interval time.Duration
+	// create pods in 'batch' or 'sequence'
+	createMethod string
 	// performance limits
 	cpuLimits            framework.ContainersCPUSummary
 	memLimits            framework.ResourceUsagePerContainer
@@ -234,8 +240,13 @@ type densityTest struct {
 	podBatchStartupLimit time.Duration
 }
 
+func (dt *densityTest) getTestName() string {
+	return fmt.Sprintf("create_%s_%d_%d_%d", dt.createMethod, dt.podsNr, dt.bgPodsNr, dt.interval.Nanoseconds()/1000000)
+}
+
 // runDensityBatchTest runs the density batch pod creation test
-func runDensityBatchTest(f *framework.Framework, rc *ResourceCollector, testArg densityTest) (time.Duration, []framework.PodLatencyData) {
+func runDensityBatchTest(f *framework.Framework, rc *ResourceCollector, testArg densityTest,
+	isLogTimeSeries bool) (time.Duration, []framework.PodLatencyData) {
 	const (
 		podType               = "density_test_pod"
 		sleepBeforeCreatePods = 30 * time.Second
@@ -308,6 +319,13 @@ func runDensityBatchTest(f *framework.Framework, rc *ResourceCollector, testArg 
 	sort.Sort(framework.LatencySlice(e2eLags))
 	batchLag := lastRunning.Time.Sub(firstCreate.Time)
 
+	// Log time series data.
+	if isLogTimeSeries {
+		logDensityTimeSeries(rc, createTimes, watchTimes, testArg.getTestName())
+	}
+	// Log throughput data.
+	logPodCreateThroughput(batchLag, e2eLags, testArg.podsNr)
+
 	return batchLag, e2eLags
 }
 
@@ -332,6 +350,9 @@ func runDensitySeqTest(f *framework.Framework, rc *ResourceCollector, testArg de
 
 	// create pods sequentially (back-to-back)
 	batchlag, e2eLags := createBatchPodSequential(f, testPods)
+
+	// Log throughput data.
+	logPodCreateThroughput(batchlag, e2eLags, testArg.podsNr)
 
 	return batchlag, e2eLags
 }
@@ -454,31 +475,36 @@ func createBatchPodSequential(f *framework.Framework, pods []*api.Pod) (time.Dur
 	return batchLag, e2eLags
 }
 
-// printAndVerifyLatency verifies that whether pod creation latency satisfies the limit.
-func printAndVerifyLatency(batchLag time.Duration, e2eLags []framework.PodLatencyData, testArg densityTest, isVerify bool) {
+// logAndVerifyLatency verifies that whether pod creation latency satisfies the limit.
+func logAndVerifyLatency(batchLag time.Duration, e2eLags []framework.PodLatencyData, podStartupLimits framework.LatencyMetric,
+	podBatchStartupLimit time.Duration, testName string, isVerify bool) {
 	framework.PrintLatencies(e2eLags, "worst client e2e total latencies")
 
-	// TODO(coufon): do not trust `kubelet' metrics since they are not reset!
+	// TODO(coufon): do not trust 'kubelet' metrics since they are not reset!
 	latencyMetrics, _ := getPodStartLatency(kubeletAddr)
 	framework.Logf("Kubelet Prometheus metrics (not reset):\n%s", framework.PrettyPrintJSON(latencyMetrics))
 
-	// check whether e2e pod startup time is acceptable.
 	podCreateLatency := framework.PodStartupLatency{Latency: framework.ExtractLatencyMetrics(e2eLags)}
-	framework.Logf("Pod create latency: %s", framework.PrettyPrintJSON(podCreateLatency))
 
-	// calculate and log throughput
-	throughputBatch := float64(testArg.podsNr) / batchLag.Minutes()
+	// log latency perf data
+	framework.PrintPerfData(getLatencyPerfData(podCreateLatency.Latency, testName))
+
+	if isVerify {
+		// check whether e2e pod startup time is acceptable.
+		framework.ExpectNoError(verifyPodStartupLatency(podStartupLimits, podCreateLatency.Latency))
+
+		// check bactch pod creation latency
+		if podBatchStartupLimit > 0 {
+			Expect(batchLag <= podBatchStartupLimit).To(Equal(true), "Batch creation startup time %v exceed limit %v",
+				batchLag, podBatchStartupLimit)
+		}
+	}
+}
+
+// logThroughput calculates and logs pod creation throughput.
+func logPodCreateThroughput(batchLag time.Duration, e2eLags []framework.PodLatencyData, podsNr int) {
+	throughputBatch := float64(podsNr) / batchLag.Minutes()
 	framework.Logf("Batch creation throughput is %.1f pods/min", throughputBatch)
 	throughputSequential := 1.0 / e2eLags[len(e2eLags)-1].Latency.Minutes()
 	framework.Logf("Sequential creation throughput is %.1f pods/min", throughputSequential)
-
-	if isVerify {
-		framework.ExpectNoError(verifyPodStartupLatency(testArg.podStartupLimits, podCreateLatency.Latency))
-
-		// check bactch pod creation latency
-		if testArg.podBatchStartupLimit > 0 {
-			Expect(batchLag <= testArg.podBatchStartupLimit).To(Equal(true), "Batch creation startup time %v exceed limit %v",
-				batchLag, testArg.podBatchStartupLimit)
-		}
-	}
 }

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -90,7 +90,7 @@ var _ = framework.KubeDescribe("Resource-usage [Serial] [Slow]", func() {
 		}
 	})
 
-	Context("regular resource usage tracking [Benchmark]", func() {
+	Context("regular resource usage tracking", func() {
 		rTests := []resourceTest{
 			{
 				podsNr: 10,
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("Resource-usage [Serial] [Slow]", func() {
 		for _, testArg := range rTests {
 			itArg := testArg
 
-			It(fmt.Sprintf("resource tracking for %d pods per node", itArg.podsNr), func() {
+			It(fmt.Sprintf("resource tracking for %d pods per node [Benchmark]", itArg.podsNr), func() {
 				runResourceUsageTest(f, rc, itArg)
 				// Log and verify resource usage
 				logAndVerifyResource(f, rc, itArg.cpuLimits, itArg.memLimits, itArg.getTestName(), true)

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -194,15 +194,9 @@ func logAndVerifyResource(f *framework.Framework, rc *ResourceCollector, cpuLimi
 
 	// Print resource usage
 	framework.PrintPerfData(framework.ResourceUsageToPerfDataWithLabels(usagePerNode,
-		map[string]string{
-			"datatype": "resource",
-			"test":     testName,
-		}))
+		map[string]string{"test": testName, "node": nodeName}))
 	framework.PrintPerfData(framework.CPUUsageToPerfDataWithLabels(cpuSummaryPerNode,
-		map[string]string{
-			"datatype": "resource",
-			"test":     testName,
-		}))
+		map[string]string{"test": testName, "node": nodeName}))
 
 	// Verify resource usage
 	if isVerify {


### PR DESCRIPTION
This PR adds a new file benchmark_util.go which contains tool functions for benchmark (we can migrate benchmark related functions into it). 

The PR logs time series data for density benchmark test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30786)

<!-- Reviewable:end -->
