### PR TITLE
Include Authentication-Info response header to authenticated requests

### DIFF
--- a/pkg/apiserver/handler_auth_test.go
+++ b/pkg/apiserver/handler_auth_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package handlers
+package apiserver
 
 import (
 	"errors"
@@ -116,5 +116,86 @@ func TestAuthenticateRequestError(t *testing.T) {
 	}
 	if !empty {
 		t.Fatalf("contextMapper should have no stored requests: %v", contextMapper)
+	}
+}
+
+type mockAuthenticator struct {
+	user user.Info
+}
+
+func (m *mockAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	if m.user == nil {
+		return nil, false, nil
+	}
+	return m.user, true, nil
+}
+
+func TestAuthenticationInfoHeader(t *testing.T) {
+	a := new(mockAuthenticator)
+
+	auth, err := NewRequestAuthenticator(
+		api.NewRequestContextMapper(),
+		a,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("unexpected call to failed handler")
+			w.Write([]byte(`{}`))
+		}),
+
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{}`))
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		user       user.Info
+		wantHeader string
+	}{
+		{
+			user:       &user.DefaultInfo{},
+			wantHeader: `username="", uid=""`,
+		},
+		{
+			user: &user.DefaultInfo{
+				Name: "jane",
+				UID:  "42",
+			},
+			wantHeader: `username="jane", uid="42"`,
+		},
+		{
+			user: &user.DefaultInfo{
+				Name: `foo"bar`, // Ensure values are properly escaped
+				UID:  "42",
+			},
+			wantHeader: `username="foo\"bar", uid="42"`,
+		},
+		{
+			user: &user.DefaultInfo{
+				Name: "Schrödinger",
+				UID:  "",
+			},
+			wantHeader: `username="Schr\u00f6dinger", uid=""`,
+		},
+		{
+			user: &user.DefaultInfo{
+				Name: "\n",
+				UID:  "",
+			},
+			wantHeader: `username="\n", uid=""`,
+		},
+	}
+
+	for _, test := range tests {
+		a.user = test.user
+
+		rr := httptest.NewRecorder()
+		auth.ServeHTTP(rr, &http.Request{})
+
+		authInfo := rr.Header().Get("Authentication-Info")
+		if test.wantHeader != authInfo {
+			t.Errorf("expected Authentication-Info=%q, got=%q", test.wantHeader, authInfo)
+		}
 	}
 }

--- a/pkg/apiserver/handler_impersonation.go
+++ b/pkg/apiserver/handler_impersonation.go
@@ -118,6 +118,7 @@ func WithImpersonation(handler http.Handler, requestContextMapper api.RequestCon
 			Groups: groups,
 			Extra:  userExtra,
 		}
+		setAuthInfo(w, newUser, authInfoImpersonationHeader)
 		requestContextMapper.Update(req, api.WithUser(ctx, newUser))
 
 		oldUser, _ := api.UserFrom(ctx)

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/kubernetes/pkg/apiserver/audit"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
-	"k8s.io/kubernetes/pkg/auth/handlers"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -517,7 +516,7 @@ func (s *GenericAPIServer) init(c *Config) {
 
 	// Install Authenticator
 	if c.Authenticator != nil {
-		authenticatedHandler, err := handlers.NewRequestAuthenticator(s.RequestContextMapper, c.Authenticator, handlers.Unauthorized(c.SupportsBasicAuth), handler)
+		authenticatedHandler, err := apiserver.NewRequestAuthenticator(s.RequestContextMapper, c.Authenticator, apiserver.Unauthorized(c.SupportsBasicAuth), handler)
 		if err != nil {
 			glog.Fatalf("Could not initialize authenticator: %v", err)
 		}


### PR DESCRIPTION
Add a 'Authentication-Info' response header to all requests which
correctly authenticate with the API server, regardless of the auth-Z
decision. The header value holds the username and uid of the user.

For example the user "jane" with UID "8881" would see the following
request header.

```
Authentication-Info: username="jane", uid="8881"
```

This is a requirement for `kubectl login` as proposed in #29350.

Updates kubernetes/features#32

cc @erictune @liggitt @deads2k @kubernetes/sig-auth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30829)

<!-- Reviewable:end -->
