### PR TITLE
Use updated deployment after rollback

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -497,7 +497,7 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 
 	if d.Spec.RollbackTo != nil {
 		revision := d.Spec.RollbackTo.Revision
-		if _, err = dc.rollback(d, &revision); err != nil {
+		if d, err = dc.rollback(d, &revision); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
@kubernetes/deployment 

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31449)

<!-- Reviewable:end -->
