### PR TITLE
Add a line break when no events in describe

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -2129,7 +2129,7 @@ func getPodsTotalRequestsAndLimits(podList *api.PodList) (reqs map[api.ResourceN
 
 func DescribeEvents(el *api.EventList, w io.Writer) {
 	if len(el.Items) == 0 {
-		fmt.Fprint(w, "No events.")
+		fmt.Fprint(w, "No events.\n")
 		return
 	}
 	sort.Sort(SortableEvents(el.Items))


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a line break in the events describer in case of no events. Without this fix, after https://github.com/kubernetes/kubernetes/commit/6caf4d5a3fed5e818e389c6c72a00de207c40517 a describe without events would result in no line break before exiting to terminal.

```
$ oc describe pod mypod
Name:           mypod
Namespace:      mynamespace
(...)
QoS Tier:   BestEffort
No events.user@localhost ~$
```

``` release-note
Add line break after events in kubectl describe
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31463)

<!-- Reviewable:end -->
