### PR TITLE
Fix/centos docker download

### DIFF
--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -53,7 +53,7 @@ function download-releases() {
   curl -L ${K8S_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes.tar.gz
 
   echo "Download docker-latest ..."
-  curl -L https://get.docker.com/builds/Linux/x86_64/docker-latest -o ${RELEASES_DIR}/docker
+  curl -L https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz -o ${RELEASES_DIR}/docker.tar.gz
 }
 
 function unpack-releases() {
@@ -95,8 +95,10 @@ function unpack-releases() {
     cp ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kubectl ${BINARY_DIR}
   fi
 
-  if [[ -f ${RELEASES_DIR}/docker ]]; then
-    cp ${RELEASES_DIR}/docker ${BINARY_DIR}/node/bin
+  if [[ -f ${RELEASES_DIR}/docker.tar.gz ]]; then
+    tar xzf ${RELEASES_DIR}/docker.tar.gz -C ${RELEASES_DIR}
+
+    cp ${RELEASES_DIR}/docker/docker* ${BINARY_DIR}/node/bin
   fi
 
   chmod -R +x ${BINARY_DIR}

--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -52,8 +52,8 @@ function download-releases() {
   echo "Download kubernetes release v${K8S_VERSION} ..."
   curl -L ${K8S_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes.tar.gz
 
-  echo "Download docker-latest ..."
-  curl -L https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz -o ${RELEASES_DIR}/docker.tar.gz
+  echo "Download docker release v${DOCKER_VERSION} ..."
+  curl -L ${DOCKER_DOWNLOAD_URL} -o ${RELEASES_DIR}/docker.tar.gz
 }
 
 function unpack-releases() {
@@ -95,6 +95,7 @@ function unpack-releases() {
     cp ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kubectl ${BINARY_DIR}
   fi
 
+  # docker
   if [[ -f ${RELEASES_DIR}/docker.tar.gz ]]; then
     tar xzf ${RELEASES_DIR}/docker.tar.gz -C ${RELEASES_DIR}
 

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -19,6 +19,9 @@
 # Directory to store release packages that will be downloaded.
 RELEASES_DIR=${RELEASES_DIR:-/tmp/downloads}
 
+# Define docker version to use.
+DOCKER_VERSION=${DOCKER_VERSION:-"1.12.0"}
+
 # Define flannel version to use.
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 
@@ -27,6 +30,9 @@ ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
 # Define k8s version to use.
 K8S_VERSION=${K8S_VERSION:-"1.3.5"}
+
+DOCKER_DOWNLOAD_URL=\
+"https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
 
 FLANNEL_DOWNLOAD_URL=\
 "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz"

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -26,7 +26,7 @@ FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
 # Define k8s version to use.
-K8S_VERSION=${K8S_VERSION:-"1.1.1"}
+K8S_VERSION=${K8S_VERSION:-"1.3.5"}
 
 FLANNEL_DOWNLOAD_URL=\
 "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz"

--- a/cluster/centos/node/scripts/docker.sh
+++ b/cluster/centos/node/scripts/docker.sh
@@ -35,7 +35,7 @@ Type=notify
 EnvironmentFile=-/run/flannel/docker
 EnvironmentFile=-/opt/kubernetes/cfg/docker
 WorkingDirectory=/opt/kubernetes/bin
-ExecStart=/opt/kubernetes/bin/docker daemon \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPTS
+ExecStart=/opt/kubernetes/bin/dockerd \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPTS
 LimitNOFILE=1048576
 LimitNPROC=1048576
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: The CentOS cluster provider attempts to download docker from a location that 404's.

**Which issue this PR fixes**: addresses https://github.com/kubernetes/kubernetes/issues/27572#issuecomment-226690177

**Special notes for your reviewer**: I don't know how Kubernetes decides docker compatibility, but it was previously pulling `latest` so I chose the most recent release. Is there any mechanism for keeping things like this up to date?

What is the status of kubernetes rpm's? As far as I could tell there aren't any 1.3 rpm's published. Are those officially supported or a community project?

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
CentOS Cluster Provider: fix docker download location & use docker 1.12.0
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30847)

<!-- Reviewable:end -->
