### PR TITLE
Avoid closing over range variables

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -164,7 +164,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
-	for _, kind := range []string{
+	for _, k := range []string{
 		"Endpoints",
 		"ResourceQuota",
 		"PersistentVolumeClaim",
@@ -172,6 +172,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		"ServiceAccount",
 		"ConfigMap",
 	} {
+		kind := k // don't close over range variables
 		err = scheme.AddFieldLabelConversionFunc("v1", kind,
 			func(label, value string) (string, string, error) {
 				switch label {

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -57,7 +57,8 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
-	for _, kind := range []string{"DaemonSet", "Deployment", "Ingress"} {
+	for _, k := range []string{"DaemonSet", "Deployment", "Ingress"} {
+		kind := k // don't close over range variables
 		err = api.Scheme.AddFieldLabelConversionFunc("extensions/v1beta1", kind,
 			func(label, value string) (string, string, error) {
 				switch label {


### PR DESCRIPTION
The consequence is only a misleading error message, but it is easy to
avoid.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31053)

<!-- Reviewable:end -->
