### PR TITLE
Quota usage checking ignores unrelated resources

### DIFF
--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -382,7 +382,9 @@ func (e *quotaEvaluator) checkRequest(quotas []api.ResourceQuota, a admission.At
 		hardResources := quota.ResourceNames(resourceQuota.Status.Hard)
 		requestedUsage := quota.Mask(deltaUsage, hardResources)
 		newUsage := quota.Add(resourceQuota.Status.Used, requestedUsage)
-		if allowed, exceeded := quota.LessThanOrEqual(newUsage, resourceQuota.Status.Hard); !allowed {
+		maskedNewUsage := quota.Mask(newUsage, quota.ResourceNames(requestedUsage))
+
+		if allowed, exceeded := quota.LessThanOrEqual(maskedNewUsage, resourceQuota.Status.Hard); !allowed {
 			failedRequestedUsage := quota.Mask(requestedUsage, exceeded)
 			failedUsed := quota.Mask(resourceQuota.Status.Used, exceeded)
 			failedHard := quota.Mask(resourceQuota.Status.Hard, exceeded)


### PR DESCRIPTION
Scenario:
1. Create 4 services
2. Add a quota that limits services to 3
3. Create a pod

Expected result:
pod creation succeeds

Actual result:
pod creation fails stating that services exceed quota.

Fix:
less than or equal check should only verify resources pertinent to request.

Related:
https://bugzilla.redhat.com/show_bug.cgi?id=1367733

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30796)

<!-- Reviewable:end -->
