### PR TITLE
WIP: add operation tracing in kubelet for performance analysis

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -211,4 +211,5 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.EvictionMinimumReclaim, "eviction-minimum-reclaim", s.EvictionMinimumReclaim, "A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.")
 	fs.Int32Var(&s.PodsPerCore, "pods-per-core", s.PodsPerCore, "Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.")
 	fs.BoolVar(&s.ProtectKernelDefaults, "protect-kernel-defaults", s.ProtectKernelDefaults, "Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.")
+	fs.BoolVar(&s.EnableTracing, "enable-tracing", s.EnableTracing, "Enable tracing of kubelet operations. Intended for testing. [default=false]")
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -303,6 +303,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		MakeIPTablesUtilChains: s.MakeIPTablesUtilChains,
 		iptablesMasqueradeBit:  int(s.IPTablesMasqueradeBit),
 		iptablesDropBit:        int(s.IPTablesDropBit),
+		EnableTracing:          s.EnableTracing,
 	}, nil
 }
 
@@ -964,6 +965,7 @@ type KubeletConfig struct {
 	MakeIPTablesUtilChains     bool
 	iptablesMasqueradeBit      int
 	iptablesDropBit            int
+	EnableTracing              bool
 }
 
 func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
@@ -1066,6 +1068,7 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.MakeIPTablesUtilChains,
 		kc.iptablesMasqueradeBit,
 		kc.iptablesDropBit,
+		kc.EnableTracing,
 	)
 
 	if err != nil {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -519,3 +519,4 @@ windows-line-endings
 www-prefix
 zone-name
 garbage-collector-enabled
+enable-tracing

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -415,6 +415,8 @@ type KubeletConfiguration struct {
 	// iptablesDropBit is the bit of the iptables fwmark space to use for dropping packets. Kubelet will ensure iptables mark and drop rules.
 	// Values must be within the range [0, 31]. Must be different from IPTablesMasqueradeBit
 	IPTablesDropBit int32 `json:"iptablesDropBit"`
+	// enableTracing enables tracing of kubelet operations. It activates lightweight tracing probes inside kubelet.
+	EnableTracing bool `json:"enableTracing"`
 }
 
 type KubeSchedulerConfiguration struct {

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -470,4 +470,6 @@ type KubeletConfiguration struct {
 	// iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
 	// Values must be within the range [0, 31]. Must be different from other mark bits.
 	IPTablesDropBit *int32 `json:"iptablesDropBit"`
+	// enableTracing enables tracing of kubelet operations. It activates lightweight tracing probes inside kubelet.
+	EnableTracing bool `json:"enableTracing"`
 }

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -331,6 +331,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 	if err := api.Convert_Pointer_int32_To_int32(&in.IPTablesDropBit, &out.IPTablesDropBit, s); err != nil {
 		return err
 	}
+	out.EnableTracing = in.EnableTracing
 	return nil
 }
 
@@ -507,6 +508,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	if err := api.Convert_int32_To_Pointer_int32(&in.IPTablesDropBit, &out.IPTablesDropBit, s); err != nil {
 		return err
 	}
+	out.EnableTracing = in.EnableTracing
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -401,6 +401,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		} else {
 			out.IPTablesDropBit = nil
 		}
+		out.EnableTracing = in.EnableTracing
 		return nil
 	}
 }

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -335,6 +335,7 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		out.MakeIPTablesUtilChains = in.MakeIPTablesUtilChains
 		out.IPTablesMasqueradeBit = in.IPTablesMasqueradeBit
 		out.IPTablesDropBit = in.IPTablesDropBit
