### PR TITLE
Don't error out if ${go_pkg_dir} already exists

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -267,10 +267,11 @@ kube::golang::create_gopath_tree() {
   local go_pkg_basedir=$(dirname "${go_pkg_dir}")
 
   mkdir -p "${go_pkg_basedir}"
-  rm -f "${go_pkg_dir}"
 
   # TODO: This symlink should be relative.
-  ln -s "${KUBE_ROOT}" "${go_pkg_dir}"
+  if [[ ! -e "${go_pkg_dir}" || "$(readlink ${go_pkg_dir})" != "${KUBE_ROOT}" ]]; then
+    ln -sTf "${KUBE_ROOT}" "${go_pkg_dir}"
+  fi
 }
 
 # Ensure the godep tool exists and is a viable version.


### PR DESCRIPTION
I have 'make' aliased to 'make -j4' for various reasons, and that's always worked fine for Kubernetes in the past.  But it recently broke because EEXIST errors from this symlink creation are fatal.  So make them not fatal, because if the path already exists, why try to create it again?  It exists because two invocations of setup_env() are run in parallel due to the -j4, and they race to create the symlink and one obviously fails.

ln: failed to create symbolic link ‘/home/dcbw/Development/containers/kubernetes/_output/local/go/src/k8s.io/kubernetes’: File exists
Makefile.generated_files:285: recipe for target '_output/bin/deepcopy-gen' failed
make[1]: **\* [_output/bin/deepcopy-gen] Error 1
make[1]: **\* Waiting for unfinished jobs....
+++ [0826 10:18:02] Generating bindata:
    /home/dcbw/Development/containers/kubernetes/test/e2e/framework/gobindata_util.go
+++ [0826 10:18:02] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
+++ [0826 10:18:03] Building go targets for linux/amd64:
    cmd/libs/go2idl/conversion-gen
Makefile:281: recipe for target 'generated_files' failed
make: **\* [generated_files] Error 2

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31525)

<!-- Reviewable:end -->
