### PR TITLE
Add ScaleExpansion to client v1.4

### DIFF
--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_scale_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/fake/fake_scale_expansion.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+)
+
+func (c *FakeScales) Get(kind string, name string) (result *v1beta1.Scale, err error) {
+	action := core.GetActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.ns
+	action.Resource = unversioned.GroupVersionResource{Resource: kind}
+	action.Subresource = "scale"
+	action.Name = name
+	obj, err := c.Fake.Invokes(action, &v1beta1.Scale{})
+	result = obj.(*v1beta1.Scale)
+	return
+}
+
+func (c *FakeScales) Update(kind string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	action := core.UpdateActionImpl{}
+	action.Verb = "update"
+	action.Namespace = c.ns
+	action.Resource = unversioned.GroupVersionResource{Resource: kind}
+	action.Subresource = "scale"
+	action.Object = scale
+	obj, err := c.Fake.Invokes(action, scale)
+	result = obj.(*v1beta1.Scale)
+	return
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/generated_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/generated_expansion.go
@@ -28,8 +28,6 @@ type PodSecurityPolicyExpansion interface{}
 
 type ReplicaSetExpansion interface{}
 
-type ScaleExpansion interface{}
-
 type ThirdPartyResourceExpansion interface{}
 
 type StorageClassExpansion interface{}

--- a/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/scale_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/extensions/v1beta1/scale_expansion.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+// The ScaleExpansion interface allows manually adding extra methods to the ScaleInterface.
+type ScaleExpansion interface {
+	Get(kind string, name string) (*v1beta1.Scale, error)
+	Update(kind string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
+}
+
+// Get takes the reference to scale subresource and returns the subresource or error, if one occurs.
+func (c *scales) Get(kind string, name string) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+
+	// TODO this method needs to take a proper unambiguous kind
+	fullyQualifiedKind := unversioned.GroupVersionKind{Kind: kind}
+	resource, _ := meta.KindToResource(fullyQualifiedKind)
+
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource(resource.Resource).
+		Name(name).
+		SubResource("scale").
+		Do().
+		Into(result)
+	return
+}
+
+func (c *scales) Update(kind string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+
+	// TODO this method needs to take a proper unambiguous kind
+	fullyQualifiedKind := unversioned.GroupVersionKind{Kind: kind}
+	resource, _ := meta.KindToResource(fullyQualifiedKind)
+
+	err = c.client.Put().
+		Namespace(scale.Namespace).
+		Resource(resource.Resource).
+		Name(scale.Name).
+		SubResource("scale").
+		Body(scale).
+		Do().
+		Into(result)
+	return
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The generated v1.4 did not carry over the complete ScaleExpansion interface. The unversioned client is using this interface and should be in sync with generated client.

**Release note**:

``` release-note

NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31116)

<!-- Reviewable:end -->
