### PR TITLE
Split the version metric out to its own package

### DIFF
--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 )
 
 func main() {

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kube-dns/dns.go
+++ b/cmd/kube-dns/dns.go
@@ -23,6 +23,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 )
 

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 )
 
 /*

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/flag"
 	fakeiptables "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/kubernetes/pkg/util/sets"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"

--- a/contrib/mesos/cmd/km/km.go
+++ b/contrib/mesos/cmd/km/km.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 )
 
 func main() {

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -160,6 +160,7 @@ pkg/util/logs
 pkg/util/maps
 pkg/util/validation/field
 pkg/util/workqueue
+pkg/version/prometheus
 pkg/volume
 pkg/volume/downwardapi
 pkg/volume/quobyte

--- a/pkg/version/prometheus/prometheus.go
+++ b/pkg/version/prometheus/prometheus.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package prometheus registers Kubernetes version information as a
+// prometheus metric.
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+func init() {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kubernetes_build_info",
+			Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
+		},
+		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+	)
+	info := version.Get()
+	buildInfo.WithLabelValues(info.Major, info.Minor, info.GitVersion, info.GitCommit, info.GitTreeState, info.BuildDate, info.GoVersion, info.Compiler, info.Platform).Set(1)
+
+	prometheus.MustRegister(buildInfo)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,8 +19,6 @@ package version
 import (
 	"fmt"
 	"runtime"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Info contains versioning information.
@@ -59,18 +57,4 @@ func Get() Info {
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
 	return info.GitVersion
-}
-
-func init() {
-	buildInfo := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "kubernetes_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
-		},
-		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
-	)
-	info := Get()
-	buildInfo.WithLabelValues(info.Major, info.Minor, info.GitVersion, info.GitCommit, info.GitTreeState, info.BuildDate, info.GoVersion, info.Compiler, info.Platform).Set(1)
-
-	prometheus.MustRegister(buildInfo)
 }


### PR DESCRIPTION
This PR breaks a client dependency on prometheus. Combined with #30638, the client will no longer depend on these packages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30902)

<!-- Reviewable:end -->
