### PR TITLE
fix feature_gates salt plumbing

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -640,6 +640,11 @@ EOF
 ENABLE_CUSTOM_METRICS: $(yaml-quote ${ENABLE_CUSTOM_METRICS})
 EOF
   fi
+  if [ -n "${FEATURE_GATES:-}" ]; then
+    cat >>$file <<EOF
+FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})
+EOF
+  fi
   if [[ "${master}" == "true" ]]; then
     # Master-only env vars.
     cat >>$file <<EOF
@@ -699,11 +704,7 @@ EOF
 INITIAL_ETCD_CLUSTER: $(yaml-quote ${INITIAL_ETCD_CLUSTER})
 EOF
     fi
-    if [ -n "${FEATURE_GATES:-}" ]; then
-      cat >>$file <<EOF
-FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})
-EOF
-    fi
+
   else
     # Node-only env vars.
     cat >>$file <<EOF

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -960,7 +960,6 @@ EOF
   fi
 
   env-to-grains "runtime_config"
-  env-to-grains "feature_gates"
   env-to-grains "kube_user"
 }
 
@@ -1004,6 +1003,7 @@ function salt-grains() {
   env-to-grains "docker_opts"
   env-to-grains "docker_root"
   env-to-grains "kubelet_root"
+  env-to-grains "feature_gates"
 }
 
 function configure-salt() {


### PR DESCRIPTION
Fix salt plumbing for `--feature-gate` from `FEATURE_GATES kube env.

Was generating grains.conf and kube-env for master only. Verified it works now for gci and debian master/nodes.

cc @thockin @timstclair

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31486)

<!-- Reviewable:end -->
