### PR TITLE
pkg/kubelet/rkt: skip empty lines in getOSReleaseInfo

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -2336,6 +2336,11 @@ func getOSReleaseInfo() (map[string]string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if len(strings.TrimSpace(line)) == 0 {
+			// Skips empty lines
+			continue
+		}
+
 		info := strings.SplitN(line, "=", 2)
 		if len(info) != 2 {
 			return nil, fmt.Errorf("unexpected entry in os-release %q", line)


### PR DESCRIPTION
Follow-up of #31022

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31032)

<!-- Reviewable:end -->
