### PR TITLE
Add constants and documentation around AWS magic numbers

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -221,6 +221,13 @@ const (
 	VolumeTypeST1 = "st1"
 )
 
+// AWS provisioning limits.
+// Source: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
+const (
+	MinTotalIOPS = 100
+	MaxTotalIOPS = 20000
+)
+
 // VolumeOptions specifies capacity and tags for a volume.
 type VolumeOptions struct {
 	CapacityGB       int
@@ -229,8 +236,7 @@ type VolumeOptions struct {
 	VolumeType       string
 	AvailabilityZone string
 	// IOPSPerGB x CapacityGB will give total IOPS of the volume to create.
-	// IOPSPerGB must be bigger than zero and smaller or equal to 30.
-	// Calculated total IOPS will be capped at 20000 IOPS.
+	// Calculated total IOPS will be capped at MaxTotalIOPS.
 	IOPSPerGB int
 	Encrypted bool
 	// fully qualified resource name to the key to use for encryption.
@@ -1509,17 +1515,19 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 		createType = volumeOptions.VolumeType
 
 	case VolumeTypeIO1:
-		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html for IOPS constraints
-		if volumeOptions.IOPSPerGB <= 0 || volumeOptions.IOPSPerGB > 30 {
-			return "", fmt.Errorf("invalid iopsPerGB value %d, must be 0 < IOPSPerGB <= 30", volumeOptions.IOPSPerGB)
-		}
+		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html
+		// for IOPS constraints. AWS will throw an error if IOPS per GB gets out
+		// of supported bounds, no need to check it here.
 		createType = volumeOptions.VolumeType
 		iops = int64(volumeOptions.CapacityGB * volumeOptions.IOPSPerGB)
-		if iops < 100 {
-			iops = 100
+
+		// Cap at min/max total IOPS, AWS would throw an error if it gets too
+		// low/high.
+		if iops < MinTotalIOPS {
+			iops = MinTotalIOPS
 		}
-		if iops > 20000 {
-			iops = 20000
+		if iops > MaxTotalIOPS {
+			iops = MaxTotalIOPS
 		}
 
 	case "":


### PR DESCRIPTION
Also, bumped max IOPS/GB to 50, it changed from 30 since last time I checked.

Source: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html

@kubernetes/sig-storage

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31115)

<!-- Reviewable:end -->
