### PR TITLE
Scheduler called by federated replicaset controller

### DIFF
--- a/federation/apis/federation/register.go
+++ b/federation/apis/federation/register.go
@@ -48,7 +48,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Cluster{},
 		&ClusterList{},
 		&api.ListOptions{},
-		&api.DeleteOptions{},
 	)
 	return nil
 }

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -90,7 +90,7 @@ func Run(s *options.CMServer) error {
 		glog.Errorf("unable to register configz: %s", err)
 	}
 	// Create the config to talk to federation-apiserver.
-	kubeconfigGetter := util.KubeconfigGetterForSecret(KubeconfigSecretName)
+	kubeconfigGetter := util.KubeconfigGetterForSecret("")
 	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
 	if err != nil || restClientCfg == nil {
 		// Retry with the deprecated name in 1.4.

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	clustercontroller "k8s.io/kubernetes/federation/pkg/federation-controller/cluster"
+	replicasetcontroller "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset"
 	servicecontroller "k8s.io/kubernetes/federation/pkg/federation-controller/service"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -144,5 +145,9 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 	if err := servicecontroller.Run(s.ConcurrentServiceSyncs, wait.NeverStop); err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)
 	}
+
+	replicaSetClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, replicasetcontroller.UserAgentName))
+	replicaSetController := replicasetcontroller.NewReplicaSetController(replicaSetClientset)
+	go replicaSetController.Run(s.ConcurrentReplicaSetSyncs, wait.NeverStop)
 	select {}
 }

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -47,6 +47,10 @@ type ControllerManagerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive service
 	// management, but more CPU (and network) load.
 	ConcurrentServiceSyncs int `json:"concurrentServiceSyncs"`
+	// concurrentReplicaSetSyncs is the number of ReplicaSets that are
+	// allowed to sync concurrently. Larger number = more responsive service
+	// management, but more CPU (and network) load.
+	ConcurrentReplicaSetSyncs int `json:"concurrentReplicaSetSyncs"`
 	// clusterMonitorPeriod is the period for syncing ClusterStatus in cluster controller.
 	ClusterMonitorPeriod unversioned.Duration `json:"clusterMonitorPeriod"`
 	// APIServerQPS is the QPS to use while talking with federation apiserver.
