### PR TITLE
add pointer to feature repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ For Q&A, our threads are at:
 
 If you're interested in being a contributor and want to get involved in developing Kubernetes, start in the [Kubernetes Developer Guide](docs/devel/README.md) and also review the [contributor guidelines](CONTRIBUTING.md).
 
+Or, if you just have an idea for a new feature, see the [Kubernetes Features](https://github.com/kubernetes/features) repository for details on how to propose it.
+
 ### Support
 
 While there are many different channels that you can use to get ahold of us, you can help make sure that we are efficient in getting you the help that you need.


### PR DESCRIPTION
Add a pointer to the "features" repo so people know that they shouldn't just open up a new 'issue' in this one.

Signed-off-by: Doug Davis dug@us.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31299)

<!-- Reviewable:end -->
