### PR TITLE
Kubelet: implement GetNetNS for new runtime api

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	internalApi "k8s.io/kubernetes/pkg/kubelet/api"
+	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -297,11 +298,37 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namesp
 
 // Returns the filesystem path of the pod's network namespace; if the
 // runtime does not handle namespace creation itself, or cannot return
-// the network namespace path, it should return an error.
-// TODO: Change ContainerID to a Pod ID since the namespace is shared
-// by all containers in the pod.
-func (m *kubeGenericRuntimeManager) GetNetNS(containerID kubecontainer.ContainerID) (string, error) {
-	return "", fmt.Errorf("not implemented")
+// the network namespace path, it returns an 'not supported' error.
+// TODO: Rename param name to sandboxID in kubecontainer.Runtime.GetNetNS().
+// TODO: Remove GetNetNS after networking is delegated to the container runtime.
+func (m *kubeGenericRuntimeManager) GetNetNS(sandboxID kubecontainer.ContainerID) (string, error) {
+	readyState := runtimeApi.PodSandBoxState_READY
+	filter := &runtimeApi.PodSandboxFilter{
+		State:         &readyState,
+		Id:            &sandboxID.ID,
+		LabelSelector: map[string]string{kubernetesManagedLabel: "true"},
+	}
+	sandboxes, err := m.runtimeService.ListPodSandbox(filter)
+	if err != nil {
+		glog.Errorf("ListPodSandbox with filter %q failed: %v", filter, err)
+		return "", err
+	}
+	if len(sandboxes) == 0 {
+		glog.Errorf("No sandbox is found with filter %q", filter)
+		return "", fmt.Errorf("Sandbox %q is not found", sandboxID)
+	}
+
+	sandboxStatus, err := m.runtimeService.PodSandboxStatus(sandboxes[0].GetId())
+	if err != nil {
+		glog.Errorf("PodSandboxStatus with id %q failed: %v", sandboxes[0].GetId(), err)
+		return "", err
+	}
+
+	if sandboxStatus.Linux != nil && sandboxStatus.Linux.Namespaces != nil {
+		return sandboxStatus.Linux.Namespaces.GetNetwork(), nil
+	}
+
+	return "", fmt.Errorf("not supported")
 }
 
 // GetPodContainerID gets pod sandbox ID

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -235,3 +235,36 @@ func TestGetPods(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", expected, actual)
 	}
 }
+
+func TestGetNetNS(t *testing.T) {
+	fakeRuntime, _, m, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "foo1",
+					Image: "busybox",
+				},
+				{
+					Name:  "foo2",
+					Image: "busybox",
+				},
+			},
+		},
+	}
+
+	// Set fake sandbox and fake containers to fakeRuntime.
+	sandbox, _, err := makeAndSetFakePod(m, fakeRuntime, pod)
+	assert.NoError(t, err)
+
+	actual, err := m.GetNetNS(kubecontainer.ContainerID{ID: sandbox.GetId()})
+	assert.Equal(t, "", actual)
+	assert.Equal(t, "not supported", err.Error())
+}


### PR DESCRIPTION
Kubelet: implement GetNetNS for new runtime api. 

CC @yujuhong @thockin @kubernetes/sig-node @kubernetes/sig-rktnetes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31091)

<!-- Reviewable:end -->
