### PR TITLE
[e2e density test] Fix unnecessary Delete RC requests when not running latency test

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -659,15 +659,15 @@ var _ = framework.KubeDescribe("Density", func() {
 				framework.ExpectNoError(framework.VerifyPodStartupLatency(podStartupLatency))
 
 				framework.LogSuspiciousLatency(startupLag, e2eLag, nodeCount, c)
+
+				By("Removing additional replication controllers")
+				for i := 1; i <= nodeCount; i++ {
+					name := additionalPodsPrefix + "-" + strconv.Itoa(i)
+					c.ReplicationControllers(ns).Delete(name, nil)
+				}
 			}
 
 			cleanupDensityTest(dConfig)
-
-			By("Removing additional replication controllers if any")
-			for i := 1; i <= nodeCount; i++ {
-				name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-				c.ReplicationControllers(ns).Delete(name, nil)
-			}
 		})
 	}
 


### PR DESCRIPTION
As the following code block
https://github.com/kubernetes/kubernetes/blob/master/test/e2e/density.go#L666-L670
shows, after running each density test case, it will attempt to delete "additional replication controllers" even though there is **no additional replication controller**.

When we are not running latency test, API Server will return "404 error code". So, I propose to move the above code block inside thedetermine statementsif `itArg.runLatencyTest{ }` , looks like:

```
if itArg.runLatencyTest {
  ...
  for i := 1; i <= nodeCount; i++ {
    name := additionalPodsPrefix + "-" + strconv.Itoa(i)
    c.ReplicationControllers(ns).Delete(name, nil)
  }
}
```

In this way, removing RC will be executed only if we set `itArg.runLatencyTest` to be `true`. It can avoid post some necessary requests to API Server.

Issuse is #30977

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30979)

<!-- Reviewable:end -->
