### PR TITLE
Support COPYING as a valid license declaration

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -59,11 +59,15 @@ process_content () {
                # licenses (except to "see license file")
                ensure_pattern="License|Copyright"
                ;;
-    # We search READMEs for copyrights and this includes notice files as well
-    # Look in as many places as we find files matching
-    COPYRIGHT) find_names=(-iname 'notice*' -o -iname 'readme*')
+      # We search READMEs for copyrights and this includes notice files as well
+      # Look in as many places as we find files matching
+      COPYRIGHT) find_names=(-iname 'notice*' -o -iname 'readme*')
                find_maxdepth=3
                ensure_pattern="Copyright"
+               ;;
+      COPYING) find_names=(-iname 'COPYING')
+               find_maxdepth=1
+               ensure_pattern="License|Copyright"
                ;;
   esac
 
@@ -81,6 +85,7 @@ process_content () {
   esac
 
   # Find files - only root and package level
+
   local_files=($(
     for dir_root in ${package} ${package_root}; do
       [[ -d ${DEPS_DIR}/${dir_root} ]] || continue
@@ -138,6 +143,7 @@ for PACKAGE in $(cat Godeps/Godeps.json | \
                  sort -f); do
   process_content ${PACKAGE} LICENSE
   process_content ${PACKAGE} COPYRIGHT
+  process_content ${PACKAGE} COPYING
 
   # display content
   echo
@@ -150,6 +156,8 @@ for PACKAGE in $(cat Godeps/Godeps.json | \
       file="${CONTENT[${PACKAGE}-LICENSE]-}"
   elif [[ -n "${CONTENT[${PACKAGE}-COPYRIGHT]-}" ]]; then
       file="${CONTENT[${PACKAGE}-COPYRIGHT]-}"
+  elif [[ -n "${CONTENT[${PACKAGE}-COPYING]-}" ]]; then
+      file="${CONTENT[${PACKAGE}-COPYING]-}" 
   fi
   if [[ -z "${file}" ]]; then
       cat > /dev/stderr << __EOF__


### PR DESCRIPTION
Problem:

Some dependencies (like https://github.com/BurntSushi/toml associated with the powerful viper library) we care about might use other license conventions like COPYING, for example, https://github.com/github/choosealicense.com/issues/243

Solution:

This PR Adds support for COPYING (i.e. to be interpretted the same as LICENSE and so on). 

cc @kubernetes/sig-testing  - this is needed for json/yaml e2e configs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31024)

<!-- Reviewable:end -->
