### PR TITLE
etcd3 backend: support TLS

### DIFF
--- a/pkg/storage/etcd/testing/testingcert/certificates.go
+++ b/pkg/storage/etcd/testing/testingcert/certificates.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package testingcert
 
 // You can use cfssl tool to generate certificates, please refer
 // https://github.com/coreos/etcd/tree/master/hack/tls-setup for more details.

--- a/pkg/storage/etcd/testing/utils.go
+++ b/pkg/storage/etcd/testing/utils.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kubernetes/pkg/storage/etcd/testing/testingcert"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	etcd "github.com/coreos/etcd/client"
@@ -125,15 +126,15 @@ func configureTestCluster(t *testing.T, name string, https bool) *EtcdTestServer
 			t.Fatal(err)
 		}
 		m.CertFile = path.Join(m.CertificatesDir, "etcdcert.pem")
-		if err = ioutil.WriteFile(m.CertFile, []byte(CertFileContent), 0644); err != nil {
+		if err = ioutil.WriteFile(m.CertFile, []byte(testingcert.CertFileContent), 0644); err != nil {
 			t.Fatal(err)
 		}
 		m.KeyFile = path.Join(m.CertificatesDir, "etcdkey.pem")
-		if err = ioutil.WriteFile(m.KeyFile, []byte(KeyFileContent), 0644); err != nil {
+		if err = ioutil.WriteFile(m.KeyFile, []byte(testingcert.KeyFileContent), 0644); err != nil {
 			t.Fatal(err)
 		}
 		m.CAFile = path.Join(m.CertificatesDir, "ca.pem")
-		if err = ioutil.WriteFile(m.CAFile, []byte(CAFileContent), 0644); err != nil {
+		if err = ioutil.WriteFile(m.CAFile, []byte(testingcert.CAFileContent), 0644); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/storage/storagebackend/factory/etcd3.go
+++ b/pkg/storage/storagebackend/factory/etcd3.go
@@ -29,12 +29,12 @@ import (
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, error) {
-	info := transport.TLSInfo{
+	tlsInfo := transport.TLSInfo{
 		CertFile: c.CertFile,
 		KeyFile:  c.KeyFile,
 		CAFile:   c.CAFile,
 	}
-	tlsConfig, err := info.ClientConfig()
+	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/storagebackend/factory/etcd3.go
+++ b/pkg/storage/storagebackend/factory/etcd3.go
@@ -19,21 +19,33 @@ package factory
 import (
 	"strings"
 
-	"github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
-
 	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/storage/etcd3"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
+	"golang.org/x/net/context"
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, error) {
+	info := transport.TLSInfo{
+		CertFile: c.CertFile,
+		KeyFile:  c.KeyFile,
+		CAFile:   c.CAFile,
+	}
+	tlsConfig, err := info.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	endpoints := c.ServerList
 	for i, s := range endpoints {
 		endpoints[i] = strings.TrimLeft(s, "http://")
 	}
 	cfg := clientv3.Config{
 		Endpoints: endpoints,
+		TLS:       tlsConfig,
 	}
 	client, err := clientv3.New(cfg)
 	if err != nil {

--- a/pkg/storage/storagebackend/factory/etcd3.go
+++ b/pkg/storage/storagebackend/factory/etcd3.go
@@ -17,8 +17,6 @@ limitations under the License.
 package factory
 
 import (
-	"strings"
-
 	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/storage/etcd3"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
@@ -39,12 +37,8 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, error) {
 		return nil, err
 	}
 
-	endpoints := c.ServerList
-	for i, s := range endpoints {
-		endpoints[i] = strings.TrimLeft(s, "http://")
-	}
 	cfg := clientv3.Config{
-		Endpoints: endpoints,
+		Endpoints: c.ServerList,
 		TLS:       tlsConfig,
 	}
 	client, err := clientv3.New(cfg)

--- a/pkg/storage/storagebackend/factory/tls_test.go
+++ b/pkg/storage/storagebackend/factory/tls_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package factory
 
 import (

--- a/pkg/storage/storagebackend/factory/tls_test.go
+++ b/pkg/storage/storagebackend/factory/tls_test.go
@@ -1,0 +1,72 @@
+package factory
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/storage/etcd/testing/testingcert"
+	"k8s.io/kubernetes/pkg/storage/storagebackend"
+
+	"github.com/coreos/etcd/integration"
+	"github.com/coreos/etcd/pkg/transport"
+)
+
+func TestTLSConnection(t *testing.T) {
+	certFile, keyFile, caFile := configureTLSCerts(t)
+
+	tlsInfo := &transport.TLSInfo{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+		CAFile:   caFile,
+	}
+
+	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{
+		Size:      1,
+		ClientTLS: tlsInfo,
+	})
+	defer cluster.Terminate(t)
+
+	cfg := storagebackend.Config{
+		Type:       storagebackend.StorageTypeETCD3,
+		ServerList: []string{cluster.Members[0].GRPCAddr()},
+		CertFile:   certFile,
+		KeyFile:    keyFile,
+		CAFile:     caFile,
+		Codec:      testapi.Default.Codec(),
+	}
+	storage, err := newETCD3Storage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = storage.Create(context.TODO(), "/abc", &api.Pod{}, nil, 0)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+}
+
+func configureTLSCerts(t *testing.T) (certFile, keyFile, caFile string) {
+	baseDir := os.TempDir()
+	tempDir, err := ioutil.TempDir(baseDir, "etcd_certificates")
+	if err != nil {
+		t.Fatal(err)
+	}
+	certFile = path.Join(tempDir, "etcdcert.pem")
+	if err := ioutil.WriteFile(certFile, []byte(testingcert.CertFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	keyFile = path.Join(tempDir, "etcdkey.pem")
+	if err := ioutil.WriteFile(keyFile, []byte(testingcert.KeyFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	caFile = path.Join(tempDir, "ca.pem")
+	if err := ioutil.WriteFile(caFile, []byte(testingcert.CAFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile, caFile
+}


### PR DESCRIPTION
What?
Support TLS in etcd3 storage backend.
It works the same as previous etcd2 config.
- [ ] Blocked on #https://github.com/kubernetes/kubernetes/pull/30480

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30843)

<!-- Reviewable:end -->
