### PR TITLE
Use scale subresource

### DIFF
--- a/pkg/kubectl/scale.go
+++ b/pkg/kubectl/scale.go
@@ -143,13 +143,13 @@ func (precondition *ScalePrecondition) ValidatePetSet(ps *apps.PetSet) error {
 	return nil
 }
 
-// ValidateReplicationController ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
-func (precondition *ScalePrecondition) ValidateReplicationController(controller *api.ReplicationController) error {
-	if precondition.Size != -1 && int(controller.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(controller.Spec.Replicas))}
+// ValidateScale ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
+func (precondition *ScalePrecondition) ValidateScale(scale *extensions.Scale) error {
+	if precondition.Size != -1 && int(scale.Spec.Replicas) != precondition.Size {
+		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(scale.Spec.Replicas))}
 	}
-	if len(precondition.ResourceVersion) != 0 && controller.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, controller.ResourceVersion}
+	if len(precondition.ResourceVersion) != 0 && scale.ResourceVersion != precondition.ResourceVersion {
+		return PreconditionError{"resource version", precondition.ResourceVersion, scale.ResourceVersion}
 	}
 	return nil
 }
@@ -161,24 +161,24 @@ type ReplicationControllerScaler struct {
 // ScaleSimple does a simple one-shot attempt at scaling. It returns the
 // resourceVersion of the replication controller if the update is successful.
 func (scaler *ReplicationControllerScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	controller, err := scaler.c.ReplicationControllers(namespace).Get(name)
+	sc := scaler.c.Extensions().Scales(namespace)
+	scale, err := sc.Get("ReplicationController", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateReplicationController(controller); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
-	controller.Spec.Replicas = int32(newSize)
-	updatedRC, err := scaler.c.ReplicationControllers(namespace).Update(controller)
-	if err != nil {
+	scale.Spec.Replicas = int32(newSize)
+	if _, err := sc.Update("ReplicationController", scale); err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, controller.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, controller.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedRC.ObjectMeta.ResourceVersion, nil
+	return scale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a ReplicationController to a new size, with optional precondition check (if preconditions is not nil),
@@ -241,17 +241,6 @@ func (scaler *ReplicationControllerScaler) Scale(namespace, name string, newSize
 	return nil
 }
 
-// ValidateReplicaSet ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
-func (precondition *ScalePrecondition) ValidateReplicaSet(replicaSet *extensions.ReplicaSet) error {
-	if precondition.Size != -1 && int(replicaSet.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(replicaSet.Spec.Replicas))}
-	}
-	if len(precondition.ResourceVersion) != 0 && replicaSet.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, replicaSet.ResourceVersion}
-	}
-	return nil
-}
-
 type ReplicaSetScaler struct {
 	c client.ExtensionsInterface
 }
@@ -259,24 +248,24 @@ type ReplicaSetScaler struct {
 // ScaleSimple does a simple one-shot attempt at scaling. It returns the
 // resourceVersion of the replicaset if the update is successful.
 func (scaler *ReplicaSetScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	rs, err := scaler.c.ReplicaSets(namespace).Get(name)
+	sc := scaler.c.Scales(namespace)
+	scale, err := sc.Get("ReplicaSet", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateReplicaSet(rs); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
-	rs.Spec.Replicas = int32(newSize)
-	updatedRS, err := scaler.c.ReplicaSets(namespace).Update(rs)
-	if err != nil {
+	scale.Spec.Replicas = int32(newSize)
+	if _, err := sc.Update("ReplicaSet", scale); err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, rs.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, rs.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedRS.ObjectMeta.ResourceVersion, nil
+	return scale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a ReplicaSet to a new size, with optional precondition check (if preconditions is
@@ -433,17 +422,6 @@ func (scaler *JobScaler) Scale(namespace, name string, newSize uint, preconditio
 	return nil
 }
 
-// ValidateDeployment ensures that the preconditions match.  Returns nil if they are valid, an error otherwise.
-func (precondition *ScalePrecondition) ValidateDeployment(deployment *extensions.Deployment) error {
-	if precondition.Size != -1 && int(deployment.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(deployment.Spec.Replicas))}
-	}
-	if len(precondition.ResourceVersion) != 0 && deployment.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, deployment.ResourceVersion}
-	}
-	return nil
-}
-
 type DeploymentScaler struct {
 	c client.ExtensionsInterface
 }
@@ -452,27 +430,25 @@ type DeploymentScaler struct {
 // count. It returns the resourceVersion of the deployment if the update is
 // successful.
 func (scaler *DeploymentScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	deployment, err := scaler.c.Deployments(namespace).Get(name)
+	sc := scaler.c.Scales(namespace)
+	scale, err := sc.Get("Deployment", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateDeployment(deployment); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
 
-	// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-	// For now I'm falling back to regular Deployment update operation.
-	deployment.Spec.Replicas = int32(newSize)
-	updatedDeployment, err := scaler.c.Deployments(namespace).Update(deployment)
-	if err != nil {
+	scale.Spec.Replicas = int32(newSize)
+	if _, err := sc.Update("Deployment", scale); err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, deployment.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, deployment.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedDeployment.ObjectMeta.ResourceVersion, nil
+	return scale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a deployment to a new size, with optional precondition check (if preconditions is not nil),

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -68,6 +68,11 @@ func TestReplicationControllerStop(t *testing.T) {
 						},
 					},
 				},
+				&extensions.Scale{
+					Spec: extensions.ScaleSpec{
+						Replicas: 0,
+					},
+				},
 			},
 			StopError:       nil,
 			ExpectedActions: []string{"get", "list", "get", "update", "get", "delete"},
@@ -104,6 +109,11 @@ func TestReplicationControllerStop(t *testing.T) {
 								Replicas: 0,
 								Selector: map[string]string{"k1": "v1"}},
 						},
+					},
+				},
+				&extensions.Scale{
+					Spec: extensions.ScaleSpec{
+						Replicas: 0,
 					},
 				},
 			},
