### PR TITLE
add selfsubjectaccessreview API

### DIFF
--- a/api/swagger-spec/authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1beta1.json
@@ -9,6 +9,51 @@
   },
   "apis": [
    {
+    "path": "/apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews",
+    "description": "API at /apis/authorization.k8s.io/v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.SelfSubjectAccessReview",
+      "method": "POST",
+      "summary": "create a SelfSubjectAccessReview",
+      "nickname": "createSelfSubjectAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.SelfSubjectAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.SelfSubjectAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews",
     "description": "API at /apis/authorization.k8s.io/v1beta1",
     "operations": [
@@ -78,9 +123,9 @@
    }
   ],
   "models": {
-   "v1beta1.SubjectAccessReview": {
-    "id": "v1beta1.SubjectAccessReview",
-    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+   "v1beta1.SelfSubjectAccessReview": {
+    "id": "v1beta1.SelfSubjectAccessReview",
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
     "required": [
      "spec"
     ],
@@ -97,8 +142,8 @@
       "$ref": "v1.ObjectMeta"
      },
      "spec": {
-      "$ref": "v1beta1.SubjectAccessReviewSpec",
-      "description": "Spec holds information about the request being evaluated"
+      "$ref": "v1beta1.SelfSubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
      },
      "status": {
       "$ref": "v1beta1.SubjectAccessReviewStatus",
@@ -214,9 +259,9 @@
      }
     }
    },
-   "v1beta1.SubjectAccessReviewSpec": {
-    "id": "v1beta1.SubjectAccessReviewSpec",
-    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+   "v1beta1.SelfSubjectAccessReviewSpec": {
+    "id": "v1beta1.SelfSubjectAccessReviewSpec",
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
     "properties": {
      "resourceAttributes": {
       "$ref": "v1beta1.ResourceAttributes",
@@ -225,21 +270,6 @@
      "nonResourceAttributes": {
       "$ref": "v1beta1.NonResourceAttributes",
       "description": "NonResourceAttributes describes information for a non-resource access request"
-     },
-     "user": {
-      "type": "string",
-      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups"
-     },
-     "group": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "Groups is the groups you're testing for."
-     },
-     "extra": {
-      "type": "object",
-      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here."
      }
     }
    },
@@ -309,6 +339,63 @@
      "evaluationError": {
       "type": "string",
       "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request."
+     }
+    }
+   },
+   "v1beta1.SubjectAccessReview": {
+    "id": "v1beta1.SubjectAccessReview",
+    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.SubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated"
+     },
+     "status": {
+      "$ref": "v1beta1.SubjectAccessReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+     }
+    }
+   },
+   "v1beta1.SubjectAccessReviewSpec": {
+    "id": "v1beta1.SubjectAccessReviewSpec",
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "resourceAttributes": {
+      "$ref": "v1beta1.ResourceAttributes",
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+     },
+     "nonResourceAttributes": {
+      "$ref": "v1beta1.NonResourceAttributes",
+      "description": "NonResourceAttributes describes information for a non-resource access request"
+     },
+     "user": {
+      "type": "string",
+      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups"
+     },
+     "group": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Groups is the groups you're testing for."
+     },
+     "extra": {
+      "type": "object",
+      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here."
      }
     }
    },

--- a/pkg/apis/authorization/types.go
+++ b/pkg/apis/authorization/types.go
@@ -38,6 +38,10 @@ type SubjectAccessReview struct {
 	Status SubjectAccessReviewStatus
 }
 
+// +genclient=true
+// +nonNamespaced=true
+// +noMethods=true
+
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action

--- a/pkg/apis/authorization/v1beta1/types.go
+++ b/pkg/apis/authorization/v1beta1/types.go
@@ -39,6 +39,10 @@ type SubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+// +genclient=true
+// +nonNamespaced=true
+// +noMethods=true
+
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
@@ -24,12 +24,17 @@ import (
 
 type AuthorizationInterface interface {
 	GetRESTClient() *restclient.RESTClient
+	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
 }
 
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
 	*restclient.RESTClient
+}
+
+func (c *AuthorizationClient) SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface {
+	return newSelfSubjectAccessReviews(c)
 }
 
 func (c *AuthorizationClient) SubjectAccessReviews() SubjectAccessReviewInterface {

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
@@ -26,6 +26,10 @@ type FakeAuthorization struct {
 	*core.Fake
 }
 
+func (c *FakeAuthorization) SelfSubjectAccessReviews() unversioned.SelfSubjectAccessReviewInterface {
+	return &FakeSelfSubjectAccessReviews{c}
+}
+
 func (c *FakeAuthorization) SubjectAccessReviews() unversioned.SubjectAccessReviewInterface {
 	return &FakeSubjectAccessReviews{c}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_generated_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_generated_expansion.go
@@ -26,3 +26,8 @@ func (c *FakeSubjectAccessReviews) Create(sar *authorizationapi.SubjectAccessRev
 	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("subjectaccessreviews"), sar), &authorizationapi.SubjectAccessReview{})
 	return obj.(*authorizationapi.SubjectAccessReview), err
 }
