### PR TITLE
Expose PetSet index in pod annotations

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -35,6 +35,9 @@ const (
 	// If there is a headless service named "my-web-service" in the same namespace as the pod, then,
 	// <hostname>.my-web-service.<namespace>.svc.<cluster domain>" would be resolved by the cluster DNS Server.
 	PodSubdomainAnnotation = "pod.beta.kubernetes.io/subdomain"
+	// The annotation value is a string specyfing the petset index.
+	// It's applied during creating the pod by petset.
+	PodPetSetIndexAnnotation = "pod.beta.kubernetes.io/petset-index"
 )
 
 // FindPort locates the container port for the given pod and portName.  If the

--- a/pkg/controller/petset/iterator.go
+++ b/pkg/controller/petset/iterator.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	utilpod "k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -32,6 +33,7 @@ func newPCB(id string, ps *apps.PetSet) (*pcb, error) {
 	if err != nil {
 		return nil, err
 	}
+	petPod.Annotations[utilpod.PodPetSetIndexAnnotation] = id
 	for _, im := range newIdentityMappers(ps) {
 		im.SetIdentity(id, petPod)
 	}

--- a/pkg/controller/petset/iterator_test.go
+++ b/pkg/controller/petset/iterator_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	utilpod "k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -95,6 +96,11 @@ func TestPetQueueScaleUp(t *testing.T) {
 		expectedName := fmt.Sprintf("%v-%d", ps.Name, i)
 		if pet.event != syncPet || pet.pod.Name != expectedName {
 			t.Errorf("Unexpected pet %+v, expected %v", pet.pod.Name, expectedName)
+		}
+		expectedIndex := fmt.Sprintf("%d", i)
+		indexAnnotation := pet.pod.Annotations[utilpod.PodPetSetIndexAnnotation]
+		if indexAnnotation != expectedIndex {
+			t.Errorf("Expected PetSet index %s in pod %v, got %s", expectedIndex, pet.pod.ObjectMeta.UID, indexAnnotation)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: It introduces `dependencies.petSetIndex` field reference to the pod downward API, which will contain its index in PetSet.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #30427

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30860)

<!-- Reviewable:end -->
