### PR TITLE
Federated namespace controller - stop reconcilation if not in sync

### DIFF
--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -221,6 +221,7 @@ func (nc *NamespaceController) reconcileNamespacesOnClusterChange() {
 func (nc *NamespaceController) reconcileNamespace(namespace string) {
 	if !nc.isSynced() {
 		nc.deliverNamespace(namespace, nc.clusterAvailableDelay, false)
+		return
 	}
 
 	baseNamespaceObj, exist, err := nc.namespaceInformerStore.GetByKey(namespace)


### PR DESCRIPTION
cc: @quinton-hoole @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30874)

<!-- Reviewable:end -->
