### PR TITLE
only compute delta on non-creating updates

### DIFF
--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -295,8 +295,8 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 	indexer.Add(resourceQuota)
 
 	// old service was a load balancer, but updated version is a node port.
-	oldService := &api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "service", Namespace: "test"},
+	existingService := &api.Service{
+		ObjectMeta: api.ObjectMeta{Name: "service", Namespace: "test", ResourceVersion: "1"},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 	newService := &api.Service{
@@ -306,7 +306,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 			Ports: []api.ServicePort{{Port: 1234}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(newService, oldService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newService, existingService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
If you're issuing an update that can cause a create, the quota admission charge should be based on the create cost, otherwise you always end up with zero.

@derekwaynecarr ptal, blocker bug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30907)

<!-- Reviewable:end -->
