### PR TITLE
[wip] Add Google Cloud DNS support to LoadBalancer Services

### DIFF
--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -46,7 +46,7 @@ function create-master-instance {
     --image "${MASTER_IMAGE}" \
     --tags "${MASTER_TAG}" \
     --network "${NETWORK}" \
-    --scopes "storage-ro,compute-rw,monitoring,logging-write" \
+    --scopes "storage-ro,compute-rw,monitoring,logging-write,https://www.googleapis.com/auth/ndev.clouddns.readwrite" \
     --can-ip-forward \
     --metadata-from-file \
       "kube-env=${KUBE_TEMP}/master-kube-env.yaml,user-data=${KUBE_ROOT}/cluster/gce/gci/master.yaml,configure-sh=${KUBE_ROOT}/cluster/gce/gci/configure.sh,cluster-name=${KUBE_TEMP}/cluster-name.txt,gci-update-strategy=${KUBE_TEMP}/gci-update.txt,gci-ensure-gke-docker=${KUBE_TEMP}/gci-ensure-gke-docker.txt,gci-docker-version=${KUBE_TEMP}/gci-docker-version.txt" \


### PR DESCRIPTION
Working on #28525.

This PR added Google Cloud DNS support to LoadBalancer Services. Features described as below:
- Stable external DNS entry for LoadBalancer type service could be requested by attaching annotation with this key(service.beta.kubernetes.io/gce-lb-dns).
- Valid domain name(owned by user) should be given with this annotation.
- DNS zone name should be in this format: clusterName-domainName(escape "." to "-" and convert it to lower case).
- The A type DNS record pointing to the LoadBalancer external IP would be created in this format: serviceName-nameSpace-clusterName.domainName
- DNS name servers need to be configured manually.
- DNS records would be deleted after services or annotations disappear.

Example annotation:
`
service.beta.kubernetes.io/gce-lb-dns: dnsexample.beta
`

Additional description:
- Annotation could be attached before or after the service is up.
- Annotation could be deleted before the service is down.
- Delete a service with dns annotation attached would also delete the DNS record.
- Domain name could be changed.
- One cluster could use multiple domains.
- DNS zones are supposed to be created ahead by users. Program will try to create zone if not present, but would not manage them.

Warnings:
- May not guarantee not leaking DNS record under controller failure.
- Only support clusters running on GCP with DNS api enabled (with DNS read/write scope).

TODO:
- Tests would be added after making sure this PR is on the right track.

@thockin @girishkalele

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30949)

<!-- Reviewable:end -->
