### PR TITLE
delete a unused function in the 'pkg/kubectl/cmd/util/helpers.go'

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -46,7 +46,6 @@ import (
 	"github.com/evanphx/json-patch"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -286,14 +285,6 @@ func isWatch(cmd *cobra.Command) bool {
 	}
 
 	return false
-}
-
-func getFlag(cmd *cobra.Command, flag string) *pflag.Flag {
-	f := cmd.Flags().Lookup(flag)
-	if f == nil {
-		glog.Fatalf("flag accessed but not defined for command %s: %s", cmd.Name(), flag)
-	}
-	return f
 }
 
 func GetFlagString(cmd *cobra.Command, flag string) string {


### PR DESCRIPTION
Delete the function `getFlag` in the `pkg/kubectl/cmd/util/helpers.go`, because it is not used anywhere in the project.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31423)

<!-- Reviewable:end -->
