### PR TITLE
Add StorageClass.Parameters to volume plugin Deleter interface.

### DIFF
--- a/pkg/controller/volume/persistentvolume/controller.go
+++ b/pkg/controller/volume/persistentvolume/controller.go
@@ -1067,7 +1067,19 @@ func (ctrl *PersistentVolumeController) deleteVolumeOperation(arg interface{}) {
 		return
 	}
 
-	if err = ctrl.doDeleteVolume(volume); err != nil {
+	// Find StorageClass.Parameters of the PV's storage class - it may contain
+	// configuration of the deleter
+	parameters, err := ctrl.findDeleterParameters(newVolume)
+	if err != nil {
+		msg := fmt.Sprintf("error getting StorageClasss parameters for deletion: %v", err)
+		glog.Error(msg)
+		ctrl.eventRecorder.Event(volume, api.EventTypeWarning, "VolumeDeleteClassError", msg)
+		// Despite the error, try to delete the volume. There is high
+		// probability that the deleter does not need the storage class
+		// parameters.
+	}
+
+	if err = ctrl.doDeleteVolume(volume, parameters); err != nil {
 		// Delete failed, update the volume and emit an event.
 		glog.V(3).Infof("deletion of volume %q failed: %v", volume.Name, err)
 		if _, err = ctrl.updateVolumePhaseWithEvent(volume, api.VolumeFailed, api.EventTypeWarning, "VolumeFailedDelete", err.Error()); err != nil {
@@ -1137,7 +1149,8 @@ func (ctrl *PersistentVolumeController) isVolumeReleased(volume *api.PersistentV
 
 // doDeleteVolume finds appropriate delete plugin and deletes given volume
 // (it will be re-used in future provisioner error cases).
-func (ctrl *PersistentVolumeController) doDeleteVolume(volume *api.PersistentVolume) error {
+// Parameters is value of StorageClass.Parameters of corresponding class.
+func (ctrl *PersistentVolumeController) doDeleteVolume(volume *api.PersistentVolume, parameters map[string]string) error {
 	glog.V(4).Infof("doDeleteVolume [%s]", volume.Name)
 	var err error
 
@@ -1167,7 +1180,7 @@ func (ctrl *PersistentVolumeController) doDeleteVolume(volume *api.PersistentVol
 	glog.V(5).Infof("found a deleter plugin %q for volume %q", plugin.GetPluginName(), volume.Name)
 
 	// Plugin found
-	deleter, err := plugin.NewDeleter(spec)
+	deleter, err := plugin.NewDeleter(parameters, spec)
 	if err != nil {
 		// Cannot create deleter
 		return fmt.Errorf("Failed to create deleter for volume %q: %v", volume.Name, err)
@@ -1321,7 +1334,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(claimObj interfa
 		ctrl.eventRecorder.Event(claim, api.EventTypeWarning, "ProvisioningFailed", strerr)
 
 		for i := 0; i < ctrl.createProvisionedPVRetryCount; i++ {
-			if err = ctrl.doDeleteVolume(volume); err == nil {
+			if err = ctrl.doDeleteVolume(volume, storageClass.Parameters); err == nil {
 				// Delete succeeded
 				glog.V(4).Infof("provisionClaimOperation [%s]: cleaning volume %s succeeded", claimToClaimKey(claim), volume.Name)
 				break

--- a/pkg/controller/volume/persistentvolume/controller_base.go
+++ b/pkg/controller/volume/persistentvolume/controller_base.go
@@ -509,6 +509,29 @@ func (ctrl *PersistentVolumeController) upgradeVolumeFrom1_2(volume *api.Persist
 	return true
 }
 
+// findDeleterParameters finds StorageClass.Parameters of storage class where
+// given volume belongs
+func (ctrl *PersistentVolumeController) findDeleterParameters(volume *api.PersistentVolume) (map[string]string, error) {
+	className := getVolumeClass(volume)
+	if className == "" {
+		return nil, nil
+	}
+
+	obj, found, err := ctrl.classes.GetByKey(className)
+	if err != nil {
+		return nil, fmt.Errorf("error getting storage class %q: %v", className, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("cannot find storage class %q", className)
+	}
+
+	class, ok := obj.(*extensions.StorageClass)
+	if !ok {
+		return nil, fmt.Errorf("expected StorageClass in class reflector, got %+v", obj)
+	}
+	return class.Parameters, nil
+}
+
 // Stateless functions
 
 func hasAnnotation(obj api.ObjectMeta, ann string) bool {

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -1173,7 +1173,7 @@ func (plugin *mockVolumePlugin) Provision() (*api.PersistentVolume, error) {
 
 // Deleter interfaces
 
-func (plugin *mockVolumePlugin) NewDeleter(spec *vol.Spec) (vol.Deleter, error) {
+func (plugin *mockVolumePlugin) NewDeleter(parameters map[string]string, spec *vol.Spec) (vol.Deleter, error) {
 	if len(plugin.deleteCalls) > 0 {
 		// mockVolumePlugin directly implements Deleter interface
 		glog.V(4).Infof("mock plugin NewDeleter called, returning mock deleter")

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -141,7 +141,7 @@ func (plugin *awsElasticBlockStorePlugin) newUnmounterInternal(volName string, p
 	}}, nil
 }
 
-func (plugin *awsElasticBlockStorePlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+func (plugin *awsElasticBlockStorePlugin) NewDeleter(parameters map[string]string, spec *volume.Spec) (volume.Deleter, error) {
 	return plugin.newDeleterInternal(spec, &AWSDiskUtil{})
 }
 

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -143,7 +143,7 @@ func (plugin *cinderPlugin) newUnmounterInternal(volName string, podUID types.UI
 		}}, nil
 }
 
-func (plugin *cinderPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+func (plugin *cinderPlugin) NewDeleter(parameters map[string]string, spec *volume.Spec) (volume.Deleter, error) {
 	return plugin.newDeleterInternal(spec, &CinderDiskUtil{})
 }
 

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -148,7 +148,7 @@ func (plugin *gcePersistentDiskPlugin) newUnmounterInternal(volName string, podU
 	}}, nil
 }
 
-func (plugin *gcePersistentDiskPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+func (plugin *gcePersistentDiskPlugin) NewDeleter(parameters map[string]string, spec *volume.Spec) (volume.Deleter, error) {
 	return plugin.newDeleterInternal(spec, &GCEDiskUtil{})
 }
 

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -116,7 +116,7 @@ func (plugin *hostPathPlugin) NewRecycler(pvName string, spec *volume.Spec) (vol
 	return plugin.newRecyclerFunc(pvName, spec, plugin.host, plugin.config)
 }
 
-func (plugin *hostPathPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+func (plugin *hostPathPlugin) NewDeleter(parameters map[string]string, spec *volume.Spec) (volume.Deleter, error) {
 	return plugin.newDeleterFunc(spec, plugin.host)
 }
 

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -107,7 +107,7 @@ func TestDeleter(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	deleter, err := plug.NewDeleter(spec)
+	deleter, err := plug.NewDeleter(nil, spec)
 	if err != nil {
 		t.Errorf("Failed to make a new Deleter: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestDeleterTempDir(t *testing.T) {
 		plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volumetest.NewFakeVolumeHost("/tmp/fake", nil, nil, "" /* rootContext */))
 		spec := &volume.Spec{PersistentVolume: &api.PersistentVolume{Spec: api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{HostPath: &api.HostPathVolumeSource{Path: test.path}}}}}
 		plug, _ := plugMgr.FindDeletablePluginBySpec(spec)
-		deleter, _ := plug.NewDeleter(spec)
+		deleter, _ := plug.NewDeleter(nil, spec)
 		err := deleter.Delete()
 		if err == nil && test.expectedFailure {
 			t.Errorf("Expected failure for test '%s' but got nil err", name)

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -137,7 +137,13 @@ type DeletableVolumePlugin interface {
 	// NewDeleter creates a new volume.Deleter which knows how to delete this
 	// resource in accordance with the underlying storage provider after the
 	// volume's release from a claim
-	NewDeleter(spec *Spec) (Deleter, error)
+	// parameters is value of StorageClass.Parameters referenced by
+	// PersistentVolume.Spec.Class (or the beta annotation) of the volume that
+	// is being deleted.
+	// The parameters can be nil in case the StorageClass instance was deleted.
+	// In this case, the deleter should do its best to delete the volume without
+	// it and throw an error when StorageClass.Parameters are really needed.
+	NewDeleter(parameters map[string]string, spec *Spec) (Deleter, error)
 }
 
 const (

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -277,7 +277,7 @@ func (plugin *FakeVolumePlugin) NewRecycler(pvName string, spec *Spec) (Recycler
 	return &fakeRecycler{"/attributesTransferredFromSpec", MetricsNil{}}, nil
 }
 
-func (plugin *FakeVolumePlugin) NewDeleter(spec *Spec) (Deleter, error) {
+func (plugin *FakeVolumePlugin) NewDeleter(parameters map[string]string, spec *Spec) (Deleter, error) {
 	return &FakeDeleter{"/attributesTransferredFromSpec", MetricsNil{}}, nil
 }
 

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -371,7 +371,7 @@ type vsphereVolumeDeleter struct {
 
 var _ volume.Deleter = &vsphereVolumeDeleter{}
 
-func (plugin *vsphereVolumePlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+func (plugin *vsphereVolumePlugin) NewDeleter(parameters map[string]string, spec *volume.Spec) (volume.Deleter, error) {
 	return plugin.newDeleterInternal(spec, &VsphereDiskUtil{})
 }
 


### PR DESCRIPTION
StorageClass may contain information necessary to delete a volume, e.g.
address of remote Ceph server and thus must be passed not only to
provisioners, but also to deleters.

@kubernetes/sig-storage

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30986)

<!-- Reviewable:end -->
