### PR TITLE
Dynamic volume gate

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/aws_ebs"
@@ -125,6 +126,8 @@ func ProbeControllerVolumePlugins(cloud cloudprovider.Interface, config componen
 // TODO: remove in Kubernetes 1.5
 func NewAlphaVolumeProvisioner(cloud cloudprovider.Interface, config componentconfig.VolumeConfiguration) (volume.ProvisionableVolumePlugin, error) {
 	switch {
+	case !utilconfig.DefaultFeatureGate.DynamicVolumeProvisioning():
+		return nil, nil
 	case cloud == nil && config.EnableHostPathProvisioning:
 		return getProvisionablePluginFromVolumePlugins(host_path.ProbeVolumePlugins(
 			volume.VolumeConfig{

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -38,18 +38,20 @@ const (
 	// specification of gates. Examples:
 	//   AllAlpha=false,NewFeature=true  will result in newFeature=true
 	//   AllAlpha=true,NewFeature=false  will result in newFeature=false
-	allAlphaGate             = "AllAlpha"
-	externalTrafficLocalOnly = "AllowExtTrafficLocalEndpoints"
-	dynamicKubeletConfig     = "DynamicKubeletConfig"
+	allAlphaGate              = "AllAlpha"
+	externalTrafficLocalOnly  = "AllowExtTrafficLocalEndpoints"
+	dynamicKubeletConfig      = "DynamicKubeletConfig"
+	dynamicVolumeProvisioning = "DynamicVolumeProvisioning"
 )
 
 var (
 	// Default values for recorded features.  Every new feature gate should be
 	// represented here.
 	knownFeatures = map[string]featureSpec{
-		allAlphaGate:             {false, alpha},
-		externalTrafficLocalOnly: {false, alpha},
-		dynamicKubeletConfig:     {false, alpha},
+		allAlphaGate:              {false, alpha},
+		externalTrafficLocalOnly:  {false, alpha},
+		dynamicKubeletConfig:      {false, alpha},
+		dynamicVolumeProvisioning: {true, alpha},
 	}
 
 	// Special handling for a few gates.
@@ -92,6 +94,10 @@ type FeatureGate interface {
 	// owner: @girishkalele
 	// alpha: v1.4
 	ExternalTrafficLocalOnly() bool
+
+	// owner: @saad-ali
+	// alpha: v1.3
+	DynamicVolumeProvisioning() bool
 
 	// TODO: Define accessors for each non-API alpha feature.
 	DynamicKubeletConfig() bool
@@ -171,6 +177,11 @@ func (f *featureGate) ExternalTrafficLocalOnly() bool {
 // DynamicKubeletConfig returns value for dynamicKubeletConfig
 func (f *featureGate) DynamicKubeletConfig() bool {
 	return f.lookup(dynamicKubeletConfig)
+}
+
+// DynamicVolumeProvisioning returns value for dynamicVolumeProvisioning
+func (f *featureGate) DynamicVolumeProvisioning() bool {
+	return f.lookup(dynamicVolumeProvisioning)
 }
 
 func (f *featureGate) lookup(key string) bool {

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -34,14 +34,14 @@ const (
 	// a featureSpec entry to knownFeatures.
 
 	// allAlphaGate is a global toggle for alpha features. Per-feature key
-	// values override the default set by allAlphaGate, if they come later in the
-	// specification of gates. Examples:
+	// values override the default set by allAlphaGate. Examples:
 	//   AllAlpha=false,NewFeature=true  will result in newFeature=true
 	//   AllAlpha=true,NewFeature=false  will result in newFeature=false
 	allAlphaGate              = "AllAlpha"
 	externalTrafficLocalOnly  = "AllowExtTrafficLocalEndpoints"
 	dynamicKubeletConfig      = "DynamicKubeletConfig"
 	dynamicVolumeProvisioning = "DynamicVolumeProvisioning"
+	// TODO: Define gate/accessor for AppArmor
 )
 
 var (
@@ -99,7 +99,8 @@ type FeatureGate interface {
 	// alpha: v1.3
 	DynamicVolumeProvisioning() bool
 
-	// TODO: Define accessors for each non-API alpha feature.
+	// owner: mtaufen
+	// alpha: v1.4
 	DynamicKubeletConfig() bool
 }
 


### PR DESCRIPTION
Rebased on #31140, only review last commit.  Adds a feature-gate flag for dynamic volume provisioning alpha, defaulting to enabled to avoid breaking people. Key should be removed when support for the alpha version of this is removed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31171)

<!-- Reviewable:end -->
