### PR TITLE
Don't set timeouts in clients in tests

### DIFF
--- a/test/e2e/federation-authn.go
+++ b/test/e2e/federation-authn.go
@@ -109,11 +109,6 @@ func invalidAuthFederationClientSet(user *framework.KubeUser) (*federation_relea
 	if err != nil {
 		return nil, fmt.Errorf("error creating federation clientset: %v", err)
 	}
-	// Set timeout for each client in the set.
-	c.DiscoveryClient.Client.Timeout = framework.SingleCallTimeout
-	c.FederationClient.Client.Timeout = framework.SingleCallTimeout
-	c.CoreClient.Client.Timeout = framework.SingleCallTimeout
-	c.ExtensionsClient.Client.Timeout = framework.SingleCallTimeout
 
 	return c, nil
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1945,18 +1945,7 @@ func loadClientFromConfig(config *restclient.Config) (*client.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err.Error())
 	}
-	if c.Client.Timeout == 0 {
-		c.Client.Timeout = SingleCallTimeout
-	}
 	return c, nil
-}
-
-func setTimeouts(cs ...*http.Client) {
-	for _, client := range cs {
-		if client.Timeout == 0 {
-			client.Timeout = SingleCallTimeout
-		}
-	}
 }
 
 func LoadFederationClientset_1_5() (*federation_release_1_5.Clientset, error) {
@@ -1969,8 +1958,6 @@ func LoadFederationClientset_1_5() (*federation_release_1_5.Clientset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating federation clientset: %v", err.Error())
 	}
-	// Set timeout for each client in the set.
-	setTimeouts(c.DiscoveryClient.Client, c.FederationClient.Client, c.CoreClient.Client, c.ExtensionsClient.Client)
 	return c, nil
 }
 


### PR DESCRIPTION
We are not setting timeouts in production - we shouldn't do it in tests then...

Addresses point 2. of #31345

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31346)

<!-- Reviewable:end -->
