### PR TITLE
pkg/kubelet/images: fix struct initialization

### DIFF
--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -199,7 +199,7 @@ func TestSerializedPuller(t *testing.T) {
 		fakeRecorder := &record.FakeRecorder{}
 		puller := NewImageManager(fakeRecorder, fakeRuntime, backOff, true)
 
-		fakeRuntime.ImageList = []Image{{"present_image", nil, nil, 0}}
+		fakeRuntime.ImageList = []Image{{ID: "present_image"}}
 		fakeRuntime.Err = c.pullerErr
 		fakeRuntime.InspectErr = c.inspectErr
 


### PR DESCRIPTION
Fixes the govet error in go 1.7

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/30997)

<!-- Reviewable:end -->
