### PR TITLE
Underscore is not a valid secret data key, so use hyphen instead.

### DIFF
--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - --secure-port=443
         - --advertise-address={{.FEDERATION_API_HOST}}
         - --client-ca-file=/srv/kubernetes/ca.crt
-        - --basic-auth-file=/srv/kubernetes/basic_auth.csv
+        - --basic-auth-file=/srv/kubernetes/basic-auth.csv
         - --tls-cert-file=/srv/kubernetes/server.cert
         - --tls-private-key-file=/srv/kubernetes/server.key
         - --admission-control={{.FEDERATION_ADMISSION_CONTROL}}

--- a/federation/manifests/federation-apiserver-secrets.yaml
+++ b/federation/manifests/federation-apiserver-secrets.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
   known-tokens.csv: {{.FEDERATION_API_KNOWN_TOKENS_BASE64}}
-  basic_auth.csv: {{.FEDERATION_API_BASIC_AUTH_BASE64}}
+  basic-auth.csv: {{.FEDERATION_API_BASIC_AUTH_BASE64}}
   ca.crt: {{.FEDERATION_APISERVER_CA_CERT_BASE64}}
   server.cert: {{.FEDERATION_APISERVER_CERT_BASE64}}
   server.key: {{.FEDERATION_APISERVER_KEY_BASE64}}


### PR DESCRIPTION
cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31413)

<!-- Reviewable:end -->
