### PR TITLE
fix makefile by having an absolute path to the dir

### DIFF
--- a/hack/make-rules/build.sh
+++ b/hack/make-rules/build.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBE_ROOT=$(realpath $(dirname "${BASH_SOURCE}")/../..)
 KUBE_VERBOSE="${KUBE_VERBOSE:-1}"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: The path was not exanding in hack/make-rules/build.sh on my machine.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

Otherwise I got all this nonsense:

```
$ make
hack/make-rules/../../hack/lib/init.sh: line 35: /usr/local/google/home/jessfraz/.go/src/k8s.io/kubernetes
/usr/local/google/home/jessfraz/.go/src/k8s.io/kubernetes/hack/lib/util.sh: No such file or directory
make[1]: *** [Makefile.generated_files:285: _output/bin/deepcopy-gen] Error 1
make: *** [Makefile:281: generated_files] Error 2
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31381)

<!-- Reviewable:end -->
