### PR TITLE
[GarbageCollector] add absent owner cache

### DIFF
--- a/pkg/controller/garbagecollector/uid_cache.go
+++ b/pkg/controller/garbagecollector/uid_cache.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+// UIDCache is an LRU cache for uid.
+type UIDCache struct {
+	mutex sync.Mutex
+	cache *lru.Cache
+}
+
+// NewUIDCache returns a UIDCache.
+func NewUIDCache(maxCacheEntries int) *UIDCache {
+	return &UIDCache{
+		cache: lru.New(maxCacheEntries),
+	}
+}
+
+// Add adds a uid to the cache.
+func (c *UIDCache) Add(uid types.UID) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.cache.Add(uid, nil)
+}
+
+// Has returns if a uid is in the cache.
+func (c *UIDCache) Has(uid types.UID) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	_, found := c.cache.Get(uid)
+	return found
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Reducing the Request sent to the API server by the garbage collector to check if an owner exists.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #
#26120

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Currently when processing an item in the dirtyQueue, the garbage collector issues GET to check if any of its owners exist. If the owner is a replication controller with 1000 pods, the garbage collector sends a GET for the RC 1000 times. This PR caches the owner's UID if it does not exist according to the API server. This cuts 1/3 of the garbage collection time of the density test in the gce-500 and gce-scale, where the QPS is the bottleneck.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31167)

<!-- Reviewable:end -->