@@ -78,13 +82,14 @@ const (
 func NewCMServer() *CMServer {
 	s := CMServer{
 		ControllerManagerConfiguration: ControllerManagerConfiguration{
-			Port:                   FederatedControllerManagerPort,
-			Address:                "0.0.0.0",
-			ConcurrentServiceSyncs: 10,
-			ClusterMonitorPeriod:   unversioned.Duration{Duration: 40 * time.Second},
-			APIServerQPS:           20.0,
-			APIServerBurst:         30,
-			LeaderElection:         leaderelection.DefaultLeaderElectionConfiguration(),
+			Port:                      FederatedControllerManagerPort,
+			Address:                   "0.0.0.0",
+			ConcurrentServiceSyncs:    10,
+			ConcurrentReplicaSetSyncs: 10,
+			ClusterMonitorPeriod:      unversioned.Duration{Duration: 40 * time.Second},
+			APIServerQPS:              20.0,
+			APIServerBurst:            30,
+			LeaderElection:            leaderelection.DefaultLeaderElectionConfiguration(),
 		},
 	}
 	return &s
@@ -97,6 +102,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.FederationName, "federation-name", s.FederationName, "Federation name.")
 	fs.StringVar(&s.ZoneName, "zone-name", s.ZoneName, "Zone name, like example.com.")
 	fs.IntVar(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
+	fs.IntVar(&s.ConcurrentReplicaSetSyncs, "concurrent-replicaset-syncs", s.ConcurrentReplicaSetSyncs, "The number of ReplicaSets syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.DurationVar(&s.ClusterMonitorPeriod.Duration, "cluster-monitor-period", s.ClusterMonitorPeriod.Duration, "The period for syncing ClusterStatus in ClusterController.")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the federation API server (overrides any value in kubeconfig)")

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicaset
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+
+	fed "k8s.io/kubernetes/federation/apis/federation"
+	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	//kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	planner "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset/planner"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	// schedule result was put into annotation in a format of "clusterName:replicas[/clusterName:replicas]..."
+	ExpectedReplicasAnnotation = "kubernetes.io/expected-replicas"
+	allClustersKey             = "THE_ALL_CLUSTER_KEY"
+	UserAgentName              = "Federation-replicaset-Controller"
+)
+
+var (
+	replicaSetReviewDelay   = 10 * time.Second
+	clusterAvailableDelay   = 20 * time.Second
+	clusterUnavailableDelay = 60 * time.Second
+)
+
+func encodeScheduleResult(scheduleResult map[string]int64) string {
+	var scheduleResultStrings []string
+	for clusterName, replicas := range scheduleResult {
+		scheduleResultStrings = append(scheduleResultStrings, clusterName+":"+strconv.FormatInt(replicas, 10))
+	}
+	return strings.Join(scheduleResultStrings, "/")
+}
+
+func decodeScheduleResult(scheduleResultString string) (map[string]int64, error) {
+	var scheduleResult = make(map[string]int64)
+	clusterReplicas := strings.Split(scheduleResultString, "/")
+	for _, clusterReplica := range clusterReplicas {
+		cr := strings.Split(clusterReplica, ":")
+		if len(cr) != 2 {
+			glog.Errorf("Failed decode schedule result: %v", cr)
+			return nil, fmt.Errorf("Failed decode schedule result: %v", cr)
+		}
+		replicas, err := strconv.ParseInt(cr[1], 10, 64)
+		if err != nil {
+			glog.Errorf("Failed parse scheduled replcias: %v:%v", cr[0], cr[1])
+			return nil, err
+		}
+		scheduleResult[cr[0]] = replicas
+	}
+	return scheduleResult, nil
+}
+
+func scheduleResultFromAnnotation(frs *extensionsv1.ReplicaSet) (scheduleResult map[string]int64, found bool, err error) {
+	accessor, err := meta.Accessor(frs)
+	if err != nil {
+		panic(err) // should never happen
+	}
+	anno := accessor.GetAnnotations()
+	scheduleResultString, found := anno[ExpectedReplicasAnnotation]
+	if found {
+		scheduleResult, err = decodeScheduleResult(scheduleResultString)
+	}
+	return
+}
+
+func scheduleResultToAnnotation(frs *extensionsv1.ReplicaSet, scheduleResult map[string]int64) {
+	accessor, err := meta.Accessor(frs)
+	if err != nil {
+		panic(err) // should never happen
+	}
+	anno := accessor.GetAnnotations()
+	if anno == nil {
+		anno = make(map[string]string)
+	}
+	anno[ExpectedReplicasAnnotation] = encodeScheduleResult(scheduleResult)
+	accessor.SetAnnotations(anno)
+}
+
+func backoff(trial int64) time.Duration {
+	if trial > 12 {
+		return 12 * 5 * time.Second
+	}
+	return time.Duration(trial) * 5 * time.Second
+}
+
+type ReplicaSetItem struct {
+	trial int64
+}
+
+type ReplicaSetController struct {
+	planner *planner.Planner
+
+	fedClient fedclientset.Interface
+
+	replicaSetController *framework.Controller
+	replicaSetStore      cache.StoreToReplicaSetLister
+
+	fedInformer fedutil.FederatedInformer
+
+	replicasetDeliverer *fedutil.DelayingDeliverer
+	clusterDeliverer    *fedutil.DelayingDeliverer
+	replicasetWorkQueue workqueue.Interface
+}
+
+// NewclusterController returns a new cluster controller
+func NewReplicaSetController(federationClient fedclientset.Interface) *ReplicaSetController {
+	frsc := &ReplicaSetController{
+		fedClient:           federationClient,
+		replicasetDeliverer: fedutil.NewDelayingDeliverer(),
+		clusterDeliverer:    fedutil.NewDelayingDeliverer(),
+		replicasetWorkQueue: workqueue.New(),
+		planner: planner.NewPlanner(&fed.FederatedReplicaSetPreferences{
+			Clusters: map[string]fed.ClusterReplicaSetPreferences{
+				"*": {Weight: 1},
+			},
+		}),
+	}
+
+	replicaSetFedInformerFactory := func(cluster *fedv1.Cluster, clientset fedclientset.Interface) (cache.Store, framework.ControllerInterface) {
+		return framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return clientset.Extensions().ReplicaSets(apiv1.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return clientset.Extensions().ReplicaSets(apiv1.NamespaceAll).Watch(options)
+				},
+			},
+			&extensionsv1.ReplicaSet{},
+			controller.NoResyncPeriodFunc(),
+			fedutil.NewTriggerOnAllChangesPreproc(
+				func(obj runtime.Object) { frsc.enqueueLocalReplicaSet(obj, replicaSetReviewDelay) },
+				func(obj runtime.Object) {},
+			),
+		)
+	}
+	clusterLifecycle := fedutil.ClusterLifecycleHandlerFuncs{
+		ClusterAvailable: func(cluster *fedv1.Cluster) { /* no rebalancing for now */ },
+		ClusterUnavailable: func(cluster *fedv1.Cluster, _ []interface{}) {
+			frsc.clusterDeliverer.DeliverAfter(allClustersKey, nil, clusterUnavailableDelay)
+		},
+	}
+	frsc.fedInformer = fedutil.NewFederatedInformer(federationClient, replicaSetFedInformerFactory, &clusterLifecycle)
+
+	frsc.replicaSetStore.Store, frsc.replicaSetController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+				return frsc.fedClient.Extensions().ReplicaSets(apiv1.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return frsc.fedClient.Extensions().ReplicaSets(apiv1.NamespaceAll).Watch(options)
+			},
+		},
+		&extensionsv1.ReplicaSet{},
+		controller.NoResyncPeriodFunc(),
+		fedutil.TriggerOnMetaAndSpecChanges(
+			func(obj runtime.Object) { frsc.enqueueFedReplicaSet(obj, replicaSetReviewDelay) },
+		),
+	)
+
+	return frsc
+}
+
+func (frsc *ReplicaSetController) Run(workers int, stopCh <-chan struct{}) {
+	go frsc.replicaSetController.Run(stopCh)
+	frsc.fedInformer.Start()
+
+	for !frsc.isSynced() {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	frsc.replicasetDeliverer.StartWithHandler(func(item *fedutil.DelayingDelivererItem) {
+		frsc.replicasetWorkQueue.Add(*item)
+	})
+	frsc.clusterDeliverer.StartWithHandler(func(_ *fedutil.DelayingDelivererItem) {
+		frsc.reconcileNamespacesOnClusterChange()
+	})
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(frsc.worker, time.Second, stopCh)
+	}
+	<-stopCh
+	glog.Infof("Shutting down ReplicaSetController")
+	frsc.replicasetDeliverer.Stop()
+	frsc.clusterDeliverer.Stop()
+	frsc.replicasetWorkQueue.ShutDown()
+
+}
+
+func (frsc *ReplicaSetController) isSynced() bool {
+	if !frsc.fedInformer.ClustersSynced() {
+		glog.V(2).Infof("Cluster list not synced")
+		return false
+	}
+	clusters, err := frsc.fedInformer.GetReadyClusters()
+	if err != nil {
+		glog.Errorf("Failed to get ready clusters: %v", err)
+		return false
+	}
+	if !frsc.fedInformer.GetTargetStore().ClustersSynced(clusters) {
+		return false
+	}
+	if !frsc.replicaSetController.HasSynced() {
+		glog.V(2).Infof("federation replicaset list not synced")
+		return false
+	}
+	return true
+}
+
+func (frsc *ReplicaSetController) enqueueLocalReplicaSet(obj interface{}, duration time.Duration) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %v: %v", obj, err)
+		return
+	}
+	_, exists, err := frsc.replicaSetStore.GetByKey(key)
+	if err != nil {
+		glog.Errorf("Couldn't get federation replicaset %v: %v", key, err)
+		return
+	}
+	if exists { // ignore replicasets exists only in local k8s
+		frsc.enqueueFedReplicaSet(obj, duration)
+	}
+}
+func (frsc *ReplicaSetController) enqueueFedReplicaSet(obj interface{}, duration time.Duration) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	frsc.replicasetDeliverer.DeliverAfter(key, ReplicaSetItem{trial: 0}, duration)
+}
+
+func (frsc *ReplicaSetController) worker() {
+	for {
+		item, quit := frsc.replicasetWorkQueue.Get()
+		if quit {
+			return
+		}
+		deliverItem := item.(fedutil.DelayingDelivererItem)
+		replicasetItem := deliverItem.Value.(ReplicaSetItem)
+		err := frsc.reconcileReplicaSet(deliverItem.Key, replicasetItem.trial)
+		frsc.replicasetWorkQueue.Done(item)
+		if err != nil {
+			glog.Errorf("Error syncing cluster controller: %v", err)
+			frsc.replicasetDeliverer.DeliverAfter(deliverItem.Key,
+				ReplicaSetItem{trial: replicasetItem.trial + 1},
+				backoff(replicasetItem.trial+1))
+		}
+	}
+}
+
+func (frsc *ReplicaSetController) schedule(replicas int32, clusters []*fedv1.Cluster,
+	expected map[string]int64, actual map[string]int64) map[string]int64 {
+	// TODO: integrate real scheduler
+	var clusterNames []string
+	for _, cluster := range clusters {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+	scheduleResult := frsc.planner.Plan(int64(replicas), clusterNames)
+	result := make(map[string]int64)
+	for clusterName := range expected {
+		result[clusterName] = 0
+	}
+	for clusterName, replicas := range scheduleResult {
+		result[clusterName] = replicas
+	}
+
+	return result
+}
+
+func (frsc *ReplicaSetController) reconcileReplicaSet(key string, trial int64) error {
+	if !frsc.isSynced() {
+		frsc.replicasetDeliverer.DeliverAfter(key, ReplicaSetItem{trial: trial}, clusterAvailableDelay)
+		return nil
+	}
+
+	glog.Infof("Start reconcile replicaset %q", key)
+	startTime := time.Now()
+	defer glog.Infof("Finished reconcile replicaset %q (%v)", key, time.Now().Sub(startTime))
+
+	obj, exists, err := frsc.replicaSetStore.Store.GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		err = frsc.deleteReplicaSet(key)
+		return err
+	}
+
+	frs := obj.(*extensionsv1.ReplicaSet)
+
+	scheduleResult, found, err := scheduleResultFromAnnotation(frs)
+
+	if !found || err != nil { // unscheduled or schedule result missing or corrupted
+		clusters, err := frsc.fedInformer.GetReadyClusters()
+		if err != nil {
+			return err
+		}
+		scheduleResult = frsc.schedule(*frs.Spec.Replicas, clusters, nil, nil)
+		scheduleResultToAnnotation(frs, scheduleResult)
+		frs, err = frsc.fedClient.Extensions().ReplicaSets(frs.Namespace).Update(frs)
+		if err != nil {
+			return err
+		}
+	}
+
+	var totalReplicas int64 = 0
+	for _, replicas := range scheduleResult {
+		totalReplicas += replicas
+	}
+	if int32(totalReplicas) != *frs.Spec.Replicas {
+		// replicas don't match, re-schedule
+		clusters, err := frsc.fedInformer.GetReadyClusters()
+		if err != nil {
+			return err
+		}
+		scheduleResult = frsc.schedule(*frs.Spec.Replicas, clusters, scheduleResult, nil)
+	}
+
+	glog.Infof("Start syncing local replicaset %v", scheduleResult)
+
+	fedStatus := extensionsv1.ReplicaSetStatus{ObservedGeneration: frs.Generation}
+	for clusterName, replicas := range scheduleResult {
+		// TODO: updater or parallelizer doesnn't help as results are needed for updating fed rs status
+		clusterClient, err := frsc.fedInformer.GetClientsetForCluster(clusterName)
+		if err != nil {
+			return err
+		}
+		var lrs *extensionsv1.ReplicaSet
+		lrsObj, exists, err := frsc.fedInformer.GetTargetStore().GetByKey(clusterName, key)
+		if err != nil {
+			return err
+		} else if !exists {
+			if replicas > 0 {
+				lrsClone, _ := api.Scheme.DeepCopy(frs)
+				lrs = lrsClone.(*extensionsv1.ReplicaSet)
+				lrs.ObjectMeta = apiv1.ObjectMeta{
+					Name:        lrs.Name,
+					Namespace:   lrs.Namespace,
+					Labels:      lrs.Labels,
+					Annotations: lrs.Annotations,
+				}
+				specReplicas := int32(replicas)
+				lrs.Spec.Replicas = &specReplicas
+				lrs, err = clusterClient.Extensions().ReplicaSets(frs.Namespace).Create(lrs)
+				if err != nil {
+					return err
+				}
+				fedStatus.Replicas += lrs.Status.Replicas
+				fedStatus.FullyLabeledReplicas += lrs.Status.FullyLabeledReplicas
+			}
+		} else {
+			lrs = lrsObj.(*extensionsv1.ReplicaSet)
+			lrsExpectedSpec := frs.Spec
+			specReplicas := int32(replicas)
+			lrsExpectedSpec.Replicas = &specReplicas
+			if !reflect.DeepEqual(lrs.Spec, lrsExpectedSpec) {
+				lrs.Spec = lrsExpectedSpec
+				lrs, err = clusterClient.Extensions().ReplicaSets(frs.Namespace).Update(lrs)
+				if err != nil {
+					return err
+				}
+			}
+			fedStatus.Replicas += lrs.Status.Replicas
+			fedStatus.FullyLabeledReplicas += lrs.Status.FullyLabeledReplicas
+			if replicas == 0 {
+				err := clusterClient.Extensions().ReplicaSets(frs.Namespace).Delete(frs.Name, &api.DeleteOptions{})
+				if err != nil && !errors.IsNotFound(err) {
+					return err
+				}
+			}
+		}
+	}
+	if fedStatus.Replicas != frs.Status.Replicas || fedStatus.FullyLabeledReplicas != frs.Status.FullyLabeledReplicas {
+		frs.Status = fedStatus
+		_, err = frsc.fedClient.Extensions().ReplicaSets(frs.Namespace).UpdateStatus(frs)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (frsc *ReplicaSetController) deleteReplicaSet(key string) error {
+	glog.Infof("deleting replicaset: %v", key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	// try delete from all clusters
+	clusters, err := frsc.fedInformer.GetReadyClusters()
+	for _, cluster := range clusters {
+		clusterClient, err := frsc.fedInformer.GetClientsetForCluster(cluster.Name)
+		if err != nil {
+			return err
+		}
+		err = clusterClient.Extensions().ReplicaSets(namespace).Delete(name, &api.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			glog.Warningf("failed deleting repicaset %v/%v/%v, err: %v", cluster.Name, namespace, name, err)
+			return err
+		}
+	}
+	return nil
+
+}
+
+func (nc *ReplicaSetController) reconcileNamespacesOnClusterChange() {
+	if !nc.isSynced() {
+		nc.clusterDeliverer.DeliverAfter(allClustersKey, nil, clusterAvailableDelay)
+	}
+	rss, _ := nc.replicaSetStore.List()
+	for _, rs := range rss {
+		key, _ := controller.KeyFunc(rs)
+		nc.replicasetDeliverer.DeliverAfter(key, ReplicaSetItem{trial: 0}, 0)
+	}
+}

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller_test.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicaset
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	fedclientfake "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"testing"
+	"time"
+	//kubeclientfake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+func TestEncodeDecodeScheduleResult(t *testing.T) {
+	scheduleResult := map[string]int64{
+		"k8s-1": 2,
+		"k8s-2": 4,
+		"k8s.3": 1234,
+	}
+	scheduleResultString := encodeScheduleResult(scheduleResult)
+	scheduleResultNew, _ := decodeScheduleResult(scheduleResultString)
+	assert.Equal(t, scheduleResult, scheduleResultNew)
+}
+
+func TestScheduleResultInAnnotation(t *testing.T) {
+	rs := mkReplicaSet("rs1", 100)
+	scheduleResult, found, err := scheduleResultFromAnnotation(rs)
+	assert.False(t, found)
+	assert.Empty(t, scheduleResult)
+	assert.Nil(t, err)
+	scheduleResult = map[string]int64{
+		"k8s-1": 2,
+		"k8s-2": 4,
+		"k8s.3": 1234,
+	}
+	scheduleResultToAnnotation(rs, scheduleResult)
+	scheduleResultNew, found, err := scheduleResultFromAnnotation(rs)
+	assert.True(t, found)
+	assert.Equal(t, scheduleResult, scheduleResultNew)
+	assert.Nil(t, err)
+}
+
+func TestReplicaSetController(t *testing.T) {
+
+	replicaSetReviewDelay = 10 * time.Millisecond
+	clusterAvailableDelay = 20 * time.Millisecond
+	clusterUnavailableDelay = 60 * time.Millisecond
+
+	fedclientset := fedclientfake.NewSimpleClientset()
+	fedrswatch := watch.NewFake()
+	fedclientset.PrependWatchReactor("replicasets", core.DefaultWatchReactor(fedrswatch, nil))
+
+	fedclientset.Federation().Clusters().Create(mkCluster("k8s-1", apiv1.ConditionTrue))
+	fedclientset.Federation().Clusters().Create(mkCluster("k8s-2", apiv1.ConditionTrue))
+
+	kube1clientset := fedclientfake.NewSimpleClientset()
+	kube1rswatch := watch.NewFake()
+	kube1clientset.PrependWatchReactor("replicasets", core.DefaultWatchReactor(kube1rswatch, nil))
+	kube2clientset := fedclientfake.NewSimpleClientset()
+	kube2rswatch := watch.NewFake()
+	kube2clientset.PrependWatchReactor("replicasets", core.DefaultWatchReactor(kube2rswatch, nil))
+
+	stopChan := make(chan struct{})
+	replicaSetController := NewReplicaSetController(fedclientset)
+	informer := toFederatedInformerForTestOnly(replicaSetController.fedInformer)
+	informer.SetClientFactory(func(cluster *fedv1.Cluster) (federation_release_1_4.Interface, error) {
+		switch cluster.Name {
+		case "k8s-1":
+			return kube1clientset, nil
+		case "k8s-2":
+			return kube2clientset, nil
+		default:
+			return nil, fmt.Errorf("Unknown cluster: %v", cluster.Name)
+		}
+	})
+
+	go replicaSetController.Run(1, stopChan)
+
+	rs := mkReplicaSet("rs", 9)
+	rs, _ = fedclientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Create(rs)
+	fedrswatch.Add(rs)
+	time.Sleep(1 * time.Second)
+
+	rs1, _ := kube1clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	rs1.Status.Replicas = *rs1.Spec.Replicas
+	rs1, _ = kube1clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).UpdateStatus(rs1)
+	kube1rswatch.Modify(rs1)
+
+	rs2, _ := kube2clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	rs2.Status.Replicas = *rs2.Spec.Replicas
+	rs2, _ = kube2clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).UpdateStatus(rs2)
+	kube2rswatch.Modify(rs2)
+
+	time.Sleep(1 * time.Second)
+	rs, _ = fedclientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	assert.Equal(t, *rs.Spec.Replicas, *rs1.Spec.Replicas+*rs2.Spec.Replicas)
+	assert.Equal(t, rs.Status.Replicas, rs1.Status.Replicas+rs2.Status.Replicas)
+
+	var replicas int32 = 20
+	rs.Spec.Replicas = &replicas
+	rs, _ = fedclientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Update(rs)
+	fedrswatch.Modify(rs)
+
+	time.Sleep(2 * time.Second)
+	rs, _ = fedclientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	rs1, _ = kube1clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	rs2, _ = kube2clientset.Extensions().ReplicaSets(apiv1.NamespaceDefault).Get(rs.Name)
+	assert.Equal(t, *rs.Spec.Replicas, *rs1.Spec.Replicas+*rs2.Spec.Replicas)
+	assert.Equal(t, rs.Status.Replicas, rs1.Status.Replicas+rs2.Status.Replicas)
+
+	close(stopChan)
+}
+
+func toFederatedInformerForTestOnly(informer fedutil.FederatedInformer) fedutil.FederatedInformerForTestOnly {
+	inter := informer.(interface{})
+	return inter.(fedutil.FederatedInformerForTestOnly)
+}
+
+func mkCluster(name string, readyStatus apiv1.ConditionStatus) *fedv1.Cluster {
+	return &fedv1.Cluster{
+		ObjectMeta: apiv1.ObjectMeta{
+			Name: name,
+		},
+		Status: fedv1.ClusterStatus{
+			Conditions: []fedv1.ClusterCondition{
+				{Type: fedv1.ClusterReady, Status: readyStatus},
+			},
+		},
+	}
+}
+
+func mkReplicaSet(name string, replicas int32) *extensionsv1.ReplicaSet {
+	return &extensionsv1.ReplicaSet{
+		ObjectMeta: apiv1.ObjectMeta{
+			Name:      name,
+			Namespace: apiv1.NamespaceDefault,
+		},
+		Spec: extensionsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+	}
+}

