### PR TITLE
Redundant code process for container_mananger start

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -441,9 +441,11 @@ func (cm *containerManagerImpl) Start() error {
 	for _, cont := range cm.systemContainers {
 		if cont.ensureStateFunc != nil {
 			numEnsureStateFuncs++
+			//If has anyone, we quit this for block
+			break
 		}
 	}
-	if numEnsureStateFuncs >= 0 {
+	if numEnsureStateFuncs > 0 {
 		// Run ensure state functions every minute.
 		go wait.Until(func() {
 			for _, cont := range cm.systemContainers {


### PR DESCRIPTION
1. need not sum the total numEnsureStateFuncs
2. numEnsureStateFuncs should > 0, or calculate numEnsureStateFuncs would be not neccessary

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31505)

<!-- Reviewable:end -->
