### PR TITLE
ObjectMeta equivalence in federated controller handlers + update in fed secrets

### DIFF
--- a/federation/pkg/federation-controller/secret/secret_controller.go
+++ b/federation/pkg/federation-controller/secret/secret_controller.go
@@ -118,7 +118,7 @@ func NewSecretController(client federation_release_1_4.Interface) *SecretControl
 				controller.NoResyncPeriodFunc(),
 				// Trigger reconcilation whenever something in federated cluster is changed. In most cases it
 				// would be just confirmation that some secret opration suceeded.
-				util.NewTriggerOnChanges(
+				util.NewTriggerOnAllChanges(
 					func(obj pkg_runtime.Object) {
 						secretcontroller.deliverSecretObj(obj, secretcontroller.secretReviewDelay, false)
 					},


### PR DESCRIPTION
Federated secrets should trigger also on data/type update, not only on object meta.

cc: @quinton-hoole @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31224)

<!-- Reviewable:end -->