--- a/federation/pkg/federation-controller/replicaset/scheduler/scheduler.go
+++ b/federation/pkg/federation-controller/replicaset/scheduler/scheduler.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+
+	fed "k8s.io/kubernetes/federation/apis/federation"
+	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	//kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	planner "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset/planner"
+	"k8s.io/kubernetes/pkg/api/meta"
+	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+const (
+	// schedule result was put into annotation in a format of "clusterName:replicas[/clusterName:replicas]..."
+	ExpectedReplicasAnnotation = "kubernetes.io/expected-replicas"
+)
+
+type Scheduler struct {
+	planner *planner.Planner
+}
+
+func NewScheduler(preferences *fed.FederatedReplicaSetPreferences) *Scheduler {
+	return &Scheduler{
+		planner: planner.NewPlanner(preferences),
+	}
+}
+
+func (scheduler *Scheduler) Schedule(frs *extensionsv1.ReplicaSet, clusters []*fedv1.Cluster) map[string]int64 {
+	var clusterNames []string
+	for _, cluster := range clusters {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+	scheduleResult := scheduler.planner.Plan(int64(*frs.Spec.Replicas), clusterNames)
+	result := make(map[string]int64)
+	for clusterName, replicas := range scheduleResult {
+		result[clusterName] = replicas
+	}
+
+	return result
+}
+
+func (scheduler *Scheduler) ScheduleFromAnnotation(frs *extensionsv1.ReplicaSet) map[string]int64 {
+	accessor, err := meta.Accessor(frs)
+	if err != nil {
+		panic(err) // should never happen
+	}
+	anno := accessor.GetAnnotations()
+	scheduleResultString, found := anno[ExpectedReplicasAnnotation]
+	scheduleResult := make(map[string]int64)
+	if found {
+		scheduleResult, err = decodeScheduleResult(scheduleResultString)
+	}
+
+	return scheduleResult
+}
+
+func decodeScheduleResult(scheduleResultString string) (map[string]int64, error) {
+	var scheduleResult = make(map[string]int64)
+	clusterReplicas := strings.Split(scheduleResultString, "/")
+	for _, clusterReplica := range clusterReplicas {
+		cr := strings.Split(clusterReplica, ":")
+		if len(cr) != 2 {
+			glog.Errorf("Failed decode schedule result: %v", cr)
+			return nil, fmt.Errorf("Failed decode schedule result: %v", cr)
+		}
+		replicas, err := strconv.ParseInt(cr[1], 10, 64)
+		if err != nil {
+			glog.Errorf("Failed parse scheduled replcias: %v:%v", cr[0], cr[1])
+			return nil, err
+		}
+		scheduleResult[cr[0]] = replicas
+	}
+
+	return scheduleResult, nil
+}


### PR DESCRIPTION
The purpose of this PR is to parse user input annotations to specify how many replicas should be allocated to each underlying cluster

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30848)

<!-- Reviewable:end -->
