### PR TITLE
Fix image inspection and matching

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -166,24 +166,19 @@ func matchImageTagOrSHA(inspected dockertypes.ImageInspect, image string) bool {
 		// No Tag or SHA specified, so just return what we have
 		return true
 	}
-	if isTagged {
-		hostname, _ := dockerref.SplitHostname(named)
-		// Check the RepoTags for an exact match
-		for _, tag := range inspected.RepoTags {
-			// Deal with image with hostname specified
-			if len(hostname) > 0 {
-				if strings.HasSuffix(image, tag) {
-					return true
-				}
 
-			} else {
-				if tag == image {
-					// We found a specific tag that we were looking for
-					return true
-				}
+	if isTagged {
+		// Check the RepoTags for a match.
+		for _, tag := range inspected.RepoTags {
+			// An image name (without the tag/digest) can be [hostname '/'] component ['/' component]*
+			// Because either the RepoTag or the name *may* contain the
+			// hostname or not, we only check for the suffix match.
+			if strings.HasSuffix(image, tag) || strings.HasSuffix(tag, image) {
+				return true
 			}
 		}
 	}
+
 	if isDigested {
 		algo := digest.Digest().Algorithm().String()
 		sha := digest.Digest().Hex()

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -184,6 +184,11 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			Output:    true,
 		},
 		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"docker.io/kubernetes/pause:latest"}},
+			Image:     "kubernetes/pause:latest",
+			Output:    true,
+		},
+		{
 			Inspected: dockertypes.ImageInspect{
 				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
 			},


### PR DESCRIPTION
An image string could contain a hostname (e.g., "docker.io") or not. The same
applies to the RepoTags returned from an image inspection. To determine whether
the image docker pulled matches what the user ask for, we check if the either
string is the suffix of the other.

/cc @dims @dchen1107 @Random-Liu

This fixes #30710

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30789)

<!-- Reviewable:end -->
