### PR TITLE
Use timeout on ReadDir calls in Kubelet volume subsystem

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/types"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/io"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -251,7 +251,7 @@ func (kl *Kubelet) getPodVolumeNameListFromDisk(podUID types.UID) ([]string, err
 	for _, volumePluginDir := range volumePluginDirs {
 		volumePluginName := volumePluginDir.Name()
 		volumePluginPath := path.Join(podVolDir, volumePluginName)
-		volumeDirs, volumeDirsStatErrs, err := util.ReadDirNoExit(volumePluginPath)
+		volumeDirs, volumeDirsStatErrs, err := io.ReadDirNoExit(volumePluginPath)
 		if err != nil {
 			return volumes, fmt.Errorf("Could not read directory %s: %v", volumePluginPath, err)
 		}

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff"
+	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -522,7 +523,8 @@ func getVolumesFromPodDir(podDir string) ([]podVolume, error) {
 		podName := podsDirInfo[i].Name()
 		podDir := path.Join(podDir, podName)
 		volumesDir := path.Join(podDir, options.DefaultKubeletVolumesDirName)
-		volumesDirInfo, err := ioutil.ReadDir(volumesDir)
+		glog.V(5).Infof("Reading pod volumes directory %v to determine volumes", volumesDir)
+		volumesDirInfo, err := io.ReadDir(volumesDir)
 		if err != nil {
 			glog.Errorf("Could not read volume directory %q: %v", volumesDir, err)
 			continue
@@ -531,7 +533,7 @@ func getVolumesFromPodDir(podDir string) ([]podVolume, error) {
 			pluginName := volumeDir.Name()
 			volumePluginPath := path.Join(volumesDir, pluginName)
 
-			volumePluginDirs, err := ioutil.ReadDir(volumePluginPath)
+			volumePluginDirs, err := io.ReadDir(volumePluginPath)
 			if err != nil {
 				glog.Errorf("Could not read volume plugin directory %q: %v", volumePluginPath, err)
 				continue

--- a/pkg/util/io/io.go
+++ b/pkg/util/io/io.go
@@ -20,11 +20,113 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/runtime"
 )
+
+// ioTimeout is the timeout to use for io operations
+const ioTimeout time.Duration = 5
+
+// Lstat wraps os.Lstat in a timeout.
+func Lstat(path string) (os.FileInfo, error) {
+	return internalLstatTimeout(path, ioTimeout)
+}
+
+func internalLstatTimeout(path string, timeout time.Duration) (os.FileInfo, error) {
+	var (
+		timer      = time.NewTimer(ioTimeout)
+		resChannel = make(chan os.FileInfo)
+		errChannel = make(chan error)
+	)
+
+	defer timer.Stop()
+
+	go func() {
+		fileInfo, err := os.Lstat(path)
+		if err != nil {
+			errChannel <- err
+		} else {
+			resChannel <- fileInfo
+		}
+	}()
+
+	select {
+	case <-timer.C:
+		return nil, fmt.Errorf("Lstat on %v timed out after %v", path, timeout)
+	case err := <-errChannel:
+		return nil, err
+	case res := <-resChannel:
+		return res, nil
+	}
+}
+
+// ReadDir is similar to ioutil.ReadDir, but returns an error after a timeout.
+func ReadDir(path string) ([]os.FileInfo, error) {
+	return internalReadDirTimeout(path, ioTimeout)
+}
+
+func internalReadDirTimeout(path string, timeout time.Duration) ([]os.FileInfo, error) {
+	timer := time.NewTimer(timeout)
+	resChannel := make(chan []os.FileInfo)
+	errChannel := make(chan error)
+
+	defer timer.Stop()
+
+	go func() {
+		entries, err := ioutil.ReadDir(path)
+		if err != nil {
+			errChannel <- err
+		} else {
+			resChannel <- entries
+		}
+	}()
+
+	select {
+	case <-timer.C:
+		return nil, fmt.Errorf("ReadDir on %v timed out after %v", path, timeout)
+	case err := <-errChannel:
+		return nil, err
+	case res := <-resChannel:
+		return res, nil
+	}
+}
+
+// ReadDirNoExit reads the directory named by dirname and returns:
+// 1.  A sparse list of directory entries that were able to be Lstat'd
+// 2.  A sparse list of errors encountered when Lstat-ing entries
+// 3.  An overall error if the directory couldn't be opened
+//
+// ReadDirNoExit uses an Lstat call that implements a timeout; if Lstat
+// on a directory entry times out, an error will be present in the error
+// list.
+func ReadDirNoExit(dirname string) ([]os.FileInfo, []error, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(-1)
+	list := make([]os.FileInfo, 0, len(names))
+	errs := make([]error, 0, len(names))
+	for _, filename := range names {
+		fip, statErr := Lstat(filepath.Join(dirname, filename))
+		if os.IsNotExist(statErr) {
+			// File disappeared between readdir + stat.
+			// Just treat it as if it didn't exist.
+			continue
+		}
+
+		list = append(list, fip)
+		errs = append(errs, statErr)
+	}
+
+	return list, errs, nil
+}
 
 // LoadPodFromFile will read, decode, and return a Pod from a file.
 func LoadPodFromFile(filePath string) (*api.Pod, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,47 +75,6 @@ func AllPtrFieldsNil(obj interface{}) bool {
 	return true
 }
 
-func FileExists(filename string) (bool, error) {
-	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// borrowed from ioutil.ReadDir
-// ReadDir reads the directory named by dirname and returns
-// a list of directory entries, minus those with lstat errors
-func ReadDirNoExit(dirname string) ([]os.FileInfo, []error, error) {
-	if dirname == "" {
-		dirname = "."
-	}
-
-	f, err := os.Open(dirname)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer f.Close()
-
-	names, err := f.Readdirnames(-1)
-	list := make([]os.FileInfo, 0, len(names))
-	errs := make([]error, 0, len(names))
-	for _, filename := range names {
-		fip, lerr := os.Lstat(dirname + "/" + filename)
-		if os.IsNotExist(lerr) {
-			// File disappeared between readdir + stat.
-			// Just treat it as if it didn't exist.
-			continue
-		}
-
-		list = append(list, fip)
-		errs = append(errs, lerr)
-	}
-
-	return list, errs, nil
-}
-
 // IntPtr returns a pointer to an int
 func IntPtr(i int) *int {
 	o := i
@@ -144,4 +103,13 @@ func Int32PtrDerefOr(ptr *int32, def int32) int32 {
 		return *ptr
 	}
 	return def
+}
+
+func FileExists(filename string) (bool, error) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
Fixes #31272 by adding timeouts to various `Lstat` and `ReadDir` calls in the kubelet volume subsystem.

cc @kubernetes/sig-storage @kubernetes/rh-cluster-infra

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31379)

<!-- Reviewable:end -->
