### PR TITLE
Make sure the StatusCode is taken into account in DoRaw()

### DIFF
--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -881,6 +881,9 @@ func (r *Request) DoRaw() ([]byte, error) {
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {
 		result.body, result.err = ioutil.ReadAll(resp.Body)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {
+			result.err = r.transformUnstructuredResponseError(resp, req, result.body)
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -59,14 +59,18 @@ var _ = framework.KubeDescribe("Networking", func() {
 		tests := []struct {
 			path string
 		}{
-			{path: "/validate"},
 			{path: "/healthz"},
+			{path: "/api"},
+			{path: "/apis"},
+			{path: "/logs"},
+			{path: "/metrics"},
+			{path: "/swaggerapi"},
+			{path: "/version"},
 			// TODO: test proxy links here
 		}
 		for _, test := range tests {
 			By(fmt.Sprintf("testing: %s", test.path))
 			data, err := f.Client.RESTClient.Get().
-				Namespace(f.Namespace.Name).
 				AbsPath(test.path).
 				DoRaw()
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if there is an error (not found) the error printed out
is to do with the inablity to convert an empty body into the expected json.

This patch will fill in the err correctly.

example of before (with NotFound error):
$ kubectl top node
failed to unmarshall heapster response: json: cannot unmarshal object into Go value of type []v1alpha1.NodeMetrics

Now:
$ kubectl top node
the server could not find the requested resource (get services http:heapster:)

**Which issue this PR fixes** 
related to bug #30818

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30969)

<!-- Reviewable:end -->
