### PR TITLE
[kube-proxy] Modify func updateServiceListener's parameter 4th name from addOrDelete to add & fix typo

### DIFF
--- a/pkg/proxy/healthcheck/api.go
+++ b/pkg/proxy/healthcheck/api.go
@@ -33,12 +33,12 @@ func UpdateEndpoints(serviceName types.NamespacedName, endpointUids sets.String)
 	healthchecker.mutationRequestChannel <- req
 }
 
-func updateServiceListener(serviceName types.NamespacedName, listenPort int, addOrDelete bool) bool {
+func updateServiceListener(serviceName types.NamespacedName, listenPort int, add bool) bool {
 	responseChannel := make(chan bool)
 	req := &proxyListenerRequest{
 		serviceName:     serviceName,
 		listenPort:      uint16(listenPort),
-		add:             addOrDelete,
+		add:             add,
 		responseChannel: responseChannel,
 	}
 	healthchecker.listenerRequestChannel <- req
@@ -50,7 +50,7 @@ func AddServiceListener(serviceName types.NamespacedName, listenPort int) bool {
 	return updateServiceListener(serviceName, listenPort, true)
 }
 
-// DeleteServiceListener Request addition of a listener for a service's health check
+// DeleteServiceListener Request deletion of a listener for a service's health check
 func DeleteServiceListener(serviceName types.NamespacedName, listenPort int) bool {
 	return updateServiceListener(serviceName, listenPort, false)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Currently, the 4th parameter name of `updateServiceListener` in kube-proxy is `addOrDelete`, 
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/healthcheck/api.go#L36

However, from the func caller, we just pass `true` for `AddServiceListener`, 
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/healthcheck/api.go#L50

and `false` for `DeleteServiceListener`,
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/healthcheck/api.go#L55

So, I think the name `addOrDelete` is unreasonable. I prefer to change the parameter name `addOrDelete` to `add` so that avoid making people confused.

In addition, there is a typo, 
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/healthcheck/api.go#L53
We should change "addition" to "deletion"!

**Which issue this PR fixes** 

addresses: #31411

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31410)

<!-- Reviewable:end -->
