### PR TITLE
choose a particular directory test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,15 @@ check test: generated_files
 
 # Build and run integration tests.
 #
+# Args:
+#   WHAT: Directory names to test.  All *_test.go files under these
+#     directories will be run.  If not specified, "everything" will be tested.
+#
 # Example:
 #   make test-integration
 .PHONY: test-integration
 test-integration: generated_files
-	hack/make-rules/test-integration.sh
+	hack/make-rules/test-integration.sh $(WHAT)
 
 # Build and run end-to-end tests.
 #

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -40,7 +40,7 @@ KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
 kube::test::find_integration_test_dirs() {
   (
     cd ${KUBE_ROOT}
-    find test/integration -name '*_test.go' -print0 \
+    find test/integration/${1-} -name '*_test.go' -print0 \
       | xargs -0n1 dirname \
       | sort -u
   )
@@ -60,7 +60,7 @@ runTests() {
   # TODO: Re-enable race detection when we switch to a thread-safe etcd client
   # KUBE_RACE="-race"
   make -C "${KUBE_ROOT}" test \
-      WHAT="$(kube::test::find_integration_test_dirs | paste -sd' ' -)" \
+      WHAT="$(kube::test::find_integration_test_dirs ${2-} | paste -sd' ' -)" \
       KUBE_GOFLAGS="${KUBE_GOFLAGS:-} -tags 'integration no-docker'" \
       KUBE_RACE="" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
@@ -90,5 +90,5 @@ fi
 # Convert the CSV to an array of API versions to test
 IFS=';' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
 for apiVersion in "${apiVersions[@]}"; do
-  runTests "${apiVersion}"
+  runTests "${apiVersion}" "${1-}"
 done

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -22,14 +22,17 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
+# For help output
+ARGHELP=""
+if [[ "$#" -gt 0 ]]; then
+    ARGHELP="WHAT='$@'"
+fi
+
 echo "NOTE: $0 has been replaced by 'make test-integration'"
 echo
 echo "The equivalent of this invocation is: "
-echo "    make test-integration"
+echo "    make test-integration ${ARGHELP}"
 echo
 echo
-echo make --no-print-directory -C "${KUBE_ROOT}" test-integration
-echo
-echo
-make --no-print-directory -C "${KUBE_ROOT}" test-integration
+make --no-print-directory -C "${KUBE_ROOT}" test-integration WHAT="$*"
 


### PR DESCRIPTION
Enables `make test-integration WHAT=auth` or whatever particular integration test director you want to run.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31533)

<!-- Reviewable:end -->
