### PR TITLE
fixes invalid null selector issue in sysdig example yaml

### DIFF
--- a/examples/sysdig-cloud/sysdig-daemonset.yaml
+++ b/examples/sysdig-cloud/sysdig-daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     app: sysdig-agent
 spec:
   template:
+    metadata:
+      labels:
+        name: sysdig-agent
     spec:
       volumes:
       - name: docker-sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Using the file DaemonSet yaml found in the example repo you get the following error upon import:

```
$ kubectl create -f sysdig.yml
The DaemonSet "sysdig-agent" is invalid.
spec.template.metadata.labels: Invalid value: null: `selector` does not match template `labels`
```

This PR fixes this issue.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```
- Corrected name label metadata for Sysdig example.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31393)

<!-- Reviewable:end -->
