### PR TITLE
Increase Dashboard UI version to v1.4.0-beta2

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.1.1
+  name: kubernetes-dashboard-v1.4.0-beta2
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.1
+    version: v1.4.0-beta2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.1
+        version: v1.4.0-beta2
         kubernetes.io/cluster-service: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.0-beta2
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   # Keep this file in sync with addons/dashboard/dashboard-controller.yaml
-  name: kubernetes-dashboard-v1.1.1
+  name: kubernetes-dashboard-v1.4.0-beta2
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.1
+    version: v1.4.0-beta2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.1
+        version: v1.4.0-beta2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.0-beta2
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
This is our first beta for 1.4. We started synchronizing versions with
the core.

Release tag:
https://github.com/kubernetes/dashboard/releases/tag/v1.4.0-beta2

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31518)

<!-- Reviewable:end -->
