### PR TITLE
Delete duplicate declaration of GetDeviceNameFromMount

### DIFF
--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -36,10 +36,6 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return "", nil
-}
-
 func (mounter *Mounter) DeviceOpened(pathname string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
#30724 and #30665 collided, breaking the build by both trying to fix it.

```
+++ [0818 17:34:44] windows/amd64: go build started
# k8s.io/kubernetes/pkg/util/mount
pkg/util/mount/mount_unsupported.go:51: (*Mounter).GetDeviceNameFromMount redeclared in this block
        previous declaration at pkg/util/mount/mount_unsupported.go:39
```

After this PR merges, `make release` should finally work again.

cc @saad-ali @jingxu97 @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31013)

<!-- Reviewable:end -->
