### PR TITLE
kubectl: display ExternalName for services

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1562,6 +1562,12 @@ func describeService(service *api.Service, endpoints *api.Endpoints, events *api
 		fmt.Fprintf(out, "Selector:\t%s\n", labels.FormatLabels(service.Spec.Selector))
 		fmt.Fprintf(out, "Type:\t%s\n", service.Spec.Type)
 		fmt.Fprintf(out, "IP:\t%s\n", service.Spec.ClusterIP)
+		if len(service.Spec.ExternalIPs) > 0 {
+			fmt.Fprintf(out, "External IPs:\t%v\n", strings.Join(service.Spec.ExternalIPs, ","))
+		}
+		if service.Spec.ExternalName != "" {
+			fmt.Fprintf(out, "External Name:\t%s\n", service.Spec.ExternalName)
+		}
 		if len(service.Status.LoadBalancer.Ingress) > 0 {
 			list := buildIngressString(service.Status.LoadBalancer.Ingress)
 			fmt.Fprintf(out, "LoadBalancer Ingress:\t%s\n", list)

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1092,6 +1092,8 @@ func getServiceExternalIP(svc *api.Service, wide bool) string {
 			return lbIps
 		}
 		return "<pending>"
+	case api.ServiceTypeExternalName:
+		return svc.Spec.ExternalName
 	}
 	return "<unknown>"
 }


### PR DESCRIPTION
User-visible part of https://github.com/kubernetes/features/issues/33

Also add ExternalIPs in `describe`

cc @thockin @smarterclayton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31246)

<!-- Reviewable:end -->
