### PR TITLE
Default host user namespace via experimental flag

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -434,6 +434,12 @@ type RunContainerOptions struct {
 	ReadOnly bool
 	// hostname for pod containers
 	Hostname string
+	// EnableHostUserNamespace sets userns=host when users request host namespaces (pid, ipc, net),
+	// are using non-namespaced capabilities (mknod, sys_time, sys_module), the pod contains a privileged container,
+	// or using host path volumes.
+	// This should only be enabled when the container runtime is performing user remapping AND if the
+	// experimental behavior is desired.
+	EnableHostUserNamespace bool
 }
 
 // VolumeInfo contains information about the volume.

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -57,6 +57,13 @@ const (
 	containerTypeLabelContainer = "container"
 	containerLogPathLabelKey    = "io.kubernetes.container.logpath"
 	sandboxIDLabelKey           = "io.kubernetes.sandbox.id"
+
+	// TODO: https://github.com/kubernetes/kubernetes/pull/31169 provides experimental
+	// defaulting of host user namespace that may be enabled when the docker daemon
+	// is using remapped UIDs.
+	// Dockershim should provide detection support for a remapping environment .
+	// This should be included in the feature proposal.  Defaulting may still occur according
+	// to kubelet behavior and system settings in addition to any API flags that may be introduced.
 )
 
 // NetworkPluginSettings is the subset of kubelet runtime args we pass

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -681,12 +681,18 @@ func (dm *DockerManager) runContainer(
 		}
 	}
 
