### PR TITLE
Fixed two issues of kubectl bash completion.

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -47,7 +47,7 @@ __kubectl_override_flags()
         for of in "${__kubectl_override_flag_list[@]}"; do
             case "${w}" in
                 --${of}=*)
-                    eval "${of}=\"--${of}=\${w}\""
+                    eval "${of}=\"${w}\""
                     ;;
                 --${of})
                     two_word_of="${of}"
@@ -115,7 +115,7 @@ __kubectl_get_containers()
     fi
     local last=${nouns[${len} -1]}
     local kubectl_out
-    if kubectl_out=$(kubectl get $(__kubectl_namespace_flag) -o template --template="${template}" pods "${last}" 2>/dev/null); then
+    if kubectl_out=$(kubectl get $(__kubectl_override_flags) -o template --template="${template}" pods "${last}" 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
     fi
 }


### PR DESCRIPTION
This patch includes the fix of the following issue:
• Correct the method invocation from "__kubectl_namespace_flag"
  to "__kubectl_override_flags"
• Support bash completion if "--namespace=xxx" style flags are
  specified in the kubectl command

Fixes #31134

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31135)

<!-- Reviewable:end -->
