### PR TITLE
Make 'allAlpha' a special feature gate

### DIFF
--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -33,24 +33,24 @@ const (
 	// To add a new feature, define a key for it below and add
 	// a featureSpec entry to knownFeatures.
 
-	// allAlpha is a global toggle for alpha features. Per-feature key
-	// values override the default set by allAlpha, if they come later in the
+	// allAlphaGate is a global toggle for alpha features. Per-feature key
+	// values override the default set by allAlphaGate, if they come later in the
 	// specification of gates. Examples:
-	//   allAlpha=false,newFeature=true  will result in newFeature=true
-	//   allAlpha=true,newFeature=false  will result in newFeature=false
-	allAlpha = "allAlpha"
+	//   AllAlpha=false,NewFeature=true  will result in newFeature=true
+	//   AllAlpha=true,NewFeature=false  will result in newFeature=false
+	allAlphaGate = "AllAlpha"
 )
 
 var (
 	// Default values for recorded features.  Every new feature gate should be
 	// represented here.
 	knownFeatures = map[string]featureSpec{
-		allAlpha: {false, alpha},
+		allAlphaGate: {false, alpha},
 	}
 
 	// Special handling for a few gates.
 	specialFeatures = map[string]func(f *featureGate, val bool){
-		allAlpha: setUnsetAlphaGates,
+		allAlphaGate: setUnsetAlphaGates,
 	}
 
 	// DefaultFeatureGate is a shared global FeatureGate.

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -156,11 +156,10 @@ func (f *featureGate) Type() string {
 
 func (f *featureGate) lookup(key string) bool {
 	defaultValue := f.known[key].enabled
-	if f.enabled == nil {
-		panic(fmt.Sprintf("--%s has not been parsed", flagName))
-	}
-	if v, ok := f.enabled[key]; ok {
-		return v
+	if f.enabled != nil {
+		if v, ok := f.enabled[key]; ok {
+			return v
+		}
 	}
 	return defaultValue
 

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -31,48 +31,78 @@ const (
 
 	// All known feature keys
 	// To add a new feature, define a key for it below and add
-	// a featureInfo entry to knownFeatures.
+	// a featureSpec entry to knownFeatures.
 
-	// allAlpha is a global toggle for alpha features. Per feature key
-	// values override the default set by allAlpha.
-	// e.g. allAlpha=false,newFeature=true will result in newFeature=true
+	// allAlpha is a global toggle for alpha features. Per-feature key
+	// values override the default set by allAlpha, if they come later in the
+	// specification of gates. Examples:
+	//   allAlpha=false,newFeature=true  will result in newFeature=true
+	//   allAlpha=true,newFeature=false  will result in newFeature=false
 	allAlpha = "allAlpha"
 )
 
 var (
-	// DefaultFeatureGate is a shared global FeatureGate.
-	DefaultFeatureGate = &featureGate{}
-
-	// Default values for recorded features.
-	knownFeatures = map[string]featureInfo{
+	// Default values for recorded features.  Every new feature gate should be
+	// represented here.
+	knownFeatures = map[string]featureSpec{
 		allAlpha: {false, alpha},
 	}
 
+	// Special handling for a few gates.
+	specialFeatures = map[string]func(f *featureGate, val bool){
+		allAlpha: setUnsetAlphaGates,
+	}
+
+	// DefaultFeatureGate is a shared global FeatureGate.
+	DefaultFeatureGate = &featureGate{
+		known:   knownFeatures,
+		special: specialFeatures,
+	}
+)
+
+type featureSpec struct {
+	enabled    bool
+	prerelease prerelease
+}
+
+type prerelease string
+
+const (
+	// Values for prerelease.
 	alpha = prerelease("ALPHA")
 	beta  = prerelease("BETA")
 	ga    = prerelease("")
 )
 
-type prerelease string
-
-type featureInfo struct {
-	enabled    bool
-	prerelease prerelease
-}
-
 // FeatureGate parses and stores flag gates for known features from
 // a string like feature1=true,feature2=false,...
 type FeatureGate interface {
 	AddFlag(fs *pflag.FlagSet)
-	// owner: @jlowdermilk
-	// alpha: v1.4
-	AllAlpha() bool
+
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v1.4
+	// MyFeature() bool
+
 	// TODO: Define accessors for each non-API alpha feature.
 }
 
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
 type featureGate struct {
-	features map[string]bool
+	known   map[string]featureSpec
+	special map[string]func(*featureGate, bool)
+	enabled map[string]bool
+}
+
+func setUnsetAlphaGates(f *featureGate, val bool) {
+	for k, v := range f.known {
+		if v.prerelease == alpha {
+			if _, found := f.enabled[k]; !found {
+				f.enabled[k] = val
+			}
+		}
+	}
 }
 
 // Set, String, and Type implement pflag.Value
@@ -80,14 +110,14 @@ type featureGate struct {
 // Set Parses a string of the form // "key1=value1,key2=value2,..." into a
 // map[string]bool of known keys or returns an error.
 func (f *featureGate) Set(value string) error {
-	f.features = make(map[string]bool)
+	f.enabled = make(map[string]bool)
 	for _, s := range strings.Split(value, ",") {
 		if len(s) == 0 {
 			continue
 		}
 		arr := strings.SplitN(s, "=", 2)
 		k := strings.TrimSpace(arr[0])
-		_, ok := knownFeatures[k]
+		_, ok := f.known[k]
 		if !ok {
 			return fmt.Errorf("unrecognized key: %s", k)
 		}
@@ -99,15 +129,21 @@ func (f *featureGate) Set(value string) error {
 		if err != nil {
 			return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
 		}
-		f.features[k] = boolValue
+		f.enabled[k] = boolValue
+
+		// Handle "special" features like "all alpha gates"
+		if fn, found := f.special[k]; found {
+			fn(f, boolValue)
+		}
 	}
-	glog.Infof("feature gates: %v", f.features)
+
+	glog.Infof("feature gates: %v", f.enabled)
 	return nil
 }
 
 func (f *featureGate) String() string {
 	pairs := []string{}
-	for k, v := range f.features {
+	for k, v := range f.enabled {
 		pairs = append(pairs, fmt.Sprintf("%s=%t", k, v))
 	}
 	sort.Strings(pairs)
@@ -118,17 +154,12 @@ func (f *featureGate) Type() string {
 	return "mapStringBool"
 }
 
-// AllAlpha returns value for allAlpha.
-func (f *featureGate) AllAlpha() bool {
-	return f.lookup(allAlpha)
-}
-
 func (f *featureGate) lookup(key string) bool {
-	defaultValue := knownFeatures[key].enabled
-	if f.features == nil {
+	defaultValue := f.known[key].enabled
+	if f.enabled == nil {
 		panic(fmt.Sprintf("--%s has not been parsed", flagName))
 	}
-	if v, ok := f.features[key]; ok {
+	if v, ok := f.enabled[key]; ok {
 		return v
 	}
 	return defaultValue
@@ -138,7 +169,7 @@ func (f *featureGate) lookup(key string) bool {
 // AddFlag adds a flag for setting global feature gates to the specified FlagSet.
 func (f *featureGate) AddFlag(fs *pflag.FlagSet) {
 	var known []string
-	for k, v := range knownFeatures {
+	for k, v := range f.known {
 		pre := ""
 		if v.prerelease != ga {
 			pre = fmt.Sprintf("%s - ", v.prerelease)

--- a/pkg/util/config/feature_gate_test.go
+++ b/pkg/util/config/feature_gate_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestFeatureGateFlag(t *testing.T) {
 	// gates for testing
-	const testAlpha = "testAlpha"
-	const testBeta = "testBeta"
+	const testAlphaGate = "TestAlpha"
+	const testBetaGate = "TestBeta"
 
 	tests := []struct {
 		arg        string
@@ -37,91 +37,91 @@ func TestFeatureGateFlag(t *testing.T) {
 		{
 			arg: "",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: false,
+				testBetaGate:  false,
 			},
 		},
 		{
 			arg: "fooBarBaz=maybeidk",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: false,
+				testBetaGate:  false,
 			},
 			parseError: "unrecognized key: fooBarBaz",
 		},
 		{
-			arg: "allAlpha=false",
+			arg: "AllAlpha=false",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: false,
+				testBetaGate:  false,
 			},
 		},
 		{
-			arg: "allAlpha=true",
+			arg: "AllAlpha=true",
 			expect: map[string]bool{
-				allAlpha:  true,
-				testAlpha: true,
-				testBeta:  false,
+				allAlphaGate:  true,
+				testAlphaGate: true,
+				testBetaGate:  false,
 			},
 		},
 		{
-			arg: "allAlpha=banana",
+			arg: "AllAlpha=banana",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: false,
+				testBetaGate:  false,
 			},
-			parseError: "invalid value of allAlpha",
+			parseError: "invalid value of AllAlpha",
 		},
 		{
-			arg: "allAlpha=false,testAlpha=true",
+			arg: "AllAlpha=false,TestAlpha=true",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: true,
-				testBeta:  false,
-			},
-		},
-		{
-			arg: "testAlpha=true,allAlpha=false",
-			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: true,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: true,
+				testBetaGate:  false,
 			},
 		},
 		{
-			arg: "allAlpha=true,testAlpha=false",
+			arg: "TestAlpha=true,AllAlpha=false",
 			expect: map[string]bool{
-				allAlpha:  true,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  false,
+				testAlphaGate: true,
+				testBetaGate:  false,
 			},
 		},
 		{
-			arg: "testAlpha=false,allAlpha=true",
+			arg: "AllAlpha=true,TestAlpha=false",
 			expect: map[string]bool{
-				allAlpha:  true,
-				testAlpha: false,
-				testBeta:  false,
+				allAlphaGate:  true,
+				testAlphaGate: false,
+				testBetaGate:  false,
 			},
 		},
 		{
-			arg: "testBeta=true,allAlpha=false",
+			arg: "TestAlpha=false,AllAlpha=true",
 			expect: map[string]bool{
-				allAlpha:  false,
-				testAlpha: false,
-				testBeta:  true,
+				allAlphaGate:  true,
+				testAlphaGate: false,
+				testBetaGate:  false,
+			},
+		},
+		{
+			arg: "TestBeta=true,AllAlpha=false",
+			expect: map[string]bool{
+				allAlphaGate:  false,
+				testAlphaGate: false,
+				testBetaGate:  true,
 			},
 		},
 	}
 	for i, test := range tests {
 		fs := pflag.NewFlagSet("testfeaturegateflag", pflag.ContinueOnError)
 		f := DefaultFeatureGate
-		f.known[testAlpha] = featureSpec{false, alpha}
-		f.known[testBeta] = featureSpec{false, beta}
+		f.known[testAlphaGate] = featureSpec{false, alpha}
+		f.known[testBetaGate] = featureSpec{false, beta}
 		f.AddFlag(fs)
 
 		err := fs.Parse([]string{fmt.Sprintf("--%s=%s", flagName, test.arg)})

--- a/pkg/util/config/feature_gate_test.go
+++ b/pkg/util/config/feature_gate_test.go
@@ -139,3 +139,21 @@ func TestFeatureGateFlag(t *testing.T) {
 		}
 	}
 }
+
+func TestFeatureGateFlagDefaults(t *testing.T) {
+	// gates for testing
+	const testAlphaGate = "TestAlpha"
+	const testBetaGate = "TestBeta"
+
+	// Don't parse the flag, assert defaults are used.
+	f := DefaultFeatureGate
+	f.known[testAlphaGate] = featureSpec{false, alpha}
+	f.known[testBetaGate] = featureSpec{true, beta}
+
+	if f.lookup(testAlphaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if f.lookup(testBetaGate) != true {
+		t.Errorf("Expected true")
+	}
+}


### PR DESCRIPTION
Rather than making all caller check both allAlpha and their own flag, make `allAlpha` set all of the alpha gates explicitly.

This is hard to test because of the globalness.  I will follow this commit with a new one to add some way to test, but I wanted to float this design

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31140)

<!-- Reviewable:end -->
