### PR TITLE
[AppArmor] Promote AppArmor annotations to beta

### DIFF
--- a/pkg/security/apparmor/helpers.go
+++ b/pkg/security/apparmor/helpers.go
@@ -25,11 +25,11 @@ import (
 // TODO: Move these values into the API package.
 const (
 	// The prefix to an annotation key specifying a container profile.
-	ContainerAnnotationKeyPrefix = "container.apparmor.security.alpha.kubernetes.io/"
+	ContainerAnnotationKeyPrefix = "container.apparmor.security.beta.kubernetes.io/"
 	// The annotation key specifying the default AppArmor profile.
-	DefaultProfileAnnotationKey = "apparmor.security.alpha.kubernetes.io/defaultProfileName"
+	DefaultProfileAnnotationKey = "apparmor.security.beta.kubernetes.io/defaultProfileName"
 	// The annotation key specifying the allowed AppArmor profiles.
-	AllowedProfilesAnnotationKey = "apparmor.security.alpha.kubernetes.io/allowedProfileNames"
+	AllowedProfilesAnnotationKey = "apparmor.security.beta.kubernetes.io/allowedProfileNames"
 
 	// The profile specifying the runtime default.
 	ProfileRuntimeDefault = "runtime/default"

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -60,12 +60,12 @@ func TestValidateProfile(t *testing.T) {
 		expectValid bool
 	}{
 		{"", true},
-		{"runtime/default", true},
+		{ProfileRuntimeDefault, true},
 		{"baz", false}, // Missing local prefix.
-		{"localhost//usr/sbin/ntpd", true},
-		{"localhost/foo-bar", true},
-		{"localhost/unloaded", false}, // Not loaded.
-		{"localhost/", false},
+		{ProfileNamePrefix + "/usr/sbin/ntpd", true},
+		{ProfileNamePrefix + "foo-bar", true},
+		{ProfileNamePrefix + "unloaded", false}, // Not loaded.
+		{ProfileNamePrefix + "", false},
 	}
 
 	for _, test := range tests {
@@ -89,8 +89,8 @@ func TestValidateBadHost(t *testing.T) {
 		expectValid bool
 	}{
 		{"", true},
-		{"runtime/default", false},
-		{"localhost/docker-default", false},
+		{ProfileRuntimeDefault, false},
+		{ProfileNamePrefix + "docker-default", false},
 	}
 
 	for _, test := range tests {
@@ -113,13 +113,13 @@ func TestValidateValidHost(t *testing.T) {
 		expectValid bool
 	}{
 		{"", true},
-		{"runtime/default", true},
-		{"localhost/docker-default", true},
-		{"localhost/foo-container", true},
-		{"localhost//usr/sbin/ntpd", true},
+		{ProfileRuntimeDefault, true},
+		{ProfileNamePrefix + "docker-default", true},
+		{ProfileNamePrefix + "foo-container", true},
+		{ProfileNamePrefix + "/usr/sbin/ntpd", true},
 		{"docker-default", false},
-		{"localhost/foo", false},
-		{"localhost/", false},
+		{ProfileNamePrefix + "foo", false},
+		{ProfileNamePrefix + "", false},
 	}
 
 	for _, test := range tests {
@@ -135,9 +135,9 @@ func TestValidateValidHost(t *testing.T) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Annotations: map[string]string{
-				"container.apparmor.security.alpha.kubernetes.io/init":  "localhost/foo-container",
-				"container.apparmor.security.alpha.kubernetes.io/test1": "runtime/default",
-				"container.apparmor.security.alpha.kubernetes.io/test2": "localhost/docker-default",
+				ContainerAnnotationKeyPrefix + "init":  ProfileNamePrefix + "foo-container",
+				ContainerAnnotationKeyPrefix + "test1": ProfileRuntimeDefault,
+				ContainerAnnotationKeyPrefix + "test2": ProfileNamePrefix + "docker-default",
 			},
 		},
 		Spec: api.PodSpec{
@@ -173,7 +173,7 @@ func TestParseProfileName(t *testing.T) {
 
 func getPodWithProfile(profile string) *api.Pod {
 	annotations := map[string]string{
-		"container.apparmor.security.alpha.kubernetes.io/test": profile,
+		ContainerAnnotationKeyPrefix + "test": profile,
 	}
 	if profile == "" {
 		annotations = map[string]string{

--- a/test/e2e_node/apparmor_test.go
+++ b/test/e2e_node/apparmor_test.go
@@ -53,12 +53,12 @@ func testAppArmorNode() {
 		f := framework.NewDefaultFramework("apparmor-test")
 
 		It("should reject an unloaded profile", func() {
-			status := runAppArmorTest(f, "localhost/"+"non-existant-profile")
+			status := runAppArmorTest(f, apparmor.ProfileNamePrefix+"non-existant-profile")
 			Expect(status.Phase).To(Equal(api.PodFailed), "PodStatus: %+v", status)
 			Expect(status.Reason).To(Equal("AppArmor"), "PodStatus: %+v", status)
 		})
 		It("should enforce a profile blocking writes", func() {
-			status := runAppArmorTest(f, "localhost/"+apparmorProfilePrefix+"deny-write")
+			status := runAppArmorTest(f, apparmor.ProfileNamePrefix+apparmorProfilePrefix+"deny-write")
 			if len(status.ContainerStatuses) == 0 {
 				framework.Failf("Unexpected pod status: %s", spew.Sdump(status))
 				return
@@ -68,7 +68,7 @@ func testAppArmorNode() {
 
 		})
 		It("should enforce a permissive profile", func() {
-			status := runAppArmorTest(f, "localhost/"+apparmorProfilePrefix+"audit-write")
+			status := runAppArmorTest(f, apparmor.ProfileNamePrefix+apparmorProfilePrefix+"audit-write")
 			if len(status.ContainerStatuses) == 0 {
 				framework.Failf("Unexpected pod status: %s", spew.Sdump(status))
 				return
@@ -84,7 +84,7 @@ func testNonAppArmorNode() {
 		f := framework.NewDefaultFramework("apparmor-test")
 
 		It("should reject a pod with an AppArmor profile", func() {
-			status := runAppArmorTest(f, "runtime/default")
+			status := runAppArmorTest(f, apparmor.ProfileRuntimeDefault)
 			Expect(status.Phase).To(Equal(api.PodFailed), "PodStatus: %+v", status)
 			Expect(status.Reason).To(Equal("AppArmor"), "PodStatus: %+v", status)
 		})
@@ -159,7 +159,7 @@ func createPodWithAppArmor(f *framework.Framework, profile string) *api.Pod {
 		ObjectMeta: api.ObjectMeta{
 			Name: fmt.Sprintf("test-apparmor-%s", strings.Replace(profile, "/", "-", -1)),
 			Annotations: map[string]string{
-				"container.apparmor.security.alpha.kubernetes.io/test": profile,
+				apparmor.ContainerAnnotationKeyPrefix + "test": profile,
 			},
 		},
 		Spec: api.PodSpec{


### PR DESCRIPTION
Justification for promoting AppArmor to beta:
1. We will provide an upgrade path to GA
2. We don't anticipate any major changes to the design, and will continue to invest in this feature
3. We will thoroughly test it. If any serious issues are uncovered we can reevaluate, and we're committed to fixing them.
4. We plan to provide beta-level support for the feature anyway (responding quickly to issues).

Note that this does not include the yet-to-be-merged status annotation (https://github.com/kubernetes/kubernetes/pull/31382). I'd like to propose keeping that one alpha for now because I'm not sure the PodStatus is the right long-term home for it (I think a separate monitoring channel, e.g. cAdvisor, would be a better solution).

/cc @thockin @matchstick @erictune

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31471)

<!-- Reviewable:end -->
