### PR TITLE
Fix overlong junit filename prefixes (2nd attempt)

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -155,12 +155,13 @@ junitFilenamePrefix() {
     return
   fi
   mkdir -p "${KUBE_JUNIT_REPORT_DIR}"
-  local KUBE_TEST_API_NO_SLASH="${KUBE_TEST_API//\//-}"
-  # This filename isn't parsed by anything,
-  # and we must avoid exceeding 255 character filename limit.
-  KUBE_TEST_API_NO_SLASH="${KUBE_TEST_API_NO_SLASH//k8s.io-/}"
-  KUBE_TEST_API_NO_SLASH="$(echo "$KUBE_TEST_API_NO_SLASH"|sed 's/\([0-9]\)alpha\([0-9]\)/\1a\2/g;s/\([0-9]\)beta\([0-9]\)/\1b\2/g')"
-  echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_NO_SLASH}_$(kube::util::sortable_date)"
+  # This filename isn't parsed by anything, and we must avoid
+  # exceeding 255 character filename limit. KUBE_TEST_API
+  # barely fits there and in coverage mode test names are
+  # appended to generated file names, easily exceeding
+  # 255 chars in length. So let's just sha1sum it.
+  local KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"|sha1sum|awk '{print $1}')"
+  echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_HASH}_$(kube::util::sortable_date)"
 }
 
 produceJUnitXMLReport() {


### PR DESCRIPTION
This is followup for #30894.
Turned out that filename shortening I used isn't enough in some cases (scroll to the right):

```
vagrant@devbox:~/work/kubernetes/src/k8s.io/kubernetes (test %) $ mkdir -p /tmp/art && time KUBE_JUNIT_REPORT_DIR=/tmp/art KUBE_COVER=y make test WHAT=cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned
Running tests for APIVersion: v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1
+++ [0822 13:57:46] Saving coverage output in '/tmp/k8s_coverage/v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1/20160822-135746'
tee: /tmp/art/junit_v1,apps-v1a1,authentication.v1b1,authorization.v1b1,autoscaling-v1,batch-v1,batch-v2a1,certificates-v1a1,extensions-v1b1,federation-v1b1,policy-v1a1,rbac.authorization.v1a1,imagepolicy.v1a1_20160822-135746-cmd_libs_go2idl_client-gen_testoutput_clientset_generated_test_internalclientset_typed_testgroup.k8s.io_unversioned.stdout: File name too long
ok      k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned   0.038s
ls: cannot access '/tmp/art/junit_v1,apps-v1a1,authentication.v1b1,authorization.v1b1,autoscaling-v1,batch-v1,batch-v2a1,certificates-v1a1,extensions-v1b1,federation-v1b1,policy-v1a1,rbac.authorization.v1a1,imagepolicy.v1a1_20160822-135746*.stdout': No such file or directory
Makefile:118: recipe for target 'test' failed
make: *** [test] Error 1

real    0m49.623s
user    2m35.224s
sys     0m9.200s
```

Looks like we have no choice here besides just using a hash as filename prefix.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31117)

<!-- Reviewable:end -->
