### PR TITLE
Add log message in Kubelet when controller attach/detach is enabled

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -129,7 +129,10 @@ func (kl *Kubelet) initialNodeStatus() (*api.Node, error) {
 			node.Annotations = make(map[string]string)
 		}
 
+		glog.Infof("Setting node annotation to enable volume controller attach/detach")
 		node.Annotations[volumehelper.ControllerManagedAttachAnnotation] = "true"
+	} else {
+		glog.Infof("Controller attach/detach is disabled for this node; Kubelet will attach and detach volumes")
 	}
 
 	// @question: should this be place after the call to the cloud provider? which also applies labels


### PR DESCRIPTION
Adds a message to the Kubelet log indicating whether controller attach/detach is enabled for a node.

cc @kubernetes/sig-storage

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31531)

<!-- Reviewable:end -->
