### PR TITLE
Avoid sorting lists when unnecessary

### DIFF
--- a/cmd/libs/go2idl/set-gen/generators/sets.go
+++ b/cmd/libs/go2idl/set-gen/generators/sets.go
@@ -337,6 +337,15 @@ func (s $.type|public$) List() []$.type|raw$ {
 	return []$.type|raw$(res)
 }
 
+// UnsortedList returns the slice with contents in random order.
+func (s $.type|public$) UnsortedList() []$.type|raw$ {
+	res :=make([]$.type|raw$, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
 // Returns a single element from the set.
 func (s $.type|public$) PopAny() ($.type|raw$, bool) {
 	for key := range s {

--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -151,7 +151,7 @@ func (c *threadSafeMap) Index(indexName string, obj interface{}) ([]interface{},
 	returnKeySet := sets.String{}
 	for _, indexKey := range indexKeys {
 		set := index[indexKey]
-		for _, key := range set.List() {
+		for _, key := range set.UnsortedList() {
 			returnKeySet.Insert(key)
 		}
 	}

--- a/pkg/util/sets/byte.go
+++ b/pkg/util/sets/byte.go
@@ -174,6 +174,15 @@ func (s Byte) List() []byte {
 	return []byte(res)
 }
 
+// UnsortedList returns the slice with contents in random order.
+func (s Byte) UnsortedList() []byte {
+	res := make([]byte, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
 // Returns a single element from the set.
 func (s Byte) PopAny() (byte, bool) {
 	for key := range s {

--- a/pkg/util/sets/int.go
+++ b/pkg/util/sets/int.go
@@ -174,6 +174,15 @@ func (s Int) List() []int {
 	return []int(res)
 }
 
+// UnsortedList returns the slice with contents in random order.
+func (s Int) UnsortedList() []int {
+	res := make([]int, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
 // Returns a single element from the set.
 func (s Int) PopAny() (int, bool) {
 	for key := range s {

--- a/pkg/util/sets/int64.go
+++ b/pkg/util/sets/int64.go
@@ -174,6 +174,15 @@ func (s Int64) List() []int64 {
 	return []int64(res)
 }
 
+// UnsortedList returns the slice with contents in random order.
+func (s Int64) UnsortedList() []int64 {
+	res := make([]int64, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
 // Returns a single element from the set.
 func (s Int64) PopAny() (int64, bool) {
 	for key := range s {

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -174,6 +174,15 @@ func (s String) List() []string {
 	return []string(res)
 }
 
+// UnsortedList returns the slice with contents in random order.
+func (s String) UnsortedList() []string {
+	res := make([]string, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
 // Returns a single element from the set.
 func (s String) PopAny() (string, bool) {
 	for key := range s {


### PR DESCRIPTION
I've seen ThreadSafeMap::List consuming ~30% of whole CPU usage, spending the whole time in sorting (while it is in fact completely unneded).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31112)

<!-- Reviewable:end -->
