### PR TITLE
AWS: Handle kube-down case where the LaunchConfig is dangling

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1345,6 +1345,11 @@ function kube-down {
       done
       echo "All instances deleted"
     fi
+    if [[ -n $(${AWS_ASG_CMD} describe-launch-configurations --launch-configuration-names ${ASG_NAME} --query LaunchConfigurations[].LaunchConfigurationName) ]]; then
+      echo "Warning: default auto-scaling launch configuration ${ASG_NAME} still exists, attempting to delete"
+      echo "  (This may happen if kube-up leaves just the launch configuration but no auto-scaling group.)"
+      ${AWS_ASG_CMD} delete-launch-configuration --launch-configuration-name ${ASG_NAME} || true
+    fi
 
     find-master-pd
     find-tagged-master-ip


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed `cluster/kube-down.sh` on AWS in the case where no minions were started.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: N/A

**Special notes for your reviewer**: N/A

**Release note**:

If we can't infer it from the tagged instances, assume we've created
the $ASG_NAME.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30816)

<!-- Reviewable:end -->
