### PR TITLE
Use kubekins-test:v20160822 everywhere

### DIFF
--- a/hack/jenkins/e2e-image/Dockerfile
+++ b/hack/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/google-containers/kubekins-test:v20160810
+FROM gcr.io/google-containers/kubekins-test:v20160822
 MAINTAINER  Erick Fejta <fejta@google.com>
 
 # Defaults of all e2e runs

--- a/hack/jenkins/e2e-image/Makefile
+++ b/hack/jenkins/e2e-image/Makefile
@@ -15,6 +15,8 @@
 IMG = gcr.io/google-containers/kubekins-e2e
 TAG = $(shell date +v%Y%m%d)
 
+all: build
+
 e2e:
 	cp ../../e2e.go .
 
@@ -29,8 +31,6 @@ upload-to-gcs.sh:
 
 clean:
 	rm -rf e2e.go e2e-runner.sh sh2ju.sh upload-to-gcs.sh
-
-all: push
 
 build: e2e e2e-runner sh2ju upload-to-gcs
 	docker build -t $(IMG):$(TAG) .

--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -45,5 +45,5 @@ docker run --rm=true \
   -e "KUBE_VERIFY_GIT_BRANCH=${KUBE_VERIFY_GIT_BRANCH:-}" \
   -e "REPO_DIR=${REPO_DIR}" \
   -e "HOST_ARTIFACTS_DIR=${HOST_ARTIFACTS_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:go1.6.3-docker1.9.1-rev3 \
+  -i gcr.io/google_containers/kubekins-test:v20160822 \
   bash -c "cd kubernetes && ${KUBE_TEST_SCRIPT:-./hack/jenkins/test-dockerized.sh}"


### PR DESCRIPTION
A step towards fixing #31148. We also need to update the test-infra repo to use the new e2e image. I'll fold that into https://github.com/kubernetes/test-infra/pull/419.

Both gcr.io/google-containers/kubekins-test:v20160822 and gcr.io/google-containers/e2e-test:v20160822 have already been pushed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31162)

<!-- Reviewable:end -->
