### PR TITLE
[WIP] Use watches instead of polling for CLI state checking

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -1080,11 +1080,11 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 	first, err = c.Extensions().ReplicaSets(first.Namespace).Get(first.Name)
 	Expect(err).NotTo(HaveOccurred())
 
-	firstCond := client.ReplicaSetHasDesiredReplicas(f.Client.Extensions(), first)
-	wait.PollImmediate(10*time.Millisecond, 1*time.Minute, firstCond)
+	err = framework.WaitForReplicaSetHasDesiredReplicas(f.Client, ns, first.Name)
+	Expect(err).NotTo(HaveOccurred())
 
-	secondCond := client.ReplicaSetHasDesiredReplicas(f.Client.Extensions(), second)
-	wait.PollImmediate(10*time.Millisecond, 1*time.Minute, secondCond)
+	err = framework.WaitForReplicaSetHasDesiredReplicas(f.Client, ns, second.Name)
+	Expect(err).NotTo(HaveOccurred())
 
 	By(fmt.Sprintf("Updating the size (up) and template at the same time for deployment %q", deploymentName))
 	newReplicas := int32(20)
@@ -1141,11 +1141,11 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 	newRs, err := deploymentutil.GetNewReplicaSet(deployment, c)
 	Expect(err).NotTo(HaveOccurred())
 
-	oldCond := client.ReplicaSetHasDesiredReplicas(f.Client.Extensions(), oldRs)
-	wait.PollImmediate(10*time.Millisecond, 1*time.Minute, oldCond)
+	err = framework.WaitForReplicaSetHasDesiredReplicas(f.Client, ns, oldRs.Name)
+	Expect(err).NotTo(HaveOccurred())
 
-	newCond := client.ReplicaSetHasDesiredReplicas(f.Client.Extensions(), newRs)
-	wait.PollImmediate(10*time.Millisecond, 1*time.Minute, newCond)
+	err = framework.WaitForReplicaSetHasDesiredReplicas(f.Client, ns, newRs.Name)
+	Expect(err).NotTo(HaveOccurred())
 
 	By(fmt.Sprintf("Updating the size (down) and template at the same time for deployment %q", deploymentName))
 	newReplicas = int32(5)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -873,6 +873,17 @@ func WaitForDefaultServiceAccountInNamespace(c *client.Client, namespace string)
 	return waitForServiceAccountInNamespace(c, namespace, "default", ServiceAccountProvisionTimeout)
 }
 
+// WaitForReplicaSetHasDesiredReplicas waits for the desired replica count for
+// a ReplicaSet's ReplicaSelector to be equals the Replicas count.
+func WaitForReplicaSetHasDesiredReplicas(c *client.Client, ns, replicaSetName string) error {
+	w, err := c.ReplicaSets(ns).Watch(api.SingleObject(api.ObjectMeta{Name: replicaSetName}))
+	if err != nil {
+		return err
+	}
+	_, err = watch.Until(1*time.Minute, w, client.ReplicaSetHasDesiredReplicas)
+	return err
+}
+
 // WaitForFederationApiserverReady waits for the federation apiserver to be ready.
 // It tests the readiness by sending a GET request and expecting a non error response.
 func WaitForFederationApiserverReady(c *federation_release_1_4.Clientset) error {


### PR DESCRIPTION
**What this PR does / why we need it**: Speed up the ReplicaSet and Job scalers by using `watch.Until` instead of polling. Changes conditions to return functions that can be used by watches instead of the usual ConditionFunc. Update `kubectl rolling-update` to also use watches. Update tests.

**Which issue this PR fixes**: part of https://github.com/kubernetes/kubernetes/issues/30501.

**Special notes for your reviewer**: there are other places that can benefit from a similar tweak so I'm not adding the 'fixes' prefix at the moment to prevent closing the issue.

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30837)

<!-- Reviewable:end -->