+		out.EnableTracing = in.EnableTracing
 		return nil
 	}
 }

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	tracing "k8s.io/kubernetes/pkg/kubelet/metrics/tracing"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/hairpin"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
@@ -2225,6 +2226,9 @@ func (dm *DockerManager) tryContainerStart(container *api.Container, pod *api.Po
 	if containerStatus != nil {
 		restartCount = containerStatus.RestartCount + 1
 	}
+
+	// Tracing probe
+	tracing.SetProbe(pod.UID, "container_syncPod")
 
 	_, err = dm.runContainerInPod(pod, container, namespaceMode, namespaceMode, pidMode, podIP, restartCount)
 	if err != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	tracing "k8s.io/kubernetes/pkg/kubelet/metrics/tracing"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
@@ -250,6 +251,7 @@ func NewMainKubelet(
 	makeIPTablesUtilChains bool,
 	iptablesMasqueradeBit int,
 	iptablesDropBit int,
+	EnableTracing bool,
 ) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
@@ -378,6 +380,9 @@ func NewMainKubelet(
 		iptablesMasqueradeBit:        iptablesMasqueradeBit,
 		iptablesDropBit:              iptablesDropBit,
 	}
+
+	// Set 'enable' for the tracing package
+	tracing.SetEnableTracing(EnableTracing)
 
 	if klet.flannelExperimentalOverlay {
 		klet.flannelHelper = NewFlannelHelper()
@@ -1663,6 +1668,12 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	if !ok || existingStatus.Phase == api.PodPending && apiPodStatus.Phase == api.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartLatency.Observe(metrics.SinceInMicroseconds(firstSeenTime))
+
+		// Tracing probe
+		if ok {
+			tracing.SetProbeWithTs(pod.UID, "firstSeen", firstSeenTime)
+			tracing.SetProbe(pod.UID, "running")
+		}
 	}
 
 	// Update status in the status manager
@@ -1720,6 +1731,11 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	if err != nil {
 		glog.Errorf("Unable to get pull secrets for pod %q: %v", format.Pod(pod), err)
 		return err
+	}
+
+	// Tracing probe
+	if updateType == kubetypes.SyncPodCreate {
+		tracing.SetProbe(pod.UID, "container")
 	}
 
 	// Call the container runtime's SyncPod callback

--- a/pkg/kubelet/metrics/tracing/tracing.go
+++ b/pkg/kubelet/metrics/tracing/tracing.go
@@ -1,0 +1,134 @@
+package tracing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	types "k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/clock"
+)
+
+var (
+	enabled        = false
+	tracingManager = NewManager()
+)
+
+// GetManager() exposes the tracing manager
+func GetManager() Manager {
+	return tracingManager
+}
+
+// SetEnableTracing enables tracing by activating tracing probes.
+func SetEnableTracing(en bool) {
+	enabled = en
+}
+
+// SetProbeWithTs places a probe in code to record the timestamp for an operation
+// TODO(coufon): currently we do not use pod UID yet. The timestamps for an operation are
+// stored in an array. In future we may store the timestamps for per pod per operation, so we
+// can track operation timestamps for a specific pod.
+func SetProbeWithTs(podUID types.UID, operation string, ts time.Time) {
+	if enabled {
+		tracingManager.NewSampleWithTs(podUID, operation, ts)
+	}
+}
+
+// SetProbe places a probe in code and use current time as the timestamp.
+func SetProbe(podUID types.UID, operation string) {
+	if enabled {
+		tracingManager.NewSample(podUID, operation)
+	}
+}
+
+// Manager is the interface of tracing managers.
+type Manager interface {
+	NewSampleWithTs(types.UID, string, time.Time)
+	NewSample(types.UID, string)
+	GetSamplesJSON() ([]byte, error)
+	ResetSamples()
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}
+
+// NewManager creates and returns a tracing manager.
+func NewManager() Manager {
+	return &lightweightManager{
+		tsPerOperation: make(tsArrayMap),
+		clock:          clock.RealClock{},
+	}
+}
+
+// tsArrayMap is a map with operation name as key, and an array of timestamps as value.
+type tsArrayMap map[string][]int64
+
+// lightweightManager is a  lightweight implementation of tracing manager.
+// It only records the sequence of timestamp when an operation starts. It does not support
+// tracing of related operations for a specific pod.
+// Currently this is enough for performance analysis and visualization.
+type lightweightManager struct {
+	tsPerOperation tsArrayMap
+	// clock is an interface that provides time related functionality in a way that makes it
+	// easy to test the code.
+	clock clock.Clock
+	// TODO(coufon): we use a read-write mutex to protect concurrent accesses to 'tsPerOperation'
+	// It is OK when operation/probe number is small. If the number is large, we may have a mutex/spin lock
+	// for each operation.
+	rwmutex sync.RWMutex
+}
+
+func (lm *lightweightManager) NewSampleWithTs(podUID types.UID, operation string, ts time.Time) {
+	lm.rwmutex.Lock()
+	_, ok := lm.tsPerOperation[operation]
+	if !ok {
+		lm.tsPerOperation[operation] = []int64{}
+	}
+	lm.tsPerOperation[operation] = append(lm.tsPerOperation[operation], ts.UnixNano())
+	lm.rwmutex.Unlock()
+}
+
+func (lm *lightweightManager) NewSample(podUID types.UID, operation string) {
+	lm.NewSampleWithTs(podUID, operation, lm.clock.Now())
+}
+
+// ResetSamples clears all samples
+func (lm *lightweightManager) ResetSamples() {
+	lm.rwmutex.Lock()
+	lm.tsPerOperation = tsArrayMap{}
+	lm.rwmutex.Unlock()
+}
+
+// GetSamplesJSON returns all samples in JSON format
+func (lm *lightweightManager) GetSamplesJSON() ([]byte, error) {
+	lm.rwmutex.RLock()
+	data, err := json.Marshal(lm.tsPerOperation)
+	lm.rwmutex.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// ServeHTTP is the http handler of tracing manager. It returns all samples in JSON for GET method,
+// and clear all samples for DELETE method.
+func (lm *lightweightManager) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if req.Method == "DELETE" {
+		lm.ResetSamples()
+		io.WriteString(res, "traces reset")
+		return
+	}
+
+	data, err := lm.GetSamplesJSON()
+
+	if err != nil {
+		res.Header().Set("Content-type", "text/html")
+		res.WriteHeader(http.StatusInternalServerError)
+		res.Write([]byte(fmt.Sprintf("<h3>Internal Error</h3><p>%v", err)))
+		return
+	}
+	res.Header().Set("Content-type", "application/json")
+	res.WriteHeader(http.StatusOK)
+	res.Write(data)
+}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/httplog"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	tracing "k8s.io/kubernetes/pkg/kubelet/metrics/tracing"
 	"k8s.io/kubernetes/pkg/kubelet/server/portforward"
 	"k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
