### PR TITLE
federation: updating cluster name validation to allow DNS labels only

### DIFF
--- a/federation/apis/federation/validation/validation.go
+++ b/federation/apis/federation/validation/validation.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/validation/field"
 )
 
-var ValidateClusterName = validation.NameIsDNSSubdomain
+var ValidateClusterName = validation.NameIsDNS1035Label
 
 func ValidateClusterSpec(spec *federation.ClusterSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/federation/apis/federation/validation/validation_test.go
+++ b/federation/apis/federation/validation/validation_test.go
@@ -61,6 +61,17 @@ func TestValidateCluster(t *testing.T) {
 				},
 			},
 		},
+		"invalid cluster name (is a subdomain)": {
+			ObjectMeta: api.ObjectMeta{Name: "mycluster.mycompany"},
+			Spec: federation.ClusterSpec{
+				ServerAddressByClientCIDRs: []federation.ServerAddressByClientCIDR{
+					{
+						ClientCIDR:    "0.0.0.0/0",
+						ServerAddress: "localhost:8888",
+					},
+				},
+			},
+		},
 	}
 	for testName, errorCase := range errorCases {
 		errs := ValidateCluster(&errorCase)


### PR DESCRIPTION
Forked from https://github.com/kubernetes/kubernetes/pull/28921

Summarizing the discussion from that PR:
- Right now, we allow name of the Cluster resource in federation/v1beta1 group version to be a subdomain (group of DNS labels separated by dots). This prevents us from using the cluster name in our dns search paths, since there is a restriction of 6 domain labels there.
- Restricting cluster name to DNS label will give us the flexibility to be able to do that in the future, if we want to. Though we do not have a concrete use case right now, the possibility is attractive.
- There is not a strong argument in favor of allowing subdomains as cluster names right now. If in future, there is one then we can get more permissive but its better to start with a stricter model.

Note that we are breaking a beta API, but it should be fine since we do not expect anyone to be using subdomain as cluster name. Have added release-note-action-required label

``` release-note
Action required: federation-only: Please update your cluster name to be a valid DNS label.
Updating federation.v1beta1.Cluster API to disallow subdomains as valid cluster names. Only DNS labels are allowed as valid cluster names now.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30956)

<!-- Reviewable:end -->
