### PR TITLE
Fix 1.2 newrelic example yaml

### DIFF
--- a/examples/newrelic/newrelic-daemonset.yaml
+++ b/examples/newrelic/newrelic-daemonset.yaml
@@ -15,8 +15,6 @@ spec:
       # Filter to specific nodes:
       # nodeSelector:
       #  app: newrelic
-      securityContext:
-        privileged: true
       hostPID: true
       hostIPC: true
       hostNetwork: true
@@ -29,6 +27,8 @@ spec:
               value: "/var/log/nrsysmond.log"
           image: newrelic/nrsysmond
           name: newrelic
+          securityContext:
+            privileged: true
           command: [ "bash", "-c", "source /etc/kube-newrelic/config && /usr/sbin/nrsysmond -E -F" ]
           volumeMounts:
             - name: newrelic-config


### PR DESCRIPTION
Minor fix for the 1.2 example yaml for the New Relic server monitor DaemonSet.

`privileged` should be in the container definition, not in the pod-level securityContext. The pods will fail to start otherwise.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31268)

<!-- Reviewable:end -->
