### PR TITLE
Filter internal Kubernetes labels from Prometheus metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1095,208 +1095,208 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1/test",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.23.2-89-g2ed7198",
-			"Rev": "2ed7198f77395ee9a172878a0a7ab92ab59a2cfd"
+			"Comment": "v0.24.0-alpha1-1-gd84e075",
+			"Rev": "d84e0758ab16ee68598702793119c9a7370c1522"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -33,7 +33,9 @@ import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/manager"
+	"github.com/google/cadvisor/metrics"
 	"github.com/google/cadvisor/utils/sysfs"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util/runtime"
 )
 
@@ -70,7 +72,27 @@ func init() {
 	}
 }
 
-// Creates a cAdvisor and exports its API on the specified port if port > 0.
+func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
+	set := map[string]string{metrics.LabelID: c.Name}
+	if len(c.Aliases) > 0 {
+		set[metrics.LabelName] = c.Aliases[0]
+	}
+	if image := c.Spec.Image; len(image) > 0 {
+		set[metrics.LabelImage] = image
+	}
+	if v, ok := c.Spec.Labels[types.KubernetesPodNameLabel]; ok {
+		set["pod_name"] = v
+	}
+	if v, ok := c.Spec.Labels[types.KubernetesPodNamespaceLabel]; ok {
+		set["namespace"] = v
+	}
+	if v, ok := c.Spec.Labels[types.KubernetesContainerNameLabel]; ok {
+		set["container_name"] = v
+	}
+	return set
+}
+
+// New creates a cAdvisor and exports its API on the specified port if port > 0.
 func New(port uint, runtime string) (Interface, error) {
 	sysFs, err := sysfs.NewRealSysFs()
 	if err != nil {
@@ -108,7 +130,7 @@ func (cc *cadvisorClient) exportHTTP(port uint) error {
 		return err
 	}
 
-	cadvisorhttp.RegisterPrometheusHandler(mux, cc, "/metrics", nil)
+	cadvisorhttp.RegisterPrometheusHandler(mux, cc, "/metrics", containerLabels)
 
 	// Only start the http server if port > 0
 	if port > 0 {

--- a/pkg/kubelet/cadvisor/cadvisor_linux_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux_test.go
@@ -1,0 +1,65 @@
+// +build cgo,linux
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cadvisor
+
+import (
+	"reflect"
+	"testing"
+
+	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/metrics"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+func TestContainerLabels(t *testing.T) {
+	container := &info.ContainerInfo{
+		ContainerReference: info.ContainerReference{
+			Name:    "/docker/f81ad5335d390944e454ea19ab0924037d57337c19731524ad96eb26e74b6c6d",
+			Aliases: []string{"k8s_POD.639b2af2_foo-web-315473031-e40e2_foobar_a369ace2-5fa9-11e6-b10f-c81f66e5e84d_851a97fd"},
+		},
+		Spec: info.ContainerSpec{
+			Image: "qux/foo:latest",
+			Labels: map[string]string{
+				"io.kubernetes.container.hash":                   "639b2af2",
+				types.KubernetesContainerNameLabel:               "POD",
+				"io.kubernetes.container.restartCount":           "0",
+				"io.kubernetes.container.terminationMessagePath": "",
+				types.KubernetesPodNameLabel:                     "foo-web-315473031-e40e2",
+				types.KubernetesPodNamespaceLabel:                "foobar",
+				"io.kubernetes.pod.terminationGracePeriod":       "30",
+				types.KubernetesPodUIDLabel:                      "a369ace2-5fa9-11e6-b10f-c81f66e5e84d",
+			},
+			Envs: map[string]string{
+				"foo+env": "prod",
+			},
+		},
+	}
+	want := map[string]string{
+		metrics.LabelID:    "/docker/f81ad5335d390944e454ea19ab0924037d57337c19731524ad96eb26e74b6c6d",
+		metrics.LabelName:  "k8s_POD.639b2af2_foo-web-315473031-e40e2_foobar_a369ace2-5fa9-11e6-b10f-c81f66e5e84d_851a97fd",
+		metrics.LabelImage: "qux/foo:latest",
+		"namespace":        "foobar",
+		"container_name":   "POD",
+		"pod_name":         "foo-web-315473031-e40e2",
+	}
+
+	if have := containerLabels(container); !reflect.DeepEqual(want, have) {
+		t.Errorf("want %v, have %v", want, have)
+	}
+}

--- a/vendor/github.com/google/cadvisor/http/handlers.go
+++ b/vendor/github.com/google/cadvisor/http/handlers.go
@@ -89,8 +89,11 @@ func RegisterHandlers(mux httpmux.Mux, containerManager manager.Manager, httpAut
 	return nil
 }
 
-func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager, prometheusEndpoint string, containerNameToLabelsFunc metrics.ContainerNameToLabelsFunc) {
-	collector := metrics.NewPrometheusCollector(containerManager, containerNameToLabelsFunc)
+// RegisterPrometheusHandler creates a new PrometheusCollector, registers it
+// on the global registry and configures the provided HTTP mux to handle the
+// given Prometheus endpoint.
+func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager, prometheusEndpoint string, f metrics.ContainerLabelsFunc) {
+	collector := metrics.NewPrometheusCollector(containerManager, f)
 	prometheus.MustRegister(collector)
 	mux.Handle(prometheusEndpoint, prometheus.Handler())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubernetes uses Docker labels as storage for some internal labels. The
majority of these labels are not meaningful metric labels and a few of
them are even harmful as they're not static and cause wrong aggregation
results.

This change provides a custom labels func to only attach meaningful
labels to cAdvisor exported metrics.

**Which issue this PR fixes**

google/cadvisor#1312

**Special notes for your reviewer**:

Depends on google/cadvisor#1429. Once that is merged, I'll update the vendor update commit.

**Release note**:

``` release-note
Remove environment variables and internal Kubernetes Docker labels from cAdvisor Prometheus metric labels.

Old behavior:

- environment variables explicitly whitelisted via --docker-env-metadata-whitelist were exported as `container_env_*=*`. Default is zero so by default non were exported
- all docker labels were exported as `container_label_*=*`

New behavior:

- Only `container_name`, `pod_name`, `namespace`, `id`, `image`, and `name` labels are exposed
- no environment variables will be exposed ever via /metrics, even if whitelisted
```

---

Given that we have full control over the exported label set, I shortened the pod_name, pod_namespace and container_name label names. Below an example of the change (reformatted for readability).

```
# BEFORE
container_cpu_cfs_periods_total{
  container_label_io_kubernetes_container_hash="5af8c3b4",
  container_label_io_kubernetes_container_name="sync",
  container_label_io_kubernetes_container_restartCount="1",
  container_label_io_kubernetes_container_terminationMessagePath="/dev/termination-log",
  container_label_io_kubernetes_pod_name="popularsearches-web-3165456836-2bfey",
  container_label_io_kubernetes_pod_namespace="popularsearches",
  container_label_io_kubernetes_pod_terminationGracePeriod="30",
  container_label_io_kubernetes_pod_uid="6a291e48-47c4-11e6-84a4-c81f66bdf8bd",
  id="/docker/68e1f15353921f4d6d4d998fa7293306c4ac828d04d1284e410ddaa75cf8cf25",
  image="redacted.com/popularsearches:42-16-ba6bd88",
  name="k8s_sync.5af8c3b4_popularsearches-web-3165456836-2bfey_popularsearches_6a291e48-47c4-11e6-84a4-c81f66bdf8bd_c02d3775"
} 72819

# AFTER
container_cpu_cfs_periods_total{
  container_name="sync",
  pod_name="popularsearches-web-3165456836-2bfey",
  namespace="popularsearches",
  id="/docker/68e1f15353921f4d6d4d998fa7293306c4ac828d04d1284e410ddaa75cf8cf25",
  image="redacted.com/popularsearches:42-16-ba6bd88",
  name="k8s_sync.5af8c3b4_popularsearches-web-3165456836-2bfey_popularsearches_6a291e48-47c4-11e6-84a4-c81f66bdf8bd_c02d3775"
} 72819
```

Feedback requested on:
- Label names. Other suggestions? Should we keep these very long ones?
- Do we need to export io.kubernetes.pod.uid? It makes working with the metrics a bit more complicated and the pod name is already unique at any time (but not over time). The UID is aslo part of `name`.

As discussed with @timstclair, this should be added to v1.4 as the current labels are harmful.

PTAL @jimmidyson @fabxc @vishh

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31064)

<!-- Reviewable:end -->
