### PR TITLE
Remove duplicated GetDeviceNameFromMount

### DIFF
--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -36,10 +36,6 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return "", nil
-}
-
 func (mounter *Mounter) DeviceOpened(pathname string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
The file `pkg/util/mount/mount_unsupported.go` has the method `GetDeviceNameFromMount` duplicated:
- https://github.com/kubernetes/kubernetes/blob/master/pkg/util/mount/mount_unsupported.go#L39
- https://github.com/kubernetes/kubernetes/blob/master/pkg/util/mount/mount_unsupported.go#L51

I removed the first one because this breaks again the build on OSX/MacOS and all the tooling.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30884)

<!-- Reviewable:end -->
