### PR TITLE
Added port mapping annotations needed for Mesos to kube-dns RC

### DIFF
--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
@@ -39,8 +39,8 @@ spec:
         version: v17.1
         kubernetes.io/cluster-service: "true"
       annotations:
-        k8s.mesosphere.io/port_UDP_53: 53
-        k8s.mesosphere.io/port_TCP_53: 53
+        k8s.mesosphere.io/port_UDP_53: "53"
+        k8s.mesosphere.io/port_TCP_53: "53"
     spec:
       containers:
       - name: kubedns

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
@@ -38,6 +38,9 @@ spec:
         k8s-app: kube-dns
         version: v17.1
         kubernetes.io/cluster-service: "true"
+      annotations:
+        k8s.mesosphere.io/port_UDP_53: 53
+        k8s.mesosphere.io/port_TCP_53: 53
     spec:
       containers:
       - name: kubedns

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
@@ -39,8 +39,8 @@ spec:
         version: v17.1
         kubernetes.io/cluster-service: "true"
       annotations:
-        k8s.mesosphere.io/port_UDP_53: 53
-        k8s.mesosphere.io/port_TCP_53: 53
+        k8s.mesosphere.io/port_UDP_53: "53"
+        k8s.mesosphere.io/port_TCP_53: "53"
     spec:
       containers:
       - name: kubedns

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
@@ -38,6 +38,9 @@ spec:
         k8s-app: kube-dns
         version: v17.1
         kubernetes.io/cluster-service: "true"
+      annotations:
+        k8s.mesosphere.io/port_UDP_53: 53
+        k8s.mesosphere.io/port_TCP_53: 53
     spec:
       containers:
       - name: kubedns

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
@@ -39,8 +39,8 @@ spec:
         version: v17.1
         kubernetes.io/cluster-service: "true"
       annotations:
-        k8s.mesosphere.io/port_UDP_53: 53
-        k8s.mesosphere.io/port_TCP_53: 53
+        k8s.mesosphere.io/port_UDP_53: "53"
+        k8s.mesosphere.io/port_TCP_53: "53"
     spec:
       containers:
       - name: kubedns

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
@@ -38,6 +38,9 @@ spec:
         k8s-app: kube-dns
         version: v17.1
         kubernetes.io/cluster-service: "true"
+      annotations:
+        k8s.mesosphere.io/port_UDP_53: 53
+        k8s.mesosphere.io/port_TCP_53: 53
     spec:
       containers:
       - name: kubedns


### PR DESCRIPTION
The Mesos support involves an alternate Endpoints Controller, see it
in `contrib/mesos/pkg/service/endpoints_controller.go`.  As noted in
the `findPort` function, this code insists on finding a host port for
every container port involved in a service endpoint --- there will be
no service Endpoint if the host port mapping is not found.

This commit adds the annotations needed for the kube DNS replication
controller.

This is a bug fix, no release note needed.

The need for host port mappings seems a bit archaic, but I am not
enough of a Mesos expert to remove it.  Perhaps someone more expert
can help out here?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31049)

<!-- Reviewable:end -->
