### PR TITLE
Add AppArmor feature gate

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/security/apparmor"
+	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/validation"
@@ -2119,13 +2120,17 @@ func ValidateAppArmorPodAnnotations(annotations map[string]string, spec *api.Pod
 		if !strings.HasPrefix(k, apparmor.ContainerAnnotationKeyPrefix) {
 			continue
 		}
+		if !utilconfig.DefaultFeatureGate.AppArmor() {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k), "AppArmor is disabled by feature-gate"))
+			continue
+		}
 		containerName := strings.TrimPrefix(k, apparmor.ContainerAnnotationKeyPrefix)
 		if !podSpecHasContainer(spec, containerName) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child(k), containerName, "container not found"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(k), containerName, "container not found"))
 		}
 
 		if err := apparmor.ValidateProfileFormat(p); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child(k), p, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(k), p, err.Error()))
 		}
 	}
 

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	utilconfig "k8s.io/kubernetes/pkg/util/config"
 )
 
 // Whether AppArmor should be disabled by default.
@@ -88,9 +89,14 @@ func (v *validator) Validate(pod *api.Pod) error {
 
 // Verify that the host and runtime is capable of enforcing AppArmor profiles.
 func validateHost(runtime string) error {
+	// Check feature-gates
+	if !utilconfig.DefaultFeatureGate.AppArmor() {
+		return errors.New("AppArmor disabled by feature-gate")
+	}
+
 	// Check build support.
 	if isDisabledBuild {
-		return errors.New("Binary not compiled for linux.")
+		return errors.New("Binary not compiled for linux")
 	}
 
 	// Check kernel support.

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -39,9 +39,9 @@ const (
 	//   AllAlpha=true,NewFeature=false  will result in newFeature=false
 	allAlphaGate              = "AllAlpha"
 	externalTrafficLocalOnly  = "AllowExtTrafficLocalEndpoints"
+	appArmor                  = "AppArmor"
 	dynamicKubeletConfig      = "DynamicKubeletConfig"
 	dynamicVolumeProvisioning = "DynamicVolumeProvisioning"
-	// TODO: Define gate/accessor for AppArmor
 )
 
 var (
@@ -50,6 +50,7 @@ var (
 	knownFeatures = map[string]featureSpec{
 		allAlphaGate:              {false, alpha},
 		externalTrafficLocalOnly:  {false, alpha},
+		appArmor:                  {true, alpha},
 		dynamicKubeletConfig:      {false, alpha},
 		dynamicVolumeProvisioning: {true, alpha},
 	}
@@ -90,6 +91,10 @@ type FeatureGate interface {
 	// // owner: @username
 	// // alpha: v1.4
 	// MyFeature() bool
+
+	// owner: @timstclair
+	// alpha: v1.4
+	AppArmor() bool
 
 	// owner: @girishkalele
 	// alpha: v1.4
@@ -173,6 +178,11 @@ func (f *featureGate) Type() string {
 // ExternalTrafficLocalOnly returns value for AllowExtTrafficLocalEndpoints
 func (f *featureGate) ExternalTrafficLocalOnly() bool {
 	return f.lookup(externalTrafficLocalOnly)
+}
+
+// AppArmor returns the value for the AppArmor feature gate.
+func (f *featureGate) AppArmor() bool {
+	return f.lookup(appArmor)
 }
 
 // DynamicKubeletConfig returns value for dynamicKubeletConfig


### PR DESCRIPTION
Add option to disable AppArmor via a feature gate. This PR treats AppArmor as Beta, and thus depends on https://github.com/kubernetes/kubernetes/pull/31471 (I will remove `do-not-merge` once that merges).

Note that disabling AppArmor means that pods with AppArmor annotations will be rejected in validation. It does not mean that the components act as though AppArmor was never implemented. This is by design, because we want to make it difficult to accidentally run a Pod with an AppArmor annotation without AppArmor protection.

/cc @dchen1107

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31473)

<!-- Reviewable:end -->
