### PR TITLE
rkt: Force `rkt fetch` to fetch from remote to conform the image pull policy.

### DIFF
--- a/pkg/kubelet/rkt/image.go
+++ b/pkg/kubelet/rkt/image.go
@@ -76,7 +76,10 @@ func (r *Runtime) PullImage(image kubecontainer.ImageSpec, pullSecrets []api.Sec
 		return err
 	}
 
-	if _, err := r.cli.RunCommand(&config, "fetch", dockerPrefix+img); err != nil {
+	// Today, `--no-store` will fetch the remote image regardless of whether the content of the image
+	// has changed or not. This causes performance downgrades when the image tag is ':latest' and
+	// the image pull policy is 'always'. The issue is tracked in https://github.com/coreos/rkt/issues/2937.
+	if _, err := r.cli.RunCommand(&config, "fetch", "--no-store", dockerPrefix+img); err != nil {
 		glog.Errorf("Failed to fetch: %v", err)
 		return err
 	}


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/27646

Use `--no-store` option for `rkt fetch` to force it to fetch from remote.
However, `--no-store` will fetch the remote image regardless of whether the content of the image has changed or not. 
This causes performance downgrade when the image tag is ':latest' and the image pull policy is 'always'. 
The issue is tracked in https://github.com/coreos/rkt/issues/2937.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31378)

<!-- Reviewable:end -->
