### PR TITLE
kubectl: cast notFound error to struct

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -454,7 +454,7 @@ func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Durati
 	errList := []error{}
 	for _, rc := range rsList.Items {
 		if err := rsReaper.Stop(rc.Namespace, rc.Name, timeout, gracePeriod); err != nil {
-			scaleGetErr, ok := err.(*ScaleError)
+			scaleGetErr, ok := err.(ScaleError)
 			if errors.IsNotFound(err) || (ok && errors.IsNotFound(scaleGetErr.ActualError)) {
 				continue
 			}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/28378 (the 404 flake)

@kubernetes/kubectl @kubernetes/deployment

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31375)

<!-- Reviewable:end -->
