### PR TITLE
Object meta fixes in federation controllers

### DIFF
--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -263,7 +263,7 @@ func (nc *NamespaceController) reconcileNamespace(namespace string) {
 			return
 		}
 		desiredNamespace := &api_v1.Namespace{
-			ObjectMeta: baseNamespace.ObjectMeta,
+			ObjectMeta: util.CopyObjectMeta(baseNamespace.ObjectMeta),
 			Spec:       baseNamespace.Spec,
 		}
 
@@ -277,7 +277,7 @@ func (nc *NamespaceController) reconcileNamespace(namespace string) {
 			clusterNamespace := clusterNamespaceObj.(*api_v1.Namespace)
 
 			// Update existing namespace, if needed.
-			if !reflect.DeepEqual(desiredNamespace.ObjectMeta, clusterNamespace.ObjectMeta) ||
+			if !util.ObjectMetaEquivalent(desiredNamespace.ObjectMeta, clusterNamespace.ObjectMeta) ||
 				!reflect.DeepEqual(desiredNamespace.Spec, clusterNamespace.Spec) {
 				operations = append(operations, util.FederatedOperation{
 					Type:        util.OperationTypeUpdate,

--- a/federation/pkg/federation-controller/secret/secret_controller.go
+++ b/federation/pkg/federation-controller/secret/secret_controller.go
@@ -272,7 +272,7 @@ func (secretcontroller *SecretController) reconcileSecret(namespace string, secr
 		}
 
 		desiredSecret := &api_v1.Secret{
-			ObjectMeta: baseSecret.ObjectMeta,
+			ObjectMeta: util.CopyObjectMeta(baseSecret.ObjectMeta),
 			Data:       baseSecret.Data,
 			Type:       baseSecret.Type,
 		}
@@ -287,7 +287,9 @@ func (secretcontroller *SecretController) reconcileSecret(namespace string, secr
 			clusterSecret := clusterSecretObj.(*api_v1.Secret)
 
 			// Update existing secret, if needed.
-			if !reflect.DeepEqual(desiredSecret.ObjectMeta, clusterSecret.ObjectMeta) {
+			if !util.ObjectMetaEquivalent(desiredSecret.ObjectMeta, clusterSecret.ObjectMeta) ||
+				!reflect.DeepEqual(desiredSecret.Data, clusterSecret.Data) ||
+				!reflect.DeepEqual(desiredSecret.Type, clusterSecret.Type) {
 				operations = append(operations, util.FederatedOperation{
 					Type:        util.OperationTypeUpdate,
 					Obj:         desiredSecret,

--- a/federation/pkg/federation-controller/util/meta.go
+++ b/federation/pkg/federation-controller/util/meta.go
@@ -22,6 +22,9 @@ import (
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
+// Copies cluster-independent, user provided data from the given ObjectMeta struct. If in
+// the future the ObjectMeta structure is expanded then any field that is not populared
+// by the api server should be included here.
 func CopyObjectMeta(obj api_v1.ObjectMeta) api_v1.ObjectMeta {
 	return api_v1.ObjectMeta{
 		Name:        obj.Name,
@@ -31,6 +34,9 @@ func CopyObjectMeta(obj api_v1.ObjectMeta) api_v1.ObjectMeta {
 	}
 }
 
+// Checks if cluster-independed, user provided data in two given ObjectMeta are eqaul. If in
+// the future the ObjectMeta structure is expanded then any field that is not populared
+// by the api server should be included here.
 func ObjectMetaEquivalent(a, b api_v1.ObjectMeta) bool {
 	if a.Name != b.Name {
 		return false

--- a/federation/pkg/federation-controller/util/meta.go
+++ b/federation/pkg/federation-controller/util/meta.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+
+	api_v1 "k8s.io/kubernetes/pkg/api/v1"
+)
+
+func CopyObjectMeta(obj api_v1.ObjectMeta) api_v1.ObjectMeta {
+	return api_v1.ObjectMeta{
+		Name:        obj.Name,
+		Namespace:   obj.Namespace,
+		Labels:      obj.Labels,
+		Annotations: obj.Annotations,
+	}
+}
+
+func ObjectMetaEquivalent(a, b api_v1.ObjectMeta) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+		return false
+	}
+	return true
+}

--- a/federation/pkg/federation-controller/util/meta_test.go
+++ b/federation/pkg/federation-controller/util/meta_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	api_v1 "k8s.io/kubernetes/pkg/api/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectMeta(t *testing.T) {
+	o1 := api_v1.ObjectMeta{
+		Namespace:       "ns1",
+		Name:            "s1",
+		UID:             "1231231412",
+		ResourceVersion: "999",
+	}
+	o3 := api_v1.ObjectMeta{
+		Namespace:   "ns1",
+		Name:        "s1",
+		UID:         "1231231412",
+		Annotations: map[string]string{"A": "B"},
+	}
+
+	o2 := CopyObjectMeta(o1)
+	assert.Equal(t, 0, len(o2.UID))
+	assert.Equal(t, 0, len(o2.ResourceVersion))
+	assert.Equal(t, o1.Name, o2.Name)
+	assert.True(t, ObjectMetaEquivalent(o1, o2))
+	assert.False(t, ObjectMetaEquivalent(o1, o3))
+}

--- a/federation/pkg/federation-controller/util/meta_test.go
+++ b/federation/pkg/federation-controller/util/meta_test.go
@@ -31,17 +31,37 @@ func TestObjectMeta(t *testing.T) {
 		UID:             "1231231412",
 		ResourceVersion: "999",
 	}
+	o2 := CopyObjectMeta(o1)
 	o3 := api_v1.ObjectMeta{
 		Namespace:   "ns1",
 		Name:        "s1",
 		UID:         "1231231412",
 		Annotations: map[string]string{"A": "B"},
 	}
-
-	o2 := CopyObjectMeta(o1)
+	o4 := api_v1.ObjectMeta{
+		Namespace:   "ns1",
+		Name:        "s1",
+		UID:         "1231255531412",
+		Annotations: map[string]string{"A": "B"},
+	}
+	o5 := api_v1.ObjectMeta{
+		Namespace:       "ns1",
+		Name:            "s1",
+		ResourceVersion: "1231231412",
+		Annotations:     map[string]string{"A": "B"},
+	}
+	o6 := api_v1.ObjectMeta{
+		Namespace:       "ns1",
+		Name:            "s1",
+		ResourceVersion: "1231255531412",
+		Annotations:     map[string]string{"A": "B"},
+	}
 	assert.Equal(t, 0, len(o2.UID))
 	assert.Equal(t, 0, len(o2.ResourceVersion))
 	assert.Equal(t, o1.Name, o2.Name)
 	assert.True(t, ObjectMetaEquivalent(o1, o2))
 	assert.False(t, ObjectMetaEquivalent(o1, o3))
+	assert.True(t, ObjectMetaEquivalent(o3, o4))
+	assert.True(t, ObjectMetaEquivalent(o5, o6))
+	assert.True(t, ObjectMetaEquivalent(o3, o5))
 }


### PR DESCRIPTION
This PR adds helper functions for handling object meta structs and applies them to the existing controllers.

cc: @quinton-hoole @jianhuiz @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31076)

<!-- Reviewable:end -->
