### PR TITLE
Register plugins via the app.RegisterPlugins() interface instead of via static initialization

### DIFF
--- a/cmd/hyperkube/federation-apiserver.go
+++ b/cmd/hyperkube/federation-apiserver.go
@@ -30,6 +30,8 @@ func NewFederationAPIServer() *Server {
 		SimpleUsage: "federation-apiserver",
 		Long:        "The API entrypoint for the federation control plane",
 		Run: func(_ *Server, args []string) error {
+			// Register all plugins the app is using
+			app.RegisterPlugins()
 			return app.Run(s)
 		},
 	}

--- a/cmd/hyperkube/kube-apiserver.go
+++ b/cmd/hyperkube/kube-apiserver.go
@@ -32,6 +32,8 @@ func NewKubeAPIServer() *Server {
 		SimpleUsage: "apiserver",
 		Long:        "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
 		Run: func(_ *Server, args []string) error {
+			// Register all plugins the app is using
+			app.RegisterPlugins()
 			return app.Run(s)
 		},
 	}

--- a/cmd/hyperkube/kube-controller-manager.go
+++ b/cmd/hyperkube/kube-controller-manager.go
@@ -32,6 +32,8 @@ func NewKubeControllerManager() *Server {
 		SimpleUsage: "controller-manager",
 		Long:        "A server that runs a set of active components. This includes replication controllers, service endpoints and nodes.",
 		Run: func(_ *Server, args []string) error {
+			// Register all plugins the app is using
+			app.RegisterPlugins()
 			return app.Run(s)
 		},
 	}

