### PR TITLE
Fixes #30886

### DIFF
--- a/pkg/util/procfs/procfs_unsupported.go
+++ b/pkg/util/procfs/procfs_unsupported.go
@@ -20,9 +20,28 @@ package procfs
 
 import (
 	"fmt"
+	"syscall"
 )
 
+type ProcFS struct{}
+
+func NewProcFS() ProcFSInterface {
+	return &ProcFS{}
+}
+
 // GetFullContainerName gets the container name given the root process id of the container.
-func GetFullContainerName(pid int) (string, error) {
+func (pfs *ProcFS) GetFullContainerName(pid int) (string, error) {
 	return "", fmt.Errorf("GetFullContainerName is unsupported in this build")
+}
+
+// Find process(es) using a regular expression and send a specified
+// signal to each process
+func PKill(name string, sig syscall.Signal) error {
+	return fmt.Errorf("PKill is unsupported in this build")
+}
+
+// Find process(es) with a specified name (exact match)
+// and return their pid(s)
+func PidOf(name string) ([]int, error) {
+	return []int{}, fmt.Errorf("PidOf is unsupported in this build")
 }


### PR DESCRIPTION
This PR fixes https://github.com/kubernetes/kubernetes/issues/30886

```
make WHAT=pkg/kubelet
+++ [0818 17:03:21] Generating bindata:
    /Users/jscheuermann/inovex/workspace/kubernetes-clone/test/e2e/framework/gobindata_util.go
+++ [0818 17:03:22] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
+++ [0818 17:03:22] Building go targets for darwin/amd64:
    pkg/kubelet

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30887)

<!-- Reviewable:end -->
