### PR TITLE
[kubelet test] Improve node status test debug info

### DIFF
--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -489,7 +489,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	}
 
 	if !api.Semantic.DeepEqual(expectedNode, updatedNode) {
-		t.Errorf("expected \n%v\n, got \n%v", expectedNode, updatedNode)
+		t.Errorf("unexpected objects: %s", diff.ObjectDiff(expectedNode, updatedNode))
 	}
 }
 
@@ -644,7 +644,8 @@ func TestUpdateExistingNodeOutOfDiskStatusWithTransitionFrequency(t *testing.T) 
 		}
 
 		if !reflect.DeepEqual(tc.expected, oodCondition) {
-			t.Errorf("%d.\nwant \n%v\n, got \n%v", tcIdx, tc.expected, oodCondition)
+			t.Errorf("%d.\nunexpected objects: %s", tcIdx, diff.ObjectDiff(tc.expected, oodCondition))
+
 		}
 	}
 }


### PR DESCRIPTION
I find the output format `%v` of glog couldn't output useful information of an `api.Node` object. The output of this line https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status_test.go#L492
is

```
kubelet_node_status_test.go:491: expected
                &TypeMeta{Kind:,APIVersion:,}
                , got
                &TypeMeta{Kind:,APIVersion:,}
```
- It's difficult for me to tell the difference between expected and got.
- I prefer to use `diff.ObjectDiff(expectedNode, updatedNode)` to output the debug information as it will point out the starting character of the different objects.

I think this line https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status_test.go#L647 can use `diff.ObjectDiff()` as well.

The related issus is #30952

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30953)

<!-- Reviewable:end -->
