### PR TITLE
add a podspecer interface

### DIFF
--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+// PodSpecer is implemented by API objects that embed a PodSpec.  It allows
+// generic inspection, admission, and mutation of things that contain a PodSpec.
+// For instance, PSP admission for Pods, RCs, RSs, Deployments, etc.
+type PodSpecer interface {
+	// PodSpec returns a reference to the PodSpec contained in the object and the
+	// fieldPath to the PodSpec for any future messages.
+	PodSpec() (spec *PodSpec, fieldPath string)
+}
+
+func (obj *Pod) PodSpec() (*PodSpec, string) {
+	return &obj.Spec, "spec"
+}
+
+func (obj *ReplicationController) PodSpec() (*PodSpec, string) {
+	return &obj.Spec.Template.Spec, "spec.template.spec"
+}

--- a/pkg/apis/apps/interfaces.go
+++ b/pkg/apis/apps/interfaces.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func (obj *PetSet) PodSpec() (*api.PodSpec, string) {
+	return &obj.Spec.Template.Spec, "spec.template.spec"
+}

--- a/pkg/apis/batch/interfaces.go
+++ b/pkg/apis/batch/interfaces.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func (obj *Job) PodSpec() (*api.PodSpec, string) {
+	return &obj.Spec.Template.Spec, "spec.template.spec"
+}
+
+func (obj *ScheduledJob) PodSpec() (*api.PodSpec, string) {
+	return &obj.Spec.JobTemplate.Spec.Template.Spec, "spec.jobtemplate.spec.template.spec"
+}

--- a/pkg/apis/extensions/interfaces.go
+++ b/pkg/apis/extensions/interfaces.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func (obj *Deployment) PodSpec() (*api.PodSpec, string) {
+	return &obj.Spec.Template.Spec, "spec.template.spec"
+}
+
+func (obj *ReplicaSet) PodSpec() (*api.PodSpec, string) {
+	return &obj.Spec.Template.Spec, "spec.template.spec"
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -523,46 +523,28 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 		},
 		PortsForObject: func(object runtime.Object) ([]string, error) {
-			// TODO: replace with a swagger schema based approach (identify pod selector via schema introspection)
-			switch t := object.(type) {
-			case *api.ReplicationController:
-				return getPorts(t.Spec.Template.Spec), nil
-			case *api.Pod:
-				return getPorts(t.Spec), nil
-			case *api.Service:
-				return getServicePorts(t.Spec), nil
-			case *extensions.Deployment:
-				return getPorts(t.Spec.Template.Spec), nil
-			case *extensions.ReplicaSet:
-				return getPorts(t.Spec.Template.Spec), nil
-			default:
-				gvks, _, err := api.Scheme.ObjectKinds(object)
-				if err != nil {
-					return nil, err
-				}
-				return nil, fmt.Errorf("cannot extract ports from %v", gvks[0])
+			if podSpecer, ok := object.(api.PodSpecer); ok {
+				podSpec, _ := podSpecer.PodSpec()
+				return getPorts(*podSpec), nil
 			}
+
+			gvks, _, err := api.Scheme.ObjectKinds(object)
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("cannot extract ports from %v", gvks[0])
 		},
 		ProtocolsForObject: func(object runtime.Object) (map[string]string, error) {
-			// TODO: replace with a swagger schema based approach (identify pod selector via schema introspection)
-			switch t := object.(type) {
-			case *api.ReplicationController:
-				return getProtocols(t.Spec.Template.Spec), nil
-			case *api.Pod:
-				return getProtocols(t.Spec), nil
-			case *api.Service:
-				return getServiceProtocols(t.Spec), nil
-			case *extensions.Deployment:
-				return getProtocols(t.Spec.Template.Spec), nil
-			case *extensions.ReplicaSet:
-				return getProtocols(t.Spec.Template.Spec), nil
-			default:
-				gvks, _, err := api.Scheme.ObjectKinds(object)
-				if err != nil {
-					return nil, err
-				}
-				return nil, fmt.Errorf("cannot extract protocols from %v", gvks[0])
+			if podSpecer, ok := object.(api.PodSpecer); ok {
+				podSpec, _ := podSpecer.PodSpec()
+				return getProtocols(*podSpec), nil
 			}
+
+			gvks, _, err := api.Scheme.ObjectKinds(object)
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("cannot extract protocols from %v", gvks[0])
 		},
 		LabelsForObject: func(object runtime.Object) (map[string]string, error) {
 			return meta.NewAccessor().Labels(object)
@@ -809,28 +791,12 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 		},
 		// UpdatePodSpecForObject update the pod specification for the provided object
 		UpdatePodSpecForObject: func(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
-			// TODO: replace with a swagger schema based approach (identify pod template via schema introspection)
-			switch t := obj.(type) {
-			case *api.Pod:
-				return true, fn(&t.Spec)
-			case *api.ReplicationController:
-				if t.Spec.Template == nil {
-					t.Spec.Template = &api.PodTemplateSpec{}
-				}
-				return true, fn(&t.Spec.Template.Spec)
-			case *extensions.Deployment:
-				return true, fn(&t.Spec.Template.Spec)
-			case *extensions.DaemonSet:
-				return true, fn(&t.Spec.Template.Spec)
-			case *extensions.ReplicaSet:
-				return true, fn(&t.Spec.Template.Spec)
-			case *apps.PetSet:
-				return true, fn(&t.Spec.Template.Spec)
-			case *batch.Job:
-				return true, fn(&t.Spec.Template.Spec)
-			default:
-				return false, fmt.Errorf("the object is not a pod or does not have a pod template")
+			if podSpecer, ok := obj.(api.PodSpecer); ok {
+				podSpec, _ := podSpecer.PodSpec()
+				return true, fn(podSpec)
 			}
+
+			return false, fmt.Errorf("the object is not a pod or does not have a pod template")
 		},
 		EditorEnvs: func() []string {
 			return []string{"KUBE_EDITOR", "EDITOR"}


### PR DESCRIPTION
Several areas of code need to make decisions about an API object based on the `PodSpec` that it can eventually create.  For instance, PSP admission and ImagePolicy admission, along with several examples of security related admission plugins downstream.  Right now in kube, they ignore the other types, which is technically safe, but hard to use since failures happen after the initial API object.

We can introduce a `PodSpecer` interface for API objects that contain a `PodSpec` so that we can stop the proliferation of switch cases that all have to be updated when a new type comes along.

@kubernetes/sig-api-machinery This would be only the second or third interface we have on our API types.  I think this one is worth it since its so core to our system, but its noteworthy.

@lavalamp @smarterclayton ptal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31342)

<!-- Reviewable:end -->
