### PR TITLE
Fix selinux denials for host path e2e tests.

### DIFF
--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -61,10 +61,19 @@ var _ = framework.KubeDescribe("HostPath", func() {
 	// This test requires mounting a folder into a container with write privileges.
 	It("should support r/w", func() {
 		volumePath := "/test-volume"
+		hostPath := "/tmp"
 		filePath := path.Join(volumePath, "test-file")
 		retryDuration := 180
+
+		if selinux.SelinuxEnabled() {
+			filePath := path.Join(hostPath, "test-file")
+			if err := relabelPathByChcon(filePath, false); err != nil {
+				framework.Logf("%v", err)
+			}
+		}
+
 		source := &api.HostPathVolumeSource{
-			Path: "/tmp",
+			Path: hostPath,
 		}
 		pod := testPodWithHostVol(volumePath, source)
 

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -19,8 +19,11 @@ package common
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
 
+	"github.com/opencontainers/runc/libcontainer/selinux"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -86,12 +89,20 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		subPath := "sub-path"
 		fileName := "test-file"
 		retryDuration := 180
+		hostPath := "/tmp"
 
 		filePathInWriter := path.Join(volumePath, fileName)
 		filePathInReader := path.Join(volumePath, subPath, fileName)
 
+		if selinux.SelinuxEnabled() {
+			dirPath := path.Join(hostPath, subPath)
+			if err := relabelPathByChcon(dirPath, true); err != nil {
+				framework.Logf("%v", err)
+			}
+		}
+
 		source := &api.HostPathVolumeSource{
-			Path: "/tmp",
+			Path: hostPath,
 		}
 		pod := testPodWithHostVol(volumePath, source)
 		// Write the file in the subPath from container 0
@@ -168,4 +179,36 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 			Volumes:       mount(source),
 		},
 	}
+}
+
+// relabelPathByChcon relabels selinux context of the provided path
+func relabelPathByChcon(path string, isDir bool) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("error converting directory %q to an absolute path: %v", path, err)
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		if isDir {
+			if err := os.MkdirAll(absPath, 0755); err != nil {
+				return fmt.Errorf("couldn't create directory %q on host: %q", absPath, err)
+			}
+		} else {
+			if _, err := os.Create(absPath); err != nil {
+				return fmt.Errorf("couldn't create file %q on host: %q", absPath, err)
+			}
+		}
+	}
+
+	chconPath, err := exec.LookPath("chcon")
+	if err != nil {
+		return fmt.Errorf("couldn't locate the command chcon on host: %v", err)
+	}
+
+	c := exec.Command(chconPath, "-Rt", "svirt_sandbox_file_t", absPath)
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("error relabelling path %s: %v", absPath, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR fixes selinux denials as the containers are accessing a subdir in /tmp as hostpath volume source for which selinux relabeling is not supported for these volumes so making them privileged.

```
time->Thu Aug 25 20:18:26 2016
type=AVC msg=audit(1472141906.557:3523): avc:  denied  { write } for  pid=15682 comm="mt" name="test-file" dev="tmpfs" ino=317712 scontext=system_u:system_r:svirt_lxc_net_t:s0:c29,c183 tcontext=system_u:object_r:docker_tmp_t:s0 tclass=file permissive=0
----
time->Thu Aug 25 20:18:27 2016
type=AVC msg=audit(1472141907.814:3527): avc:  denied  { open } for  pid=15771 comm="mt" path="/test-volume/sub-path/test-file" dev="tmpfs" ino=317712 scontext=system_u:system_r:svirt_lxc_net_t:s0:c143,c496 tcontext=system_u:object_r:docker_tmp_t:s0 tclass=file permissive=0
----
time->Thu Aug 25 20:18:29 2016
type=AVC msg=audit(1472141909.814:3528): avc:  denied  { open } for  pid=15771 comm="mt" path="/test-volume/sub-path/test-file" dev="tmpfs" ino=317712 scontext=system_u:system_r:svirt_lxc_net_t:s0:c143,c496 tcontext=system_u:object_r:docker_tmp_t:s0 tclass=file permissive=0
```

@kubernetes/rh-cluster-infra @pmorie

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31542)

<!-- Reviewable:end -->
