### PR TITLE
Use PATCH to resume/pause deployment

### DIFF
--- a/pkg/client/unversioned/deployment.go
+++ b/pkg/client/unversioned/deployment.go
@@ -33,6 +33,7 @@ type DeploymentInterface interface {
 	Get(name string) (*extensions.Deployment, error)
 	Delete(name string, options *api.DeleteOptions) error
 	Create(*extensions.Deployment) (*extensions.Deployment, error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error)
 	Update(*extensions.Deployment) (*extensions.Deployment, error)
 	UpdateStatus(*extensions.Deployment) (*extensions.Deployment, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
@@ -79,6 +80,13 @@ func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
 func (c *deployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
 	err = c.client.Post().Namespace(c.ns).Resource("deployments").Body(deployment).Do().Into(result)
+	return
+}
+
+// Patch takes the partial representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *deployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Patch(api.StrategicMergePatchType).Namespace(c.ns).Resource("deployments").SubResource(subresources...).Name(name).Body(data).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/testclient/fake_deployments.go
+++ b/pkg/client/unversioned/testclient/fake_deployments.go
@@ -70,6 +70,16 @@ func (c *FakeDeployments) Create(deployment *extensions.Deployment) (*extensions
 	return obj.(*extensions.Deployment), err
 }
 
+func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (*extensions.Deployment, error) {
+	deployment := &extensions.Deployment{}
+	obj, err := c.Fake.Invokes(NewPatchAction("deployments", c.Namespace, deployment), deployment)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.Deployment), err
+}
+
 func (c *FakeDeployments) Update(deployment *extensions.Deployment) (*extensions.Deployment, error) {
 	obj, err := c.Fake.Invokes(NewUpdateAction("deployments", c.Namespace, deployment), deployment)
 	if obj == nil {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -637,8 +637,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				if t.Spec.Paused {
 					return true, nil
 				}
-				t.Spec.Paused = true
-				_, err := c.Extensions().Deployments(t.Namespace).Update(t)
+				body := []byte("{\"spec\":{\"paused\":true}}")
+				_, err = c.Extensions().Deployments(t.Namespace).Patch(t.Name, api.StrategicMergePatchType, body)
 				return false, err
 			default:
 				gvks, _, err := api.Scheme.ObjectKinds(object)
@@ -659,8 +659,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				if !t.Spec.Paused {
 					return true, nil
 				}
-				t.Spec.Paused = false
-				_, err := c.Extensions().Deployments(t.Namespace).Update(t)
+				body := []byte("{\"spec\":{\"paused\":false}}")
+				_, err = c.Extensions().Deployments(t.Namespace).Patch(t.Name, api.StrategicMergePatchType, body)
 				return false, err
 			default:
 				gvks, _, err := api.Scheme.ObjectKinds(object)


### PR DESCRIPTION
Replace PUT with PATCH when pausing/resuming rollout

fixes #20437 

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note

NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30919)

<!-- Reviewable:end -->
