### PR TITLE
Return the current kubeconfig as the starting config in ClientConfigGetter.

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -85,7 +85,7 @@ func (g *ClientConfigGetter) GetLoadingPrecedence() []string {
 	return nil
 }
 func (g *ClientConfigGetter) GetStartingConfig() (*clientcmdapi.Config, error) {
-	return nil, nil
+	return g.kubeconfigGetter()
 }
 func (g *ClientConfigGetter) GetDefaultFilename() string {
 	return ""


### PR DESCRIPTION
This fixes issue #30790.

``` release-note
Fixes the panic that occurs in the federation controller manager when registering a GKE cluster to the federation. Fixes issue #30790.
```

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30940)

<!-- Reviewable:end -->
