### PR TITLE
rkt: Improve support for privileged pod (pod whose all containers are privileged) 

### DIFF
--- a/pkg/kubelet/rkt/config.go
+++ b/pkg/kubelet/rkt/config.go
@@ -88,20 +88,20 @@ func (r *Runtime) getConfig(cfg *Config) (*Config, error) {
 
 	flags := resp.Info.GlobalFlags
 
-	if cfg.Dir == "" {
+	if flags.Dir != "" {
 		cfg.Dir = flags.Dir
 	}
-	if cfg.InsecureOptions == "" {
-		cfg.InsecureOptions = flags.InsecureFlags
-	}
-	if cfg.LocalConfigDir == "" {
+	if flags.LocalConfigDir != "" {
 		cfg.LocalConfigDir = flags.LocalConfigDir
 	}
-	if cfg.UserConfigDir == "" {
+	if flags.UserConfigDir != "" {
 		cfg.UserConfigDir = flags.UserConfigDir
 	}
-	if cfg.SystemConfigDir == "" {
+	if flags.SystemConfigDir != "" {
 		cfg.SystemConfigDir = flags.SystemConfigDir
+	}
+	if flags.InsecureFlags != "" {
+		cfg.InsecureOptions = fmt.Sprintf("%s,%s", cfg.InsecureOptions, flags.InsecureFlags)
 	}
 
 	return cfg, nil

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -70,8 +70,8 @@ const (
 	RktType                      = "rkt"
 	DefaultRktAPIServiceEndpoint = "localhost:15441"
 
-	minimumRktBinVersion     = "1.9.1"
-	recommendedRktBinVersion = "1.9.1"
+	minimumRktBinVersion     = "1.13.0"
+	recommendedRktBinVersion = "1.13.0"
 
 	minimumRktApiVersion  = "1.0.0-alpha"
 	minimumSystemdVersion = "219"
@@ -967,7 +967,26 @@ func (r *Runtime) usesRktHostNetwork(pod *api.Pod) bool {
 
 // generateRunCommand crafts a 'rkt run-prepared' command with necessary parameters.
 func (r *Runtime) generateRunCommand(pod *api.Pod, uuid, netnsName string) (string, error) {
-	runPrepared := buildCommand(r.config, "run-prepared").Args
+	config := *r.config
+	privileged := true
+
+	for _, c := range pod.Spec.Containers {
+		ctx := securitycontext.DetermineEffectiveSecurityContext(pod, &c)
+		if ctx == nil || ctx.Privileged == nil || *ctx.Privileged == false {
+			privileged = false
+			break
+		}
+	}
+
+	// Use "all-run" insecure option (https://github.com/coreos/rkt/pull/2983) to take care
+	// of privileged pod.
+	// TODO(yifan): Have more granular app-level control of the insecure options.
+	// See: https://github.com/coreos/rkt/issues/2996.
+	if privileged {
+		config.InsecureOptions = fmt.Sprintf("%s,%s", config.InsecureOptions, "all-run")
+	}
+
+	runPrepared := buildCommand(&config, "run-prepared").Args
 
 	var hostname string
 	var err error


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/31100

This takes advantage of https://github.com/coreos/rkt/pull/2983 . By appending the new `--all-run` insecure-options to `rkt run-prepared` command when all the containers are privileged. The pod now gets more privileged power.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31286)

<!-- Reviewable:end -->
