### PR TITLE
Add validation preventing recycle of / in a hostPath PV

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1087,6 +1087,12 @@ func ValidatePersistentVolume(pv *api.PersistentVolume) field.ErrorList {
 	if numVolumes == 0 {
 		allErrs = append(allErrs, field.Required(specPath, "must specify a volume type"))
 	}
+
+	// do not allow hostPath mounts of '/' to have a 'recycle' reclaim policy
+	if pv.Spec.HostPath != nil && path.Clean(pv.Spec.HostPath.Path) == "/" && pv.Spec.PersistentVolumeReclaimPolicy == api.PersistentVolumeReclaimRecycle {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("persistentVolumeReclaimPolicy"), "may not be 'recycle' for a hostPath mount of '/'"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -549,6 +549,32 @@ func TestValidatePersistentVolumes(t *testing.T) {
 				},
 			}),
 		},
+		"host mount of / with recycle reclaim policy": {
+			isExpectedFailure: true,
+			volume: testVolume("bad-recycle-do-not-want", "", api.PersistentVolumeSpec{
+				Capacity: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					HostPath: &api.HostPathVolumeSource{Path: "/"},
+				},
+				PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRecycle,
+			}),
+		},
+		"host mount of / with recycle reclaim policy 2": {
+			isExpectedFailure: true,
+			volume: testVolume("bad-recycle-do-not-want", "", api.PersistentVolumeSpec{
+				Capacity: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+				AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					HostPath: &api.HostPathVolumeSource{Path: "/a/.."},
+				},
+				PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRecycle,
+			}),
+		},
 	}
 
 	for name, scenario := range scenarios {


### PR DESCRIPTION
Adds a validation that prevents a user from recycling `/` when it is used in a hostPath PV

cc @kubernetes/sig-storage 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31146)

<!-- Reviewable:end -->
