### PR TITLE
set propagation to "shared" for hostPath volume

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -386,6 +386,8 @@ type Mount struct {
 	ReadOnly bool
 	// Whether the mount needs SELinux relabeling
 	SELinuxRelabel bool
+	// The Propagation of the volume.
+	Propagation string
 }
 
 type PortMapping struct {

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -386,8 +386,8 @@ type Mount struct {
 	ReadOnly bool
 	// Whether the mount needs SELinux relabeling
 	SELinuxRelabel bool
-	// The Propagation of the volume.
-	Propagation string
+	// Whether the mount need Propagation mode set.
+	NeedPropagation bool
 }
 
 type PortMapping struct {

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2404,49 +2404,71 @@ func makePod(name string, spec *api.PodSpec) *api.Pod {
 
 func TestMakeMountBindings(t *testing.T) {
 	tests := []struct {
-		mounts             []kubecontainer.Mount
-		selinux            bool
-		propagationSupport bool
-		bindings           []string
+		mounts      []kubecontainer.Mount
+		selinux     bool
+		propagation string
+		bindings    []string
 	}{
 		{
 			mounts: []kubecontainer.Mount{
 				{
-					HostPath:      "/tmp",
-					ContainerPath: "/tmp1",
-					ReadOnly:      true,
-					Propagation:   "shared",
+					HostPath:        "/tmp",
+					ContainerPath:   "/tmp1",
+					ReadOnly:        true,
+					NeedPropagation: true,
 				},
 				{
-					HostPath:       "/tmp",
-					ContainerPath:  "/tmp2",
-					ReadOnly:       false,
-					SELinuxRelabel: true,
-					Propagation:    "shared",
+					HostPath:        "/tmp",
+					ContainerPath:   "/tmp2",
+					ReadOnly:        false,
+					SELinuxRelabel:  true,
+					NeedPropagation: true,
 				},
 			},
-			selinux:            false,
-			propagationSupport: true,
+			selinux:     false,
+			propagation: "rshared",
 			bindings: []string{
-				"/tmp:/tmp1:ro,shared",
-				"/tmp:/tmp2:shared",
+				"/tmp:/tmp1:ro,rshared",
+				"/tmp:/tmp2:rshared",
 			},
 		},
 		{
 			mounts: []kubecontainer.Mount{
 				{
-					HostPath:       "/tmp",
-					ContainerPath:  "/tmp1",
-					ReadOnly:       true,
-					SELinuxRelabel: true,
-					Propagation:    "shared",
+					HostPath:        "/tmp",
+					ContainerPath:   "/tmp1",
+					ReadOnly:        true,
+					NeedPropagation: true,
+				},
+				{
+					HostPath:        "/tmp",
+					ContainerPath:   "/tmp2",
+					ReadOnly:        false,
+					SELinuxRelabel:  true,
+					NeedPropagation: true,
+				},
+			},
+			selinux:     false,
+			propagation: "rslave",
+			bindings: []string{
+				"/tmp:/tmp1:ro,rslave",
+				"/tmp:/tmp2:rslave",
+			},
+		},
+		{
+			mounts: []kubecontainer.Mount{
+				{
+					HostPath:        "/tmp",
+					ContainerPath:   "/tmp1",
+					ReadOnly:        true,
+					SELinuxRelabel:  true,
+					NeedPropagation: true,
 				},
 				{
 					HostPath:       "/tmp",
 					ContainerPath:  "/tmp2",
 					ReadOnly:       false,
 					SELinuxRelabel: true,
-					Propagation:    "shared",
 				},
 				{
 					HostPath:       "/tmp",
@@ -2455,8 +2477,8 @@ func TestMakeMountBindings(t *testing.T) {
 					SELinuxRelabel: false,
 				},
 			},
-			selinux:            true,
-			propagationSupport: false,
+			selinux:     true,
+			propagation: "",
 			bindings: []string{
 				"/tmp:/tmp1:ro,Z",
 				"/tmp:/tmp2:Z",
@@ -2465,7 +2487,7 @@ func TestMakeMountBindings(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		bindings := makeMountBindings(test.mounts, test.selinux, test.propagationSupport)
+		bindings := makeMountBindings(test.mounts, test.selinux, test.propagation)
 		if !reflect.DeepEqual(bindings, test.bindings) {
 			t.Errorf("Expected %v, got %v", test.bindings, bindings)
 		}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -147,6 +147,7 @@ func makeMounts(pod *api.Pod, podDir string, container *api.Container, hostName,
 			HostPath:       hostPath,
 			ReadOnly:       mount.ReadOnly,
 			SELinuxRelabel: relabelVolume,
+			Propagation:    vol.Mounter.GetAttributes().Propagation,
 		})
 	}
 	if mountEtcHostsFile {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -142,12 +142,12 @@ func makeMounts(pod *api.Pod, podDir string, container *api.Container, hostName,
 		}
 
 		mounts = append(mounts, kubecontainer.Mount{
-			Name:           mount.Name,
-			ContainerPath:  containerPath,
-			HostPath:       hostPath,
-			ReadOnly:       mount.ReadOnly,
-			SELinuxRelabel: relabelVolume,
-			Propagation:    vol.Mounter.GetAttributes().Propagation,
+			Name:            mount.Name,
+			ContainerPath:   containerPath,
+			HostPath:        hostPath,
+			ReadOnly:        mount.ReadOnly,
+			SELinuxRelabel:  relabelVolume,
+			NeedPropagation: vol.Mounter.GetAttributes().NeedPropagation,
 		})
 	}
 	if mountEtcHostsFile {

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -183,6 +183,7 @@ func (b *hostPathMounter) GetAttributes() volume.Attributes {
 		ReadOnly:        b.readOnly,
 		Managed:         false,
 		SupportsSELinux: false,
+		Propagation:     "shared",
 	}
 }
 

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -183,7 +183,7 @@ func (b *hostPathMounter) GetAttributes() volume.Attributes {
 		ReadOnly:        b.readOnly,
 		Managed:         false,
 		SupportsSELinux: false,
-		Propagation:     "shared",
+		NeedPropagation: true,
 	}
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -88,8 +88,8 @@ type Attributes struct {
 	ReadOnly        bool
 	Managed         bool
 	SupportsSELinux bool
-	// Default to private to keep consistent with old behavior.
-	Propagation string
+	// Default to false to keep consistent with old behavior.
+	NeedPropagation bool
 }
 
 // Mounter interface provides methods to set up/mount the volume.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -88,6 +88,8 @@ type Attributes struct {
 	ReadOnly        bool
 	Managed         bool
 	SupportsSELinux bool
+	// Default to private to keep consistent with old behavior.
+	Propagation string
 }
 
 // Mounter interface provides methods to set up/mount the volume.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
We had a lot of discussions in #20698, @thockin @vishh @luxas @kfox1111 @andrewmchen @eparis @mikedanese @victorgp @Kaffa-MY @liyimeng 
I believe all of us at least agree HostPath should be mounted "shared" by default, can you help review this?

We already seen a lot of requests on this, hope it could catch up 1.4 ...

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
Set default propagation to "shared" for hostPath volume.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31504)

<!-- Reviewable:end -->