--- a/cmd/hyperkube/kubelet.go
+++ b/cmd/hyperkube/kubelet.go
@@ -34,6 +34,8 @@ func NewKubelet() *Server {
 		configuration data, with the running set of containers by starting or stopping
 		Docker containers.`,
 		Run: func(_ *Server, _ []string) error {
+			// Register all plugins the app is using
+			app.RegisterPlugins()
 			return app.Run(s, nil)
 		},
 	}

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -47,6 +47,8 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
+	// Register all admission and cloudprovider plugins
+	app.RegisterPlugins()
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -21,24 +21,47 @@ package app
 // given binary target.
 import (
 	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Admission policies
-	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/imagepolicy"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/initialresources"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/limitranger"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/storageclass/default"
+	"k8s.io/kubernetes/plugin/pkg/admission/admit"
+	"k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
+	"k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
+	"k8s.io/kubernetes/plugin/pkg/admission/deny"
+	"k8s.io/kubernetes/plugin/pkg/admission/exec"
+	"k8s.io/kubernetes/plugin/pkg/admission/imagepolicy"
+	"k8s.io/kubernetes/plugin/pkg/admission/initialresources"
+	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	"k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label"
+	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
+	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy"
+	"k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
+	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	defaultstorage "k8s.io/kubernetes/plugin/pkg/admission/storageclass/default"
 )
+
+// RegisterPlugins registers all admission controllers and cloud providers
+func RegisterPlugins() {
+	providers.RegisterCloudProviders()
+
+	admit.RegisterPlugin()
+	alwayspullimages.RegisterPlugin()
+	antiaffinity.RegisterPlugin()
+	deny.RegisterPlugin()
+	exec.RegisterPlugin()
+	imagepolicy.RegisterPlugin()
+	initialresources.RegisterPlugin()
+	limitranger.RegisterPlugin()
+	autoprovision.RegisterPlugin()
+	exists.RegisterPlugin()
+	lifecycle.RegisterPlugin()
+	label.RegisterPlugin()
+	resourcequota.RegisterPlugin()
+	podsecuritypolicy.RegisterPlugin()
+	scdeny.RegisterPlugin()
+	serviceaccount.RegisterPlugin()
+	defaultstorage.RegisterPlugin()
+}

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -25,7 +25,7 @@ import (
 
 	// Cloud providers
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Volume plugins
 	"github.com/golang/glog"
@@ -50,6 +50,10 @@ import (
 	"k8s.io/kubernetes/pkg/volume/rbd"
 	"k8s.io/kubernetes/pkg/volume/vsphere_volume"
 )
+
+func RegisterPlugins() {
+	providers.RegisterCloudProviders()
+}
 
 // ProbeAttachableVolumePlugins collects all volume plugins for the attach/
 // detach controller. VolumeConfiguration is used ot get FlexVolumePluginDir

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -50,6 +50,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
+	app.RegisterPlugins()
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -19,8 +19,8 @@ package app
 // This file exists to force the desired plugin implementations to be linked.
 import (
 	// Credential providers
-	_ "k8s.io/kubernetes/pkg/credentialprovider/aws"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+	_ "k8s.io/kubernetes/pkg/credentialprovider/aws" // Note: aws isn't registered in the "normal" way; it has it's own Init() method
+	cred_gcp "k8s.io/kubernetes/pkg/credentialprovider/gcp"
 	// Network plugins
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/cni"
@@ -50,8 +50,13 @@ import (
 	"k8s.io/kubernetes/pkg/volume/secret"
 	"k8s.io/kubernetes/pkg/volume/vsphere_volume"
 	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers"
 )
+
+func RegisterPlugins() {
+	providers.RegisterCloudProviders()
+	cred_gcp.RegisterPlugin()
+}
 
 // ProbeVolumePlugins collects all volume plugins into an easy to use list.
 // PluginDir specifies the directory to search for additional third party

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -45,6 +45,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
+	app.RegisterPlugins()
 	if err := app.Run(s, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/federation/cmd/federation-apiserver/apiserver.go
+++ b/federation/cmd/federation-apiserver/apiserver.go
@@ -45,6 +45,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
+	app.RegisterPlugins()
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/federation/cmd/federation-apiserver/app/plugins.go
+++ b/federation/cmd/federation-apiserver/app/plugins.go
@@ -21,10 +21,19 @@ package app
 // given binary target.
 import (
 	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Admission policies
-	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
-	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	"k8s.io/kubernetes/plugin/pkg/admission/admit"
+	"k8s.io/kubernetes/plugin/pkg/admission/deny"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 )
+
+// RegisterPlugins registers all admission controllers and cloud providers
+func RegisterPlugins() {
+	providers.RegisterCloudProviders()
+
+	admit.RegisterPlugin()
+	deny.RegisterPlugin()
+	lifecycle.RegisterPlugin()
+}

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -666,7 +666,8 @@ func (s *awsSdkEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttribute
 	return s.ec2.ModifyInstanceAttribute(request)
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		creds := credentials.NewChainCredentials(
 			[]credentials.Provider{

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -62,7 +62,8 @@ type Cloud struct {
 	VirtualMachinesClient   compute.VirtualMachinesClient
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(CloudProviderName, NewCloud)
 }
 

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -48,7 +48,8 @@ type CSCloud struct {
 	zone      string
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readConfig(config)
 		if err != nil {

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -147,7 +147,8 @@ type Disks interface {
 	GetAutoLabelsForPD(name string, zone string) (map[string]string, error)
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return newGCECloud(config) })
 }
 

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -48,7 +48,8 @@ var (
 	noHostNameSpecified = errors.New("No hostname specified")
 )
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(
 		ProviderName,
 		func(configReader io.Reader) (cloudprovider.Interface, error) {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -114,7 +114,8 @@ type Config struct {
 	LoadBalancer LoadBalancerOpts
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readConfig(config)
 		if err != nil {

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -79,7 +79,8 @@ type XmlVmsList struct {
 	Vm      []XmlVmInfo `xml:"vm"`
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName,
 		func(config io.Reader) (cloudprovider.Interface, error) {
 			return newOVirtCloud(config)

--- a/pkg/cloudprovider/providers/ovirt/ovirt_test.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt_test.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
+func init() {
+	RegisterCloudProvider()
+}
+
 func TestOVirtCloudConfiguration(t *testing.T) {
 	config1 := (io.Reader)(nil)
 

--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -14,17 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package providers
 
 import (
 	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 )
+
+// RegisterCloudProviders registers all cloud providers
+func RegisterCloudProviders() {
+	aws.RegisterCloudProvider()
+	azure.RegisterCloudProvider()
+	cloudstack.RegisterCloudProvider()
+	gce.RegisterCloudProvider()
+	mesos.RegisterCloudProvider()
+	openstack.RegisterCloudProvider()
+	ovirt.RegisterCloudProvider()
+	rackspace.RegisterCloudProvider()
+	vsphere.RegisterCloudProvider()
+}

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -162,7 +162,8 @@ func readInstanceID() (string, error) {
 	return parseMetaData(file)
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readConfig(config)
 		if err != nil {

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -177,7 +177,8 @@ func readConfig(config io.Reader) (VSphereConfig, error) {
 	return cfg, err
 }
 
-func init() {
+// RegisterCloudProvider registers the current cloud provider
+func RegisterCloudProvider() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readConfig(config)
 		if err != nil {

--- a/pkg/credentialprovider/gcp/jwt.go
+++ b/pkg/credentialprovider/gcp/jwt.go
@@ -48,7 +48,7 @@ type jwtProvider struct {
 
 // init registers the various means by which credentials may
 // be resolved on GCP.
-func init() {
+func RegisterPlugin() {
 	credentialprovider.RegisterCredentialProvider("google-jwt-key",
 		&credentialprovider.CachingDockerConfigProvider{
 			Provider: &jwtProvider{

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -39,6 +39,10 @@ import (
 	"github.com/golang/glog"
 )
 
+func init() {
+	kubeletapp.RegisterPlugins()
+}
+
 type HollowKubelet struct {
 	KubeletConfiguration *componentconfig.KubeletConfiguration
 	KubeletDeps          *kubelet.KubeletDeps

--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("AlwaysAdmit", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewAlwaysAdmit(), nil
 	})

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -34,7 +34,8 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewAlwaysPullImages(), nil
 	})

--- a/plugin/pkg/admission/antiaffinity/admission.go
+++ b/plugin/pkg/admission/antiaffinity/admission.go
@@ -28,7 +28,8 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("LimitPodHardAntiAffinityTopology", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewInterPodAntiAffinity(client), nil
 	})

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("AlwaysDeny", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewAlwaysDeny(), nil
 	})

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -28,7 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("DenyEscalatingExec", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewDenyEscalatingExec(client), nil
 	})

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -42,11 +42,8 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 )
 
-var (
-	groupVersions = []unversioned.GroupVersion{v1alpha1.SchemeGroupVersion}
-)
-
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("ImagePolicyWebhook", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		newImagePolicyWebhook, err := NewImagePolicyWebhook(client, config)
 		if err != nil {
@@ -223,6 +220,8 @@ func NewImagePolicyWebhook(client clientset.Interface, configFile io.Reader) (ad
 	if err := normalizeWebhookConfig(&whConfig); err != nil {
 		return nil, err
 	}
+
+	groupVersions := []unversioned.GroupVersion{v1alpha1.SchemeGroupVersion}
 
 	gw, err := webhook.NewGenericWebhook(whConfig.KubeConfigFile, groupVersions, whConfig.RetryBackoff)
 	if err != nil {

--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -47,7 +47,8 @@ const (
 )
 
 // WARNING: this feature is experimental and will definitely change.
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("InitialResources", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		s, err := newDataSource(*source)
 		if err != nil {

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -41,7 +41,8 @@ const (
 	limitRangerAnnotation = "kubernetes.io/limit-ranger"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("LimitRanger", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewLimitRanger(client, &DefaultLimitRangerActions{})
 	})

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -30,7 +30,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller/informers"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("NamespaceAutoProvision", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewProvision(client), nil
 	})

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -30,7 +30,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller/informers"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("NamespaceExists", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewExists(client), nil
 	})

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -48,7 +48,8 @@ const (
 	missingNamespaceWait = 50 * time.Millisecond
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewLifecycle(client, sets.NewString(api.NamespaceDefault, api.NamespaceSystem))
 	})

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -32,7 +32,8 @@ import (
 	vol "k8s.io/kubernetes/pkg/volume"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("PersistentVolumeLabel", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		persistentVolumeLabelAdmission := NewPersistentVolumeLabel()
 		return persistentVolumeLabelAdmission, nil

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -28,7 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/quota/install"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("ResourceQuota",
 		func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 			registry := install.NewRegistry(client)

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package admission
+package podsecuritypolicy // import "k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy"
 
 import (
 	"fmt"
@@ -44,7 +44,8 @@ const (
 	PluginName = "PodSecurityPolicy"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		plugin := NewPlugin(client, psp.NewSimpleStrategyFactory(), getMatchingPolicies, false)
 		plugin.Run()

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package admission
+package podsecuritypolicy
 
 import (
 	"fmt"

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -27,7 +27,8 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin("SecurityContextDeny", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewSecurityContextDeny(client), nil
 	})

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -52,7 +52,8 @@ const DefaultAPITokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 // PluginName is the name of this admission plugin
 const PluginName = "ServiceAccount"
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		serviceAccountAdmission := NewServiceAccount(client)
 		serviceAccountAdmission.Run()

--- a/plugin/pkg/admission/storageclass/default/admission.go
+++ b/plugin/pkg/admission/storageclass/default/admission.go
@@ -36,7 +36,8 @@ const (
 	PluginName = "DefaultStorageClass"
 )
 
-func init() {
+// RegisterPlugin registers the current admission plugin
+func RegisterPlugin() {
 	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
 		plugin := newPlugin(client)
 		plugin.Run()

--- a/test/integration/federation/server_test.go
+++ b/test/integration/federation/server_test.go
@@ -91,6 +91,7 @@ func TestRun(t *testing.T) {
 	s.ServiceClusterIPRange = *ipNet
 	s.StorageConfig.ServerList = []string{"http://localhost:2379"}
 	go func() {
+		app.RegisterPlugins()
 		if err := app.Run(s); err != nil {
 			t.Fatalf("Error in bringing up the server: %v", err)
 		}


### PR DESCRIPTION
ref: #31431

I also came across some packages were the directory name != package name, and made them equal

@smarterclayton @lavalamp @vishh @kubernetes/sig-api-machinery @jbeda @timothysc

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31432)

<!-- Reviewable:end -->
