### PR TITLE
oidc auth provider: don't trim issuer URL

### DIFF
--- a/plugin/pkg/client/auth/oidc/oidc.go
+++ b/plugin/pkg/client/auth/oidc/oidc.go
@@ -97,7 +97,7 @@ func newOIDCAuthProvider(_ string, cfg map[string]string, persister restclient.A
 	}
 	hc := &http.Client{Transport: trans}
 
-	providerCfg, err := oidc.FetchProviderConfig(hc, strings.TrimSuffix(issuer, "/"))
+	providerCfg, err := oidc.FetchProviderConfig(hc, issuer)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching provider config: %v", err)
 	}


### PR DESCRIPTION
This mirrors a similar side fix for the API server authenticator.
Don't trim the issuer URL provided by the user since OpenID Connect
mandates that this URL exactly matches the URL returned by the
issuer during discovery.

This change only impacts clients attempting to connect to providers that
are non-spec compliant.

No test updates since this is already tested by the go-oidc client
package.

See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation

Server side fix #29860
Updates #29749

cc @kubernetes/sig-auth @hanikesn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30944)

<!-- Reviewable:end -->
