### PR TITLE
Added encryption to EBS dynamic provisioner

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -211,9 +211,11 @@ type EC2Metadata interface {
 
 // VolumeOptions specifies capacity and tags for a volume.
 type VolumeOptions struct {
-	CapacityGB int
-	Tags       map[string]string
-	PVCName    string
+	CapacityGB        int
+	Tags              map[string]string
+	PVCName           string
+	Encrypted         bool
+	EncryptionKeyName string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -1483,6 +1485,8 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 	volSize := int64(volumeOptions.CapacityGB)
 	request.Size = &volSize
 	request.VolumeType = aws.String(DefaultVolumeType)
+	request.Encrypted = volumeOptions.Encrypted
+	request.KmsKeyId = volumeOptions.EncryptionKeyName
 	response, err := c.ec2.CreateVolume(request)
 	if err != nil {
 		return "", err

--- a/pkg/controller/volume/persistentvolume/controller.go
+++ b/pkg/controller/volume/persistentvolume/controller.go
@@ -1212,6 +1212,11 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(claimObj interfa
 		ClusterName:                   ctrl.clusterName,
 		PVName:                        pvName,
 		PVCName:                       claim.Name,
+
+		// will this need anything considering I see
+		//    Parameters:                    storageClass.Parameters,
+		// in https://github.com/kubernetes/kubernetes/pull/29006
+		// EBS plugin just accesses Parameters directly?
 	}
 
 	// Provision the volume

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -79,9 +79,11 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (strin
 	// AWS works with gigabytes, convert to GiB with rounding up
 	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))
 	volumeOptions := &aws.VolumeOptions{
-		CapacityGB: requestGB,
-		Tags:       tags,
-		PVCName:    c.options.PVCName,
+		CapacityGB:        requestGB,
+		Tags:              tags,
+		PVCName:           c.options.PVCName,
+		Encrypted:         c.options.Encrypted,
+		EncryptionKeyName: c.options.EncryptionKeyName,
 	}
 
 	name, err := cloud.CreateDisk(volumeOptions)

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -55,6 +55,10 @@ type VolumeOptions struct {
 	ClusterName string
 	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
 	CloudTags *map[string]string
+	// Encrypted is a flag that denotes whether or not a provisioned volume is encrypted
+	Encrypted bool
+	// EncryptionKeyName is the fully-qualified name of a key resource in a cloud provider
+	EncryptionKeyName string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a


### PR DESCRIPTION
Resolves https://github.com/kubernetes/kubernetes/issues/30792

Adds encryption as an option to the EBS provisioner.

``` release-note
```

@kubernetes/sig-storage @abhgupta

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30841)

<!-- Reviewable:end -->
