### PR TITLE
Document selinux considerations in wordpress-mysql example

### DIFF
--- a/examples/mysql-wordpress-pd/local-volumes.yaml
+++ b/examples/mysql-wordpress-pd/local-volumes.yaml
@@ -10,7 +10,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: /tmp/pv-1
+    path: /tmp/data/pv-1
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -24,4 +24,4 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: /tmp/pv-2
+    path: /tmp/data/pv-2


### PR DESCRIPTION
Fixes #31269.
Even though host path is unsuitable for production environments, it is an option in the wordpress-mysql example. When I followed this example on a RHEL 7.2 system I had issues with selinux.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31357)

<!-- Reviewable:end -->
