### PR TITLE
Fix lint verify error

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -90,10 +90,11 @@ source control system). Use `apt-get install mercurial` or `yum install
 mercurial` on Linux, or [brew.sh](http://brew.sh) on OS X, or download directly
 from mercurial.
 
-Install godep (may require sudo):
+Install godep and go-bindata (may require sudo):
 
 ```sh
 go get -u github.com/tools/godep
+go get -u github.com/jteeuwen/go-bindata/go-bindata
 ```
 
 Note:

--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -31,8 +31,8 @@ import (
 const (
 	StatusUnprocessableEntity = 422
 	StatusTooManyRequests     = 429
-	// HTTP recommendations are for servers to define 5xx error codes
-	// for scenarios not covered by behavior. In this case, ServerTimeout
+	// StatusServerTimeout : HTTP recommendations are for servers to define 5xx error
+	// codes for scenarios not covered by behavior. In this case, ServerTimeout
 	// is an indication that a transient server error has occurred and the
 	// client *should* retry, with an optional Retry-After header to specify
 	// the back off window.


### PR DESCRIPTION
**What this PR does / why we need it**: 

_make verify_ was failing due to a golint warning (some documentation guideline was not followed).

**Which issue this PR fixes** 

Quick comment update to pass the golint warning

**Special notes for your reviewer**:

This pull request was first step of a large pull request I am working on: adding **filebeat** support next to **fluentd** support, because filebeat is more performant (written in go iso ruby).

**Release note**:
Not applicable

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31340)

<!-- Reviewable:end -->
