### PR TITLE
Fix path to kubernetes_skew

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -339,7 +339,7 @@ if [[ -n "${JENKINS_PUBLISHED_SKEW_VERSION:-}" ]]; then
     #       master.
     #         # - for client skew tests, we want to use the skewed kubectl
     #         (that's what we're testing).
-    GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/../kubernetes_skew/cluster/kubectl.sh"
+    GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/kubernetes_skew/cluster/kubectl.sh"
   fi
 fi
 


### PR DESCRIPTION
Previously this was `$(pwd)/kubernetes/../kubernetes_old` this is equivalent to `$(pwd)/kubernetes_old` although we also changed the `old` to `skew` instead.

Fixes https://github.com/kubernetes/kubernetes/issues/31149

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31312)

<!-- Reviewable:end -->
