### PR TITLE
change to stderr

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -273,7 +273,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 		{
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
-				NewCmdDescribe(f, out),
+				NewCmdDescribe(f, out, err),
 				NewCmdLogs(f, out),
 				NewCmdAttach(f, in, out, err),
 				NewCmdExec(f, in, out, err),

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -74,7 +74,7 @@ var (
 		kubectl describe pods frontend`)
 )
 
-func NewCmdDescribe(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdDescribe(f *cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	options := &DescribeOptions{}
 	describerSettings := &kubectl.DescriberSettings{}
 
@@ -87,7 +87,7 @@ func NewCmdDescribe(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    describe_long,
 		Example: describe_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunDescribe(f, out, cmd, args, options, describerSettings)
+			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)
 			cmdutil.CheckErr(err)
 		},
 		ValidArgs:  validArgs,
@@ -103,7 +103,7 @@ func NewCmdDescribe(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *DescribeOptions, describerSettings *kubectl.DescriberSettings) error {
+func RunDescribe(f *cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string, options *DescribeOptions, describerSettings *kubectl.DescriberSettings) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
 	allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
@@ -114,7 +114,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		enforceNamespace = false
 	}
 	if len(args) == 0 && len(options.Filenames) == 0 {
-		fmt.Fprint(out, "You must specify the type of resource to describe. ", valid_resources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 

--- a/pkg/kubectl/cmd/describe_test.go
+++ b/pkg/kubectl/cmd/describe_test.go
@@ -36,8 +36,8 @@ func TestDescribeUnknownSchemaObject(t *testing.T) {
 	}
 	tf.Namespace = "non-default"
 	buf := bytes.NewBuffer([]byte{})
-
-	cmd := NewCmdDescribe(f, buf)
+	buferr := bytes.NewBuffer([]byte{})
+	cmd := NewCmdDescribe(f, buf, buferr)
 	cmd.Run(cmd, []string{"type", "foo"})
 
 	if d.Name != "foo" || d.Namespace != "non-default" {
@@ -68,8 +68,8 @@ func TestDescribeObject(t *testing.T) {
 	}
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
-
-	cmd := NewCmdDescribe(f, buf)
+	buferr := bytes.NewBuffer([]byte{})
+	cmd := NewCmdDescribe(f, buf, buferr)
 	cmd.Flags().Set("filename", "../../../examples/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Run(cmd, []string{})
 
@@ -94,7 +94,8 @@ func TestDescribeListObjects(t *testing.T) {
 
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdDescribe(f, buf)
+	buferr := bytes.NewBuffer([]byte{})
+	cmd := NewCmdDescribe(f, buf, buferr)
 	cmd.Run(cmd, []string{"pods"})
 	if buf.String() != fmt.Sprintf("%s\n\n%s", d.Output, d.Output) {
 		t.Errorf("unexpected output: %s", buf.String())
@@ -113,7 +114,8 @@ func TestDescribeObjectShowEvents(t *testing.T) {
 
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdDescribe(f, buf)
+	buferr := bytes.NewBuffer([]byte{})
+	cmd := NewCmdDescribe(f, buf, buferr)
 	cmd.Flags().Set("show-events", "true")
 	cmd.Run(cmd, []string{"pods"})
 	if d.Settings.ShowEvents != true {
@@ -133,7 +135,8 @@ func TestDescribeObjectSkipEvents(t *testing.T) {
 
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdDescribe(f, buf)
+	buferr := bytes.NewBuffer([]byte{})
+	cmd := NewCmdDescribe(f, buf, buferr)
 	cmd.Flags().Set("show-events", "false")
 	cmd.Run(cmd, []string{"pods"})
 	if d.Settings.ShowEvents != false {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -167,7 +167,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	}
 
 	if len(args) == 0 && len(options.Filenames) == 0 {
-		fmt.Fprint(out, "You must specify the type of resource to get. ", valid_resources)
+		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 


### PR DESCRIPTION
`fmt.Fprint(out, "You must specify the type of resource to describe. ", valid_resources)`

change this to stderr.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31210)

<!-- Reviewable:end -->
