### PR TITLE
Fix rc scaler watch

### DIFF
--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -66,7 +66,7 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -75,7 +75,7 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update conflict failure, got %v", err)
 	}
 	preconditions = ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc = ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Errorf("Expected error on precondition failure")
@@ -90,7 +90,7 @@ func TestReplicationControllerScaleInvalid(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -304,7 +304,7 @@ func TestJobScaleRetry(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -313,7 +313,7 @@ func TestJobScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update failure, got %v", err)
 	}
 	preconditions = ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc = ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Errorf("Expected error on precondition failure")
@@ -348,7 +348,7 @@ func TestJobScaleInvalid(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -553,7 +553,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -562,7 +562,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update failure, got %v", err)
 	}
 	preconditions = &ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count)
+	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil)
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Errorf("Expected error on precondition failure")
@@ -597,7 +597,7 @@ func TestDeploymentScaleInvalid(t *testing.T) {
 	name := "foo"
 	namespace := "default"
 
-	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
The RC scaler uses Watch to monitor if the RC is scaled. The Watch was sent with resourceVersion=0, so the watch event it gets back starts from any point in the history, so the result is not valid.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

Probably will fix #30990
Fix #30469

**Special notes for your reviewer**:

This breaks the load test because the reaper doesn't actually wait until all the pods are gone before it deletes the RC.

I haven't run the node-100 test myself to verify it fixes the problem though.

cc @deads2k @smarterclayton @lavalamp

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31051)

<!-- Reviewable:end -->
