### PR TITLE
kubectl rollout status waits for available pods

### DIFF
--- a/pkg/kubectl/rollout_status_test.go
+++ b/pkg/kubectl/rollout_status_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+func TestDeploymentStatusViewerStatus(t *testing.T) {
+	tests := []struct {
+		generation   int64
+		specReplicas int32
+		status       extensions.DeploymentStatus
+		msg          string
+		done         bool
+	}{
+		{
+			generation:   0,
+			specReplicas: 1,
+			status: extensions.DeploymentStatus{
+				ObservedGeneration:  1,
+				Replicas:            1,
+				UpdatedReplicas:     0,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 0,
+			},
+
+			msg:  "Waiting for rollout to finish: 0 out of 1 new replicas have been updated...\n",
+			done: false,
+		},
+		{
+			generation:   1,
+			specReplicas: 1,
+			status: extensions.DeploymentStatus{
+				ObservedGeneration:  1,
+				Replicas:            2,
+				UpdatedReplicas:     1,
+				AvailableReplicas:   2,
+				UnavailableReplicas: 0,
+			},
+
+			msg:  "Waiting for rollout to finish: 1 old replicas are pending termination...\n",
+			done: false,
+		},
+		{
+			generation:   1,
+			specReplicas: 2,
+			status: extensions.DeploymentStatus{
+				ObservedGeneration:  1,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 1,
+			},
+
+			msg:  "Waiting for rollout to finish: 1 of 2 updated replicas are available...\n",
+			done: false,
+		},
+		{
+			generation:   1,
+			specReplicas: 2,
+			status: extensions.DeploymentStatus{
+				ObservedGeneration:  1,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				AvailableReplicas:   2,
+				UnavailableReplicas: 0,
+			},
+
+			msg:  "deployment foo successfully rolled out\n",
+			done: true,
+		},
+		{
+			generation:   2,
+			specReplicas: 2,
+			status: extensions.DeploymentStatus{
+				ObservedGeneration:  1,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				AvailableReplicas:   2,
+				UnavailableReplicas: 0,
+			},
+
+			msg:  "Waiting for deployment spec update to be observed...\n",
+			done: false,
+		},
+	}
+
+	for _, test := range tests {
+		d := &extensions.Deployment{
+			ObjectMeta: api.ObjectMeta{
+				Name:       "foo",
+				UID:        "8764ae47-9092-11e4-8393-42010af018ff",
+				Generation: test.generation,
+			},
+			Spec: extensions.DeploymentSpec{
+				Replicas: test.specReplicas,
+			},
+			Status: test.status,
+		}
+		client := testclient.NewSimpleFake(d).Extensions()
+		dsv := &DeploymentStatusViewer{c: client}
+		msg, done, err := dsv.Status("bar", "foo")
+		if err != nil {
+			t.Fatalf("DeploymentStatusViewer.Status(): %v", err)
+		}
+		if done != test.done || msg != test.msg {
+			t.Errorf("DeploymentStatusViewer.Status() for deployment with generation %d, %d replicas specified, and status %+v returned %q, %t, want %q, %t",
+				test.generation,
+				test.specReplicas,
+				test.status,
+				msg,
+				done,
+				test.msg,
+				test.done,
+			)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This changes kubectl rollout status to wait until all updated replicas are available before finishing.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #31130

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
Changes 'kubectl rollout status' to wait until all updated replicas are available before finishing.
```

Currently kubectl rollout status finishes when Deployment.Spec.Replicas == Deployment.Status.UpdatedReplicas, but it's less surprising to the user for kubectl rollout status to wait until Deployment.Status.UpdatedReplicas == Deployment.Status.Replics == Deployment.Status.AvailableReplicas

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31499)

<!-- Reviewable:end -->
