### PR TITLE
Revalidate device path before calling DeviceOpened()

### DIFF
--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -230,6 +230,6 @@ func (detacher *awsElasticBlockStoreDetacher) WaitForDetach(devicePath string, t
 	}
 }
 
-func (detacher *awsElasticBlockStoreDetacher) UnmountDevice(deviceMountPath string) error {
+func (detacher *awsElasticBlockStoreDetacher) UnmountDevice(deviceMountPath string) (string, error) {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -19,7 +19,6 @@ package azure_dd
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -250,12 +249,6 @@ func (detacher *azureDiskDetacher) WaitForDetach(devicePath string, timeout time
 }
 
 // UnmountDevice unmounts the volume on the node
-func (detacher *azureDiskDetacher) UnmountDevice(deviceMountPath string) error {
-	volume := path.Base(deviceMountPath)
-	if err := util.UnmountPath(deviceMountPath, detacher.mounter); err != nil {
-		glog.Errorf("Error unmounting %q: %v", volume, err)
-		return err
-	} else {
-		return nil
-	}
+func (detacher *azureDiskDetacher) UnmountDevice(deviceMountPath string) (string, error) {
+	return util.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -262,6 +262,6 @@ func (detacher *cinderDiskDetacher) WaitForDetach(devicePath string, timeout tim
 	}
 }
 
-func (detacher *cinderDiskDetacher) UnmountDevice(deviceMountPath string) error {
+func (detacher *cinderDiskDetacher) UnmountDevice(deviceMountPath string) (string, error) {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -256,6 +256,6 @@ func (detacher *gcePersistentDiskDetacher) WaitForDetach(devicePath string, time
 	}
 }
 
-func (detacher *gcePersistentDiskDetacher) UnmountDevice(deviceMountPath string) error {
+func (detacher *gcePersistentDiskDetacher) UnmountDevice(deviceMountPath string) (string, error) {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.host.GetMounter())
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -436,11 +436,11 @@ func (fv *FakeVolume) WaitForDetach(devicePath string, timeout time.Duration) er
 	return nil
 }
 
-func (fv *FakeVolume) UnmountDevice(globalMountPath string) error {
+func (fv *FakeVolume) UnmountDevice(globalMountPath string) (string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.UnmountDeviceCallCount++
-	return nil
+	return "", nil
 }
 
 type fakeRecycler struct {

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -934,7 +934,7 @@ func (oe *operationExecutor) generateUnmountDeviceFunc(
 				err)
 		}
 		// Execute unmount
-		unmountDeviceErr := volumeDetacher.UnmountDevice(deviceMountPath)
+		devicePath, unmountDeviceErr := volumeDetacher.UnmountDevice(deviceMountPath)
 		if unmountDeviceErr != nil {
 			// On failure, return error. Caller will log and retry.
 			return fmt.Errorf(
@@ -943,15 +943,20 @@ func (oe *operationExecutor) generateUnmountDeviceFunc(
 				deviceToDetach.VolumeSpec.Name(),
 				unmountDeviceErr)
 		}
+		// if a valid device path is returned, use it; otherwise use that in deviceToDetach
+		if len(devicePath) == 0 {
+			devicePath = deviceToDetach.DevicePath
+		}
 		// Before logging that UnmountDevice succeeded and moving on,
 		// use mounter.DeviceOpened to check if the device is in use anywhere
 		// else on the system. Retry if it returns true.
-		deviceOpened, deviceOpenedErr := mounter.DeviceOpened(deviceToDetach.DevicePath)
+		deviceOpened, deviceOpenedErr := mounter.DeviceOpened(devicePath)
 		if deviceOpenedErr != nil {
 			return fmt.Errorf(
-				"UnmountDevice.DeviceOpened failed for volume %q (spec.Name: %q) with: %v",
+				"UnmountDevice.DeviceOpened failed for volume %q (spec.Name: %q) device %q with: %v",
 				deviceToDetach.VolumeName,
 				deviceToDetach.VolumeSpec.Name(),
+				devicePath,
 				deviceOpenedErr)
 		}
 		// The device is still in use elsewhere. Caller will log and retry.
@@ -963,9 +968,10 @@ func (oe *operationExecutor) generateUnmountDeviceFunc(
 		}
 
 		glog.Infof(
-			"UnmountDevice succeeded for volume %q (spec.Name: %q).",
+			"UnmountDevice succeeded for volume %q (spec.Name: %q) device path %q.",
 			deviceToDetach.VolumeName,
-			deviceToDetach.VolumeSpec.Name())
+			deviceToDetach.VolumeSpec.Name(),
+			devicePath)
 
 		// Update actual state of world
 		markDeviceUnmountedErr := actualStateOfWorld.MarkDeviceAsUnmounted(

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -63,38 +63,39 @@ func SetReady(dir string) {
 	file.Close()
 }
 
-// UnmountPath is a common unmount routine that unmounts the given path and
-// deletes the remaining directory if successful.
-func UnmountPath(mountPath string, mounter mount.Interface) error {
+// UnmountPath is a common unmount routine that retrieves the device path, unmounts the given path and
+// deletes the remaining directory if successful. The device path is returned to the caller for other processing.
+func UnmountPath(mountPath string, mounter mount.Interface) (string, error) {
 	if pathExists, pathErr := PathExists(mountPath); pathErr != nil {
-		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+		return "", fmt.Errorf("Error checking if path exists: %v", pathErr)
 	} else if !pathExists {
 		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", mountPath)
-		return nil
+		return "", nil
 	}
 
 	notMnt, err := mounter.IsLikelyNotMountPoint(mountPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if notMnt {
 		glog.Warningf("Warning: %q is not a mountpoint, deleting", mountPath)
-		return os.Remove(mountPath)
+		return "", os.Remove(mountPath)
 	}
 
+	devicePath, _, _ := mount.GetDeviceNameFromMount(mounter, mountPath)
 	// Unmount the mount path
 	if err := mounter.Unmount(mountPath); err != nil {
-		return err
+		return devicePath, err
 	}
 	notMnt, mntErr := mounter.IsLikelyNotMountPoint(mountPath)
 	if mntErr != nil {
-		return err
+		return devicePath, err
 	}
 	if notMnt {
 		glog.V(4).Info("%q is unmounted, deleting the directory", mountPath)
-		return os.Remove(mountPath)
+		return devicePath, os.Remove(mountPath)
 	}
-	return nil
+	return devicePath, nil
 }
 
 // PathExists returns true if the specified path exists.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -165,10 +165,10 @@ type Detacher interface {
 	// period an error is returned.
 	WaitForDetach(devicePath string, timeout time.Duration) error
 
-	// UnmountDevice unmounts the global mount of the disk. This
+	// UnmountDevice retrieves the device path that is mounted on, unmounts the global mount of the disk. This
 	// should only be called once all bind mounts have been
-	// unmounted.
-	UnmountDevice(deviceMountPath string) error
+	// unmounted. The device path, if existed, is returned for further processing.
+	UnmountDevice(deviceMountPath string) (string, error)
 }
 
 func RenameDirectory(oldPath, newName string) (string, error) {

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -238,6 +238,6 @@ func (detacher *vsphereVMDKDetacher) WaitForDetach(devicePath string, timeout ti
 	}
 }
 
-func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error {
+func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) (string, error) {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }


### PR DESCRIPTION
Refactor `UnmountDevice()` so it can return the device path. Use this device path for DeviceOpened().

This is a followup to #29836 and addresses the remaining issues in #31186 

@saad-ali @brendandburns @colemickens @jingxu97 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31366)

<!-- Reviewable:end -->
