### PR TITLE
Example of unversioned pkg uses correct Config struct

### DIFF
--- a/pkg/client/unversioned/doc.go
+++ b/pkg/client/unversioned/doc.go
@@ -23,32 +23,33 @@ Most consumers should use the Config object to create a Client:
 
     import (
       client "k8s.io/kubernetes/pkg/client/unversioned"
+      "k8s.io/kubernetes/pkg/client/restclient"
       "k8s.io/kubernetes/pkg/api"
     )
 
     [...]
 
-    config := &client.Config{
+    config := &restclient.Config{
       Host:     "http://localhost:8080",
       Username: "test",
       Password: "password",
     }
-    client, err := client.New(config)
+    c, err := client.New(config)
     if err != nil {
       // handle error
     }
-    pods, err := client.Pods(api.NamespaceDefault).List(api.ListOptions{})
+    pods, err := c.Pods(api.NamespaceDefault).List(api.ListOptions{})
     if err != nil {
       // handle error
     }
 
 More advanced consumers may wish to provide their own transport via a http.RoundTripper:
 
-    config := &client.Config{
+    config := &restclient.Config{
       Host:      "https://localhost:8080",
       Transport: oauthclient.Transport(),
     }
-    client, err := client.New(config)
+    c, err := client.New(config)
 
 The RESTClient type implements the Kubernetes API conventions (see `docs/devel/api-conventions.md`)
 for a given API path and is intended for use by consumers implementing their own Kubernetes


### PR DESCRIPTION
Currently this Doc has incorrect example - https://godoc.org/k8s.io/kubernetes/pkg/client/unversioned

So when developers use it they are confused why `client` pkg has no `Config` struct, actually this is a struct from `restclient` pkg.

Also pkg name and variable name should be equal:
`client, err := client.New(config)`

Thanks,
Alex

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30963)

<!-- Reviewable:end -->
