### PR TITLE
Fix overlong junit filename prefixes

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -156,8 +156,10 @@ junitFilenamePrefix() {
   fi
   mkdir -p "${KUBE_JUNIT_REPORT_DIR}"
   local KUBE_TEST_API_NO_SLASH="${KUBE_TEST_API//\//-}"
-  # This file name isn't parsed by anything, and tee needs a shorter file name.
+  # This filename isn't parsed by anything,
+  # and we must avoid exceeding 255 character filename limit.
   KUBE_TEST_API_NO_SLASH="${KUBE_TEST_API_NO_SLASH//k8s.io-/}"
+  KUBE_TEST_API_NO_SLASH="$(echo "$KUBE_TEST_API_NO_SLASH"|sed 's/\([0-9]\)alpha\([0-9]\)/\1a\2/g;s/\([0-9]\)beta\([0-9]\)/\1b\2/g')"
   echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_NO_SLASH}_$(kube::util::sortable_date)"
 }
 


### PR DESCRIPTION
Build scripts construct filenames that are longer than 255 chars when producing JUnit output for tests and `KUBE_COVER=y`:

```
vagrant@devbox:~/work/kubernetes/src/k8s.io/kubernetes (test %) $ KUBE_JUNIT_REPORT_DIR=/tmp/art KUBE_COVER=y make test
E0818 15:33:29.312549    9426 conversion.go:589] Warning: could not generate autoConvert functions for k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerSpec <-> k8s.io/kubernetes/pkg/apis/autoscaling.HorizontalPodAutoscalerSpec
E0818 15:33:29.323685    9426 conversion.go:589] Warning: could not generate autoConvert functions for k8s.io/kubernetes/pkg/apis/extensions/v1beta1.JobSpec <-> k8s.io/kubernetes/pkg/apis/batch.JobSpec
E0818 15:33:29.344775    9426 conversion.go:589] Warning: could not generate autoConvert functions for k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RollingUpdateDeployment <-> k8s.io/kubernetes/pkg/apis/extensions.RollingUpdateDeployment
E0818 15:33:29.349260    9426 conversion.go:589] Warning: could not generate autoConvert functions for k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ScaleStatus <-> k8s.io/kubernetes/pkg/apis/extensions.ScaleStatus
Running tests for APIVersion: v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1
+++ [0818 15:33:30] Saving coverage output in '/tmp/k8s_coverage/v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1/20160818-153330'
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_genutils.stdout: File name too long
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_kube-apiserver_app.stdout: File name too long
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_hyperkube.stdout: File name too long
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_kube-apiserver_app_options.stdout: File name too long
ok      k8s.io/kubernetes/cmd/genutils  0.002s
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_kubelet_app.stdout: File name too long
qok     k8s.io/kubernetes/cmd/kube-apiserver/app/options    0.159s
tee: /tmp/art/junit_v1,apps-v1alpha1,authentication.v1beta1,authorization.v1beta1,autoscaling-v1,batch-v1,batch-v2alpha1,certificates-v1alpha1,extensions-v1beta1,federation-v1beta1,policy-v1alpha1,rbac.authorization.v1alpha1,imagepolicy.v1alpha1_20160818-153330-cmd_kube-proxy_app.stdout: File name too long
```

Let's shorten filenames a bit more to make them fit in 255 chars. This is probably temporary solution too, the bulletproof one being (e.g.) using `sha1sum` of `KUBE_TEST_API` but that would produce files with meaningless filenames so for now maybe it may wait.

(there was recent attempt to shorten the filenames by removing `k8s.io`s, but that was not enough for `KUBE_COVER=y`)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30894)

<!-- Reviewable:end -->
