### PR TITLE
Add support for the standard objectmeta field selectors

### DIFF
--- a/pkg/apis/certificates/v1alpha1/conversion.go
+++ b/pkg/apis/certificates/v1alpha1/conversion.go
@@ -16,9 +16,24 @@ limitations under the License.
 
 package v1alpha1
 
-import "k8s.io/kubernetes/pkg/runtime"
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	// Add non-generated conversion functions here. Currently there are none.
-	return nil
+
+	return api.Scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "CertificateSigningRequest",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	)
 }

--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -339,16 +339,16 @@ func (r resourceTypeToFieldMapping) filterField(resourceType, field, value strin
 
 type versionToResourceToFieldMapping map[unversioned.GroupVersion]resourceTypeToFieldMapping
 
+// filterField transforms the given field/value selector for the given groupVersion and resource
 func (v versionToResourceToFieldMapping) filterField(groupVersion *unversioned.GroupVersion, resourceType, field, value string) (newField, newValue string, err error) {
 	rMapping, ok := v[*groupVersion]
 	if !ok {
-		glog.Warningf("Field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", groupVersion, resourceType, field, value)
+		// no groupVersion overrides registered, default to identity mapping
 		return field, value, nil
 	}
 	newField, newValue, err = rMapping.filterField(resourceType, field, value)
 	if err != nil {
-		// This is only a warning until we find and fix all of the client's usages.
-		glog.Warningf("Field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", groupVersion, resourceType, field, value)
+		// no groupVersionResource overrides registered, default to identity mapping
 		return field, value, nil
 	}
 	return newField, newValue, nil

--- a/pkg/registry/certificates/strategy.go
+++ b/pkg/registry/certificates/strategy.go
@@ -184,5 +184,5 @@ func Matcher(label labels.Selector, field fields.Selector) *generic.SelectionPre
 
 // SelectableFields returns a field set that can be used for filter selection
 func SelectableFields(obj *certificates.CertificateSigningRequest) fields.Set {
-	return nil
+	return generic.ObjectMetaFieldsSet(obj.ObjectMeta, false)
 }


### PR DESCRIPTION
certificates API was missing standard field selectors (noticed in https://github.com/kubernetes/kubernetes/pull/30922/files/4120179db5ce6c3fadc872a268347f5be038f98f#r75413160)

also silences client-side warnings when using field selectors that don't have a registered client-side transformation (no functional change, since we were already returning the original field/value). if we want to trend toward embedding less conversion logic in our clients, I don't see us fully duplicating field selector conversions client-side to make that warning disappear.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30950)

<!-- Reviewable:end -->
