### PR TITLE
Fix caching of go dirs during build

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -28,6 +28,8 @@ if [[ -z "${1:-}" ]]; then
 fi
 CACHE="$1"; shift
 
+trap "rm -f '${CACHE}'" HUP INT TERM ERR
+
 # This is a partial 'find' command.  The caller is expected to pass the
 # remaining arguments.
 #


### PR DESCRIPTION
Sometimes when you press `^C` during `make` the subsequent attempt to run `make` hangs due to zero-sized cache file for `ALL_GO_DIRS` var in Makefile.generated_files:

```
vagrant@devbox:~/work/kubernetes/src/k8s.io/kubernetes (master *%) $ KUBE_JUNIT_REPORT_DIR=/tmp/art KUBE_COVER=y make test
# hangs...
^CMakefile:279: recipe for target 'generated_files' failed
make: *** [generated_files] Interrupt

vagrant@devbox:~/work/kubernetes/src/k8s.io/kubernetes (master *%) $ ls -l .make/all_go_dirs.mk
-rw-rw-r-- 1 vagrant vagrant 0 Aug 18 15:03 .make/all_go_dirs.mk
```

 Corresponding process subtree looks like the following:

```
└─make test
    └─make -f Makefile.generated_files generated_files
        └─bash -c grep --color=never -l '+k8s:deepcopy-gen='  | xargs -n1 dirname | sort -u
            ├─grep --color=never -l +k8s:deepcopy-gen=
            ├─sort -u
            └─xargs -n1 dirname
```

Let's remove the cache file if `cache_go_dirs.sh` gets interrupted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30893)

<!-- Reviewable:end -->
