### PR TITLE
Refactor gluster provisioning configuration

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -94,16 +94,14 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
   restuserkey: "password"
 ```
 
 * `endpoint`: `glusterfs-cluster` is the endpoint/service name which includes GlusterFS trusted pool IP addresses and this parameter is mandatory.
-* `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner.
-* `restauthenabled` : Gluster REST service authentication boolean is required if the authentication is enabled on the REST server. If this value is 'true', 'restuser' and 'restuserkey' have to be filled.
-* `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool.
-* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server.
+* `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be a valid URL and this is a mandatory parameter for GlusterFS dynamic provisioner.
+* `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool. This parameter is optional, empty string will be used when omitted.
+* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server. This parameter is optional, empty string will be used when omitted.
 
 #### OpenStack Cinder
 

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -6,6 +6,5 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
   restuserkey: "password"


### PR DESCRIPTION
- glusterfsClusterConf.glusterRestvolpath is not used
- glusterfsClusterConf.restauthenabled removed
- whole struct provisioningConfig renamed
- renamed struct members
- added validation of resturl and endpoint

This is prerequisite of passing configuration from provisioner to deleter through PV.Annotations.

@humblec @rootfs, PTAL

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31243)

<!-- Reviewable:end -->
