### PR TITLE
Fix sort hint in `hack/verify-golint.sh`

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -44,7 +44,7 @@ if ! diff -u "${linted_file}" <(LANG=C sort "${linted_file}"); then
 		echo
 		echo "hack/.linted_packages is not in alphabetical order. Please sort it:"
 		echo
-		echo "  sort -o hack/.linted_packages hack/.linted_packages"
+		echo "  LANG=C sort -o hack/.linted_packages hack/.linted_packages"
 		echo
 	} >&2
 	false


### PR DESCRIPTION
The `verify-golint.sh` sorts all items with `LANG=C sort`, but it only hints developers to use `sort`, which causes a little trouble for me.

/cc @jfrazelle  @sttts

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31409)

<!-- Reviewable:end -->
