### PR TITLE
Added INSTANCE_PREFIX to project hash to avoid S3 bucket clash

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -606,9 +606,9 @@ function upload-server-tars() {
       local project_hash=
       local key=$(aws configure get aws_access_key_id)
       if which md5 > /dev/null 2>&1; then
-        project_hash=$(md5 -q -s "${USER} ${key}")
+        project_hash=$(md5 -q -s "${USER} ${key} ${INSTANCE_PREFIX}")
       else
-        project_hash=$(echo -n "${USER} ${key}" | md5sum | awk '{ print $1 }')
+        project_hash=$(echo -n "${USER} ${key} ${INSTANCE_PREFIX}" | md5sum | awk '{ print $1 }')
       fi
       AWS_S3_BUCKET="kubernetes-staging-${project_hash}"
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where if you run multiple k8s clusters in same region S3 resources are being overwritten and therefore node bootstrapping stalls, i.e. when using Auto scaling.

**Special notes for your reviewer**:
By adding the `INSTANCE_PREFIX` to the project hash in the S3 bucket the bucket will not be overwritten.

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30912)

<!-- Reviewable:end -->
