### PR TITLE
Move init-container feature from alpha to beta.

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -419,7 +419,7 @@ func Convert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, 
 }
 
 func Convert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out *api.PodStatusResult, s conversion.Scope) error {
-	// TODO: when we move init container to beta, remove these conversions
+	// TODO: sometime after we move init container to stable, remove these conversions
 	if value, ok := in.Annotations[PodInitContainerStatusesAnnotationKey]; ok {
 		var values []ContainerStatus
 		if err := json.Unmarshal([]byte(value), &values); err != nil {
@@ -453,7 +453,7 @@ func Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, 
 		return err
 	}
 
-	// TODO: when we move init container to beta, remove these conversions
+	// TODO: sometime after we move init container to stable, remove these conversions.
 	if old := out.Annotations; old != nil {
 		out.Annotations = make(map[string]string, len(old))
 		for k, v := range old {
@@ -469,14 +469,22 @@ func Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, 
 			return err
 		}
 		out.Annotations[PodInitContainersAnnotationKey] = string(value)
+		out.Annotations[PodInitContainersBetaAnnotationKey] = string(value)
 	} else {
 		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainersBetaAnnotationKey)
 	}
 	return nil
 }
 
 func Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
-	// TODO: when we move init container to beta, remove these conversions
+	// TODO: sometime after we move init container to stable, remove these conversions
+	// If there is a beta annotation, copy to alpha key.
+	// See commit log for PR #31026 for why we do this.
+	if valueBeta, okBeta := in.Annotations[PodInitContainersBetaAnnotationKey]; okBeta {
+		in.Annotations[PodInitContainersAnnotationKey] = valueBeta
+	}
+	// Move the annotation to the internal repr. field
 	if value, ok := in.Annotations[PodInitContainersAnnotationKey]; ok {
 		var values []Container
 		if err := json.Unmarshal([]byte(value), &values); err != nil {
@@ -501,6 +509,7 @@ func Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out 
 			out.Annotations[k] = v
 		}
 		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainersBetaAnnotationKey)
 	}
 	return nil
 }
@@ -554,7 +563,7 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 		return err
 	}
 
-	// TODO: when we move init container to beta, remove these conversions
+	// TODO: sometime after we move init container to stable, remove these conversions
 	if len(out.Spec.InitContainers) > 0 || len(out.Status.InitContainerStatuses) > 0 {
 		old := out.Annotations
 		out.Annotations = make(map[string]string, len(old))
@@ -562,6 +571,7 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 			out.Annotations[k] = v
 		}
 		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainersBetaAnnotationKey)
 		delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
 	}
 	if len(out.Spec.InitContainers) > 0 {
@@ -570,6 +580,7 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 			return err
 		}
 		out.Annotations[PodInitContainersAnnotationKey] = string(value)