+	userNsMode := ""
+	if opts.EnableHostUserNamespace {
+		userNsMode = "host"
+	}
+
 	hc := &dockercontainer.HostConfig{
 		Binds:          binds,
 		NetworkMode:    dockercontainer.NetworkMode(netMode),
 		IpcMode:        dockercontainer.IpcMode(ipcMode),
 		UTSMode:        dockercontainer.UTSMode(utsMode),
 		PidMode:        dockercontainer.PidMode(pidMode),
+		UsernsMode:     dockercontainer.UsernsMode(userNsMode),
 		ReadonlyRootfs: readOnlyRootFilesystem(container),
 		Resources: dockercontainer.Resources{
 			Memory:     memoryLimit,

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net"
 	"sort"
 	"testing"
@@ -28,10 +29,12 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/testing/core"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -1262,5 +1265,232 @@ func TestMakeDevices(t *testing.T) {
 
 	for _, test := range testCases {
 		assert.Equal(t, test.devices, makeDevices(test.container), "[test %q]", test.test)
+	}
+}
+
+func TestHasPrivilegedContainer(t *testing.T) {
+	newBoolPtr := func(b bool) *bool {
+		return &b
+	}
+	tests := map[string]struct {
+		securityContext *api.SecurityContext
+		expected        bool
+	}{
+		"nil sc": {
+			securityContext: nil,
+			expected:        false,
+		},
+		"nil privleged": {
+			securityContext: &api.SecurityContext{},
+			expected:        false,
+		},
+		"false privleged": {
+			securityContext: &api.SecurityContext{Privileged: newBoolPtr(false)},
+			expected:        false,
+		},
+		"true privleged": {
+			securityContext: &api.SecurityContext{Privileged: newBoolPtr(true)},
+			expected:        true,
+		},
+	}
+
+	for k, v := range tests {
+		pod := &api.Pod{
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{SecurityContext: v.securityContext},
+				},
+			},
+		}
+		actual := hasPrivilegedContainer(pod)
+		if actual != v.expected {
+			t.Errorf("%s expected %t but got %t", k, v.expected, actual)
+		}
+	}
+}
+
+func TestHasHostMountPVC(t *testing.T) {
+	tests := map[string]struct {
+		pvError       error
+		pvcError      error
+		expected      bool
+		podHasPVC     bool
+		pvcIsHostPath bool
+	}{
+		"no pvc": {podHasPVC: false, expected: false},
+		"error fetching pvc": {
+			podHasPVC: true,
+			pvcError:  fmt.Errorf("foo"),
+			expected:  false,
+		},
+		"error fetching pv": {
+			podHasPVC: true,
+			pvError:   fmt.Errorf("foo"),
+			expected:  false,
+		},
+		"host path pvc": {
+			podHasPVC:     true,
+			pvcIsHostPath: true,
+			expected:      true,
+		},
+		"non host path pvc": {
+			podHasPVC:     true,
+			pvcIsHostPath: false,
+			expected:      false,
+		},
+	}
+
+	for k, v := range tests {
+		testKubelet := newTestKubelet(t, false)
+		pod := &api.Pod{
+			Spec: api.PodSpec{},
+		}
+
+		volumeToReturn := &api.PersistentVolume{
+			Spec: api.PersistentVolumeSpec{},
+		}
+
+		if v.podHasPVC {
+			pod.Spec.Volumes = []api.Volume{
+				{
+					VolumeSource: api.VolumeSource{
+						PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{},
+					},
+				},
+			}
+
+			if v.pvcIsHostPath {
+				volumeToReturn.Spec.PersistentVolumeSource = api.PersistentVolumeSource{
+					HostPath: &api.HostPathVolumeSource{},
+				}
+			}
+
+		}
+
+		testKubelet.fakeKubeClient.AddReactor("get", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &api.PersistentVolumeClaim{
+				Spec: api.PersistentVolumeClaimSpec{
+					VolumeName: "foo",
+				},
+			}, v.pvcError
+		})
+		testKubelet.fakeKubeClient.AddReactor("get", "persistentvolumes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, volumeToReturn, v.pvError
+		})
+
+		actual := testKubelet.kubelet.hasHostMountPVC(pod)
+		if actual != v.expected {
+			t.Errorf("%s expected %t but got %t", k, v.expected, actual)
+		}
+
+	}
+}
+
+func TestHasNonNamespacedCapability(t *testing.T) {
+	createPodWithCap := func(caps []api.Capability) *api.Pod {
+		pod := &api.Pod{
+			Spec: api.PodSpec{
+				Containers: []api.Container{{}},
+			},
+		}
+
+		if len(caps) > 0 {
+			pod.Spec.Containers[0].SecurityContext = &api.SecurityContext{
+				Capabilities: &api.Capabilities{
+					Add: caps,
+				},
+			}
+		}
+		return pod
+	}
+
+	nilCaps := createPodWithCap([]api.Capability{api.Capability("foo")})
+	nilCaps.Spec.Containers[0].SecurityContext = nil
+
+	tests := map[string]struct {
+		pod      *api.Pod
+		expected bool
+	}{
+		"nil security contxt":           {createPodWithCap(nil), false},
+		"nil caps":                      {nilCaps, false},
+		"namespaced cap":                {createPodWithCap([]api.Capability{api.Capability("foo")}), false},
+		"non-namespaced cap MKNOD":      {createPodWithCap([]api.Capability{api.Capability("MKNOD")}), true},
+		"non-namespaced cap SYS_TIME":   {createPodWithCap([]api.Capability{api.Capability("SYS_TIME")}), true},
+		"non-namespaced cap SYS_MODULE": {createPodWithCap([]api.Capability{api.Capability("SYS_MODULE")}), true},
+	}
+
+	for k, v := range tests {
+		actual := hasNonNamespacedCapability(v.pod)
+		if actual != v.expected {
+			t.Errorf("%s failed, expected %t but got %t", k, v.expected, actual)
+		}
+	}
+}
+
+func TestHasHostVolume(t *testing.T) {
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			Volumes: []api.Volume{
+				{
+					VolumeSource: api.VolumeSource{
+						HostPath: &api.HostPathVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	result := hasHostVolume(pod)
+	if !result {
+		t.Errorf("expected host volume to enable host user namespace")
+	}
+
+	pod.Spec.Volumes[0].VolumeSource.HostPath = nil
+	result = hasHostVolume(pod)
+	if result {
+		t.Errorf("expected nil host volume to not enable host user namespace")
+	}
+}
+
+func TestHasHostNamespace(t *testing.T) {
+	tests := map[string]struct {
+		psc      *api.PodSecurityContext
+		expected bool
+	}{
+		"nil psc": {psc: nil, expected: false},
+		"host pid true": {
+			psc: &api.PodSecurityContext{
+				HostPID: true,
+			},
+			expected: true,
+		},
+		"host ipc true": {
+			psc: &api.PodSecurityContext{
+				HostIPC: true,
+			},
+			expected: true,
+		},
+		"host net true": {
+			psc: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
+			expected: true,
+		},
+		"no host ns": {
+			psc:      &api.PodSecurityContext{},
+			expected: false,
+		},
+	}
+
+	for k, v := range tests {
+		pod := &api.Pod{
+			Spec: api.PodSpec{
+				SecurityContext: v.psc,
+			},
+		}
+		actual := hasHostNamespace(pod)
+		if actual != v.expected {
+			t.Errorf("%s failed, expected %t but got %t", k, v.expected, actual)
+		}
 	}
 }

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -43,18 +43,26 @@ const (
 	dynamicKubeletConfig      = "DynamicKubeletConfig"
 	dynamicVolumeProvisioning = "DynamicVolumeProvisioning"
 	streamingProxyRedirects   = "StreamingProxyRedirects"
+
+	// experimentalHostUserNamespaceDefaulting Default userns=host for containers
+	// that are using other host namespaces, host mounts, the pod contains a privileged container,
+	// or specific non-namespaced capabilities
+	// (MKNOD, SYS_MODULE, SYS_TIME). This should only be enabled if user namespace remapping is enabled
+	// in the docker daemon.
+	experimentalHostUserNamespaceDefaultingGate = "ExperimentalHostUserNamespaceDefaulting"
 )
 
 var (
 	// Default values for recorded features.  Every new feature gate should be
 	// represented here.
 	knownFeatures = map[string]featureSpec{
-		allAlphaGate:              {false, alpha},
-		externalTrafficLocalOnly:  {true, beta},
-		appArmor:                  {true, beta},
-		dynamicKubeletConfig:      {false, alpha},
-		dynamicVolumeProvisioning: {true, alpha},
-		streamingProxyRedirects:   {false, alpha},
+		allAlphaGate:                                {false, alpha},
+		externalTrafficLocalOnly:                    {true, beta},
+		appArmor:                                    {true, beta},
+		dynamicKubeletConfig:                        {false, alpha},
+		dynamicVolumeProvisioning:                   {true, alpha},
+		streamingProxyRedirects:                     {false, alpha},
+		experimentalHostUserNamespaceDefaultingGate: {false, alpha},
 	}
 
 	// Special handling for a few gates.
@@ -115,6 +123,10 @@ type FeatureGate interface {
 	// owner: timstclair
 	// alpha: v1.5
 	StreamingProxyRedirects() bool
+
+	// owner: @pweil-
+	// alpha: v1.5
+	ExperimentalHostUserNamespaceDefaulting() bool
 }
 
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
@@ -207,6 +219,11 @@ func (f *featureGate) DynamicVolumeProvisioning() bool {
 // redirects from the backend (Kubelet) for streaming requests (exec/attach/port-forward).
 func (f *featureGate) StreamingProxyRedirects() bool {
 	return f.lookup(streamingProxyRedirects)
+}
+
+// ExperimentalHostUserNamespaceDefaulting returns value for experimentalHostUserNamespaceDefaulting
+func (f *featureGate) ExperimentalHostUserNamespaceDefaulting() bool {
+	return f.lookup(experimentalHostUserNamespaceDefaultingGate)
 }
 
 func (f *featureGate) lookup(key string) bool {


### PR DESCRIPTION
@vishh @ncdc @pmorie @smarterclayton @thockin 

Initial thought on the implementation https://github.com/kubernetes/kubernetes/pull/30684#issuecomment-241523425 wasn't quite right.  Since we need to dereference a PVC in some cases the defaulting code didn't fit nicely in the docker manager code (would've coupled it with a kube client and would've been messy).  I think passing this in via the runtime config turned out cleaner.  PTAL

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31169)

<!-- Reviewable:end -->
