### PR TITLE
e2e: log wget output on CheckConnectivityToHost error

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4665,7 +4665,18 @@ func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeo
 		return err
 	}
 	defer podClient.Delete(podName, nil)
-	return WaitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
+	err = WaitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
+
+	if err != nil {
+		logs, logErr := GetPodLogs(f.Client, f.Namespace.Name, pod.Name, contName)
+		if logErr != nil {
+			Logf("Warning: Failed to get logs from pod %q: %v", pod.Name, logErr)
+		} else {
+			Logf("pod %s/%s \"wget\" logs:\n%s", f.Namespace.Name, pod.Name, logs)
+		}
+	}
+
+	return err
 }
 
 // CoreDump SSHs to the master and all nodes and dumps their logs into dir.


### PR DESCRIPTION
Log output might help to diagnose e2e flakes, whether they are caused by dns issues or connection timeouts.

Might help with flake https://github.com/kubernetes/kubernetes/issues/28188.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31516)

<!-- Reviewable:end -->
