### PR TITLE
Print out resource name when evicting pods

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -37,8 +37,8 @@ const (
 	unsupportedEvictionSignal = "unsupported eviction signal %v"
 	// the reason reported back in status.
 	reason = "Evicted"
-	// the message associated with the reason.
-	message = "The node was low on compute resources."
+	// the message format associated with the reason.
+	messageFmt = "The node was low on %s."
 	// disk, in bytes.  internal to this module, used to account for local disk usage.
 	resourceDisk api.ResourceName = "disk"
 	// inodes, number. internal to this module, used to account for local disk inode consumption.
@@ -887,4 +887,8 @@ func deleteImages(imageGC ImageGC, reportBytesFreed bool) nodeReclaimFunc {
 		}
 		return resource.NewQuantity(reclaimed, resource.BinarySI), nil
 	}
+}
+
+func getMessage(resource api.ResourceName) string {
+	return fmt.Sprintf(messageFmt, resource)
 }


### PR DESCRIPTION
This fixes #31397

/cc @derekwaynecarr

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31401)

<!-- Reviewable:end -->