@@ -268,7 +278,7 @@ func TestReplicationControllerStop(t *testing.T) {
 			continue
 		}
 		for i, verb := range test.ExpectedActions {
-			if actions[i].GetResource() != "replicationcontrollers" {
+			if actions[i].GetResource() != "replicationcontrollers" && actions[i].GetSubresource() != "scale" {
 				t.Errorf("%s unexpected action: %+v, expected %s-replicationController", test.Name, actions[i], verb)
 			}
 			if actions[i].GetVerb() != verb {
@@ -314,6 +324,11 @@ func TestReplicaSetStop(t *testing.T) {
 						},
 					},
 				},
+				&extensions.Scale{
+					Spec: extensions.ScaleSpec{
+						Replicas: 0,
+					},
+				},
 			},
 			StopError:       nil,
 			ExpectedActions: []string{"get", "get", "update", "get", "get", "delete"},
@@ -355,6 +370,11 @@ func TestReplicaSetStop(t *testing.T) {
 						},
 					},
 				},
+				&extensions.Scale{
+					Spec: extensions.ScaleSpec{
+						Replicas: 0,
+					},
+				},
 			},
 			StopError:       nil,
 			ExpectedActions: []string{"get", "get", "update", "get", "get", "delete"},
@@ -378,7 +398,7 @@ func TestReplicaSetStop(t *testing.T) {
 			continue
 		}
 		for i, verb := range test.ExpectedActions {
-			if actions[i].GetResource() != "replicasets" {
+			if actions[i].GetResource() != "replicasets" && actions[i].GetSubresource() != "scale" {
 				t.Errorf("%s unexpected action: %+v, expected %s-replicaSet", test.Name, actions[i], verb)
 			}
 			if actions[i].GetVerb() != verb {
@@ -570,6 +590,11 @@ func TestDeploymentStop(t *testing.T) {
 						},
 					},
 				},
+				&extensions.Scale{
+					Spec: extensions.ScaleSpec{
+						Replicas: 0,
+					},
+				},
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
@@ -598,7 +623,7 @@ func TestDeploymentStop(t *testing.T) {
 			if actions[i].GetVerb() != action[0] {
 				t.Errorf("%s unexpected verb: %+v, expected %s", test.Name, actions[i], expAction)
 			}
-			if actions[i].GetResource() != action[1] {
+			if actions[i].GetResource() != action[1] && actions[i].GetSubresource() != "scale" {
 				t.Errorf("%s unexpected resource: %+v, expected %s", test.Name, actions[i], expAction)
 			}
 			if len(action) == 3 && actions[i].GetSubresource() != action[2] {


### PR DESCRIPTION
Fixes #29698

Use scale subresource for ReplicationController, ReplicaSet and Deployment.
Couldn't do Jobs and PetSet since they live in a different group.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31111)

<!-- Reviewable:end -->
