### PR TITLE
skip benchmark in jenkins serial test

### DIFF
--- a/test/e2e_node/jenkins/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/jenkins-serial.properties
@@ -3,7 +3,7 @@ GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/image-config.yaml
 GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
-GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]"'
+GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
 SETUP_NODE=false
 # DISABLED --cgroups-per-qos flag until feature stabilized.
 #TEST_ARGS=--cgroups-per-qos=false

--- a/test/e2e_node/runner/run_e2e.go
+++ b/test/e2e_node/runner/run_e2e.go
@@ -110,7 +110,7 @@ type GCEImage struct {
 	PreviousImages int `json:"previous_images, omitempty"`
 
 	Machine string `json:"machine, omitempty"`
-	// The test is regarded as 'benchmark' is Tests is non-empty
+	// This test is for benchmark (no limit verification, more result log, node name has format 'machine-image-uuid') if 'Tests' is non-empty.
 	Tests []string `json:"tests, omitempty"`
 }
 
@@ -591,6 +591,8 @@ func imageToInstanceName(imageConfig *internalGCEImage) string {
 	if imageConfig.machine == "" {
 		return *instanceNamePrefix + "-" + imageConfig.image
 	}
+	// For benchmark test, node name has the format 'machine-image-uuid'.
+	// Node name is added to test data item labels and used for benchmark dashboard.
 	return imageConfig.machine + "-" + imageConfig.image + "-" + uuid.NewUUID().String()[:8]
 }
 
@@ -605,6 +607,7 @@ func machineType(machine string) string {
 	return fmt.Sprintf("zones/%s/machineTypes/%s", *zone, machine)
 }
 
+// testsToGinkgoFocus converts the test string list to Ginkgo focus
 func testsToGinkgoFocus(tests []string) string {
 	focus := "--focus=\""
 	for i, test := range tests {


### PR DESCRIPTION
This PR changes jenkins-serial.properties to skip benchmark tests (with tag [Benchmark]) in jenkins serial tests. It also add more comments in run_e2e.go.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31164)

<!-- Reviewable:end -->
