### PR TITLE
Check init containers in PodContainerRunning

### DIFF
--- a/pkg/client/unversioned/conditions.go
+++ b/pkg/client/unversioned/conditions.go
@@ -238,6 +238,15 @@ func PodContainerRunning(containerName string) watch.ConditionFunc {
 				}
 				return s.State.Running != nil, nil
 			}
+			for _, s := range t.Status.InitContainerStatuses {
+				if s.Name != containerName {
+					continue
+				}
+				if s.State.Terminated != nil {
+					return false, ErrContainerTerminated
+				}
+				return s.State.Running != nil, nil
+			}
 			return false, nil
 		}
 		return false, nil


### PR DESCRIPTION
Sometimes when an init container runs and terminates quickly, PodContainerRunning can go into a
state where the pod indicates it's still running, but the container is already terminated. Handle
that condition by returning ErrContainerTerminated when it happens.

See also #29952

@smarterclayton @fabianofranz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31150)

<!-- Reviewable:end -->
