### PR TITLE
Use the rawTerminal setting from the container itself

### DIFF
--- a/pkg/kubelet/dockershim/legacy.go
+++ b/pkg/kubelet/dockershim/legacy.go
@@ -36,7 +36,11 @@ func (ds *dockerService) AttachContainer(id kubecontainer.ContainerID, stdin io.
 }
 
 func (ds *dockerService) GetContainerLogs(pod *api.Pod, containerID kubecontainer.ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error) {
-	return dockertools.GetContainerLogs(ds.client, pod, containerID, logOptions, stdout, stderr)
+	container, err := ds.client.InspectContainer(containerID.ID)
+	if err != nil {
+		return err
+	}
+	return dockertools.GetContainerLogs(ds.client, pod, containerID, logOptions, stdout, stderr, container.Config.Tty)
 }
 
 func (ds *dockerService) PortForward(sandboxID string, port uint16, stream io.ReadWriteCloser) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks whether the container is set for rawTerminal connection and uses the appropriate connection.
Prevents the output `Error from server: Unrecognized input header` when doing `kubectl run`.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: 
helps with case 1 in #28695, resolves #30159

**Special notes for your reviewer**:

**Release note**:

```
release-note-none
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31558)

<!-- Reviewable:end -->
