### PR TITLE
Implement "equivalence classes" and caching thereof

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -91,8 +91,8 @@ func PredicateMetadata(pod *api.Pod, nodeInfoMap map[string]*schedulercache.Node
 	}
 	return &predicateMetadata{
 		podBestEffort:             isPodBestEffort(pod),
-		podRequest:                getResourceRequest(pod),
-		podPorts:                  getUsedPorts(pod),
+		podRequest:                GetResourceRequest(pod),
+		podPorts:                  GetUsedPorts(pod),
 		matchingAntiAffinityTerms: matchingTerms,
 	}
 }
@@ -417,7 +417,7 @@ func (c *VolumeZoneChecker) predicate(pod *api.Pod, meta interface{}, nodeInfo *
 	return true, nil, nil
 }
 
-func getResourceRequest(pod *api.Pod) *schedulercache.Resource {
+func GetResourceRequest(pod *api.Pod) *schedulercache.Resource {
 	result := schedulercache.Resource{}
 	for _, container := range pod.Spec.Containers {
 		requests := container.Resources.Requests
@@ -459,7 +459,7 @@ func PodFitsResources(pod *api.Pod, meta interface{}, nodeInfo *schedulercache.N
 		podRequest = predicateMeta.podRequest
 	} else {
 		// We couldn't parse metadata - fallback to computing it.
-		podRequest = getResourceRequest(pod)
+		podRequest = GetResourceRequest(pod)
 	}
 	if podRequest.MilliCPU == 0 && podRequest.Memory == 0 && podRequest.NvidiaGPU == 0 {
 		return len(predicateFails) == 0, predicateFails, nil
@@ -724,14 +724,14 @@ func PodFitsHostPorts(pod *api.Pod, meta interface{}, nodeInfo *schedulercache.N
 		wantPorts = predicateMeta.podPorts
 	} else {
 		// We couldn't parse metadata - fallback to computing it.
-		wantPorts = getUsedPorts(pod)
+		wantPorts = GetUsedPorts(pod)
 	}
 	if len(wantPorts) == 0 {
 		return true, nil, nil
 	}
 
 	// TODO: Aggregate it at the NodeInfo level.
-	existingPorts := getUsedPorts(nodeInfo.Pods()...)
+	existingPorts := GetUsedPorts(nodeInfo.Pods()...)
 	for wport := range wantPorts {
 		if wport != 0 && existingPorts[wport] {
 			return false, []algorithm.PredicateFailureReason{ErrPodNotFitsHostPorts}, nil
@@ -740,7 +740,7 @@ func PodFitsHostPorts(pod *api.Pod, meta interface{}, nodeInfo *schedulercache.N
 	return true, nil, nil
 }
 
-func getUsedPorts(pods ...*api.Pod) map[int]bool {
+func GetUsedPorts(pods ...*api.Pod) map[int]bool {
 	ports := make(map[int]bool)
 	for _, pod := range pods {
 		for j := range pod.Spec.Containers {

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -467,7 +467,7 @@ func TestGetUsedPorts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ports := getUsedPorts(test.pods...)
+		ports := GetUsedPorts(test.pods...)
 		if !reflect.DeepEqual(test.ports, ports) {
 			t.Errorf("%s: expected %v, got %v", "test get used ports", test.ports, ports)
 		}

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -36,3 +36,5 @@ type PriorityConfig struct {
 type PredicateFailureReason interface {
 	GetReason() string
 }
+
+type GetEquivalencePodFunc func(pod *api.Pod) interface{}

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 
 	"github.com/golang/glog"
 )
@@ -94,6 +95,8 @@ func init() {
 	factory.RegisterFitPredicate("HostName", predicates.PodFitsHost)
 	// Fit is determined by node selector query.
 	factory.RegisterFitPredicate("MatchNodeSelector", predicates.PodSelectorMatches)
+	// Use equivalence class to speed up predicates & priorities
+	factory.RegisterGetEquivalencePodFunction(GetEquivalencePod)
 }
 
 func defaultPredicates() sets.String {
@@ -188,7 +191,6 @@ func defaultPriorities() sets.String {
 				Weight: 1,
 			},
 		),
-		factory.RegisterGetEquivalencePodFunction(GetEquivalencePod),
 	)
 }
 
@@ -208,5 +210,5 @@ type EquivalencePod struct {
 	Volumes      []api.Volume
 	NodeSelector map[string]string
 	Ports        map[int]bool
-	Request      predicates.ResourceRequest
+	Request      *schedulercache.Resource
 }

--- a/plugin/pkg/scheduler/equivalencecache/equivalence_cache.go
+++ b/plugin/pkg/scheduler/equivalencecache/equivalence_cache.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equivalencecache
+
+import (
+	//	"github.com/golang/glog"
+	"github.com/golang/groupcache/lru"
+	"hash/adler32"
+
+	"k8s.io/kubernetes/pkg/api"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
+	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
+	"sync"
+)
+
+const maxCacheEntries = 4096
+
+type HostPredicate struct {
+	Fit        bool
+	FailReason sets.String
+}
+
+type podCacheEnty struct {
+	Fit        bool
+	FailReason sets.String
+	Score      schedulerapi.HostPriority
+}
+
+type AlgorithmCache struct {
+	predicatesCache *lru.Cache
+	prioritiesCache *lru.Cache
+}
+
+func newAlgorithmCache() AlgorithmCache {
+	return AlgorithmCache{
+		predicatesCache: lru.New(maxCacheEntries),
+		prioritiesCache: lru.New(maxCacheEntries),
+	}
+}
+
+// Store a map of predicate cache with maxsize
+type EquivalenceCache struct {
+	getEquivalencePod algorithm.GetEquivalencePodFunc
+	algorithmCache    map[string]AlgorithmCache
+	//	realCacheLock     *sync.RWMutex
+
+	invalidAlgorithmCacheList sets.String
+	allCacheExpired           bool
+	expireLock                *sync.RWMutex
+}
+
+func NewEquivalenceCache(getEquivalencePodFunc algorithm.GetEquivalencePodFunc) *EquivalenceCache {
+	return &EquivalenceCache{
+		getEquivalencePod: getEquivalencePodFunc,
+		algorithmCache:    make(map[string]AlgorithmCache),
+		//		realCacheLock:         new(sync.RWMutex),
+		invalidAlgorithmCacheList: sets.NewString(),
+		allCacheExpired:           false,
+		expireLock:                new(sync.RWMutex),
+	}
+}
+
+func (ec *EquivalenceCache) addPodPriority(podKey uint64, nodeName string, score int) {
+	if _, exist := ec.algorithmCache[nodeName]; !exist {
+		ec.algorithmCache[nodeName] = newAlgorithmCache()
+	}
+	ec.algorithmCache[nodeName].prioritiesCache.Add(podKey, schedulerapi.HostPriority{Host: nodeName, Score: score})
+}
+
+func (ec *EquivalenceCache) addPodPredicate(podKey uint64, nodeName string, fit bool, failReason sets.String) {
+	if _, exist := ec.algorithmCache[nodeName]; !exist {
+		ec.algorithmCache[nodeName] = newAlgorithmCache()
+	}
+	ec.algorithmCache[nodeName].predicatesCache.Add(podKey, HostPredicate{Fit: fit, FailReason: failReason})
+}
+
+func (ec *EquivalenceCache) AddPodPredicatesCache(pod *api.Pod, fitNodeList *api.NodeList, failedPredicates *FailedPredicateMap) {
+	equivalenceHash := ec.hashEquivalencePod(pod)
+
+	for _, fitNode := range fitNodeList.Items {
+		ec.addPodPredicate(equivalenceHash, fitNode.Name, true, sets.String{})
+	}
+	for failNodeName, failReason := range *failedPredicates {
+		ec.addPodPredicate(equivalenceHash, failNodeName, false, failReason)
+	}
+}
+
+func (ec *EquivalenceCache) AddPodPrioritiesCache(pod *api.Pod, priorities schedulerapi.HostPriorityList) {
+	equivalenceHash := ec.hashEquivalencePod(pod)
+
+	for _, priority := range priorities {
+		ec.addPodPriority(equivalenceHash, priority.Host, priority.Score)
+	}
+}
+
+func (ec *EquivalenceCache) GetCachedPredicates(pod *api.Pod, nodes api.NodeList) (api.NodeList, FailedPredicateMap, api.NodeList) {
+	fitNodeList := api.NodeList{}
+	failedPredicates := FailedPredicateMap{}
+	noCacheNodeList := api.NodeList{}
+
+	equivalenceHash := ec.hashEquivalencePod(pod)
+
+	for _, node := range nodes.Items {
+		findCache := false
+		if algorithmCache, exist := ec.algorithmCache[node.Name]; exist {
+			if cachePredicate, exist := algorithmCache.predicatesCache.Get(equivalenceHash); exist {
+				hostPredicate := cachePredicate.(HostPredicate)
+				if hostPredicate.Fit {
+					fitNodeList.Items = append(fitNodeList.Items, node)
+				} else {
+					failedPredicates[node.Name] = hostPredicate.FailReason
+				}
+				findCache = true
+			}
+		}
+		if !findCache {
+			noCacheNodeList.Items = append(noCacheNodeList.Items, node)
+		}
+	}
+	//	glog.Infof("Get predicate cache: %v ----%v, nodes: %v has no cache date.", fitNodeList.Items, failedPredicates, noCacheNodeList.Items)
+	return fitNodeList, failedPredicates, noCacheNodeList
+}
+
+func (ec *EquivalenceCache) GetCachedPriorities(pod *api.Pod, nodes api.NodeList) (schedulerapi.HostPriorityList, api.NodeList) {
+	cachedPriorities := schedulerapi.HostPriorityList{}
+	noCacheNodeList := api.NodeList{}
+
+	equivalenceHash := ec.hashEquivalencePod(pod)
+
+	for _, node := range nodes.Items {
+		findCache := false
+		if algorithmCache, exist := ec.algorithmCache[node.Name]; exist {
+			if cachePriority, exist := algorithmCache.prioritiesCache.Get(equivalenceHash); exist {
+				hostPriotity := cachePriority.(schedulerapi.HostPriority)
+				cachedPriorities = append(cachedPriorities, hostPriotity)
+				findCache = true
+			}
+		}
+		if !findCache {
+			noCacheNodeList.Items = append(noCacheNodeList.Items, node)
+		}
+	}
+
+	return cachedPriorities, noCacheNodeList
+}
+
+func (ec *EquivalenceCache) SendInvalidAlgorithmCacheReq(nodeName string) {
+	ec.expireLock.RLock()
+	allExpired := ec.allCacheExpired
+	ec.expireLock.RUnlock()
+
+	if !allExpired {
+		ec.expireLock.Lock()
+		defer ec.expireLock.Unlock()
+		ec.invalidAlgorithmCacheList.Insert(nodeName)
+	}
+}
+
+func (ec *EquivalenceCache) SendClearAllCacheReq() {
+	ec.expireLock.RLock()
+	allExpired := ec.allCacheExpired
+	ec.expireLock.RUnlock()
+
+	if !allExpired {
+		ec.expireLock.Lock()
+		ec.allCacheExpired = true
+		ec.expireLock.Unlock()
+	}
+}
+
+func (ec *EquivalenceCache) HandleExpireDate() {
+	ec.expireLock.Lock()
+	defer ec.expireLock.Unlock()
+
+	// Remove expired AlgorithmCache
+	if ec.allCacheExpired {
+		ec.algorithmCache = make(map[string]AlgorithmCache)
+	} else {
+		for _, node := range ec.invalidAlgorithmCacheList.List() {
+			delete(ec.algorithmCache, node)
+		}
+	}
+
+	// Clear expired data records for next cycle
+	ec.invalidAlgorithmCacheList = sets.NewString()
+	ec.allCacheExpired = false
+}
+
+// hashEquivalencePod returns the hash of equivalence pod.
+func (ec *EquivalenceCache) hashEquivalencePod(pod *api.Pod) uint64 {
+	equivalencePod := ec.getEquivalencePod(pod)
+	hash := adler32.New()
+	hashutil.DeepHashObject(hash, equivalencePod)
+	return uint64(hash.Sum32())
+}

--- a/plugin/pkg/scheduler/extender_test.go
+++ b/plugin/pkg/scheduler/extender_test.go
@@ -282,7 +282,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		for ii := range test.extenders {
 			extenders = append(extenders, &test.extenders[ii])
 		}
-		scheduler := NewGenericScheduler(schedulertesting.PodsToCache(test.pods), test.predicates, test.prioritizers, extenders)
+		scheduler := NewGenericScheduler(schedulertesting.PodsToCache(test.pods), nil, test.predicates, test.prioritizers, extenders)
 		machine, err := scheduler.Schedule(test.pod, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {
 			if err == nil {

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -64,6 +64,8 @@ var (
 	fitPredicateMap      = make(map[string]FitPredicateFactory)
 	priorityFunctionMap  = make(map[string]PriorityConfigFactory)
 	algorithmProviderMap = make(map[string]AlgorithmProviderConfig)
+
+	getEquivalencePodFunc algorithm.GetEquivalencePodFunc = nil
 )
 
 const (
@@ -203,6 +205,11 @@ func RegisterCustomPriorityFunction(policy schedulerapi.PriorityPolicy) string {
 	}
 
 	return RegisterPriorityConfigFactory(policy.Name, *pcf)
+}
+
+func RegisterGetEquivalencePodFunction(equivalenceFunc algorithm.GetEquivalencePodFunc) {
+	glog.Info("Register getEquivalencePodFunc.")
+	getEquivalencePodFunc = equivalenceFunc
 }
 
 // This check is useful for testing providers.

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -296,7 +296,7 @@ func TestGenericScheduler(t *testing.T) {
 		for _, name := range test.nodes {
 			cache.AddNode(&api.Node{ObjectMeta: api.ObjectMeta{Name: name}})
 		}
-		scheduler := NewGenericScheduler(cache, test.predicates, test.prioritizers, []algorithm.SchedulerExtender{})
+		scheduler := NewGenericScheduler(cache, nil, test.predicates, test.prioritizers, []algorithm.SchedulerExtender{})
 		machine, err := scheduler.Schedule(test.pod, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
 
 		if !reflect.DeepEqual(err, test.wErr) {

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -383,6 +383,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.Cache, nodeLister algorithm.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate) (*Scheduler, chan *api.Binding, chan error) {
 	algo := NewGenericScheduler(
 		scache,
+		nil,
 		predicateMap,
 		[]algorithm.PriorityConfig{},
 		[]algorithm.SchedulerExtender{})


### PR DESCRIPTION
**NOTE**

> This implementation has been move to #36238, we keep this PR open just to hold old discussions.

----below is the original description-----

ref #17390, it's a replacement of #18938 as @davidopp requested, most of ideas owes to the original PR.

cc @davidopp @wojtek-t 

Details
1. In `plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go`, `GetEquivalencePod` is defined to check `Equivalence` or not.
2. A `equivalence_cache.go` is added to cache predicates & priorities. `GetEquivalencePod` is injected into `equivalence_cache` to get equivalence class of a pod.
3. In `plugin/pkg/scheduler/factory/factory.go`, a group of `xxxPopulator` are added to sync `equivalence_cache`. Initialize scheduler  with`EquivalencePodCache` if possible.
4. In `plugin/pkg/scheduler/generic_scheduler.go`, added `equivalenceCache` awareness to `Schedule()`.

> The reason I keep a separate cache is that algorithm already imported `schedulerCache` and `NodeInfo`, this will be  a cycle import.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30844)

<!-- Reviewable:end -->
