### PR TITLE
kubectl: Support executing command within "kubectl proxy"

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/golang/glog"
@@ -84,13 +86,78 @@ func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringP("address", "", "127.0.0.1", "The IP address on which to serve on.")
 	cmd.Flags().Bool("disable-filter", false, "If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.")
 	cmd.Flags().StringP("unix-socket", "u", "", "Unix socket on which to run the proxy.")
+	cmd.Flags().StringP("exec", "e", "", "Command to be executed with the proxy address. {} will be replaced by the proxy URL.")
 	return cmd
+}
+
+type executorInterface interface {
+	Exec(argv0 string, argv []string) error
+	LookPath(argv []string) (string, error)
+}
+
+type syscallExecutor struct {
+	out io.Writer
+}
+
+func (e *syscallExecutor) Exec(argv0 string, argv []string) error {
+	cmd := exec.Command(argv0, argv...)
+
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	go io.Copy(e.out, pipe)
+
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*syscallExecutor) LookPath(argv []string) (string, error) {
+	return exec.LookPath(argv[0])
+}
+
+type proxyExec struct {
+	executor executorInterface
+}
+
+func (p proxyExec) Run(execCommand, address string, port int) error {
+	r, err := regexp.Compile("{}")
+	if err != nil {
+		return err
+	}
+	execCommand = r.ReplaceAllString(execCommand, fmt.Sprintf("http://%s:%d", address, port))
+
+	argv := strings.Split(execCommand, " ")
+	argv0, err := p.executor.LookPath(argv)
+	if err != nil {
+		return err
+	}
+
+	if err := p.executor.Exec(argv0, argv); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	path := cmdutil.GetFlagString(cmd, "unix-socket")
 	port := cmdutil.GetFlagInt(cmd, "port")
 	address := cmdutil.GetFlagString(cmd, "address")
+
+	execCommand := cmdutil.GetFlagString(cmd, "exec")
+
+	if execCommand != "" && path != "" {
+		return errors.New("Don't specify both --exec and --path, --exec doesn't work with unix sockets.")
+	}
 
 	if port != default_port && path != "" {
 		return errors.New("Don't specify both --unix-socket and --port")
@@ -135,7 +202,15 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	fmt.Fprintf(out, "Starting to serve on %s", l.Addr().String())
-	glog.Fatal(server.ServeOnListener(l))
+
+	if execCommand == "" {
+		fmt.Fprintf(out, "Starting to serve on %s", l.Addr().String())
+		glog.Fatal(server.ServeOnListener(l))
+	} else {
+		go server.ServeOnListener(l)
+		p := proxyExec{executor: &syscallExecutor{out: out}}
+		return p.Run(execCommand, address, port)
+	}
+
 	return nil
 }

--- a/pkg/kubectl/cmd/proxy_test.go
+++ b/pkg/kubectl/cmd/proxy_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type executorMock struct {
+	mock.Mock
+}
+
+var _ executorInterface = new(executorMock)
+
+func (m executorMock) Exec(argv0 string, argv []string) error {
+	args := m.Called(argv0, argv)
+	return args.Error(0)
+}
+
+func (m executorMock) LookPath(argv []string) (string, error) {
+	return fmt.Sprintf("/usr/bin/%s", argv[0]), nil
+}
+
+func TestRunProxyExec(t *testing.T) {
+	tests := []struct {
+		execCommand                      string
+		address                          string
+		port                             int
+		expectedArgv0                    string
+		expectedFormattedSplittedCommand []string
+	}{
+		{
+			execCommand:                      "curl {}/api",
+			address:                          "127.0.0.1",
+			port:                             8080,
+			expectedArgv0:                    "/usr/bin/curl",
+			expectedFormattedSplittedCommand: []string{"curl", "http://127.0.0.1:8080/api"},
+		},
+		{
+			execCommand:                      "links {}/api/v1",
+			address:                          "10.0.0.1",
+			port:                             9091,
+			expectedArgv0:                    "/usr/bin/links",
+			expectedFormattedSplittedCommand: []string{"links", "http://10.0.0.1:9091/api/v1"},
+		},
+	}
+	m := &executorMock{}
+	p := proxyExec{executor: m}
+	for _, tc := range tests {
+		m.On("Exec", tc.expectedArgv0, tc.expectedFormattedSplittedCommand).Return(nil)
+		err := p.Run(tc.execCommand, tc.address, tc.port)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: It allows to execute commands within `kubectl proxy` and replace `{}` with the URL to proxy. Example:

```
$ ./cluster/kubectl.sh proxy --exec "curl {}/api"
{
  "kind": "APIVersions",
  "versions": [
    "v1"
  ],
  "serverAddressByClientCIDRs": [
    {
      "clientCIDR": "0.0.0.0/0",
      "serverAddress": "172.18.48.92:6443"
    }
  ]
}%
```

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #31178

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Fixes #31178

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31240)

<!-- Reviewable:end -->
