### PR TITLE
Print a message if metrics are not yet available.

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -107,11 +107,7 @@ func (o *TopNodeOptions) Validate() error {
 }
 
 func (o TopNodeOptions) RunTopNode() error {
-	metrics, err := o.Client.GetNodeMetrics(o.ResourceName, o.Selector)
-	if err != nil {
-		return err
-	}
-
+	var err error
 	selector := labels.Everything()
 	if len(o.Selector) > 0 {
 		selector, err = labels.Parse(o.Selector)
@@ -119,6 +115,11 @@ func (o TopNodeOptions) RunTopNode() error {
 			return err
 		}
 	}
+	metrics, err := o.Client.GetNodeMetrics(o.ResourceName, selector)
+	if err != nil {
+		return err
+	}
+
 	var nodes []api.Node
 	if len(o.ResourceName) > 0 {
 		node, err := o.Client.Nodes().Get(o.ResourceName)

--- a/pkg/kubectl/metricsutil/metrics_client.go
+++ b/pkg/kubectl/metricsutil/metrics_client.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 const (
@@ -96,8 +97,8 @@ func nodeMetricsUrl(name string) (string, error) {
 	return fmt.Sprintf("%s/nodes/%s", metricsRoot, name), nil
 }
 
-func (cli *HeapsterMetricsClient) GetNodeMetrics(nodeName string, selector string) ([]metrics_api.NodeMetrics, error) {
-	params := map[string]string{"labelSelector": selector}
+func (cli *HeapsterMetricsClient) GetNodeMetrics(nodeName string, selector labels.Selector) ([]metrics_api.NodeMetrics, error) {
+	params := map[string]string{"labelSelector": selector.String()}
 	path, err := nodeMetricsUrl(nodeName)
 	if err != nil {
 		return []metrics_api.NodeMetrics{}, err
@@ -125,7 +126,7 @@ func (cli *HeapsterMetricsClient) GetNodeMetrics(nodeName string, selector strin
 	return metrics, nil
 }
 
-func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string, allNamespaces bool, selector string) ([]metrics_api.PodMetrics, error) {
+func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string, allNamespaces bool, selector labels.Selector) ([]metrics_api.PodMetrics, error) {
 	if allNamespaces {
 		namespace = api.NamespaceAll
 	}
@@ -133,7 +134,8 @@ func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string
 	if err != nil {
 		return []metrics_api.PodMetrics{}, err
 	}
-	params := map[string]string{"labelSelector": selector}
+
+	params := map[string]string{"labelSelector": selector.String()}
 	allMetrics := make([]metrics_api.PodMetrics, 0)
 
 	resultRaw, err := GetHeapsterMetrics(cli, path, params)


### PR DESCRIPTION
**What this PR does / why we need it**:
It takes about 80s to gather first metrics for the newly created pod. We would like to indicate this to the user, so that they don't mistake it for the command failure.

In case no metrics are found, we check whether there should be any, and if yes, print the appropriate message to the user.

**Which issue this PR fixes**
#30826

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31510)

<!-- Reviewable:end -->