+		out.Annotations[PodInitContainersBetaAnnotationKey] = string(value)
 	}
 	if len(out.Status.InitContainerStatuses) > 0 {
 		value, err := json.Marshal(out.Status.InitContainerStatuses)
@@ -594,7 +605,13 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 }
 
 func Convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error {
-	// TODO: when we move init container to beta, remove these conversions
+	// If there is a beta annotation, copy to alpha key.
+	// See commit log for PR #31026 for why we do this.
+	if valueBeta, okBeta := in.Annotations[PodInitContainersBetaAnnotationKey]; okBeta {
+		in.Annotations[PodInitContainersAnnotationKey] = valueBeta
+	}
+	// TODO: sometime after we move init container to stable, remove these conversions
+	// Move the annotation to the internal repr. field
 	if value, ok := in.Annotations[PodInitContainersAnnotationKey]; ok {
 		var values []Container
 		if err := json.Unmarshal([]byte(value), &values); err != nil {
@@ -632,6 +649,7 @@ func Convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error 
 			out.Annotations[k] = v
 		}
 		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainersBetaAnnotationKey)
 		delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
 	}
 	return nil

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1655,11 +1655,17 @@ const (
 const (
 	// This annotation key will be used to contain an array of v1 JSON encoded Containers
 	// for init containers. The annotation will be placed into the internal type and cleared.
+	// This key is only recognized by version >= 1.4.
+	PodInitContainersBetaAnnotationKey = "pod.beta.kubernetes.io/init-containers"
+	// This annotation key will be used to contain an array of v1 JSON encoded Containers
+	// for init containers. The annotation will be placed into the internal type and cleared.
+	// This key is recognized by version >= 1.3. For version 1.4 code, this key
+	// will have its value copied to the beta key.
 	PodInitContainersAnnotationKey = "pod.alpha.kubernetes.io/init-containers"
 	// This annotation key will be used to contain an array of v1 JSON encoded
 	// ContainerStatuses for init containers. The annotation will be placed into the internal
 	// type and cleared.
-	PodInitContainerStatusesAnnotationKey = "pod.alpha.kubernetes.io/init-container-statuses"
+	PodInitContainerStatusesAnnotationKey = "pod.beta.kubernetes.io/init-container-statuses"
 )
 
 // PodSpec is a description of a pod.


### PR DESCRIPTION
``` release-note
Moved init-container feature from alpha to beta.

Security Action Required: 

This only applies to you if you use the PodSecurityPolicy feature.  You are using that feature if `kubectl get podsecuritypolicy` returns one or more objects.  If it returns an error, you are not using it.  

If there are any pods with the key `pods.beta.kubernetes.io/init-containers`, then that pod may not have been filtered by the PodSecurityPolicy.  You should find such pods and either delete them or audit them to ensure they do not use features that you intend to be blocked by PodSecurityPolicy.  

Explanation of Feature


In 1.3, an init container is specified with this annotation key
on the pod or pod template: `pods.alpha.kubernetes.io/init-containers`.

In 1.4, either that key or this key: `pods.beta.kubernetes.io/init-containers`,
can be used.

When you GET an object, you will see both annotation keys with the same values.

You can safely roll back from 1.4 to 1.3, and things with init-containers
will still work (pods, deployments, etc).

If you are running 1.3, only use the alpha annotation, or it may be lost when
rolling forward.

The status has moved from annotation key
`pods.beta.kubernetes.io/init-container-statuses` to
`pods.beta.kubernetes.io/init-container-statuses`.
Any code that inspects this annotation should be changed to use the new key.

State of Initialization will continue to be reported in both pods.alpha.kubernetes.io/initialized
and in `podStatus.conditions.{status: "True", type: Initialized}`
```

Mini-design for this change:

Goals:
1. A user can create an object with the beta annotation
  on 1.4, and it works.  The fact that the annotation has beta
  in it communicates to the user that the feature is beta,
  and so the user should have confidence in using it.  Preferably,
  when the user gets the annotation back, he see the beta
  annotation.
1) If someone had an existing alpha object in their apiserver,
  such as a RS with a pod template with an init-containers
  annotation on it, it should continue to work (init containers
  run) when stack upgraded to 1.4.
2) If someone is using a chart or blog post that has alpha
  annotation on it and they create it on a 1.4 cluster, it should
  work.
3) If someone had something with an init container in 1.4
  and they roll back stack to 1.3, it should not silently stop
  working (init containers don't run anymore).

To meet all these, we mirror an absent beta label from the alpha
key and vice versa.  If they are out of sync, we use the alpha
one. We do this in conversion since there was already logic there.

In 1.3 code, all annotations are preserved across a round trip
(v1 -> api -> v1), and the alpha annotation turns into the internal
field that kubelet uses.

In 1.4 code, the alpha annotation is always preserved across
a round trip, and a beta annotation is always set equal to
the alpha one, after a round trip.

Currently, the kubelet always sees the object after a round trip
when it GETs it.  But, we don't want to rely on that behavior,
since it will break when fastpath is implemented.

So, we rely on this:
all objects either are created with an alpha annotation (1.3 or 1.4
code) or are created with a beta annotation under 1.4.  In the later
case, they are round tripped at creation time, and so get both
annotations.  So all subsequent GETs see both labels.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31026)

<!-- Reviewable:end -->
