### PR TITLE
[e2e test] Fix e2e test pause image hard code

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -461,7 +461,7 @@ func CreateNodeSelectorPods(f *framework.Framework, id string, replicas int, nod
 		Name:         "node-selector",
 		Namespace:    f.Namespace.Name,
 		Timeout:      defaultTimeout,
-		Image:        "gcr.io/google_containers/pause-amd64:3.0",
+		Image:        framework.GetPauseImageName(f.Client),
 		Replicas:     replicas,
 		HostPorts:    map[string]int{"port1": 4321},
 		NodeSelector: map[string]string{"cluster-autoscaling-test.special-node": "true"},

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -691,7 +691,7 @@ var _ = framework.KubeDescribe("Density", func() {
 			}
 			RCName = "density" + strconv.Itoa(totalPods) + "-" + strconv.Itoa(i) + "-" + uuid
 			RCConfigs[i] = framework.RCConfig{Client: c,
-				Image:                "gcr.io/google_containers/pause-amd64:3.0",
+				Image:                framework.GetPauseImageName(f.Client),
 				Name:                 RCName,
 				Namespace:            ns,
 				Labels:               map[string]string{"type": "densityPod"},


### PR DESCRIPTION
Use `framework.GetPauseImageName(f.Client)` instead of hard code(such as `"gcr.io/google_containers/pause-amd64:3.0"`) to represent pause image name.

Related issus is #30967

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30964)

<!-- Reviewable:end -->
