### PR TITLE
Add go-bindata as development dependency

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -90,10 +90,11 @@ source control system). Use `apt-get install mercurial` or `yum install
 mercurial` on Linux, or [brew.sh](http://brew.sh) on OS X, or download directly
 from mercurial.
 
-Install godep (may require sudo):
+Install godep and go-bindata (may require sudo):
 
 ```sh
 go get -u github.com/tools/godep
+go get -u github.com/jteeuwen/go-bindata/go-bindata
 ```
 
 Note:


### PR DESCRIPTION
**What this PR does / why we need it**: 
Small update in the developer notes (a go dependency was missing, which I noticed when setting up my own development environment)

**Which issue this PR fixes**: 
Not applicable

**Special notes for your reviewer**:

**Release note**:
N/A

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31259)

<!-- Reviewable:end -->
