### PR TITLE
add GenericAPIServer posthooks for initialization

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -199,6 +199,7 @@ plugin/pkg/auth/authenticator/password/allow
 plugin/pkg/auth/authenticator/request/basicauth
 plugin/pkg/auth/authenticator/request/union
 plugin/pkg/auth/authorizer
+plugin/pkg/auth/authorizer/rbac/bootstrappolicy
 plugin/pkg/client/auth
 plugin/pkg/client/auth/gcp
 test/e2e/cleanup

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -46,10 +46,10 @@ import (
 )
 
 // setUp is a convience function for setting up for (most) tests.
-func setUp(t *testing.T) (GenericAPIServer, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
+func setUp(t *testing.T) (*GenericAPIServer, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdServer, _ := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 
-	genericapiserver := GenericAPIServer{}
+	genericapiserver := &GenericAPIServer{}
 	config := Config{}
 	config.PublicAddress = net.ParseIP("192.168.10.4")
 	config.RequestContextMapper = api.NewRequestContextMapper()

--- a/pkg/genericapiserver/hooks.go
+++ b/pkg/genericapiserver/hooks.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapiserver
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+)
+
+// PostStartHookFunc is a function that is called after the server has started.
+// It must properly handle cases like:
+//  1. asynchronous start in multiple API server processes
+//  2. conflicts between the different processes all trying to perform the same action
+//  3. partially complete work (API server crashes while running your hook)
+//  4. API server access **BEFORE** your hook has completed
+// Think of it like a mini-controller that is super privileged and gets to run in-process
+// If you use this feature, tag @deads2k on github who has promised to review code for anyone's PostStartHook
+// until it becomes easier to use.
+type PostStartHookFunc func(context PostStartHookContext) error
+
+// PostStartHookContext provides information about this API server to a PostStartHookFunc
+type PostStartHookContext struct {
+	// TODO this should probably contain a cluster-admin powered client config which can be used to loopback
+	// to this API server.  That client config doesn't exist yet.
+}
+
+// AddPostStartHook allows you to add a PostStartHook.
+func (s *GenericAPIServer) AddPostStartHook(name string, hook PostStartHookFunc) error {
+	if len(name) == 0 {
+		return fmt.Errorf("missing name")
+	}
+	if hook == nil {
+		return nil
+	}
+
+	s.postStartHookLock.Lock()
+	defer s.postStartHookLock.Unlock()
+
+	if s.postStartHooksCalled {
+		return fmt.Errorf("unable to add %q because PostStartHooks have already been called", name)
+	}
+	if s.PostStartHooks == nil {
+		s.PostStartHooks = map[string]PostStartHookFunc{}
+	}
+	if _, exists := s.PostStartHooks[name]; exists {
+		return fmt.Errorf("unable to add %q because it is already registered", name)
+	}
+
+	s.PostStartHooks[name] = hook
+
+	return nil
+}
+
+// RunPostStartHooks runs the PostStartHooks for the server
+func (s *GenericAPIServer) RunPostStartHooks(context PostStartHookContext) {
+	s.postStartHookLock.Lock()
+	defer s.postStartHookLock.Unlock()
+	s.postStartHooksCalled = true
+
+	for hookName, hook := range s.PostStartHooks {
+		go runPostStartHook(hookName, hook, context)
+	}
+}
+
+func runPostStartHook(name string, hook PostStartHookFunc, context PostStartHookContext) {
+	var err error
+	func() {
+		// don't let the hook *accidentally* panic and kill the server
+		defer utilruntime.HandleCrash()
+		err = hook(context)
+	}()
+	// if the hook intentionally wants to kill server, let it.
+	if err != nil {
+		glog.Fatalf("PostStartHook %q failed: %v", name, err)
+	}
+}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrappolicy
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+// ClusterRoles returns the cluster roles to bootstrap an API server with
+func ClusterRoles() []rbacapi.ClusterRole {
+	return []rbacapi.ClusterRole{
+		// TODO update the expression of these rules to match openshift for ease of inspection
+		{
+			ObjectMeta: api.ObjectMeta{Name: "cluster-admin"},
+			Rules: []rbacapi.PolicyRule{
+				{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+				{Verbs: []string{"*"}, NonResourceURLs: []string{"*"}},
+			},
+		},
+	}
+}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -155,6 +155,11 @@ func startMasterOrDie(masterConfig *master.Config) (*master.Master, *httptest.Se
 		glog.Fatalf("error in bringing up the master: %v", err)
 	}
 
+	// TODO have this start method actually use the normal start sequence for the API server
+	// this method never actually calls the `Run` method for the API server
+	// fire the post hooks ourselves
+	m.GenericAPIServer.RunPostStartHooks(genericapiserver.PostStartHookContext{})
+
 	return m, s
 }
 


### PR DESCRIPTION
Adds the concept of a `PostStartHook` to the `GenericAPIServer` to allow post-server start hooks.  This gives a standard location to perform post-start bootstrapping tasks.  The common case usage we have downstream are security related bootstrapping tasks that are performed on the "empty etcd" initialization cases.  The RBAC authorizer is a good example of this in kube.  It needs a location to create default policies to start a server which is capable of being accessed.

Kube is also likely to hit this for things like PSP and breaking the monolithic controller user into separate, scoped service accounts.

@kubernetes/sig-api-machinery for the `GenericAPIServer` bits
@kubernetes/sig-auth for the particular clusterrole bootstrapping. I've only done one to start, but I suspect we'll start making more and probably introduce a binding so that the RBAC super-user doesn't remain a special case forever.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31529)

<!-- Reviewable:end -->
