### PR TITLE
use valid_resources to replace kubectl.PossibleResourceTypes

### DIFF
--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -51,8 +51,7 @@ var (
 		will first check for an exact match on TYPE and NAME_PREFIX. If no such resource
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
 
-		`) +
-		kubectl.PossibleResourceTypes
+		`) + valid_resources
 
 	describe_example = dedent.Dedent(`
 		# Describe a node

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -39,7 +39,7 @@ var (
 	explainLong = dedent.Dedent(`
 		Documentation of resources.
 
-		`) + kubectl.PossibleResourceTypes
+		`) + valid_resources
 )
 
 // NewCmdExplain returns a cobra command for swagger docs

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -42,7 +42,7 @@ var (
 	get_long = dedent.Dedent(`
 		Display one or many resources.
 
-		`) + kubectl.PossibleResourceTypes + dedent.Dedent(`
+		`) + valid_resources + dedent.Dedent(`
 
 		This command will hide resources that have completed. For instance, pods that are in the Succeeded or Failed phases.
 		You can see the full results for any resource by providing the '--show-all' flag.

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -30,12 +30,6 @@ import (
 
 const (
 	kubectlAnnotationPrefix = "kubectl.kubernetes.io/"
-	// TODO: auto-generate this
-	PossibleResourceTypes = `Possible resource types include (case insensitive): pods (aka 'po'), services (aka 'svc'), deployments (aka 'deploy'),
-replicasets (aka 'rs'), replicationcontrollers (aka 'rc'), nodes (aka 'no'), events (aka 'ev'), limitranges (aka 'limits'),
-persistentvolumes (aka 'pv'), persistentvolumeclaims (aka 'pvc'), resourcequotas (aka 'quota'), namespaces (aka 'ns'),
-serviceaccounts (aka 'sa'), ingresses (aka 'ing'), horizontalpodautoscalers (aka 'hpa'), daemonsets (aka 'ds'), configmaps (aka 'cm'),
-componentstatuses (aka 'cs), endpoints (aka 'ep'), petsets (alpha feature, may be unstable) and secrets.`
 )
 
 type NamespaceInfo struct {


### PR DESCRIPTION
``` release
Fix resource list printed by kubectl help 
```

 `kubectl get` return 

> You must specify the type of resource to get. Valid resource types include:
> - componentstatuses (aka 'cs')
> - configmaps
> - daemonsets (aka 'ds')
> - deployments
> - events (aka 'ev')
> - endpoints (aka 'ep')
> - horizontalpodautoscalers (aka 'hpa')
> - ingress (aka 'ing')
> - jobs
> - limitranges (aka 'limits')
> - nodes (aka 'no')
> - namespaces (aka 'ns')
> - pods (aka 'po')
> - persistentvolumes (aka 'pv')
> - persistentvolumeclaims (aka 'pvc')
> - quota
> - resourcequotas (aka 'quota')
> - replicasets (aka 'rs')
> - replicationcontrollers (aka 'rc')
> - secrets
> - serviceaccounts (aka 'sa')
> - services (aka 'svc')
>   error: Required resource not specified.
>   See 'kubectl get -h' for help and examples.

while `kubectl get --help` return

> root@k8s-node1:~# kubectl get --help
> Display one or many resources.
> Possible resource types include (case insensitive): pods (po), services (svc), deployments,
> replicasets (rs), replicationcontrollers (rc), nodes (no), events (ev), limitranges (limits),
> persistentvolumes (pv), persistentvolumeclaims (pvc), resourcequotas (quota), namespaces (ns),
> serviceaccounts (sa), ingresses (ing), horizontalpodautoscalers (hpa), daemonsets (ds), configmaps,
> componentstatuses (cs), endpoints (ep), and secrets.
> By specifying the output as 'template' and providing a Go template as the value
> of the --template flag, you can filter the attributes of the fetched resource(s).
> ......

kubectl.PossibleResourceTypes missing some resouces such as jobs quota.
describe and explain have the same problem.

i think using valid_resources to replace kubectl.PossibleResourceTypes more suitable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30955)

<!-- Reviewable:end -->
