### PR TITLE
[kube-proxy] Modify log level from Info to Warning when proxyMode unknown

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -355,7 +355,7 @@ func getProxyMode(proxyMode string, client nodeGetter, hostname string, iptver i
 	} else if proxyMode == proxyModeIptables {
 		return tryIptablesProxy(iptver, kcompat)
 	} else if proxyMode != "" {
-		glog.V(1).Infof("Flag proxy-mode=%q unknown, assuming iptables proxy", proxyMode)
+		glog.Warningf("Flag proxy-mode=%q unknown, assuming iptables proxy", proxyMode)
 		return tryIptablesProxy(iptver, kcompat)
 	}
 	// proxyMode == "" - choose the best option.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Currently, we use `glog.Infof` to print the log when proxy-mode is unknown, I think we may need to modify to `glog.Warningf`.

**Which issue this PR fixes**: 

fixes #31405

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31404)

<!-- Reviewable:end -->
