### PR TITLE
openstack: prefer instance ID from metadata instead of nodeName

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -36,6 +36,22 @@ type Instances struct {
 	flavor_to_resource map[string]*api.NodeResources // keyed by flavor id
 }
 
+func probeInstanceID(client *gophercloud.ServiceClient, name string) (string, error) {
+	// Attempt to read id from config drive.
+	id, err := readInstanceID()
+	if err == nil {
+		return id, nil
+	}
+
+	// Attempt to get the server by the name from the API
+	server, err := getServerByName(client, name)
+	if err != nil {
+		return "", err
+	}
+
+	return server.ID, nil
+}
+
 // Instances returns an implementation of Instances for OpenStack.
 func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 	glog.V(4).Info("openstack.Instances() called")
@@ -134,11 +150,7 @@ func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
 
 // ExternalID returns the cloud provider ID of the specified instance (deprecated).
 func (i *Instances) ExternalID(name string) (string, error) {
-	srv, err := getServerByName(i.compute, name)
-	if err != nil {
-		return "", err
-	}
-	return srv.ID, nil
+	return probeInstanceID(i.compute, name)
 }
 
 // InstanceID returns the kubelet's cloud provider ID.
@@ -148,13 +160,13 @@ func (os *OpenStack) InstanceID() (string, error) {
 
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(name string) (string, error) {
-	srv, err := getServerByName(i.compute, name)
+	id, err := probeInstanceID(i.compute, name)
 	if err != nil {
 		return "", err
 	}
 	// In the future it is possible to also return an endpoint as:
 	// <endpoint>/<instanceid>
-	return "/" + srv.ID, nil
+	return "/" + id, nil
 }
 
 // InstanceType returns the type of the specified instance.


### PR DESCRIPTION
Right now, the openstack provider code requires the instance name and the kubelet nodeName to be the same in order to work properly.  This restriction is not readily apparent and leads to a lot of misconfiguration.  Additionally the instance name is not required to be unique, meaning that the provider code can not currently handle situations with duplicate instance names.

This PR modifies the code to prefer local file (cloud-init) or cloud server metadata to determine the unique instance ID and use it for instance queries and configuration.

My only concern is that the this code needs to be executed only by the kubelet on the node in order to work properly.  However, looking at the code, this assumption is true and the other provider code already assumes it.

The rackspace provider code as an example:
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/rackspace/rackspace.go#L123

xref https://bugzilla.redhat.com/show_bug.cgi?id=1367201
xref https://bugzilla.redhat.com/show_bug.cgi?id=1321964

@kubernetes/rh-cluster-infra @ncdc @anguslees

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30791)

<!-- Reviewable:end -->
