### PR TITLE
Bump nfs server image tag in pv e2e

### DIFF
--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -415,7 +415,7 @@ var _ = framework.KubeDescribe("PersistentVolumes", func() {
 	NFSconfig = VolumeTestConfig{
 		namespace:   api.NamespaceDefault,
 		prefix:      "nfs",
-		serverImage: "gcr.io/google_containers/volume-nfs:0.6",
+		serverImage: "gcr.io/google_containers/volume-nfs:0.7",
 		serverPorts: []int{2049},
 		serverArgs:  []string{"-G", "777", "/exports"},
 	}


### PR DESCRIPTION
Image modified in https://github.com/kubernetes/kubernetes/pull/30084 has been pushed, so we can bump this back up to enable the part where pod writes to server with restrictive permissions

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31532)

<!-- Reviewable:end -->
