### PR TITLE
Use `make release` on Jenkins to support crossbuilds

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -62,7 +62,8 @@ git clean -fdx
 # docker images -q | xargs -r docker rmi
 
 # Build
-go run ./hack/e2e.go -v --build
+# Jobs explicitly set KUBE_FASTBUILD to desired settings.
+make release
 
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then


### PR DESCRIPTION
Partner PR to https://github.com/kubernetes/test-infra/pull/440 to fix https://github.com/kubernetes/test-infra/issues/393.

We probably should pull the build functionality out of e2e.go entirely, but I leave that to future work.

cc @luxas @david-mcmahon @fejta

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31302)

<!-- Reviewable:end -->
