### PR TITLE
Adds Operational Actions to the Kubernetes layer

### DIFF
--- a/cluster/juju/layers/kubernetes/README.md
+++ b/cluster/juju/layers/kubernetes/README.md
@@ -72,6 +72,22 @@ change the `mount-point` value in layer.yaml before the charms is deployed.
 To avoid data loss you must attach the storage before making the connection to
 the etcd cluster.
 
+## Operational Actions
+
+**Microbot** - Deploys mini containers that serve up static webpages and
+identify the container ID that's serving the request. Useful to deploy a
+phaux workload for visualizations quickly, or to test reverse proxy that
+does not depend on session affinity.
+
+**Pause** - Cordon the unit by marking it as unscheduleable. It also drains
+the workloads from the unit, making it feesible to perform maintenance tasks
+without disrupting end user experience.
+
+**Resume** - UnCordon the unit. No workload balancing is done at this time,
+the kubernetes scheduler will being filling the unit back up with workloads
+depending on unit-pressure, which is based on resource allocation/uitilization.
+
+
 ## State Events
 While this charm is meant to be a top layer, it can be used to build other
 solutions.  This charm sets or removes states from the reactive framework that

--- a/cluster/juju/layers/kubernetes/actions.yaml
+++ b/cluster/juju/layers/kubernetes/actions.yaml
@@ -13,9 +13,7 @@ microbot:
         description: If true removes the microbots
 pause:
     description: |
-      Cordon the unit, pausing all future workload scheduling on this unit,
-      and drains active workloads
+      Cordon the unit, draining all active workloads.
 resume:
     description: |
-      UnCordon the unit, enabling workload scheduling. Workloads
-      will automatically balance into the unit
+      UnCordon the unit, enabling workload scheduling.

--- a/cluster/juju/layers/kubernetes/actions.yaml
+++ b/cluster/juju/layers/kubernetes/actions.yaml
@@ -1,2 +1,21 @@
 guestbook-example:
     description: Launch the guestbook example in your k8s cluster
+microbot:
+    description: Launch microbot containers
+    options:
+      replicas:
+        type: int
+        default: 3
+        description: Number of microbots to launch in kubernetes
+      delete:
+        type: bool
+        default: False
+        description: If true removes the microbots
+pause:
+    description: |
+      Cordon the unit, pausing all future workload scheduling on this unit,
+      and drains active workloads
+resume:
+    description: |
+      UnCordon the unit, enabling workload scheduling. Workloads
+      will automatically balance into the unit

--- a/cluster/juju/layers/kubernetes/actions/microbot
+++ b/cluster/juju/layers/kubernetes/actions/microbot
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+REPLICAS=$(action-get replicas)
+DELETE=$(action-get delete)
+
+if [ -z "${REPLICAS}" ]; then
+  # Defaults to 3 in the yaml, assume default if nothing is provided
+  replicas=3
+fi
+
+if [ ! -z "${DELETE}" ]; then
+  kubectl --kubeconfig=/root/.kube/config delete deployment microbot
+  exit 0
+fi
+
+kubectl --kubeconfig=/root/.kube/config run microbot --image=dontrebootme/microbot:v1 --port=80 --replicas=$REPLICAS

--- a/cluster/juju/layers/kubernetes/actions/pause
+++ b/cluster/juju/layers/kubernetes/actions/pause
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+kubectl --kubeconfig=/root/.kube/config cordon $(unit-get private-address)
+kubectl --kubeconfig=/root/.kube/config drain $(unit-get private-address) --force
+status-set 'waiting' 'Kubernetes Unit paused'

--- a/cluster/juju/layers/kubernetes/actions/pause
+++ b/cluster/juju/layers/kubernetes/actions/pause
@@ -4,4 +4,4 @@ set -ex
 
 kubectl --kubeconfig=/root/.kube/config cordon $(unit-get private-address)
 kubectl --kubeconfig=/root/.kube/config drain $(unit-get private-address) --force
-status-set 'waiting' 'Kubernetes Unit paused'
+status-set 'waiting' 'Kubernetes unit paused'

--- a/cluster/juju/layers/kubernetes/actions/resume
+++ b/cluster/juju/layers/kubernetes/actions/resume
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+kubectl --kubeconfig=/root/.kube/config uncordon $(unit-get private-address)
+status-set 'active' 'Kubernetes unit resumed'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds management actions to the Kubernetes charm to cordon/drain nodes, as well as resume operation once the action(s) have been taken.

**Special notes for your reviewer**:

If you wish to test these actions, feel free to deploy

```
export KUBERNETES_PROVIDER=juju
cluster/kube-up.sh
... once deployed ...
juju run-action kubernetes/0 microbot replicas=15
juju run-action kubernetes/1 pause
... verify unit is cordoned, and drained ...
juju run-action kubernetes/1 resume
```

**Release note**:

``` release-note
Adds operational actions to the juju charm layer - pause/resume
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31202)

<!-- Reviewable:end -->
