### PR TITLE
Implement ExternalName in kube-dns

### DIFF
--- a/pkg/dns/treecache.go
+++ b/pkg/dns/treecache.go
@@ -155,8 +155,14 @@ func (cache *TreeCache) deletePath(path ...string) bool {
 		return false
 	}
 	if parentNode := cache.getSubCache(path[:len(path)-1]...); parentNode != nil {
-		if _, ok := parentNode.ChildNodes[path[len(path)-1]]; ok {
-			delete(parentNode.ChildNodes, path[len(path)-1])
+		name := path[len(path)-1]
+		if _, ok := parentNode.ChildNodes[name]; ok {
+			delete(parentNode.ChildNodes, name)
+			return true
+		}
+		// ExternalName services are stored with their name as the leaf key
+		if _, ok := parentNode.Entries[name]; ok {
+			delete(parentNode.Entries, name)
 			return true
 		}
 	}


### PR DESCRIPTION
Part of the ongoing saga formerly known as https://github.com/kubernetes/features/issues/33

This is the prelude (first commit) in #30931, spawn into a separate PR to allow building a new kube-dns image before e2e tests (the rest of #30931) are updated.

ExternalName allows kubedns to return CNAME records for external
services. No proxying is involved.

cc @thockin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31159)

<!-- Reviewable:end -->
