### PR TITLE
Fix error message when using rollout with no or unknown resource type

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -75,12 +75,18 @@ func NewCmdRolloutPause(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    pause_long,
 		Example: pause_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.CompletePause(f, cmd, out, args); err != nil {
-				cmdutil.CheckErr(err)
+			completeErr := options.CompletePause(f, cmd, out, args)
+			if completeErr != nil {
+				// Allow to proceed with objects we were able to collect and fail later.
+				if len(options.Infos) == 0 {
+					cmdutil.CheckErr(completeErr)
+				}
 			}
-			if err := options.RunPause(); err != nil {
-				cmdutil.CheckErr(err)
+			err := options.RunPause()
+			if err == nil {
+				err = completeErr
 			}
+			cmdutil.CheckErr(err)
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -75,16 +75,12 @@ func NewCmdRolloutPause(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    pause_long,
 		Example: pause_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			allErrs := []error{}
-			err := options.CompletePause(f, cmd, out, args)
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.CompletePause(f, cmd, out, args); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			err = options.RunPause()
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.RunPause(); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			cmdutil.CheckErr(utilerrors.Flatten(utilerrors.NewAggregate(allErrs)))
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -73,12 +73,18 @@ func NewCmdRolloutResume(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    resume_long,
 		Example: resume_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.CompleteResume(f, cmd, out, args); err != nil {
-				cmdutil.CheckErr(err)
+			completeErr := options.CompleteResume(f, cmd, out, args)
+			if completeErr != nil {
+				// Allow to proceed with objects we were able to collect and fail later.
+				if len(options.Infos) == 0 {
+					cmdutil.CheckErr(completeErr)
+				}
 			}
-			if err := options.RunResume(); err != nil {
-				cmdutil.CheckErr(err)
+			err := options.RunResume()
+			if err == nil {
+				err = completeErr
 			}
+			cmdutil.CheckErr(err)
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -73,16 +73,12 @@ func NewCmdRolloutResume(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    resume_long,
 		Example: resume_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			allErrs := []error{}
-			err := options.CompleteResume(f, cmd, out, args)
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.CompleteResume(f, cmd, out, args); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			err = options.RunResume()
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.RunResume(); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			cmdutil.CheckErr(utilerrors.Flatten(utilerrors.NewAggregate(allErrs)))
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -72,16 +72,12 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    undo_long,
 		Example: undo_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			allErrs := []error{}
-			err := options.CompleteUndo(f, cmd, out, args)
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.CompleteUndo(f, cmd, out, args); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			err = options.RunUndo()
-			if err != nil {
-				allErrs = append(allErrs, err)
+			if err := options.RunUndo(); err != nil {
+				cmdutil.CheckErr(err)
 			}
-			cmdutil.CheckErr(utilerrors.Flatten(utilerrors.NewAggregate(allErrs)))
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -72,12 +72,18 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    undo_long,
 		Example: undo_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.CompleteUndo(f, cmd, out, args); err != nil {
-				cmdutil.CheckErr(err)
+			completeErr := options.CompleteUndo(f, cmd, out, args)
+			if completeErr != nil {
+				// Allow to proceed with objects we were able to collect and fail later.
+				if len(options.Infos) == 0 {
+					cmdutil.CheckErr(completeErr)
+				}
 			}
-			if err := options.RunUndo(); err != nil {
-				cmdutil.CheckErr(err)
+			err := options.RunUndo()
+			if err == nil {
+				err = completeErr
 			}
+			cmdutil.CheckErr(err)
 		},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,


### PR DESCRIPTION
Make the errors when using `kubectl rollout` with no resource type specified look like:

``` console
# kubectl rollout pause ruby-ex
the server doesn't have a resource type "ruby-ex"
```

instead of:

``` console
# kubectl rollout pause ruby-ex
no matches for {  ruby-ex}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31234)

<!-- Reviewable:end -->
