### PR TITLE
Add EBS Encryption support to autoprovisioning.

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -59,11 +59,15 @@ parameters:
   type: io1
   zone: us-east-1d
   iopsPerGB: "10"
+  encrypted: "true"
+  kmsKeyId: "arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef"
 ```
 
 * `type`: `io1`, `gp2`, `sc1`, `st1`. See AWS docs for details. Default: `gp2`.
 * `zone`: AWS zone. If not specified, a random zone in the same region as controller-manager will be chosen.
 * `iopsPerGB`: only for `io1` volumes. I/O operations per second per GiB. AWS volume plugin multiplies this with size of requested volume to compute IOPS of the volume and caps it at 20 000 IOPS (maximum supported by AWS, see AWS docs).
+* `encrypted`: enable EBS encryption on the disk. If not specified, no encryption is used.
+* `kmsKeyId`: which KMS key to use for EBS encryption. If not specified, the default key is used. If this is specified, `encrypted` must also be set.
 
 #### GCE
 

--- a/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
+++ b/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
@@ -7,3 +7,4 @@ parameters:
   type: io1
   zone: us-east-1d
   iopsPerGB: "10"
+  encrypted: "true"

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -232,6 +232,8 @@ type VolumeOptions struct {
 	// IOPSPerGB must be bigger than zero and smaller or equal to 30.
 	// Calculated total IOPS will be capped at 20000 IOPS.
 	IOPSPerGB int
+	Encrypted bool
+	KMSKeyId  string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -1531,6 +1533,12 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 	volSize := int64(volumeOptions.CapacityGB)
 	request.Size = &volSize
 	request.VolumeType = &createType
+	encrypted := volumeOptions.Encrypted
+	request.Encrypted = &encrypted
+	kmsKeyId := volumeOptions.KMSKeyId
+	if encrypted && kmsKeyId != "" {
+		request.KmsKeyId = &kmsKeyId
+	}
 	if iops > 0 {
 		request.Iops = &iops
 	}

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -98,6 +98,13 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (strin
 			if err != nil {
 				return "", 0, nil, fmt.Errorf("invalid iopsPerGB value %q, must be integer between 1 and 30: %v", v, err)
 			}
+		case "encrypted":
+			volumeOptions.Encrypted, err = strconv.ParseBool(v)
+			if err != nil {
+				return "", 0, nil, fmt.Errorf("invalid encrypted value %q, must be true/false/1/0: %v", v, err)
+			}
+		case "kmskeyid":
+			volumeOptions.KMSKeyId = v
 		default:
 			return "", 0, nil, fmt.Errorf("invalid option %q for volume plugin %s", k, c.plugin.GetPluginName())
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This adds support for creating encrypted volumes to the EBS autoprovisioner. For various (legal) reasons I need to have all my EBS volumes encrypted. EBS handles key management via KMS, so you can optionally specify the key to use.

There are some restrictions on the [instance types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances) to which these volumes can be attached. The scheduler doesn't currently take care of that.

**Special notes for your reviewer**: I didn't find any tests for EBS `StorageClass` parsing or the AWS `CreateVolume` implementation so I didn't add any. I could try adding tests for these if you'd prefer.

**Release note**:

``` release-note
Add support for auto-provisioning encrypted EBS volumes.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30928)

<!-- Reviewable:end -->