+
+func (c *FakeSelfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("selfsubjectaccessreviews"), sar), &authorizationapi.SelfSubjectAccessReview{})
+	return obj.(*authorizationapi.SelfSubjectAccessReview), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_selfsubjectaccessreview.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+// FakeSelfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
+type FakeSelfSubjectAccessReviews struct {
+	Fake *FakeAuthorization
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+// SelfSubjectAccessReviewsGetter has a method to return a SelfSubjectAccessReviewInterface.
+// A group's client should implement this interface.
+type SelfSubjectAccessReviewsGetter interface {
+	SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface
+}
+
+// SelfSubjectAccessReviewInterface has methods to work with SelfSubjectAccessReview resources.
+type SelfSubjectAccessReviewInterface interface {
+	SelfSubjectAccessReviewExpansion
+}
+
+// selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
+type selfSubjectAccessReviews struct {
+	client *AuthorizationClient
+}
+
+// newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
+func newSelfSubjectAccessReviews(c *AuthorizationClient) *selfSubjectAccessReviews {
+	return &selfSubjectAccessReviews{
+		client: c,
+	}
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview_expansion.go
@@ -20,14 +20,14 @@ import (
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 )
 
-type SubjectAccessReviewExpansion interface {
-	Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error)
+type SelfSubjectAccessReviewExpansion interface {
+	Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error)
 }
 
-func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
-	result = &authorizationapi.SubjectAccessReview{}
+func (c *selfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	result = &authorizationapi.SelfSubjectAccessReview{}
 	err = c.client.Post().
-		Resource("subjectaccessreviews").
+		Resource("selfsubjectaccessreviews").
 		Body(sar).
 		Do().
 		Into(result)

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/authorization_client.go
@@ -25,12 +25,17 @@ import (
 
 type AuthorizationInterface interface {
 	GetRESTClient() *restclient.RESTClient
+	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
 }
 
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
 	*restclient.RESTClient
+}
+
+func (c *AuthorizationClient) SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface {
+	return newSelfSubjectAccessReviews(c)
 }
 
 func (c *AuthorizationClient) SubjectAccessReviews() SubjectAccessReviewInterface {

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_authorization_client.go
@@ -26,6 +26,10 @@ type FakeAuthorization struct {
 	*core.Fake
 }
 
+func (c *FakeAuthorization) SelfSubjectAccessReviews() v1beta1.SelfSubjectAccessReviewInterface {
+	return &FakeSelfSubjectAccessReviews{c}
+}
+
 func (c *FakeAuthorization) SubjectAccessReviews() v1beta1.SubjectAccessReviewInterface {
 	return &FakeSubjectAccessReviews{c}
 }

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_selfsubjectaccessreview.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+// FakeSelfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
+type FakeSelfSubjectAccessReviews struct {
+	Fake *FakeAuthorization
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_subjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_subjectaccessreview_expansion.go
@@ -26,3 +26,8 @@ func (c *FakeSubjectAccessReviews) Create(sar *authorizationapi.SubjectAccessRev
 	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("subjectaccessreviews"), sar), &authorizationapi.SubjectAccessReview{})
 	return obj.(*authorizationapi.SubjectAccessReview), err
 }
+
+func (c *FakeSelfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("selfsubjectaccessreviews"), sar), &authorizationapi.SelfSubjectAccessReview{})
+	return obj.(*authorizationapi.SelfSubjectAccessReview), err
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// SelfSubjectAccessReviewsGetter has a method to return a SelfSubjectAccessReviewInterface.
+// A group's client should implement this interface.
+type SelfSubjectAccessReviewsGetter interface {
+	SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface
+}
+
+// SelfSubjectAccessReviewInterface has methods to work with SelfSubjectAccessReview resources.
+type SelfSubjectAccessReviewInterface interface {
+	SelfSubjectAccessReviewExpansion
+}
+
+// selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
+type selfSubjectAccessReviews struct {
+	client *AuthorizationClient
+}
+
+// newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
+func newSelfSubjectAccessReviews(c *AuthorizationClient) *selfSubjectAccessReviews {
+	return &selfSubjectAccessReviews{
+		client: c,
+	}
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1beta1
 
 import (
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 )
 
-type SubjectAccessReviewExpansion interface {
-	Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error)
+type SelfSubjectAccessReviewExpansion interface {
+	Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error)
 }
 
-func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
-	result = &authorizationapi.SubjectAccessReview{}
+func (c *selfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
+	result = &authorizationapi.SelfSubjectAccessReview{}
 	err = c.client.Post().
-		Resource("subjectaccessreviews").
+		Resource("selfsubjectaccessreviews").
 		Body(sar).
 		Do().
 		Into(result)

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -525,12 +525,13 @@ func (gc *GarbageCollector) monitorFor(resource unversioned.GroupVersionResource
 }
 
 var ignoredResources = map[unversioned.GroupVersionResource]struct{}{
-	unversioned.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicationcontrollers"}:         {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "bindings"}:                                      {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuses"}:                             {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}:                                        {},
-	unversioned.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1beta1", Resource: "tokenreviews"}:        {},
-	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "subjectaccessreviews"}: {},
+	unversioned.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicationcontrollers"}:             {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "bindings"}:                                          {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuses"}:                                 {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}:                                            {},
+	unversioned.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1beta1", Resource: "tokenreviews"}:            {},
+	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "subjectaccessreviews"}:     {},
+	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "selfsubjectaccessreviews"}: {},
 }
 
 func NewGarbageCollector(metaOnlyClientPool dynamic.ClientPool, clientPool dynamic.ClientPool, resources []unversioned.GroupVersionResource) (*GarbageCollector, error) {

--- a/pkg/master/storage_authorization.go
+++ b/pkg/master/storage_authorization.go
@@ -22,6 +22,7 @@ import (
 	authorizationv1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry/authorization/selfsubjectaccessreview"
 	"k8s.io/kubernetes/pkg/registry/authorization/subjectaccessreview"
 )
 
@@ -52,6 +53,9 @@ func (p AuthorizationRESTStorageProvider) v1beta1Storage(apiResourceConfigSource
 	storage := map[string]rest.Storage{}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("subjectaccessreviews")) {
 		storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
+		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
 	}
 
 	return storage

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfsubjectaccessreview
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationvalidation "k8s.io/kubernetes/pkg/apis/authorization/validation"
+	"k8s.io/kubernetes/pkg/auth/authorizer"
+	authorizationutil "k8s.io/kubernetes/pkg/registry/authorization/util"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type REST struct {
+	authorizer authorizer.Authorizer
+}
+
+func NewREST(authorizer authorizer.Authorizer) *REST {
+	return &REST{authorizer}
+}
+
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.SelfSubjectAccessReview{}
+}
+
+func (r *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
+	selfSAR, ok := obj.(*authorizationapi.SelfSubjectAccessReview)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("not a SelfSubjectAccessReview: %#v", obj))
+	}
+	if errs := authorizationvalidation.ValidateSelfSubjectAccessReview(selfSAR); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(authorizationapi.Kind(selfSAR.Kind), "", errs)
+	}
+	userToCheck, exists := api.UserFrom(ctx)
+	if !exists {
+		return nil, apierrors.NewBadRequest("no user present on request")
+	}
+
+	var authorizationAttributes authorizer.AttributesRecord
+	if selfSAR.Spec.ResourceAttributes != nil {
+		authorizationAttributes = authorizationutil.ResourceAttributesFrom(userToCheck, *selfSAR.Spec.ResourceAttributes)
+	} else {
+		authorizationAttributes = authorizationutil.NonResourceAttributesFrom(userToCheck, *selfSAR.Spec.NonResourceAttributes)
+	}
+
+	allowed, reason, evaluationErr := r.authorizer.Authorize(authorizationAttributes)
+
+	selfSAR.Status = authorizationapi.SubjectAccessReviewStatus{
+		Allowed: allowed,
+		Reason:  reason,
+	}
+	if evaluationErr != nil {
+		selfSAR.Status.EvaluationError = evaluationErr.Error()
+	}
+
+	return selfSAR, nil
+}


### PR DESCRIPTION
Exposes the REST API for self subject access reviews.  This allows a user to see whether or not they can perform a particular action.

@kubernetes/sig-auth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31271)

<!-- Reviewable:end -->
