### PR TITLE
Error if someone uses the sub-makefile directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,4 +278,4 @@ $(notdir $(abspath $(wildcard federation/cmd/*/))): generated_files
 #   make generated_files
 .PHONY: generated_files
 generated_files:
-	$(MAKE) -f Makefile.$@ $@
+	$(MAKE) -f Makefile.$@ $@ CALLED_FROM_MAIN_MAKEFILE=1

--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Don't allow users to call this directly.  There are too many variables this
+# assumes to inherit from the main Makefile.  This is not a user-facing file.
+ifeq ($(CALLED_FROM_MAIN_MAKEFILE),)
+    $(error Please use the main Makefile, e.g. `make generated_files`)
+endif
+
 # Don't allow an implicit 'all' rule.  This is not a user-facing file.
 ifeq ($(MAKECMDGOALS),)
     $(error This Makefile requires an explicit rule to be specified)


### PR DESCRIPTION
Produce a more helpful failure when someone errantly uses the generated_files makefile directly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31161)

<!-- Reviewable:end -->