@@ -260,6 +261,9 @@ func (s *Server) InstallDefaultHandlers() {
 
 	s.restfulCont.Add(stats.CreateHandlers(s.host, s.resourceAnalyzer))
 	s.restfulCont.Handle("/metrics", prometheus.Handler())
+
+	// Handler of tracing manager
+	s.restfulCont.Handle("/traces", tracing.GetManager())
 
 	ws = new(restful.WebService)
 	ws.

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -372,6 +372,7 @@ func (es *e2eService) startKubeletServer() (*server, error) {
 		"--pod-cidr=10.180.0.0/24", // Assign a fixed CIDR to the node because there is no node controller.
 		"--eviction-hard", framework.TestContext.EvictionHard,
 		"--eviction-pressure-transition-period", "30s",
+		"--enable-tracing", "true",
 	)
 	if framework.TestContext.CgroupsPerQOS {
 		// TODO: enable this when the flag is stable and available in kubelet.


### PR DESCRIPTION
This PR contains an initial trial of enabling operation tracing inside kubelet. 

Current performance analysis treats kubelet as a black box. Performance test can only measure e2e data such as pod startup latency, which is insufficient for understanding performance issues and optimizing code. This PR implements a very basic tracing, which records the sequence of timestamps when it arrives at a probe in code. This timestamp sequence can be visualized in node benchmark dashboard. Then we can see whether there is a large latency between two operations.

An example of using tracing can be found in #31143 .

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31280)

<!-- Reviewable:end -->
