### PR TITLE
Update build docs to include path for scripts.

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -21,18 +21,18 @@ There is also early support for building Docker "run" containers
 
 ## Key scripts
 
-The following scripts are found in the `build/` directory:
+The following scripts are found in the `build/` directory. Note that all scripts must be run from the Kubernetes root directory.
 
-* `run.sh`: Run a command in a build docker container.  Common invocations:
-  *  `run.sh make`: Build just linux binaries in the container.  Pass options and packages as necessary.
-  *  `run.sh make cross`: Build all binaries for all platforms
-  *  `run.sh make test`: Run all unit tests
-  *  `run.sh make test-integration`: Run integration test
-  *  `run.sh make test-cmd`: Run CLI tests
-* `copy-output.sh`: This will copy the contents of `_output/dockerized/bin` from any remote Docker container to the local `_output/dockerized/bin`.  Right now this is only necessary on Mac OS X with `boot2docker` when your git repo isn't under `/Users`.
-* `make-clean.sh`: Clean out the contents of `_output/dockerized` and remove any local built container images.
-* `shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
-* `release.sh`: Build everything, test it, and (optionally) upload the results to a GCS bucket.
+* `build/run.sh`: Run a command in a build docker container.  Common invocations:
+  *  `build/run.sh make`: Build just linux binaries in the container.  Pass options and packages as necessary.
+  *  `build/run.sh make cross`: Build all binaries for all platforms
+  *  `build/run.sh make test`: Run all unit tests
+  *  `build/run.sh make test-integration`: Run integration test
+  *  `build/run.sh make test-cmd`: Run CLI tests
+* `build/copy-output.sh`: This will copy the contents of `_output/dockerized/bin` from any remote Docker container to the local `_output/dockerized/bin`.  Right now this is only necessary on Mac OS X with `boot2docker` when your git repo isn't under `/Users`.
+* `build/make-clean.sh`: Clean out the contents of `_output/dockerized` and remove any local built container images.
+* `build/shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
+* `build/release.sh`: Build everything, test it, and (optionally) upload the results to a GCS bucket.
 
 ## Releasing
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This fix updates the build docs (`build/README.md`) to include the path of `build/` for shell scripts (like `run.sh`, `shell.sh`).

The reason is that while trying to follow the `build/README.md` to build the kubernetes, it is not obvious that all the scripts, e.g., `run.sh make`, `shell.sh`, etc. needs to be executed from the root directory (vs. executed from the `build/` directory).

In other words, the executation should be:

```
build/run.sh make
build/make-clean.sh
...
```

This fix adds `build/` so that it is easy for user to follow the steps.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31398)

<!-- Reviewable:end -->
