### PR TITLE
Add kubectl describe cmd support for vSphere volume

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -610,6 +610,8 @@ func describeVolumes(volumes []api.Volume, out io.Writer, space string) {
 			printDownwardAPIVolumeSource(volume.VolumeSource.DownwardAPI, out)
 		case volume.VolumeSource.AzureDisk != nil:
 			printAzureDiskVolumeSource(volume.VolumeSource.AzureDisk, out)
+		case volume.VolumeSource.VsphereVolume != nil:
+			printVsphereVolumeSource(volume.VolumeSource.VsphereVolume, out)
 		default:
 			fmt.Fprintf(out, "  <unknown>\n")
 		}
@@ -738,6 +740,13 @@ func printAzureDiskVolumeSource(d *api.AzureDiskVolumeSource, out io.Writer) {
 		d.DiskName, d.DataDiskURI, *d.FSType, *d.CachingMode, *d.ReadOnly)
 }
 
+func printVsphereVolumeSource(vsphere *api.VsphereVirtualDiskVolumeSource, out io.Writer) {
+	fmt.Fprintf(out, "    Type:\tvSphereVolume (a Persistent Disk resource in vSphere)\n"+
+		"    VolumePath:\t%v\n"+
+		"    FSType:\t%v\n",
+		vsphere.VolumePath, vsphere.FSType)
+}
+
 type PersistentVolumeDescriber struct {
 	client.Interface
 }
@@ -789,6 +798,8 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string, describerSe
 			printRBDVolumeSource(pv.Spec.RBD, out)
 		case pv.Spec.Quobyte != nil:
 			printQuobyteVolumeSource(pv.Spec.Quobyte, out)
+		case pv.Spec.VsphereVolume != nil:
+			printVsphereVolumeSource(pv.Spec.VsphereVolume, out)
 		}
 
 		if events != nil {


### PR DESCRIPTION
This PR does following,
Add kubectl describe cmd support for vSphere volume

Examples:

> kubectl describe pod redis
> .......
> Volumes:
>   vmdk-storage:
>     Type:   vSphereVolume (a Persistent Disk resource in vSphere)
>     VolumePath: [Datastore] test1
>     FSType: ext4
> .........
> 
> kubectl describe pv pv0001
> Name:       pv0001
> Labels:     <none>
> Status:     Available
> Claim:
> Reclaim Policy: Recycle
> Access Modes:   RWO
> Capacity:   2Gi
> Message:
> Source:
>     Type:   vSphereVolume (a Persistent Disk resource in vSphere)
>     VolumePath: [vsanDatastore] volumes/test11
>     FSType: ext4
> No events.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31045)

<!-- Reviewable:end -->
