### PR TITLE
federation: Adding support for namespace admission controls in federation-apiserver

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -94,7 +94,7 @@ function create-federation-api-objects {
     export FEDERATION_API_NODEPORT=32111
     export FEDERATION_NAMESPACE
     export FEDERATION_NAME="${FEDERATION_NAME:-federation}"
-    export DNS_ZONE_NAME="${DNS_ZONE_NAME:-federation.example}"  # See https://tools.ietf.org/html/rfc2606
+    export DNS_ZONE_NAME="${DNS_ZONE_NAME:-federation.example.}"  # See https://tools.ietf.org/html/rfc2606
 
     template="go run ${KUBE_ROOT}/federation/cluster/template.go"
 

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -186,6 +186,9 @@ function create-federation-api-objects {
     export FEDERATION_APISERVER_CERT_BASE64="${FEDERATION_APISERVER_CERT_BASE64}"
     export FEDERATION_APISERVER_KEY_BASE64="${FEDERATION_APISERVER_KEY_BASE64}"
 
+    # Enable the NamespaceLifecycle admission control by default.
+    export FEDERATION_ADMISSION_CONTROL="${FEDERATION_ADMISSION_CONTROL:-NamespaceLifecycle}"
+
     for file in federation-etcd-pvc.yaml federation-apiserver-{deployment,secrets}.yaml federation-controller-manager-deployment.yaml; do
       $template "${manifests_root}/${file}" | $host_kubectl create -f -
     done

--- a/federation/cmd/federation-apiserver/app/plugins.go
+++ b/federation/cmd/federation-apiserver/app/plugins.go
@@ -26,4 +26,5 @@ import (
 	// Admission policies
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 )

--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - --basic-auth-file=/srv/kubernetes/basic_auth.csv
         - --tls-cert-file=/srv/kubernetes/server.cert
         - --tls-private-key-file=/srv/kubernetes/server.key
-        # TODO: --admission-control values must be set when support is added for each type of control.
+        - --admission-control={{.FEDERATION_ADMISSION_CONTROL}}
         - --token-auth-file=/srv/kubernetes/known-tokens.csv
         ports:
         - containerPort: 443

--- a/test/e2e/federated-secret.go
+++ b/test/e2e/federated-secret.go
@@ -40,24 +40,27 @@ var _ = framework.KubeDescribe("Federation secrets [Feature:Federation]", func()
 		AfterEach(func() {
 			framework.SkipUnlessFederated(f.Client)
 
+			nsName := f.FederationNamespace.Name
 			// Delete registered secrets.
 			// This is if a test failed, it should not affect other tests.
-			secretList, err := f.FederationClientset_1_4.Core().Secrets(f.Namespace.Name).List(api.ListOptions{})
+			secretList, err := f.FederationClientset_1_4.Core().Secrets(nsName).List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			for _, secret := range secretList.Items {
-				err := f.FederationClientset_1_4.Core().Secrets(f.Namespace.Name).Delete(secret.Name, &api.DeleteOptions{})
+				err := f.FederationClientset_1_4.Core().Secrets(nsName).Delete(secret.Name, &api.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
 
 		It("should be created and deleted successfully", func() {
 			framework.SkipUnlessFederated(f.Client)
-			secret := createSecretOrFail(f.FederationClientset_1_4, f.Namespace.Name)
-			By(fmt.Sprintf("Creation of secret %q in namespace %q succeeded.  Deleting secret.", secret.Name, f.Namespace.Name))
+
+			nsName := f.FederationNamespace.Name
+			secret := createSecretOrFail(f.FederationClientset_1_4, nsName)
+			By(fmt.Sprintf("Creation of secret %q in namespace %q succeeded.  Deleting secret.", secret.Name, nsName))
 			// Cleanup
-			err := f.FederationClientset_1_4.Core().Secrets(f.Namespace.Name).Delete(secret.Name, &api.DeleteOptions{})
+			err := f.FederationClientset_1_4.Core().Secrets(nsName).Delete(secret.Name, &api.DeleteOptions{})
 			framework.ExpectNoError(err, "Error deleting secret %q in namespace %q", secret.Name, secret.Namespace)
-			By(fmt.Sprintf("Deletion of secret %q in namespace %q succeeded.", secret.Name, f.Namespace.Name))
+			By(fmt.Sprintf("Deletion of secret %q in namespace %q succeeded.", secret.Name, nsName))
 		})
 
 	})

--- a/test/e2e/federation-authn.go
+++ b/test/e2e/federation-authn.go
@@ -40,8 +40,9 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 		It("should accept cluster resources when the client has right authentication credentials", func() {
 			framework.SkipUnlessFederated(f.Client)
 
-			svc := createServiceOrFail(f.FederationClientset_1_4, f.Namespace.Name, FederatedServiceName)
-			deleteServiceOrFail(f.FederationClientset_1_4, f.Namespace.Name, svc.Name)
+			nsName := f.FederationNamespace.Name
+			svc := createServiceOrFail(f.FederationClientset_1_4, nsName, FederatedServiceName)
+			deleteServiceOrFail(f.FederationClientset_1_4, nsName, svc.Name)
 		})
 
 		It("should not accept cluster resources when the client has invalid authentication credentials", func() {
@@ -57,10 +58,11 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			fcs, err := invalidAuthFederationClientSet(contexts[0].User)
 			framework.ExpectNoError(err)
 
-			svc, err := createService(fcs, f.Namespace.Name, FederatedServiceName)
+			nsName := f.FederationNamespace.Name
+			svc, err := createService(fcs, nsName, FederatedServiceName)
 			Expect(errors.IsUnauthorized(err)).To(BeTrue())
 			if err == nil && svc != nil {
-				deleteServiceOrFail(fcs, f.Namespace.Name, svc.Name)
+				deleteServiceOrFail(fcs, nsName, svc.Name)
 			}
 		})
 
@@ -70,10 +72,11 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			fcs, err := invalidAuthFederationClientSet(nil)
 			ExpectNoError(err)
 
-			svc, err := createService(fcs, f.Namespace.Name, FederatedServiceName)
+			nsName := f.FederationNamespace.Name
+			svc, err := createService(fcs, nsName, FederatedServiceName)
 			Expect(errors.IsUnauthorized(err)).To(BeTrue())
 			if err == nil && svc != nil {
-				deleteServiceOrFail(fcs, f.Namespace.Name, svc.Name)
+				deleteServiceOrFail(fcs, nsName, svc.Name)
 			}
 		})
 	})

--- a/test/e2e/federation-event.go
+++ b/test/e2e/federation-event.go
@@ -40,23 +40,26 @@ var _ = framework.KubeDescribe("Federation events [Feature:Federation]", func() 
 		AfterEach(func() {
 			framework.SkipUnlessFederated(f.Client)
 
+			nsName := f.FederationNamespace.Name
 			// Delete registered events.
-			eventList, err := f.FederationClientset_1_4.Core().Events(f.Namespace.Name).List(api.ListOptions{})
+			eventList, err := f.FederationClientset_1_4.Core().Events(nsName).List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			for _, event := range eventList.Items {
-				err := f.FederationClientset_1_4.Core().Events(f.Namespace.Name).Delete(event.Name, &api.DeleteOptions{})
+				err := f.FederationClientset_1_4.Core().Events(nsName).Delete(event.Name, &api.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
 
 		It("should be created and deleted successfully", func() {
 			framework.SkipUnlessFederated(f.Client)
-			event := createEventOrFail(f.FederationClientset_1_4, f.Namespace.Name)
-			By(fmt.Sprintf("Creation of event %q in namespace %q succeeded.  Deleting event.", event.Name, f.Namespace.Name))
+
+			nsName := f.FederationNamespace.Name
+			event := createEventOrFail(f.FederationClientset_1_4, nsName)
+			By(fmt.Sprintf("Creation of event %q in namespace %q succeeded.  Deleting event.", event.Name, nsName))
 			// Cleanup
-			err := f.FederationClientset_1_4.Core().Events(f.Namespace.Name).Delete(event.Name, &api.DeleteOptions{})
+			err := f.FederationClientset_1_4.Core().Events(nsName).Delete(event.Name, &api.DeleteOptions{})
 			framework.ExpectNoError(err, "Error deleting event %q in namespace %q", event.Name, event.Namespace)
-			By(fmt.Sprintf("Deletion of event %q in namespace %q succeeded.", event.Name, f.Namespace.Name))
+			By(fmt.Sprintf("Deletion of event %q in namespace %q succeeded.", event.Name, nsName))
 		})
 
 	})

--- a/test/e2e/federation-ingress.go
+++ b/test/e2e/federation-ingress.go
@@ -42,23 +42,26 @@ var _ = framework.KubeDescribe("Federation ingresses [Feature:Federation]", func
 		AfterEach(func() {
 			framework.SkipUnlessFederated(f.Client)
 
+			nsName := f.FederationNamespace.Name
 			// Delete registered ingresses.
-			ingressList, err := f.FederationClientset_1_4.Extensions().Ingresses(f.Namespace.Name).List(api.ListOptions{})
+			ingressList, err := f.FederationClientset_1_4.Extensions().Ingresses(nsName).List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			for _, ingress := range ingressList.Items {
-				err := f.FederationClientset_1_4.Extensions().Ingresses(f.Namespace.Name).Delete(ingress.Name, &api.DeleteOptions{})
+				err := f.FederationClientset_1_4.Extensions().Ingresses(nsName).Delete(ingress.Name, &api.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
 
 		It("should be created and deleted successfully", func() {
 			framework.SkipUnlessFederated(f.Client)
-			ingress := createIngressOrFail(f.FederationClientset_1_4, f.Namespace.Name)
-			By(fmt.Sprintf("Creation of ingress %q in namespace %q succeeded.  Deleting ingress.", ingress.Name, f.Namespace.Name))
+
+			nsName := f.FederationNamespace.Name
+			ingress := createIngressOrFail(f.FederationClientset_1_4, nsName)
+			By(fmt.Sprintf("Creation of ingress %q in namespace %q succeeded.  Deleting ingress.", ingress.Name, nsName))
 			// Cleanup
-			err := f.FederationClientset_1_4.Extensions().Ingresses(f.Namespace.Name).Delete(ingress.Name, &api.DeleteOptions{})
+			err := f.FederationClientset_1_4.Extensions().Ingresses(nsName).Delete(ingress.Name, &api.DeleteOptions{})
 			framework.ExpectNoError(err, "Error deleting ingress %q in namespace %q", ingress.Name, ingress.Namespace)
-			By(fmt.Sprintf("Deletion of ingress %q in namespace %q succeeded.", ingress.Name, f.Namespace.Name))
+			By(fmt.Sprintf("Deletion of ingress %q in namespace %q succeeded.", ingress.Name, nsName))
 		})
 
 	})

--- a/test/e2e/federation-replicaset.go
+++ b/test/e2e/federation-replicaset.go
@@ -42,22 +42,25 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 			framework.SkipUnlessFederated(f.Client)
 
 			// Delete registered replicasets.
-			replicasetList, err := f.FederationClientset_1_4.Extensions().ReplicaSets(f.Namespace.Name).List(api.ListOptions{})
+			nsName := f.FederationNamespace.Name
+			replicasetList, err := f.FederationClientset_1_4.Extensions().ReplicaSets(nsName).List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			for _, replicaset := range replicasetList.Items {
-				err := f.FederationClientset_1_4.Extensions().ReplicaSets(f.Namespace.Name).Delete(replicaset.Name, &api.DeleteOptions{})
+				err := f.FederationClientset_1_4.Extensions().ReplicaSets(nsName).Delete(replicaset.Name, &api.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
 
 		It("should be created and deleted successfully", func() {
 			framework.SkipUnlessFederated(f.Client)
-			replicaset := createReplicaSetOrFail(f.FederationClientset_1_4, f.Namespace.Name)
-			By(fmt.Sprintf("Creation of replicaset %q in namespace %q succeeded.  Deleting replicaset.", replicaset.Name, f.Namespace.Name))
+
+			nsName := f.FederationNamespace.Name
+			replicaset := createReplicaSetOrFail(f.FederationClientset_1_4, nsName)
+			By(fmt.Sprintf("Creation of replicaset %q in namespace %q succeeded.  Deleting replicaset.", replicaset.Name, nsName))
 			// Cleanup
-			err := f.FederationClientset_1_4.Extensions().ReplicaSets(f.Namespace.Name).Delete(replicaset.Name, &api.DeleteOptions{})
+			err := f.FederationClientset_1_4.Extensions().ReplicaSets(nsName).Delete(replicaset.Name, &api.DeleteOptions{})
 			framework.ExpectNoError(err, "Error deleting replicaset %q in namespace %q", replicaset.Name, replicaset.Namespace)
-			By(fmt.Sprintf("Deletion of replicaset %q in namespace %q succeeded.", replicaset.Name, f.Namespace.Name))
+			By(fmt.Sprintf("Deletion of replicaset %q in namespace %q succeeded.", replicaset.Name, nsName))
 		})
 
 	})
@@ -72,7 +75,8 @@ func createReplicaSetOrFail(clientset *federation_release_1_4.Clientset, namespa
 	replicas := int32(5)
 	replicaset := &v1beta1.ReplicaSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name: FederationReplicaSetName,
+			Name:      FederationReplicaSetName,
+			Namespace: namespace,
 		},
 		Spec: v1beta1.ReplicaSetSpec{
 			Replicas: &replicas,


### PR DESCRIPTION
Now that we have namespaces in federation apiserver, we can support namespace admission controls.

There are 3 of these:
namespace/autoprovision, namespace/exists and namespace/lifecycle.
namespace/autoprovision, namespace/exists should be deprecated in kubernetes(https://github.com/kubernetes/kubernetes/issues/31195). Adding support for namespace/lifecycle to federation-apiserver.
As in kube-apiserver, enabling namespace/lifecycle by default.

``` release-note
Action required: If you have a running federation control plane, you will have to ensure that for all federation resources, the corresponding namespace exists in federation control plane.

federation-apiserver now supports NamespaceLifecycle admission control, which is enabled by default. Set the --admission-control flag on the server to change that.
```

cc @kubernetes/sig-cluster-federation @quinton-hoole

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31139)

<!-- Reviewable:end -->
