### PR TITLE
kubelet: simple tls auth

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -96,6 +96,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address for the Kubelet to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.Int32Var(&s.Port, "port", s.Port, "The port for the Kubelet to serve on.")
 	fs.Int32Var(&s.ReadOnlyPort, "read-only-port", s.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")
+	fs.StringVar(&s.ClientCAFile, "client-ca-file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	fs.StringVar(&s.TLSCertFile, "tls-cert-file", s.TLSCertFile, ""+
 		"File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). "+
 		"If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key "+

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -502,6 +502,17 @@ func InitializeTLS(kc *componentconfig.KubeletConfiguration) (*server.TLSOptions
 		CertFile: kc.TLSCertFile,
 		KeyFile:  kc.TLSPrivateKeyFile,
 	}
+
+	if len(kc.ClientCAFile) > 0 {
+		clientCAs, err := crypto.CertPoolFromFile(kc.ClientCAFile)
+		if err != nil {
+			glog.Fatalf("Unable to load client CA file: %v", err)
+		}
+		// Specify allowed CAs for client certificates
+		tlsOptions.Config.ClientCAs = clientCAs
+		tlsOptions.Config.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
 	return tlsOptions, nil
 }
 

--- a/pkg/apis/componentconfig/types.generated.go
+++ b/pkg/apis/componentconfig/types.generated.go
@@ -1218,36 +1218,36 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep130 := !z.EncBinary()
 			yy2arr130 := z.EncBasicHandle().StructToArray
-			var yyq130 [105]bool
+			var yyq130 [106]bool
 			_, _, _ = yysep130, yyq130, yy2arr130
 			const yyr130 bool = false
 			yyq130[0] = x.Kind != ""
 			yyq130[1] = x.APIVersion != ""
-			yyq130[51] = x.CloudProvider != ""
-			yyq130[52] = x.CloudConfigFile != ""
-			yyq130[53] = x.KubeletCgroups != ""
-			yyq130[54] = x.CgroupsPerQOS != false
-			yyq130[55] = x.RuntimeCgroups != ""
-			yyq130[56] = x.SystemCgroups != ""
-			yyq130[57] = x.CgroupRoot != ""
-			yyq130[61] = true
-			yyq130[62] = x.RktPath != ""
-			yyq130[63] = x.RktAPIEndpoint != ""
-			yyq130[64] = x.RktStage1Image != ""
-			yyq130[85] = true
-			yyq130[86] = x.NodeIP != ""
-			yyq130[90] = x.EvictionHard != ""
-			yyq130[91] = x.EvictionSoft != ""
-			yyq130[92] = x.EvictionSoftGracePeriod != ""
-			yyq130[93] = true
-			yyq130[94] = x.EvictionMaxPodGracePeriod != 0
-			yyq130[95] = x.EvictionMinimumReclaim != ""
-			yyq130[104] = len(x.AllowedUnsafeSysctls) != 0
+			yyq130[52] = x.CloudProvider != ""
+			yyq130[53] = x.CloudConfigFile != ""
+			yyq130[54] = x.KubeletCgroups != ""
+			yyq130[55] = x.CgroupsPerQOS != false
+			yyq130[56] = x.RuntimeCgroups != ""
+			yyq130[57] = x.SystemCgroups != ""
+			yyq130[58] = x.CgroupRoot != ""
+			yyq130[62] = true
+			yyq130[63] = x.RktPath != ""
+			yyq130[64] = x.RktAPIEndpoint != ""
+			yyq130[65] = x.RktStage1Image != ""
+			yyq130[86] = true
+			yyq130[87] = x.NodeIP != ""
+			yyq130[91] = x.EvictionHard != ""
+			yyq130[92] = x.EvictionSoft != ""
+			yyq130[93] = x.EvictionSoftGracePeriod != ""
+			yyq130[94] = true
+			yyq130[95] = x.EvictionMaxPodGracePeriod != 0
+			yyq130[96] = x.EvictionMinimumReclaim != ""
+			yyq130[105] = len(x.AllowedUnsafeSysctls) != 0
 			var yynn130 int
 			if yyr130 || yy2arr130 {
-				r.EncodeArrayStart(105)
+				r.EncodeArrayStart(106)
 			} else {
-				yynn130 = 83
+				yynn130 = 84
 				for _, b := range yyq130 {
 					if b {
 						yynn130++
@@ -1526,17 +1526,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym174
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.TLSCertFile))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClientCAFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("tlsCertFile"))
+				r.EncodeString(codecSelferC_UTF81234, string("clientCAFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym175 := z.EncBinary()
 				_ = yym175
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.TLSCertFile))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClientCAFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1545,17 +1545,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym177
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.TLSPrivateKeyFile))
+					r.EncodeString(codecSelferC_UTF81234, string(x.TLSCertFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("tlsPrivateKeyFile"))
+				r.EncodeString(codecSelferC_UTF81234, string("tlsCertFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym178 := z.EncBinary()
 				_ = yym178
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.TLSPrivateKeyFile))
+					r.EncodeString(codecSelferC_UTF81234, string(x.TLSCertFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1564,17 +1564,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym180
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CertDirectory))
+					r.EncodeString(codecSelferC_UTF81234, string(x.TLSPrivateKeyFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("certDirectory"))
+				r.EncodeString(codecSelferC_UTF81234, string("tlsPrivateKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym181 := z.EncBinary()
 				_ = yym181
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CertDirectory))
+					r.EncodeString(codecSelferC_UTF81234, string(x.TLSPrivateKeyFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1583,17 +1583,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym183
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CertDirectory))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
+				r.EncodeString(codecSelferC_UTF81234, string("certDirectory"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym184 := z.EncBinary()
 				_ = yym184
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CertDirectory))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1602,17 +1602,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym186
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodInfraContainerImage))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("podInfraContainerImage"))
+				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym187 := z.EncBinary()
 				_ = yym187
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodInfraContainerImage))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1621,17 +1621,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym189
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerEndpoint))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodInfraContainerImage))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("dockerEndpoint"))
+				r.EncodeString(codecSelferC_UTF81234, string("podInfraContainerImage"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym190 := z.EncBinary()
 				_ = yym190
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerEndpoint))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodInfraContainerImage))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1640,17 +1640,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym192
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.RootDirectory))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerEndpoint))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("rootDirectory"))
+				r.EncodeString(codecSelferC_UTF81234, string("dockerEndpoint"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym193 := z.EncBinary()
 				_ = yym193
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.RootDirectory))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerEndpoint))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1659,17 +1659,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym195
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.SeccompProfileRoot))
+					r.EncodeString(codecSelferC_UTF81234, string(x.RootDirectory))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("seccompProfileRoot"))
+				r.EncodeString(codecSelferC_UTF81234, string("rootDirectory"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym196 := z.EncBinary()
 				_ = yym196
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.SeccompProfileRoot))
+					r.EncodeString(codecSelferC_UTF81234, string(x.RootDirectory))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1678,14 +1678,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym198
 				if false {
 				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.SeccompProfileRoot))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("seccompProfileRoot"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym199 := z.EncBinary()
+				_ = yym199
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.SeccompProfileRoot))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym201 := z.EncBinary()
+				_ = yym201
+				if false {
+				} else {
 					r.EncodeBool(bool(x.AllowPrivileged))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("allowPrivileged"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym199 := z.EncBinary()
-				_ = yym199
+				yym202 := z.EncBinary()
+				_ = yym202
 				if false {
 				} else {
 					r.EncodeBool(bool(x.AllowPrivileged))
@@ -1696,8 +1715,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostNetworkSources == nil {
 					r.EncodeNil()
 				} else {
-					yym201 := z.EncBinary()
-					_ = yym201
+					yym204 := z.EncBinary()
+					_ = yym204
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostNetworkSources, false, e)
@@ -1710,8 +1729,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostNetworkSources == nil {
 					r.EncodeNil()
 				} else {
-					yym202 := z.EncBinary()
-					_ = yym202
+					yym205 := z.EncBinary()
+					_ = yym205
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostNetworkSources, false, e)
@@ -1723,8 +1742,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostPIDSources == nil {
 					r.EncodeNil()
 				} else {
-					yym204 := z.EncBinary()
-					_ = yym204
+					yym207 := z.EncBinary()
+					_ = yym207
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostPIDSources, false, e)
@@ -1737,8 +1756,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostPIDSources == nil {
 					r.EncodeNil()
 				} else {
-					yym205 := z.EncBinary()
-					_ = yym205
+					yym208 := z.EncBinary()
+					_ = yym208
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostPIDSources, false, e)
@@ -1750,8 +1769,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostIPCSources == nil {
 					r.EncodeNil()
 				} else {
-					yym207 := z.EncBinary()
-					_ = yym207
+					yym210 := z.EncBinary()
+					_ = yym210
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostIPCSources, false, e)
@@ -1764,8 +1783,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.HostIPCSources == nil {
 					r.EncodeNil()
 				} else {
-					yym208 := z.EncBinary()
-					_ = yym208
+					yym211 := z.EncBinary()
+					_ = yym211
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.HostIPCSources, false, e)
@@ -1774,8 +1793,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym210 := z.EncBinary()
-				_ = yym210
+				yym213 := z.EncBinary()
+				_ = yym213
 				if false {
 				} else {
 					r.EncodeInt(int64(x.RegistryPullQPS))
@@ -1784,30 +1803,11 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("registryPullQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym211 := z.EncBinary()
-				_ = yym211
-				if false {
-				} else {
-					r.EncodeInt(int64(x.RegistryPullQPS))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym213 := z.EncBinary()
-				_ = yym213
-				if false {
-				} else {
-					r.EncodeInt(int64(x.RegistryBurst))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("registryBurst"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym214 := z.EncBinary()
 				_ = yym214
 				if false {
 				} else {
-					r.EncodeInt(int64(x.RegistryBurst))
+					r.EncodeInt(int64(x.RegistryPullQPS))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1816,17 +1816,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym216
 				if false {
 				} else {
-					r.EncodeInt(int64(x.EventRecordQPS))
+					r.EncodeInt(int64(x.RegistryBurst))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("eventRecordQPS"))
+				r.EncodeString(codecSelferC_UTF81234, string("registryBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym217 := z.EncBinary()
 				_ = yym217
 				if false {
 				} else {
-					r.EncodeInt(int64(x.EventRecordQPS))
+					r.EncodeInt(int64(x.RegistryBurst))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1835,17 +1835,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym219
 				if false {
 				} else {
-					r.EncodeInt(int64(x.EventBurst))
+					r.EncodeInt(int64(x.EventRecordQPS))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("eventBurst"))
+				r.EncodeString(codecSelferC_UTF81234, string("eventRecordQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym220 := z.EncBinary()
 				_ = yym220
 				if false {
 				} else {
-					r.EncodeInt(int64(x.EventBurst))
+					r.EncodeInt(int64(x.EventRecordQPS))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1854,14 +1854,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym222
 				if false {
 				} else {
+					r.EncodeInt(int64(x.EventBurst))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("eventBurst"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym223 := z.EncBinary()
+				_ = yym223
+				if false {
+				} else {
+					r.EncodeInt(int64(x.EventBurst))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym225 := z.EncBinary()
+				_ = yym225
+				if false {
+				} else {
 					r.EncodeBool(bool(x.EnableDebuggingHandlers))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableDebuggingHandlers"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym223 := z.EncBinary()
-				_ = yym223
+				yym226 := z.EncBinary()
+				_ = yym226
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableDebuggingHandlers))
@@ -1869,48 +1888,29 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy225 := &x.MinimumGCAge
-				yym226 := z.EncBinary()
-				_ = yym226
+				yy228 := &x.MinimumGCAge
+				yym229 := z.EncBinary()
+				_ = yym229
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy225) {
-				} else if !yym226 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy225)
+				} else if z.HasExtensions() && z.EncExt(yy228) {
+				} else if !yym229 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy228)
 				} else {
-					z.EncFallback(yy225)
+					z.EncFallback(yy228)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minimumGCAge"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy227 := &x.MinimumGCAge
-				yym228 := z.EncBinary()
-				_ = yym228
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy227) {
-				} else if !yym228 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy227)
-				} else {
-					z.EncFallback(yy227)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym230 := z.EncBinary()
-				_ = yym230
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MaxPerPodContainerCount))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxPerPodContainerCount"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy230 := &x.MinimumGCAge
 				yym231 := z.EncBinary()
 				_ = yym231
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy230) {
+				} else if !yym231 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy230)
 				} else {
-					r.EncodeInt(int64(x.MaxPerPodContainerCount))
+					z.EncFallback(yy230)
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1919,17 +1919,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym233
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxContainerCount))
+					r.EncodeInt(int64(x.MaxPerPodContainerCount))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxContainerCount"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxPerPodContainerCount"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym234 := z.EncBinary()
 				_ = yym234
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxContainerCount))
+					r.EncodeInt(int64(x.MaxPerPodContainerCount))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1938,17 +1938,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym236
 				if false {
 				} else {
-					r.EncodeInt(int64(x.CAdvisorPort))
+					r.EncodeInt(int64(x.MaxContainerCount))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("cAdvisorPort"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxContainerCount"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym237 := z.EncBinary()
 				_ = yym237
 				if false {
 				} else {
-					r.EncodeInt(int64(x.CAdvisorPort))
+					r.EncodeInt(int64(x.MaxContainerCount))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1957,17 +1957,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym239
 				if false {
 				} else {
-					r.EncodeInt(int64(x.HealthzPort))
+					r.EncodeInt(int64(x.CAdvisorPort))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
+				r.EncodeString(codecSelferC_UTF81234, string("cAdvisorPort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym240 := z.EncBinary()
 				_ = yym240
 				if false {
 				} else {
-					r.EncodeInt(int64(x.HealthzPort))
+					r.EncodeInt(int64(x.CAdvisorPort))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1976,17 +1976,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym242
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
+					r.EncodeInt(int64(x.HealthzPort))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
+				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym243 := z.EncBinary()
 				_ = yym243
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
+					r.EncodeInt(int64(x.HealthzPort))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1995,17 +1995,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym245
 				if false {
 				} else {
-					r.EncodeInt(int64(x.OOMScoreAdj))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
+				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym246 := z.EncBinary()
 				_ = yym246
 				if false {
 				} else {
-					r.EncodeInt(int64(x.OOMScoreAdj))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2014,17 +2014,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym248
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterNode))
+					r.EncodeInt(int64(x.OOMScoreAdj))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("registerNode"))
+				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym249 := z.EncBinary()
 				_ = yym249
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterNode))
+					r.EncodeInt(int64(x.OOMScoreAdj))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2033,17 +2033,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym251
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+					r.EncodeBool(bool(x.RegisterNode))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("clusterDomain"))
+				r.EncodeString(codecSelferC_UTF81234, string("registerNode"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym252 := z.EncBinary()
 				_ = yym252
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+					r.EncodeBool(bool(x.RegisterNode))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2052,17 +2052,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym254
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("masterServiceNamespace"))
+				r.EncodeString(codecSelferC_UTF81234, string("clusterDomain"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym255 := z.EncBinary()
 				_ = yym255
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2071,14 +2071,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym257
 				if false {
 				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("masterServiceNamespace"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym258 := z.EncBinary()
+				_ = yym258
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym260 := z.EncBinary()
+				_ = yym260
+				if false {
+				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDNS))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterDNS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym258 := z.EncBinary()
-				_ = yym258
+				yym261 := z.EncBinary()
+				_ = yym261
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDNS))
@@ -2086,34 +2105,21 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy260 := &x.StreamingConnectionIdleTimeout
-				yym261 := z.EncBinary()
-				_ = yym261
+				yy263 := &x.StreamingConnectionIdleTimeout
+				yym264 := z.EncBinary()
+				_ = yym264
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy260) {
-				} else if !yym261 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy260)
+				} else if z.HasExtensions() && z.EncExt(yy263) {
+				} else if !yym264 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy263)
 				} else {
-					z.EncFallback(yy260)
+					z.EncFallback(yy263)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("streamingConnectionIdleTimeout"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy262 := &x.StreamingConnectionIdleTimeout
-				yym263 := z.EncBinary()
-				_ = yym263
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy262) {
-				} else if !yym263 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy262)
-				} else {
-					z.EncFallback(yy262)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy265 := &x.NodeStatusUpdateFrequency
+				yy265 := &x.StreamingConnectionIdleTimeout
 				yym266 := z.EncBinary()
 				_ = yym266
 				if false {
@@ -2123,24 +2129,24 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy265)
 				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy268 := &x.NodeStatusUpdateFrequency
+				yym269 := z.EncBinary()
+				_ = yym269
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy268) {
+				} else if !yym269 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy268)
+				} else {
+					z.EncFallback(yy268)
+				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeStatusUpdateFrequency"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy267 := &x.NodeStatusUpdateFrequency
-				yym268 := z.EncBinary()
-				_ = yym268
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy267) {
-				} else if !yym268 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy267)
-				} else {
-					z.EncFallback(yy267)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy270 := &x.ImageMinimumGCAge
+				yy270 := &x.NodeStatusUpdateFrequency
 				yym271 := z.EncBinary()
 				_ = yym271
 				if false {
@@ -2150,38 +2156,32 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy270)
 				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy273 := &x.ImageMinimumGCAge
+				yym274 := z.EncBinary()
+				_ = yym274
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy273) {
+				} else if !yym274 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy273)
+				} else {
+					z.EncFallback(yy273)
+				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("imageMinimumGCAge"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy272 := &x.ImageMinimumGCAge
-				yym273 := z.EncBinary()
-				_ = yym273
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy272) {
-				} else if !yym273 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy272)
-				} else {
-					z.EncFallback(yy272)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym275 := z.EncBinary()
-				_ = yym275
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("imageGCHighThresholdPercent"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy275 := &x.ImageMinimumGCAge
 				yym276 := z.EncBinary()
 				_ = yym276
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy275) {
+				} else if !yym276 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy275)
 				} else {
-					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
+					z.EncFallback(yy275)
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2190,17 +2190,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym278
 				if false {
 				} else {
-					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("imageGCLowThresholdPercent"))
+				r.EncodeString(codecSelferC_UTF81234, string("imageGCHighThresholdPercent"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym279 := z.EncBinary()
 				_ = yym279
 				if false {
 				} else {
-					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2209,14 +2209,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym281
 				if false {
 				} else {
+					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("imageGCLowThresholdPercent"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym282 := z.EncBinary()
+				_ = yym282
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym284 := z.EncBinary()
+				_ = yym284
+				if false {
+				} else {
 					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lowDiskSpaceThresholdMB"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym282 := z.EncBinary()
-				_ = yym282
+				yym285 := z.EncBinary()
+				_ = yym285
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
@@ -2224,48 +2243,29 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy284 := &x.VolumeStatsAggPeriod
-				yym285 := z.EncBinary()
-				_ = yym285
+				yy287 := &x.VolumeStatsAggPeriod
+				yym288 := z.EncBinary()
+				_ = yym288
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy284) {
-				} else if !yym285 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy284)
+				} else if z.HasExtensions() && z.EncExt(yy287) {
+				} else if !yym288 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy287)
 				} else {
-					z.EncFallback(yy284)
+					z.EncFallback(yy287)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeStatsAggPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy286 := &x.VolumeStatsAggPeriod
-				yym287 := z.EncBinary()
-				_ = yym287
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy286) {
-				} else if !yym287 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy286)
-				} else {
-					z.EncFallback(yy286)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym289 := z.EncBinary()
-				_ = yym289
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginName"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy289 := &x.VolumeStatsAggPeriod
 				yym290 := z.EncBinary()
 				_ = yym290
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy289) {
+				} else if !yym290 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy289)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
+					z.EncFallback(yy289)
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2274,17 +2274,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym292
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NetworkPluginMTU))
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginMTU"))
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym293 := z.EncBinary()
 				_ = yym293
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NetworkPluginMTU))
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2293,17 +2293,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym295
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+					r.EncodeInt(int64(x.NetworkPluginMTU))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginDir"))
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginMTU"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym296 := z.EncBinary()
 				_ = yym296
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+					r.EncodeInt(int64(x.NetworkPluginMTU))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2312,42 +2312,36 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym298
 				if false {
 				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginDir"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym299 := z.EncBinary()
+				_ = yym299
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym301 := z.EncBinary()
+				_ = yym301
+				if false {
+				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumePluginDir))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumePluginDir"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym299 := z.EncBinary()
-				_ = yym299
+				yym302 := z.EncBinary()
+				_ = yym302
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumePluginDir))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[51] {
-					yym301 := z.EncBinary()
-					_ = yym301
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[51] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym302 := z.EncBinary()
-					_ = yym302
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
-					}
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2357,7 +2351,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym304
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2365,13 +2359,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[52] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
+					r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym305 := z.EncBinary()
 					_ = yym305
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 					}
 				}
 			}
@@ -2382,7 +2376,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym307
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2390,13 +2384,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[53] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kubeletCgroups"))
+					r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym308 := z.EncBinary()
 					_ = yym308
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 					}
 				}
 			}
@@ -2407,21 +2401,21 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym310
 					if false {
 					} else {
-						r.EncodeBool(bool(x.CgroupsPerQOS))
+						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq130[54] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("CgroupsPerQOS"))
+					r.EncodeString(codecSelferC_UTF81234, string("kubeletCgroups"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym311 := z.EncBinary()
 					_ = yym311
 					if false {
 					} else {
-						r.EncodeBool(bool(x.CgroupsPerQOS))
+						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
 					}
 				}
 			}
@@ -2432,21 +2426,21 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym313
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+						r.EncodeBool(bool(x.CgroupsPerQOS))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq130[55] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("runtimeCgroups"))
+					r.EncodeString(codecSelferC_UTF81234, string("CgroupsPerQOS"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym314 := z.EncBinary()
 					_ = yym314
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+						r.EncodeBool(bool(x.CgroupsPerQOS))
 					}
 				}
 			}
@@ -2457,7 +2451,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym316
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2465,13 +2459,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[56] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("systemCgroups"))
+					r.EncodeString(codecSelferC_UTF81234, string("runtimeCgroups"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym317 := z.EncBinary()
 					_ = yym317
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
 					}
 				}
 			}
@@ -2482,7 +2476,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym319
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2490,33 +2484,39 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[57] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cgroupRoot"))
+					r.EncodeString(codecSelferC_UTF81234, string("systemCgroups"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym320 := z.EncBinary()
 					_ = yym320
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym322 := z.EncBinary()
-				_ = yym322
-				if false {
+				if yyq130[58] {
+					yym322 := z.EncBinary()
+					_ = yym322
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("containerRuntime"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym323 := z.EncBinary()
-				_ = yym323
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
+				if yyq130[58] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cgroupRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym323 := z.EncBinary()
+					_ = yym323
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+					}
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2525,17 +2525,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym325
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("remoteRuntimeEndpoint"))
+				r.EncodeString(codecSelferC_UTF81234, string("containerRuntime"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym326 := z.EncBinary()
 				_ = yym326
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2544,14 +2544,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym328
 				if false {
 				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("remoteRuntimeEndpoint"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym329 := z.EncBinary()
+				_ = yym329
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym331 := z.EncBinary()
+				_ = yym331
+				if false {
+				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteImageEndpoint))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("remoteImageEndpoint"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym329 := z.EncBinary()
-				_ = yym329
+				yym332 := z.EncBinary()
+				_ = yym332
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteImageEndpoint))
@@ -2559,59 +2578,34 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[61] {
-					yy331 := &x.RuntimeRequestTimeout
-					yym332 := z.EncBinary()
-					_ = yym332
+				if yyq130[62] {
+					yy334 := &x.RuntimeRequestTimeout
+					yym335 := z.EncBinary()
+					_ = yym335
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy331) {
-					} else if !yym332 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy331)
+					} else if z.HasExtensions() && z.EncExt(yy334) {
+					} else if !yym335 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy334)
 					} else {
-						z.EncFallback(yy331)
+						z.EncFallback(yy334)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[61] {
+				if yyq130[62] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runtimeRequestTimeout"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy333 := &x.RuntimeRequestTimeout
-					yym334 := z.EncBinary()
-					_ = yym334
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy333) {
-					} else if !yym334 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy333)
-					} else {
-						z.EncFallback(yy333)
-					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[62] {
-					yym336 := z.EncBinary()
-					_ = yym336
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[62] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rktPath"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy336 := &x.RuntimeRequestTimeout
 					yym337 := z.EncBinary()
 					_ = yym337
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy336) {
+					} else if !yym337 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy336)
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
+						z.EncFallback(yy336)
 					}
 				}
 			}
@@ -2622,7 +2616,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym339
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2630,13 +2624,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[63] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rktAPIEndpoint"))
+					r.EncodeString(codecSelferC_UTF81234, string("rktPath"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym340 := z.EncBinary()
 					_ = yym340
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
 					}
 				}
 			}
@@ -2647,7 +2641,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym342
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2655,33 +2649,39 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[64] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rktStage1Image"))
+					r.EncodeString(codecSelferC_UTF81234, string("rktAPIEndpoint"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym343 := z.EncBinary()
 					_ = yym343
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym345 := z.EncBinary()
-				_ = yym345
-				if false {
+				if yyq130[65] {
+					yym345 := z.EncBinary()
+					_ = yym345
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
+					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("lockFilePath"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym346 := z.EncBinary()
-				_ = yym346
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
+				if yyq130[65] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rktStage1Image"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym346 := z.EncBinary()
+					_ = yym346
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
+					}
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2690,17 +2690,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym348
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ExitOnLockContention))
+					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("exitOnLockContention"))
+				r.EncodeString(codecSelferC_UTF81234, string("lockFilePath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym349 := z.EncBinary()
 				_ = yym349
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ExitOnLockContention))
+					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2709,17 +2709,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym351
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ConfigureCBR0))
+					r.EncodeBool(bool(x.ExitOnLockContention))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("configureCbr0"))
+				r.EncodeString(codecSelferC_UTF81234, string("exitOnLockContention"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym352 := z.EncBinary()
 				_ = yym352
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ConfigureCBR0))
+					r.EncodeBool(bool(x.ExitOnLockContention))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2728,17 +2728,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym354
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
+					r.EncodeBool(bool(x.ConfigureCBR0))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("hairpinMode"))
+				r.EncodeString(codecSelferC_UTF81234, string("configureCbr0"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym355 := z.EncBinary()
 				_ = yym355
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
+					r.EncodeBool(bool(x.ConfigureCBR0))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2747,17 +2747,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym357
 				if false {
 				} else {
-					r.EncodeBool(bool(x.BabysitDaemons))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("babysitDaemons"))
+				r.EncodeString(codecSelferC_UTF81234, string("hairpinMode"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym358 := z.EncBinary()
 				_ = yym358
 				if false {
 				} else {
-					r.EncodeBool(bool(x.BabysitDaemons))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2766,17 +2766,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym360
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxPods))
+					r.EncodeBool(bool(x.BabysitDaemons))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxPods"))
+				r.EncodeString(codecSelferC_UTF81234, string("babysitDaemons"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym361 := z.EncBinary()
 				_ = yym361
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxPods))
+					r.EncodeBool(bool(x.BabysitDaemons))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2785,17 +2785,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym363
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NvidiaGPUs))
+					r.EncodeInt(int64(x.MaxPods))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nvidiaGPUs"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxPods"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym364 := z.EncBinary()
 				_ = yym364
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NvidiaGPUs))
+					r.EncodeInt(int64(x.MaxPods))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2804,17 +2804,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym366
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
+					r.EncodeInt(int64(x.NvidiaGPUs))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("dockerExecHandlerName"))
+				r.EncodeString(codecSelferC_UTF81234, string("nvidiaGPUs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym367 := z.EncBinary()
 				_ = yym367
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
+					r.EncodeInt(int64(x.NvidiaGPUs))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2823,17 +2823,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym369
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
+				r.EncodeString(codecSelferC_UTF81234, string("dockerExecHandlerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym370 := z.EncBinary()
 				_ = yym370
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2842,17 +2842,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym372
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("resolvConf"))
+				r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym373 := z.EncBinary()
 				_ = yym373
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2861,17 +2861,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym375
 				if false {
 				} else {
-					r.EncodeBool(bool(x.CPUCFSQuota))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("cpuCFSQuota"))
+				r.EncodeString(codecSelferC_UTF81234, string("resolvConf"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym376 := z.EncBinary()
 				_ = yym376
 				if false {
 				} else {
-					r.EncodeBool(bool(x.CPUCFSQuota))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2880,17 +2880,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym378
 				if false {
 				} else {
-					r.EncodeBool(bool(x.Containerized))
+					r.EncodeBool(bool(x.CPUCFSQuota))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("containerized"))
+				r.EncodeString(codecSelferC_UTF81234, string("cpuCFSQuota"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym379 := z.EncBinary()
 				_ = yym379
 				if false {
 				} else {
-					r.EncodeBool(bool(x.Containerized))
+					r.EncodeBool(bool(x.CPUCFSQuota))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2899,17 +2899,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym381
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxOpenFiles))
+					r.EncodeBool(bool(x.Containerized))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxOpenFiles"))
+				r.EncodeString(codecSelferC_UTF81234, string("containerized"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym382 := z.EncBinary()
 				_ = yym382
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxOpenFiles))
+					r.EncodeBool(bool(x.Containerized))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2918,17 +2918,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym384
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ReconcileCIDR))
+					r.EncodeInt(int64(x.MaxOpenFiles))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("reconcileCIDR"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxOpenFiles"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym385 := z.EncBinary()
 				_ = yym385
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ReconcileCIDR))
+					r.EncodeInt(int64(x.MaxOpenFiles))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2937,17 +2937,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym387
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterSchedulable))
+					r.EncodeBool(bool(x.ReconcileCIDR))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("registerSchedulable"))
+				r.EncodeString(codecSelferC_UTF81234, string("reconcileCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym388 := z.EncBinary()
 				_ = yym388
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterSchedulable))
+					r.EncodeBool(bool(x.ReconcileCIDR))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2956,17 +2956,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym390
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+					r.EncodeBool(bool(x.RegisterSchedulable))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
+				r.EncodeString(codecSelferC_UTF81234, string("registerSchedulable"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym391 := z.EncBinary()
 				_ = yym391
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+					r.EncodeBool(bool(x.RegisterSchedulable))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2975,17 +2975,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym393
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIQPS))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
+				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym394 := z.EncBinary()
 				_ = yym394
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIQPS))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2994,17 +2994,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym396
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIBurst))
+					r.EncodeInt(int64(x.KubeAPIQPS))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
+				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym397 := z.EncBinary()
 				_ = yym397
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIBurst))
+					r.EncodeInt(int64(x.KubeAPIQPS))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3013,17 +3013,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym399
 				if false {
 				} else {
-					r.EncodeBool(bool(x.SerializeImagePulls))
+					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serializeImagePulls"))
+				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym400 := z.EncBinary()
 				_ = yym400
 				if false {
 				} else {
-					r.EncodeBool(bool(x.SerializeImagePulls))
+					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3032,14 +3032,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym402
 				if false {
 				} else {
+					r.EncodeBool(bool(x.SerializeImagePulls))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("serializeImagePulls"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym403 := z.EncBinary()
+				_ = yym403
+				if false {
+				} else {
+					r.EncodeBool(bool(x.SerializeImagePulls))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym405 := z.EncBinary()
+				_ = yym405
+				if false {
+				} else {
 					r.EncodeBool(bool(x.ExperimentalFlannelOverlay))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("experimentalFlannelOverlay"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym403 := z.EncBinary()
-				_ = yym403
+				yym406 := z.EncBinary()
+				_ = yym406
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ExperimentalFlannelOverlay))
@@ -3047,42 +3066,42 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[85] {
-					yy405 := &x.OutOfDiskTransitionFrequency
-					yym406 := z.EncBinary()
-					_ = yym406
+				if yyq130[86] {
+					yy408 := &x.OutOfDiskTransitionFrequency
+					yym409 := z.EncBinary()
+					_ = yym409
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy405) {
-					} else if !yym406 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy405)
+					} else if z.HasExtensions() && z.EncExt(yy408) {
+					} else if !yym409 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy408)
 					} else {
-						z.EncFallback(yy405)
+						z.EncFallback(yy408)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[85] {
+				if yyq130[86] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("outOfDiskTransitionFrequency"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy407 := &x.OutOfDiskTransitionFrequency
-					yym408 := z.EncBinary()
-					_ = yym408
+					yy410 := &x.OutOfDiskTransitionFrequency
+					yym411 := z.EncBinary()
+					_ = yym411
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy407) {
-					} else if !yym408 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy407)
+					} else if z.HasExtensions() && z.EncExt(yy410) {
+					} else if !yym411 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy410)
 					} else {
-						z.EncFallback(yy407)
+						z.EncFallback(yy410)
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[86] {
-					yym410 := z.EncBinary()
-					_ = yym410
+				if yyq130[87] {
+					yym413 := z.EncBinary()
+					_ = yym413
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeIP))
@@ -3091,12 +3110,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[86] {
+				if yyq130[87] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeIP"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym411 := z.EncBinary()
-					_ = yym411
+					yym414 := z.EncBinary()
+					_ = yym414
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeIP))
@@ -3108,8 +3127,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.NodeLabels == nil {
 					r.EncodeNil()
 				} else {
-					yym413 := z.EncBinary()
-					_ = yym413
+					yym416 := z.EncBinary()
+					_ = yym416
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.NodeLabels, false, e)
@@ -3122,8 +3141,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.NodeLabels == nil {
 					r.EncodeNil()
 				} else {
-					yym414 := z.EncBinary()
-					_ = yym414
+					yym417 := z.EncBinary()
+					_ = yym417
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.NodeLabels, false, e)
@@ -3132,8 +3151,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym416 := z.EncBinary()
-				_ = yym416
+				yym419 := z.EncBinary()
+				_ = yym419
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.NonMasqueradeCIDR))
@@ -3142,8 +3161,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nonMasqueradeCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym417 := z.EncBinary()
-				_ = yym417
+				yym420 := z.EncBinary()
+				_ = yym420
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.NonMasqueradeCIDR))
@@ -3151,8 +3170,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym419 := z.EncBinary()
-				_ = yym419
+				yym422 := z.EncBinary()
+				_ = yym422
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableCustomMetrics))
@@ -3161,36 +3180,11 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableCustomMetrics"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym420 := z.EncBinary()
-				_ = yym420
+				yym423 := z.EncBinary()
+				_ = yym423
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableCustomMetrics))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[90] {
-					yym422 := z.EncBinary()
-					_ = yym422
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[90] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("evictionHard"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym423 := z.EncBinary()
-					_ = yym423
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
-					}
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3200,7 +3194,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym425
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
+						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3208,13 +3202,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[91] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("evictionSoft"))
+					r.EncodeString(codecSelferC_UTF81234, string("evictionHard"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym426 := z.EncBinary()
 					_ = yym426
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
+						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
 					}
 				}
 			}
@@ -3225,7 +3219,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym428
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoftGracePeriod))
+						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3233,10 +3227,35 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[92] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("evictionSoftGracePeriod"))
+					r.EncodeString(codecSelferC_UTF81234, string("evictionSoft"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym429 := z.EncBinary()
 					_ = yym429
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[93] {
+					yym431 := z.EncBinary()
+					_ = yym431
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoftGracePeriod))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq130[93] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("evictionSoftGracePeriod"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym432 := z.EncBinary()
+					_ = yym432
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoftGracePeriod))
@@ -3245,59 +3264,34 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[93] {
-					yy431 := &x.EvictionPressureTransitionPeriod
-					yym432 := z.EncBinary()
-					_ = yym432
+				if yyq130[94] {
+					yy434 := &x.EvictionPressureTransitionPeriod
+					yym435 := z.EncBinary()
+					_ = yym435
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy431) {
-					} else if !yym432 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy431)
+					} else if z.HasExtensions() && z.EncExt(yy434) {
+					} else if !yym435 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy434)
 					} else {
-						z.EncFallback(yy431)
+						z.EncFallback(yy434)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[93] {
+				if yyq130[94] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionPressureTransitionPeriod"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy433 := &x.EvictionPressureTransitionPeriod
-					yym434 := z.EncBinary()
-					_ = yym434
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy433) {
-					} else if !yym434 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy433)
-					} else {
-						z.EncFallback(yy433)
-					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[94] {
-					yym436 := z.EncBinary()
-					_ = yym436
-					if false {
-					} else {
-						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
-					}
-				} else {
-					r.EncodeInt(0)
-				}
-			} else {
-				if yyq130[94] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("evictionMaxPodGracePeriod"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy436 := &x.EvictionPressureTransitionPeriod
 					yym437 := z.EncBinary()
 					_ = yym437
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy436) {
+					} else if !yym437 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy436)
 					} else {
-						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
+						z.EncFallback(yy436)
 					}
 				}
 			}
@@ -3308,18 +3302,43 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym439
 					if false {
 					} else {
+						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq130[95] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("evictionMaxPodGracePeriod"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym440 := z.EncBinary()
+					_ = yym440
+					if false {
+					} else {
+						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[96] {
+					yym442 := z.EncBinary()
+					_ = yym442
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionMinimumReclaim))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[95] {
+				if yyq130[96] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionMinimumReclaim"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym440 := z.EncBinary()
-					_ = yym440
+					yym443 := z.EncBinary()
+					_ = yym443
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionMinimumReclaim))
@@ -3328,8 +3347,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym442 := z.EncBinary()
-				_ = yym442
+				yym445 := z.EncBinary()
+				_ = yym445
 				if false {
 				} else {
 					r.EncodeInt(int64(x.PodsPerCore))
@@ -3338,8 +3357,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podsPerCore"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym443 := z.EncBinary()
-				_ = yym443
+				yym446 := z.EncBinary()
+				_ = yym446
 				if false {
 				} else {
 					r.EncodeInt(int64(x.PodsPerCore))
@@ -3347,8 +3366,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym445 := z.EncBinary()
-				_ = yym445
+				yym448 := z.EncBinary()
+				_ = yym448
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableControllerAttachDetach))
@@ -3357,8 +3376,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableControllerAttachDetach"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym446 := z.EncBinary()
-				_ = yym446
+				yym449 := z.EncBinary()
+				_ = yym449
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableControllerAttachDetach))
@@ -3369,8 +3388,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SystemReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym448 := z.EncBinary()
-					_ = yym448
+					yym451 := z.EncBinary()
+					_ = yym451
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SystemReserved) {
 					} else {
@@ -3384,8 +3403,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SystemReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym449 := z.EncBinary()
-					_ = yym449
+					yym452 := z.EncBinary()
+					_ = yym452
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SystemReserved) {
 					} else {
@@ -3398,8 +3417,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.KubeReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym451 := z.EncBinary()
-					_ = yym451
+					yym454 := z.EncBinary()
+					_ = yym454
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.KubeReserved) {
 					} else {
@@ -3413,8 +3432,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.KubeReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym452 := z.EncBinary()
-					_ = yym452
+					yym455 := z.EncBinary()
+					_ = yym455
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.KubeReserved) {
 					} else {
@@ -3424,8 +3443,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym454 := z.EncBinary()
-				_ = yym454
+				yym457 := z.EncBinary()
+				_ = yym457
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ProtectKernelDefaults))
@@ -3434,30 +3453,11 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("protectKernelDefaults"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym455 := z.EncBinary()
-				_ = yym455
-				if false {
-				} else {
-					r.EncodeBool(bool(x.ProtectKernelDefaults))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym457 := z.EncBinary()
-				_ = yym457
-				if false {
-				} else {
-					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("makeIPTablesUtilChains"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym458 := z.EncBinary()
 				_ = yym458
 				if false {
 				} else {
-					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
+					r.EncodeBool(bool(x.ProtectKernelDefaults))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3466,17 +3466,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym460
 				if false {
 				} else {
-					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
+					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("iptablesMasqueradeBit"))
+				r.EncodeString(codecSelferC_UTF81234, string("makeIPTablesUtilChains"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym461 := z.EncBinary()
 				_ = yym461
 				if false {
 				} else {
-					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
+					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3485,14 +3485,33 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym463
 				if false {
 				} else {
+					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("iptablesMasqueradeBit"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym464 := z.EncBinary()
+				_ = yym464
+				if false {
+				} else {
+					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym466 := z.EncBinary()
+				_ = yym466
+				if false {
+				} else {
 					r.EncodeInt(int64(x.IPTablesDropBit))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesDropBit"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym464 := z.EncBinary()
-				_ = yym464
+				yym467 := z.EncBinary()
+				_ = yym467
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IPTablesDropBit))
@@ -3500,12 +3519,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[104] {
+				if yyq130[105] {
 					if x.AllowedUnsafeSysctls == nil {
 						r.EncodeNil()
 					} else {
-						yym466 := z.EncBinary()
-						_ = yym466
+						yym469 := z.EncBinary()
+						_ = yym469
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.AllowedUnsafeSysctls, false, e)
@@ -3515,15 +3534,15 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[104] {
+				if yyq130[105] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("experimentalAllowedUnsafeSysctls"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AllowedUnsafeSysctls == nil {
 						r.EncodeNil()
 					} else {
-						yym467 := z.EncBinary()
-						_ = yym467
+						yym470 := z.EncBinary()
+						_ = yym470
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.AllowedUnsafeSysctls, false, e)
@@ -3544,25 +3563,25 @@ func (x *KubeletConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym468 := z.DecBinary()
-	_ = yym468
+	yym471 := z.DecBinary()
+	_ = yym471
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct469 := r.ContainerType()
-		if yyct469 == codecSelferValueTypeMap1234 {
-			yyl469 := r.ReadMapStart()
-			if yyl469 == 0 {
+		yyct472 := r.ContainerType()
+		if yyct472 == codecSelferValueTypeMap1234 {
+			yyl472 := r.ReadMapStart()
+			if yyl472 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl469, d)
+				x.codecDecodeSelfFromMap(yyl472, d)
 			}
-		} else if yyct469 == codecSelferValueTypeArray1234 {
-			yyl469 := r.ReadArrayStart()
-			if yyl469 == 0 {
+		} else if yyct472 == codecSelferValueTypeArray1234 {
+			yyl472 := r.ReadArrayStart()
+			if yyl472 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl469, d)
+				x.codecDecodeSelfFromArray(yyl472, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3574,12 +3593,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys470Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys470Slc
-	var yyhl470 bool = l >= 0
-	for yyj470 := 0; ; yyj470++ {
-		if yyhl470 {
-			if yyj470 >= l {
+	var yys473Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys473Slc
+	var yyhl473 bool = l >= 0
+	for yyj473 := 0; ; yyj473++ {
+		if yyhl473 {
+			if yyj473 >= l {
 				break
 			}
 		} else {
@@ -3588,10 +3607,10 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys470Slc = r.DecodeBytes(yys470Slc, true, true)
-		yys470 := string(yys470Slc)
+		yys473Slc = r.DecodeBytes(yys473Slc, true, true)
+		yys473 := string(yys473Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys470 {
+		switch yys473 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3614,45 +3633,45 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.SyncFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv474 := &x.SyncFrequency
-				yym475 := z.DecBinary()
-				_ = yym475
+				yyv477 := &x.SyncFrequency
+				yym478 := z.DecBinary()
+				_ = yym478
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv474) {
-				} else if !yym475 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv474)
+				} else if z.HasExtensions() && z.DecExt(yyv477) {
+				} else if !yym478 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv477)
 				} else {
-					z.DecFallback(yyv474, false)
+					z.DecFallback(yyv477, false)
 				}
 			}
 		case "fileCheckFrequency":
 			if r.TryDecodeAsNil() {
 				x.FileCheckFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv476 := &x.FileCheckFrequency
-				yym477 := z.DecBinary()
-				_ = yym477
+				yyv479 := &x.FileCheckFrequency
+				yym480 := z.DecBinary()
+				_ = yym480
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv476) {
-				} else if !yym477 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv476)
+				} else if z.HasExtensions() && z.DecExt(yyv479) {
+				} else if !yym480 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv479)
 				} else {
-					z.DecFallback(yyv476, false)
+					z.DecFallback(yyv479, false)
 				}
 			}
 		case "httpCheckFrequency":
 			if r.TryDecodeAsNil() {
 				x.HTTPCheckFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv478 := &x.HTTPCheckFrequency
-				yym479 := z.DecBinary()
-				_ = yym479
+				yyv481 := &x.HTTPCheckFrequency
+				yym482 := z.DecBinary()
+				_ = yym482
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv478) {
-				} else if !yym479 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv478)
+				} else if z.HasExtensions() && z.DecExt(yyv481) {
+				} else if !yym482 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv481)
 				} else {
-					z.DecFallback(yyv478, false)
+					z.DecFallback(yyv481, false)
 				}
 			}
 		case "manifestURL":
@@ -3690,6 +3709,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.ReadOnlyPort = 0
 			} else {
 				x.ReadOnlyPort = int32(r.DecodeInt(32))
+			}
+		case "clientCAFile":
+			if r.TryDecodeAsNil() {
+				x.ClientCAFile = ""
+			} else {
+				x.ClientCAFile = string(r.DecodeString())
 			}
 		case "tlsCertFile":
 			if r.TryDecodeAsNil() {
@@ -3749,36 +3774,36 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.HostNetworkSources = nil
 			} else {
-				yyv495 := &x.HostNetworkSources
-				yym496 := z.DecBinary()
-				_ = yym496
+				yyv499 := &x.HostNetworkSources
+				yym500 := z.DecBinary()
+				_ = yym500
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv495, false, d)
+					z.F.DecSliceStringX(yyv499, false, d)
 				}
 			}
 		case "hostPIDSources":
 			if r.TryDecodeAsNil() {
 				x.HostPIDSources = nil
 			} else {
-				yyv497 := &x.HostPIDSources
-				yym498 := z.DecBinary()
-				_ = yym498
+				yyv501 := &x.HostPIDSources
+				yym502 := z.DecBinary()
+				_ = yym502
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv497, false, d)
+					z.F.DecSliceStringX(yyv501, false, d)
 				}
 			}
 		case "hostIPCSources":
 			if r.TryDecodeAsNil() {
 				x.HostIPCSources = nil
 			} else {
-				yyv499 := &x.HostIPCSources
-				yym500 := z.DecBinary()
-				_ = yym500
+				yyv503 := &x.HostIPCSources
+				yym504 := z.DecBinary()
+				_ = yym504
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv499, false, d)
+					z.F.DecSliceStringX(yyv503, false, d)
 				}
 			}
 		case "registryPullQPS":
@@ -3815,15 +3840,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.MinimumGCAge = pkg1_unversioned.Duration{}
 			} else {
-				yyv506 := &x.MinimumGCAge
-				yym507 := z.DecBinary()
-				_ = yym507
+				yyv510 := &x.MinimumGCAge
+				yym511 := z.DecBinary()
+				_ = yym511
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv506) {
-				} else if !yym507 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv506)
+				} else if z.HasExtensions() && z.DecExt(yyv510) {
+				} else if !yym511 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv510)
 				} else {
-					z.DecFallback(yyv506, false)
+					z.DecFallback(yyv510, false)
 				}
 			}
 		case "maxPerPodContainerCount":
@@ -3890,37 +3915,7 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.StreamingConnectionIdleTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv518 := &x.StreamingConnectionIdleTimeout
-				yym519 := z.DecBinary()
-				_ = yym519
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv518) {
-				} else if !yym519 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv518)
-				} else {
-					z.DecFallback(yyv518, false)
-				}
-			}
-		case "nodeStatusUpdateFrequency":
-			if r.TryDecodeAsNil() {
-				x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
-			} else {
-				yyv520 := &x.NodeStatusUpdateFrequency
-				yym521 := z.DecBinary()
-				_ = yym521
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv520) {
-				} else if !yym521 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv520)
-				} else {
-					z.DecFallback(yyv520, false)
-				}
-			}
-		case "imageMinimumGCAge":
-			if r.TryDecodeAsNil() {
-				x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
-			} else {
-				yyv522 := &x.ImageMinimumGCAge
+				yyv522 := &x.StreamingConnectionIdleTimeout
 				yym523 := z.DecBinary()
 				_ = yym523
 				if false {
@@ -3929,6 +3924,36 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 					z.DecJSONUnmarshal(yyv522)
 				} else {
 					z.DecFallback(yyv522, false)
+				}
+			}
+		case "nodeStatusUpdateFrequency":
+			if r.TryDecodeAsNil() {
+				x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
+			} else {
+				yyv524 := &x.NodeStatusUpdateFrequency
+				yym525 := z.DecBinary()
+				_ = yym525
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv524) {
+				} else if !yym525 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv524)
+				} else {
+					z.DecFallback(yyv524, false)
+				}
+			}
+		case "imageMinimumGCAge":
+			if r.TryDecodeAsNil() {
+				x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
+			} else {
+				yyv526 := &x.ImageMinimumGCAge
+				yym527 := z.DecBinary()
+				_ = yym527
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv526) {
+				} else if !yym527 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv526)
+				} else {
+					z.DecFallback(yyv526, false)
 				}
 			}
 		case "imageGCHighThresholdPercent":
@@ -3953,15 +3978,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.VolumeStatsAggPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv527 := &x.VolumeStatsAggPeriod
-				yym528 := z.DecBinary()
-				_ = yym528
+				yyv531 := &x.VolumeStatsAggPeriod
+				yym532 := z.DecBinary()
+				_ = yym532
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv527) {
-				} else if !yym528 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv527)
+				} else if z.HasExtensions() && z.DecExt(yyv531) {
+				} else if !yym532 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv531)
 				} else {
-					z.DecFallback(yyv527, false)
+					z.DecFallback(yyv531, false)
 				}
 			}
 		case "networkPluginName":
@@ -4052,15 +4077,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.RuntimeRequestTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv543 := &x.RuntimeRequestTimeout
-				yym544 := z.DecBinary()
-				_ = yym544
+				yyv547 := &x.RuntimeRequestTimeout
+				yym548 := z.DecBinary()
+				_ = yym548
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv543) {
-				} else if !yym544 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv543)
+				} else if z.HasExtensions() && z.DecExt(yyv547) {
+				} else if !yym548 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv547)
 				} else {
-					z.DecFallback(yyv543, false)
+					z.DecFallback(yyv547, false)
 				}
 			}
 		case "rktPath":
@@ -4205,15 +4230,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.OutOfDiskTransitionFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv568 := &x.OutOfDiskTransitionFrequency
-				yym569 := z.DecBinary()
-				_ = yym569
+				yyv572 := &x.OutOfDiskTransitionFrequency
+				yym573 := z.DecBinary()
+				_ = yym573
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv568) {
-				} else if !yym569 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv568)
+				} else if z.HasExtensions() && z.DecExt(yyv572) {
+				} else if !yym573 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv572)
 				} else {
-					z.DecFallback(yyv568, false)
+					z.DecFallback(yyv572, false)
 				}
 			}
 		case "nodeIP":
@@ -4226,12 +4251,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.NodeLabels = nil
 			} else {
-				yyv571 := &x.NodeLabels
-				yym572 := z.DecBinary()
-				_ = yym572
+				yyv575 := &x.NodeLabels
+				yym576 := z.DecBinary()
+				_ = yym576
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv571, false, d)
+					z.F.DecMapStringStringX(yyv575, false, d)
 				}
 			}
 		case "nonMasqueradeCIDR":
@@ -4268,15 +4293,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.EvictionPressureTransitionPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv578 := &x.EvictionPressureTransitionPeriod
-				yym579 := z.DecBinary()
-				_ = yym579
+				yyv582 := &x.EvictionPressureTransitionPeriod
+				yym583 := z.DecBinary()
+				_ = yym583
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv578) {
-				} else if !yym579 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv578)
+				} else if z.HasExtensions() && z.DecExt(yyv582) {
+				} else if !yym583 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv582)
 				} else {
-					z.DecFallback(yyv578, false)
+					z.DecFallback(yyv582, false)
 				}
 			}
 		case "evictionMaxPodGracePeriod":
@@ -4307,26 +4332,26 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.SystemReserved = nil
 			} else {
-				yyv584 := &x.SystemReserved
-				yym585 := z.DecBinary()
-				_ = yym585
+				yyv588 := &x.SystemReserved
+				yym589 := z.DecBinary()
+				_ = yym589
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv584) {
+				} else if z.HasExtensions() && z.DecExt(yyv588) {
 				} else {
-					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv584), d)
+					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv588), d)
 				}
 			}
 		case "kubeReserved":
 			if r.TryDecodeAsNil() {
 				x.KubeReserved = nil
 			} else {
-				yyv586 := &x.KubeReserved
-				yym587 := z.DecBinary()
-				_ = yym587
+				yyv590 := &x.KubeReserved
+				yym591 := z.DecBinary()
+				_ = yym591
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv586) {
+				} else if z.HasExtensions() && z.DecExt(yyv590) {
 				} else {
-					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv586), d)
+					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv590), d)
 				}
 			}
 		case "protectKernelDefaults":
@@ -4357,18 +4382,18 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.AllowedUnsafeSysctls = nil
 			} else {
-				yyv592 := &x.AllowedUnsafeSysctls
-				yym593 := z.DecBinary()
-				_ = yym593
+				yyv596 := &x.AllowedUnsafeSysctls
+				yym597 := z.DecBinary()
+				_ = yym597
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv592, false, d)
+					z.F.DecSliceStringX(yyv596, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys470)
-		} // end switch yys470
-	} // end for yyj470
+			z.DecStructFieldNotFound(-1, yys473)
+		} // end switch yys473
+	} // end for yyj473
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -4376,16 +4401,16 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj594 int
-	var yyb594 bool
-	var yyhl594 bool = l >= 0
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	var yyj598 int
+	var yyb598 bool
+	var yyhl598 bool = l >= 0
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4395,13 +4420,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4411,13 +4436,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4427,13 +4452,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodManifestPath = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4441,57 +4466,7 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.SyncFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv598 := &x.SyncFrequency
-		yym599 := z.DecBinary()
-		_ = yym599
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv598) {
-		} else if !yym599 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv598)
-		} else {
-			z.DecFallback(yyv598, false)
-		}
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.FileCheckFrequency = pkg1_unversioned.Duration{}
-	} else {
-		yyv600 := &x.FileCheckFrequency
-		yym601 := z.DecBinary()
-		_ = yym601
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv600) {
-		} else if !yym601 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv600)
-		} else {
-			z.DecFallback(yyv600, false)
-		}
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.HTTPCheckFrequency = pkg1_unversioned.Duration{}
-	} else {
-		yyv602 := &x.HTTPCheckFrequency
+		yyv602 := &x.SyncFrequency
 		yym603 := z.DecBinary()
 		_ = yym603
 		if false {
@@ -4502,13 +4477,63 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 			z.DecFallback(yyv602, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.FileCheckFrequency = pkg1_unversioned.Duration{}
+	} else {
+		yyv604 := &x.FileCheckFrequency
+		yym605 := z.DecBinary()
+		_ = yym605
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv604) {
+		} else if !yym605 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv604)
+		} else {
+			z.DecFallback(yyv604, false)
+		}
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.HTTPCheckFrequency = pkg1_unversioned.Duration{}
+	} else {
+		yyv606 := &x.HTTPCheckFrequency
+		yym607 := z.DecBinary()
+		_ = yym607
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv606) {
+		} else if !yym607 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv606)
+		} else {
+			z.DecFallback(yyv606, false)
+		}
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4518,13 +4543,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ManifestURL = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4534,13 +4559,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ManifestURLHeader = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4550,13 +4575,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableServer = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4566,13 +4591,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4582,13 +4607,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4598,13 +4623,29 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ReadOnlyPort = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ClientCAFile = ""
+	} else {
+		x.ClientCAFile = string(r.DecodeString())
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4614,13 +4655,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.TLSCertFile = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4630,13 +4671,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.TLSPrivateKeyFile = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4646,13 +4687,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CertDirectory = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4662,13 +4703,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HostnameOverride = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4678,13 +4719,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodInfraContainerImage = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4694,13 +4735,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.DockerEndpoint = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4710,13 +4751,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RootDirectory = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4726,13 +4767,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SeccompProfileRoot = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4742,13 +4783,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.AllowPrivileged = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4756,21 +4797,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostNetworkSources = nil
 	} else {
-		yyv619 := &x.HostNetworkSources
-		yym620 := z.DecBinary()
-		_ = yym620
+		yyv624 := &x.HostNetworkSources
+		yym625 := z.DecBinary()
+		_ = yym625
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv619, false, d)
+			z.F.DecSliceStringX(yyv624, false, d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4778,21 +4819,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostPIDSources = nil
 	} else {
-		yyv621 := &x.HostPIDSources
-		yym622 := z.DecBinary()
-		_ = yym622
+		yyv626 := &x.HostPIDSources
+		yym627 := z.DecBinary()
+		_ = yym627
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv621, false, d)
+			z.F.DecSliceStringX(yyv626, false, d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4800,21 +4841,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostIPCSources = nil
 	} else {
-		yyv623 := &x.HostIPCSources
-		yym624 := z.DecBinary()
-		_ = yym624
+		yyv628 := &x.HostIPCSources
+		yym629 := z.DecBinary()
+		_ = yym629
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv623, false, d)
+			z.F.DecSliceStringX(yyv628, false, d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4824,13 +4865,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegistryPullQPS = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4840,13 +4881,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegistryBurst = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4856,13 +4897,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EventRecordQPS = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4872,13 +4913,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EventBurst = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4888,13 +4929,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableDebuggingHandlers = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4902,24 +4943,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.MinimumGCAge = pkg1_unversioned.Duration{}
 	} else {
-		yyv630 := &x.MinimumGCAge
-		yym631 := z.DecBinary()
-		_ = yym631
+		yyv635 := &x.MinimumGCAge
+		yym636 := z.DecBinary()
+		_ = yym636
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv630) {
-		} else if !yym631 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv630)
+		} else if z.HasExtensions() && z.DecExt(yyv635) {
+		} else if !yym636 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv635)
 		} else {
-			z.DecFallback(yyv630, false)
+			z.DecFallback(yyv635, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4929,13 +4970,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxPerPodContainerCount = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4945,13 +4986,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxContainerCount = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4961,13 +5002,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CAdvisorPort = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4977,13 +5018,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HealthzPort = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4993,13 +5034,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HealthzBindAddress = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5009,13 +5050,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.OOMScoreAdj = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5025,13 +5066,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegisterNode = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5041,13 +5082,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ClusterDomain = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5057,13 +5098,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MasterServiceNamespace = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5073,13 +5114,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ClusterDNS = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5087,24 +5128,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.StreamingConnectionIdleTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv642 := &x.StreamingConnectionIdleTimeout
-		yym643 := z.DecBinary()
-		_ = yym643
+		yyv647 := &x.StreamingConnectionIdleTimeout
+		yym648 := z.DecBinary()
+		_ = yym648
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv642) {
-		} else if !yym643 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv642)
+		} else if z.HasExtensions() && z.DecExt(yyv647) {
+		} else if !yym648 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv647)
 		} else {
-			z.DecFallback(yyv642, false)
+			z.DecFallback(yyv647, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5112,24 +5153,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv644 := &x.NodeStatusUpdateFrequency
-		yym645 := z.DecBinary()
-		_ = yym645
+		yyv649 := &x.NodeStatusUpdateFrequency
+		yym650 := z.DecBinary()
+		_ = yym650
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv644) {
-		} else if !yym645 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv644)
+		} else if z.HasExtensions() && z.DecExt(yyv649) {
+		} else if !yym650 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv649)
 		} else {
-			z.DecFallback(yyv644, false)
+			z.DecFallback(yyv649, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5137,80 +5178,7 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
 	} else {
-		yyv646 := &x.ImageMinimumGCAge
-		yym647 := z.DecBinary()
-		_ = yym647
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv646) {
-		} else if !yym647 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv646)
-		} else {
-			z.DecFallback(yyv646, false)
-		}
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ImageGCHighThresholdPercent = 0
-	} else {
-		x.ImageGCHighThresholdPercent = int32(r.DecodeInt(32))
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ImageGCLowThresholdPercent = 0
-	} else {
-		x.ImageGCLowThresholdPercent = int32(r.DecodeInt(32))
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.LowDiskSpaceThresholdMB = 0
-	} else {
-		x.LowDiskSpaceThresholdMB = int32(r.DecodeInt(32))
-	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
-	} else {
-		yyb594 = r.CheckBreak()
-	}
-	if yyb594 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.VolumeStatsAggPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv651 := &x.VolumeStatsAggPeriod
+		yyv651 := &x.ImageMinimumGCAge
 		yym652 := z.DecBinary()
 		_ = yym652
 		if false {
@@ -5221,13 +5189,86 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 			z.DecFallback(yyv651, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ImageGCHighThresholdPercent = 0
+	} else {
+		x.ImageGCHighThresholdPercent = int32(r.DecodeInt(32))
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ImageGCLowThresholdPercent = 0
+	} else {
+		x.ImageGCLowThresholdPercent = int32(r.DecodeInt(32))
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.LowDiskSpaceThresholdMB = 0
+	} else {
+		x.LowDiskSpaceThresholdMB = int32(r.DecodeInt(32))
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.VolumeStatsAggPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv656 := &x.VolumeStatsAggPeriod
+		yym657 := z.DecBinary()
+		_ = yym657
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv656) {
+		} else if !yym657 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv656)
+		} else {
+			z.DecFallback(yyv656, false)
+		}
+	}
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
+	} else {
+		yyb598 = r.CheckBreak()
+	}
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5237,13 +5278,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginName = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5253,13 +5294,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginMTU = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5269,13 +5310,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginDir = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5285,13 +5326,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.VolumePluginDir = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5301,13 +5342,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CloudProvider = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5317,13 +5358,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CloudConfigFile = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5333,13 +5374,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeletCgroups = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5349,13 +5390,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CgroupsPerQOS = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5365,13 +5406,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RuntimeCgroups = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5381,13 +5422,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SystemCgroups = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5397,13 +5438,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CgroupRoot = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5413,13 +5454,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ContainerRuntime = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5429,13 +5470,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RemoteRuntimeEndpoint = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5445,13 +5486,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RemoteImageEndpoint = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5459,24 +5500,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.RuntimeRequestTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv667 := &x.RuntimeRequestTimeout
-		yym668 := z.DecBinary()
-		_ = yym668
+		yyv672 := &x.RuntimeRequestTimeout
+		yym673 := z.DecBinary()
+		_ = yym673
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv667) {
-		} else if !yym668 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv667)
+		} else if z.HasExtensions() && z.DecExt(yyv672) {
+		} else if !yym673 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv672)
 		} else {
-			z.DecFallback(yyv667, false)
+			z.DecFallback(yyv672, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5486,13 +5527,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktPath = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5502,13 +5543,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktAPIEndpoint = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5518,13 +5559,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktStage1Image = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5534,13 +5575,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.LockFilePath = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5550,13 +5591,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ExitOnLockContention = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5566,13 +5607,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ConfigureCBR0 = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5582,13 +5623,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HairpinMode = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5598,13 +5639,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.BabysitDaemons = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5614,13 +5655,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxPods = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5630,13 +5671,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NvidiaGPUs = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5646,13 +5687,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.DockerExecHandlerName = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5662,13 +5703,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodCIDR = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5678,13 +5719,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ResolverConfig = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5694,13 +5735,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CPUCFSQuota = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5710,13 +5751,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Containerized = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5726,13 +5767,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxOpenFiles = int64(r.DecodeInt(64))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5742,13 +5783,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ReconcileCIDR = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5758,13 +5799,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegisterSchedulable = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5774,13 +5815,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5790,13 +5831,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeAPIQPS = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5806,13 +5847,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5822,13 +5863,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SerializeImagePulls = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5838,13 +5879,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ExperimentalFlannelOverlay = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5852,24 +5893,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.OutOfDiskTransitionFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv692 := &x.OutOfDiskTransitionFrequency
-		yym693 := z.DecBinary()
-		_ = yym693
+		yyv697 := &x.OutOfDiskTransitionFrequency
+		yym698 := z.DecBinary()
+		_ = yym698
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv692) {
-		} else if !yym693 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv692)
+		} else if z.HasExtensions() && z.DecExt(yyv697) {
+		} else if !yym698 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv697)
 		} else {
-			z.DecFallback(yyv692, false)
+			z.DecFallback(yyv697, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5879,13 +5920,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NodeIP = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5893,21 +5934,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.NodeLabels = nil
 	} else {
-		yyv695 := &x.NodeLabels
-		yym696 := z.DecBinary()
-		_ = yym696
+		yyv700 := &x.NodeLabels
+		yym701 := z.DecBinary()
+		_ = yym701
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv695, false, d)
+			z.F.DecMapStringStringX(yyv700, false, d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5917,13 +5958,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NonMasqueradeCIDR = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5933,13 +5974,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableCustomMetrics = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5949,13 +5990,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionHard = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5965,13 +6006,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionSoft = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5981,13 +6022,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionSoftGracePeriod = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5995,24 +6036,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.EvictionPressureTransitionPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv702 := &x.EvictionPressureTransitionPeriod
-		yym703 := z.DecBinary()
-		_ = yym703
+		yyv707 := &x.EvictionPressureTransitionPeriod
+		yym708 := z.DecBinary()
+		_ = yym708
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv702) {
-		} else if !yym703 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv702)
+		} else if z.HasExtensions() && z.DecExt(yyv707) {
+		} else if !yym708 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv707)
 		} else {
-			z.DecFallback(yyv702, false)
+			z.DecFallback(yyv707, false)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6022,13 +6063,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionMaxPodGracePeriod = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6038,13 +6079,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionMinimumReclaim = string(r.DecodeString())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6054,13 +6095,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodsPerCore = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6070,13 +6111,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableControllerAttachDetach = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6084,22 +6125,22 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.SystemReserved = nil
 	} else {
-		yyv708 := &x.SystemReserved
-		yym709 := z.DecBinary()
-		_ = yym709
+		yyv713 := &x.SystemReserved
+		yym714 := z.DecBinary()
+		_ = yym714
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv708) {
+		} else if z.HasExtensions() && z.DecExt(yyv713) {
 		} else {
-			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv708), d)
+			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv713), d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6107,22 +6148,22 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.KubeReserved = nil
 	} else {
-		yyv710 := &x.KubeReserved
-		yym711 := z.DecBinary()
-		_ = yym711
+		yyv715 := &x.KubeReserved
+		yym716 := z.DecBinary()
+		_ = yym716
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv710) {
+		} else if z.HasExtensions() && z.DecExt(yyv715) {
 		} else {
-			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv710), d)
+			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv715), d)
 		}
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6132,13 +6173,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ProtectKernelDefaults = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6148,13 +6189,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MakeIPTablesUtilChains = bool(r.DecodeBool())
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6164,13 +6205,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.IPTablesMasqueradeBit = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6180,13 +6221,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.IPTablesDropBit = int32(r.DecodeInt(32))
 	}
-	yyj594++
-	if yyhl594 {
-		yyb594 = yyj594 > l
+	yyj598++
+	if yyhl598 {
+		yyb598 = yyj598 > l
 	} else {
-		yyb594 = r.CheckBreak()
+		yyb598 = r.CheckBreak()
 	}
-	if yyb594 {
+	if yyb598 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6194,26 +6235,26 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.AllowedUnsafeSysctls = nil
 	} else {
-		yyv716 := &x.AllowedUnsafeSysctls
-		yym717 := z.DecBinary()
-		_ = yym717
+		yyv721 := &x.AllowedUnsafeSysctls
+		yym722 := z.DecBinary()
+		_ = yym722
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv716, false, d)
+			z.F.DecSliceStringX(yyv721, false, d)
 		}
 	}
 	for {
-		yyj594++
-		if yyhl594 {
-			yyb594 = yyj594 > l
+		yyj598++
+		if yyhl598 {
+			yyb598 = yyj598 > l
 		} else {
-			yyb594 = r.CheckBreak()
+			yyb598 = r.CheckBreak()
 		}
-		if yyb594 {
+		if yyb598 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj594-1, "")
+		z.DecStructFieldNotFound(yyj598-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6225,36 +6266,36 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym718 := z.EncBinary()
-		_ = yym718
+		yym723 := z.EncBinary()
+		_ = yym723
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep719 := !z.EncBinary()
-			yy2arr719 := z.EncBasicHandle().StructToArray
-			var yyq719 [14]bool
-			_, _, _ = yysep719, yyq719, yy2arr719
-			const yyr719 bool = false
-			yyq719[0] = x.Kind != ""
-			yyq719[1] = x.APIVersion != ""
-			var yynn719 int
-			if yyr719 || yy2arr719 {
+			yysep724 := !z.EncBinary()
+			yy2arr724 := z.EncBasicHandle().StructToArray
+			var yyq724 [14]bool
+			_, _, _ = yysep724, yyq724, yy2arr724
+			const yyr724 bool = false
+			yyq724[0] = x.Kind != ""
+			yyq724[1] = x.APIVersion != ""
+			var yynn724 int
+			if yyr724 || yy2arr724 {
 				r.EncodeArrayStart(14)
 			} else {
-				yynn719 = 12
-				for _, b := range yyq719 {
+				yynn724 = 12
+				for _, b := range yyq724 {
 					if b {
-						yynn719++
+						yynn724++
 					}
 				}
-				r.EncodeMapStart(yynn719)
-				yynn719 = 0
+				r.EncodeMapStart(yynn724)
+				yynn724 = 0
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq719[0] {
-					yym721 := z.EncBinary()
-					_ = yym721
+				if yyq724[0] {
+					yym726 := z.EncBinary()
+					_ = yym726
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6263,23 +6304,23 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq719[0] {
+				if yyq724[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym722 := z.EncBinary()
-					_ = yym722
+					yym727 := z.EncBinary()
+					_ = yym727
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq719[1] {
-					yym724 := z.EncBinary()
-					_ = yym724
+				if yyq724[1] {
+					yym729 := z.EncBinary()
+					_ = yym729
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6288,22 +6329,22 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq719[1] {
+				if yyq724[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym725 := z.EncBinary()
-					_ = yym725
+					yym730 := z.EncBinary()
+					_ = yym730
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym727 := z.EncBinary()
-				_ = yym727
+				yym732 := z.EncBinary()
+				_ = yym732
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -6312,17 +6353,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym728 := z.EncBinary()
-				_ = yym728
+				yym733 := z.EncBinary()
+				_ = yym733
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym730 := z.EncBinary()
-				_ = yym730
+				yym735 := z.EncBinary()
+				_ = yym735
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -6331,17 +6372,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym731 := z.EncBinary()
-				_ = yym731
+				yym736 := z.EncBinary()
+				_ = yym736
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym733 := z.EncBinary()
-				_ = yym733
+				yym738 := z.EncBinary()
+				_ = yym738
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -6350,17 +6391,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("algorithmProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym734 := z.EncBinary()
-				_ = yym734
+				yym739 := z.EncBinary()
+				_ = yym739
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym736 := z.EncBinary()
-				_ = yym736
+				yym741 := z.EncBinary()
+				_ = yym741
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -6369,17 +6410,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("policyConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym737 := z.EncBinary()
-				_ = yym737
+				yym742 := z.EncBinary()
+				_ = yym742
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym739 := z.EncBinary()
-				_ = yym739
+				yym744 := z.EncBinary()
+				_ = yym744
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -6388,17 +6429,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableProfiling"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym740 := z.EncBinary()
-				_ = yym740
+				yym745 := z.EncBinary()
+				_ = yym745
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym742 := z.EncBinary()
-				_ = yym742
+				yym747 := z.EncBinary()
+				_ = yym747
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
@@ -6407,17 +6448,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym743 := z.EncBinary()
-				_ = yym743
+				yym748 := z.EncBinary()
+				_ = yym748
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym745 := z.EncBinary()
-				_ = yym745
+				yym750 := z.EncBinary()
+				_ = yym750
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -6426,17 +6467,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym746 := z.EncBinary()
-				_ = yym746
+				yym751 := z.EncBinary()
+				_ = yym751
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym748 := z.EncBinary()
-				_ = yym748
+				yym753 := z.EncBinary()
+				_ = yym753
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -6445,17 +6486,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym749 := z.EncBinary()
-				_ = yym749
+				yym754 := z.EncBinary()
+				_ = yym754
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym751 := z.EncBinary()
-				_ = yym751
+				yym756 := z.EncBinary()
+				_ = yym756
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -6464,17 +6505,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("schedulerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym752 := z.EncBinary()
-				_ = yym752
+				yym757 := z.EncBinary()
+				_ = yym757
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym754 := z.EncBinary()
-				_ = yym754
+				yym759 := z.EncBinary()
+				_ = yym759
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HardPodAffinitySymmetricWeight))
@@ -6483,17 +6524,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hardPodAffinitySymmetricWeight"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym755 := z.EncBinary()
-				_ = yym755
+				yym760 := z.EncBinary()
+				_ = yym760
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HardPodAffinitySymmetricWeight))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym757 := z.EncBinary()
-				_ = yym757
+				yym762 := z.EncBinary()
+				_ = yym762
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FailureDomains))
@@ -6502,25 +6543,25 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("failureDomains"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym758 := z.EncBinary()
-				_ = yym758
+				yym763 := z.EncBinary()
+				_ = yym763
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FailureDomains))
 				}
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy760 := &x.LeaderElection
-				yy760.CodecEncodeSelf(e)
+				yy765 := &x.LeaderElection
+				yy765.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy761 := &x.LeaderElection
-				yy761.CodecEncodeSelf(e)
+				yy766 := &x.LeaderElection
+				yy766.CodecEncodeSelf(e)
 			}
-			if yyr719 || yy2arr719 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6533,25 +6574,25 @@ func (x *KubeSchedulerConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym762 := z.DecBinary()
-	_ = yym762
+	yym767 := z.DecBinary()
+	_ = yym767
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct763 := r.ContainerType()
-		if yyct763 == codecSelferValueTypeMap1234 {
-			yyl763 := r.ReadMapStart()
-			if yyl763 == 0 {
+		yyct768 := r.ContainerType()
+		if yyct768 == codecSelferValueTypeMap1234 {
+			yyl768 := r.ReadMapStart()
+			if yyl768 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl763, d)
+				x.codecDecodeSelfFromMap(yyl768, d)
 			}
-		} else if yyct763 == codecSelferValueTypeArray1234 {
-			yyl763 := r.ReadArrayStart()
-			if yyl763 == 0 {
+		} else if yyct768 == codecSelferValueTypeArray1234 {
+			yyl768 := r.ReadArrayStart()
+			if yyl768 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl763, d)
+				x.codecDecodeSelfFromArray(yyl768, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6563,12 +6604,12 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys764Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys764Slc
-	var yyhl764 bool = l >= 0
-	for yyj764 := 0; ; yyj764++ {
-		if yyhl764 {
-			if yyj764 >= l {
+	var yys769Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys769Slc
+	var yyhl769 bool = l >= 0
+	for yyj769 := 0; ; yyj769++ {
+		if yyhl769 {
+			if yyj769 >= l {
 				break
 			}
 		} else {
@@ -6577,10 +6618,10 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys764Slc = r.DecodeBytes(yys764Slc, true, true)
-		yys764 := string(yys764Slc)
+		yys769Slc = r.DecodeBytes(yys769Slc, true, true)
+		yys769 := string(yys769Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys764 {
+		switch yys769 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6663,13 +6704,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv778 := &x.LeaderElection
-				yyv778.CodecDecodeSelf(d)
+				yyv783 := &x.LeaderElection
+				yyv783.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys764)
-		} // end switch yys764
-	} // end for yyj764
+			z.DecStructFieldNotFound(-1, yys769)
+		} // end switch yys769
+	} // end for yyj769
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6677,16 +6718,16 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj779 int
-	var yyb779 bool
-	var yyhl779 bool = l >= 0
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	var yyj784 int
+	var yyb784 bool
+	var yyhl784 bool = l >= 0
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6696,13 +6737,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6712,13 +6753,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6728,13 +6769,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6744,13 +6785,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6760,13 +6801,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.AlgorithmProvider = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6776,13 +6817,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.PolicyConfigFile = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6792,13 +6833,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.EnableProfiling = bool(r.DecodeBool())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6808,13 +6849,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6824,13 +6865,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.KubeAPIQPS = float32(r.DecodeFloat(true))
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6840,13 +6881,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6856,13 +6897,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.SchedulerName = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6872,13 +6913,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.HardPodAffinitySymmetricWeight = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6888,13 +6929,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.FailureDomains = string(r.DecodeString())
 	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
+	yyj784++
+	if yyhl784 {
+		yyb784 = yyj784 > l
 	} else {
-		yyb779 = r.CheckBreak()
+		yyb784 = r.CheckBreak()
 	}
-	if yyb779 {
+	if yyb784 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6902,21 +6943,21 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv793 := &x.LeaderElection
-		yyv793.CodecDecodeSelf(d)
+		yyv798 := &x.LeaderElection
+		yyv798.CodecDecodeSelf(d)
 	}
 	for {
-		yyj779++
-		if yyhl779 {
-			yyb779 = yyj779 > l
+		yyj784++
+		if yyhl784 {
+			yyb784 = yyj784 > l
 		} else {
-			yyb779 = r.CheckBreak()
+			yyb784 = r.CheckBreak()
 		}
-		if yyb779 {
+		if yyb784 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj779-1, "")
+		z.DecStructFieldNotFound(yyj784-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6928,33 +6969,33 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym794 := z.EncBinary()
-		_ = yym794
+		yym799 := z.EncBinary()
+		_ = yym799
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep795 := !z.EncBinary()
-			yy2arr795 := z.EncBasicHandle().StructToArray
-			var yyq795 [4]bool
-			_, _, _ = yysep795, yyq795, yy2arr795
-			const yyr795 bool = false
-			var yynn795 int
-			if yyr795 || yy2arr795 {
+			yysep800 := !z.EncBinary()
+			yy2arr800 := z.EncBasicHandle().StructToArray
+			var yyq800 [4]bool
+			_, _, _ = yysep800, yyq800, yy2arr800
+			const yyr800 bool = false
+			var yynn800 int
+			if yyr800 || yy2arr800 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn795 = 4
-				for _, b := range yyq795 {
+				yynn800 = 4
+				for _, b := range yyq800 {
 					if b {
-						yynn795++
+						yynn800++
 					}
 				}
-				r.EncodeMapStart(yynn795)
-				yynn795 = 0
+				r.EncodeMapStart(yynn800)
+				yynn800 = 0
 			}
-			if yyr795 || yy2arr795 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym797 := z.EncBinary()
-				_ = yym797
+				yym802 := z.EncBinary()
+				_ = yym802
 				if false {
 				} else {
 					r.EncodeBool(bool(x.LeaderElect))
@@ -6963,43 +7004,16 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElect"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym798 := z.EncBinary()
-				_ = yym798
+				yym803 := z.EncBinary()
+				_ = yym803
 				if false {
 				} else {
 					r.EncodeBool(bool(x.LeaderElect))
 				}
 			}
-			if yyr795 || yy2arr795 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy800 := &x.LeaseDuration
-				yym801 := z.EncBinary()
-				_ = yym801
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy800) {
-				} else if !yym801 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy800)
-				} else {
-					z.EncFallback(yy800)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("leaseDuration"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy802 := &x.LeaseDuration
-				yym803 := z.EncBinary()
-				_ = yym803
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy802) {
-				} else if !yym803 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy802)
-				} else {
-					z.EncFallback(yy802)
-				}
-			}
-			if yyr795 || yy2arr795 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy805 := &x.RenewDeadline
+				yy805 := &x.LeaseDuration
 				yym806 := z.EncBinary()
 				_ = yym806
 				if false {
@@ -7011,9 +7025,9 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("renewDeadline"))
+				r.EncodeString(codecSelferC_UTF81234, string("leaseDuration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy807 := &x.RenewDeadline
+				yy807 := &x.LeaseDuration
 				yym808 := z.EncBinary()
 				_ = yym808
 				if false {
@@ -7024,9 +7038,9 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy807)
 				}
 			}
-			if yyr795 || yy2arr795 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy810 := &x.RetryPeriod
+				yy810 := &x.RenewDeadline
 				yym811 := z.EncBinary()
 				_ = yym811
 				if false {
@@ -7038,9 +7052,9 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("retryPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("renewDeadline"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy812 := &x.RetryPeriod
+				yy812 := &x.RenewDeadline
 				yym813 := z.EncBinary()
 				_ = yym813
 				if false {
@@ -7051,7 +7065,34 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy812)
 				}
 			}
-			if yyr795 || yy2arr795 {
+			if yyr800 || yy2arr800 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy815 := &x.RetryPeriod
+				yym816 := z.EncBinary()
+				_ = yym816
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy815) {
+				} else if !yym816 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy815)
+				} else {
+					z.EncFallback(yy815)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("retryPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy817 := &x.RetryPeriod
+				yym818 := z.EncBinary()
+				_ = yym818
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy817) {
+				} else if !yym818 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy817)
+				} else {
+					z.EncFallback(yy817)
+				}
+			}
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7064,25 +7105,25 @@ func (x *LeaderElectionConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym814 := z.DecBinary()
-	_ = yym814
+	yym819 := z.DecBinary()
+	_ = yym819
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct815 := r.ContainerType()
-		if yyct815 == codecSelferValueTypeMap1234 {
-			yyl815 := r.ReadMapStart()
-			if yyl815 == 0 {
+		yyct820 := r.ContainerType()
+		if yyct820 == codecSelferValueTypeMap1234 {
+			yyl820 := r.ReadMapStart()
+			if yyl820 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl815, d)
+				x.codecDecodeSelfFromMap(yyl820, d)
 			}
-		} else if yyct815 == codecSelferValueTypeArray1234 {
-			yyl815 := r.ReadArrayStart()
-			if yyl815 == 0 {
+		} else if yyct820 == codecSelferValueTypeArray1234 {
+			yyl820 := r.ReadArrayStart()
+			if yyl820 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl815, d)
+				x.codecDecodeSelfFromArray(yyl820, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7094,12 +7135,12 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys816Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys816Slc
-	var yyhl816 bool = l >= 0
-	for yyj816 := 0; ; yyj816++ {
-		if yyhl816 {
-			if yyj816 >= l {
+	var yys821Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys821Slc
+	var yyhl821 bool = l >= 0
+	for yyj821 := 0; ; yyj821++ {
+		if yyhl821 {
+			if yyj821 >= l {
 				break
 			}
 		} else {
@@ -7108,10 +7149,10 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys816Slc = r.DecodeBytes(yys816Slc, true, true)
-		yys816 := string(yys816Slc)
+		yys821Slc = r.DecodeBytes(yys821Slc, true, true)
+		yys821 := string(yys821Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys816 {
+		switch yys821 {
 		case "leaderElect":
 			if r.TryDecodeAsNil() {
 				x.LeaderElect = false
@@ -7122,51 +7163,51 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.LeaseDuration = pkg1_unversioned.Duration{}
 			} else {
-				yyv818 := &x.LeaseDuration
-				yym819 := z.DecBinary()
-				_ = yym819
+				yyv823 := &x.LeaseDuration
+				yym824 := z.DecBinary()
+				_ = yym824
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv818) {
-				} else if !yym819 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv818)
+				} else if z.HasExtensions() && z.DecExt(yyv823) {
+				} else if !yym824 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv823)
 				} else {
-					z.DecFallback(yyv818, false)
+					z.DecFallback(yyv823, false)
 				}
 			}
 		case "renewDeadline":
 			if r.TryDecodeAsNil() {
 				x.RenewDeadline = pkg1_unversioned.Duration{}
 			} else {
-				yyv820 := &x.RenewDeadline
-				yym821 := z.DecBinary()
-				_ = yym821
+				yyv825 := &x.RenewDeadline
+				yym826 := z.DecBinary()
+				_ = yym826
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv820) {
-				} else if !yym821 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv820)
+				} else if z.HasExtensions() && z.DecExt(yyv825) {
+				} else if !yym826 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv825)
 				} else {
-					z.DecFallback(yyv820, false)
+					z.DecFallback(yyv825, false)
 				}
 			}
 		case "retryPeriod":
 			if r.TryDecodeAsNil() {
 				x.RetryPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv822 := &x.RetryPeriod
-				yym823 := z.DecBinary()
-				_ = yym823
+				yyv827 := &x.RetryPeriod
+				yym828 := z.DecBinary()
+				_ = yym828
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv822) {
-				} else if !yym823 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv822)
+				} else if z.HasExtensions() && z.DecExt(yyv827) {
+				} else if !yym828 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv827)
 				} else {
-					z.DecFallback(yyv822, false)
+					z.DecFallback(yyv827, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys816)
-		} // end switch yys816
-	} // end for yyj816
+			z.DecStructFieldNotFound(-1, yys821)
+		} // end switch yys821
+	} // end for yyj821
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7174,16 +7215,16 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj824 int
-	var yyb824 bool
-	var yyhl824 bool = l >= 0
-	yyj824++
-	if yyhl824 {
-		yyb824 = yyj824 > l
+	var yyj829 int
+	var yyb829 bool
+	var yyhl829 bool = l >= 0
+	yyj829++
+	if yyhl829 {
+		yyb829 = yyj829 > l
 	} else {
-		yyb824 = r.CheckBreak()
+		yyb829 = r.CheckBreak()
 	}
-	if yyb824 {
+	if yyb829 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7193,13 +7234,13 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.LeaderElect = bool(r.DecodeBool())
 	}
-	yyj824++
-	if yyhl824 {
-		yyb824 = yyj824 > l
+	yyj829++
+	if yyhl829 {
+		yyb829 = yyj829 > l
 	} else {
-		yyb824 = r.CheckBreak()
+		yyb829 = r.CheckBreak()
 	}
-	if yyb824 {
+	if yyb829 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7207,24 +7248,24 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.LeaseDuration = pkg1_unversioned.Duration{}
 	} else {
-		yyv826 := &x.LeaseDuration
-		yym827 := z.DecBinary()
-		_ = yym827
+		yyv831 := &x.LeaseDuration
+		yym832 := z.DecBinary()
+		_ = yym832
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv826) {
-		} else if !yym827 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv826)
+		} else if z.HasExtensions() && z.DecExt(yyv831) {
+		} else if !yym832 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv831)
 		} else {
-			z.DecFallback(yyv826, false)
+			z.DecFallback(yyv831, false)
 		}
 	}
-	yyj824++
-	if yyhl824 {
-		yyb824 = yyj824 > l
+	yyj829++
+	if yyhl829 {
+		yyb829 = yyj829 > l
 	} else {
-		yyb824 = r.CheckBreak()
+		yyb829 = r.CheckBreak()
 	}
-	if yyb824 {
+	if yyb829 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7232,24 +7273,24 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.RenewDeadline = pkg1_unversioned.Duration{}
 	} else {
-		yyv828 := &x.RenewDeadline
-		yym829 := z.DecBinary()
-		_ = yym829
+		yyv833 := &x.RenewDeadline
+		yym834 := z.DecBinary()
+		_ = yym834
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv828) {
-		} else if !yym829 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv828)
+		} else if z.HasExtensions() && z.DecExt(yyv833) {
+		} else if !yym834 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv833)
 		} else {
-			z.DecFallback(yyv828, false)
+			z.DecFallback(yyv833, false)
 		}
 	}
-	yyj824++
-	if yyhl824 {
-		yyb824 = yyj824 > l
+	yyj829++
+	if yyhl829 {
+		yyb829 = yyj829 > l
 	} else {
-		yyb824 = r.CheckBreak()
+		yyb829 = r.CheckBreak()
 	}
-	if yyb824 {
+	if yyb829 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7257,29 +7298,29 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.RetryPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv830 := &x.RetryPeriod
-		yym831 := z.DecBinary()
-		_ = yym831
+		yyv835 := &x.RetryPeriod
+		yym836 := z.DecBinary()
+		_ = yym836
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv830) {
-		} else if !yym831 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv830)
+		} else if z.HasExtensions() && z.DecExt(yyv835) {
+		} else if !yym836 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv835)
 		} else {
-			z.DecFallback(yyv830, false)
+			z.DecFallback(yyv835, false)
 		}
 	}
 	for {
-		yyj824++
-		if yyhl824 {
-			yyb824 = yyj824 > l
+		yyj829++
+		if yyhl829 {
+			yyb829 = yyj829 > l
 		} else {
-			yyb824 = r.CheckBreak()
+			yyb829 = r.CheckBreak()
 		}
-		if yyb824 {
+		if yyb829 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj824-1, "")
+		z.DecStructFieldNotFound(yyj829-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7291,36 +7332,36 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym832 := z.EncBinary()
-		_ = yym832
+		yym837 := z.EncBinary()
+		_ = yym837
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep833 := !z.EncBinary()
-			yy2arr833 := z.EncBasicHandle().StructToArray
-			var yyq833 [59]bool
-			_, _, _ = yysep833, yyq833, yy2arr833
-			const yyr833 bool = false
-			yyq833[0] = x.Kind != ""
-			yyq833[1] = x.APIVersion != ""
-			var yynn833 int
-			if yyr833 || yy2arr833 {
+			yysep838 := !z.EncBinary()
+			yy2arr838 := z.EncBasicHandle().StructToArray
+			var yyq838 [59]bool
+			_, _, _ = yysep838, yyq838, yy2arr838
+			const yyr838 bool = false
+			yyq838[0] = x.Kind != ""
+			yyq838[1] = x.APIVersion != ""
+			var yynn838 int
+			if yyr838 || yy2arr838 {
 				r.EncodeArrayStart(59)
 			} else {
-				yynn833 = 57
-				for _, b := range yyq833 {
+				yynn838 = 57
+				for _, b := range yyq838 {
 					if b {
-						yynn833++
+						yynn838++
 					}
 				}
-				r.EncodeMapStart(yynn833)
-				yynn833 = 0
+				r.EncodeMapStart(yynn838)
+				yynn838 = 0
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq833[0] {
-					yym835 := z.EncBinary()
-					_ = yym835
+				if yyq838[0] {
+					yym840 := z.EncBinary()
+					_ = yym840
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7329,23 +7370,23 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq833[0] {
+				if yyq838[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym836 := z.EncBinary()
-					_ = yym836
+					yym841 := z.EncBinary()
+					_ = yym841
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq833[1] {
-					yym838 := z.EncBinary()
-					_ = yym838
+				if yyq838[1] {
+					yym843 := z.EncBinary()
+					_ = yym843
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7354,22 +7395,22 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq833[1] {
+				if yyq838[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym839 := z.EncBinary()
-					_ = yym839
+					yym844 := z.EncBinary()
+					_ = yym844
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym841 := z.EncBinary()
-				_ = yym841
+				yym846 := z.EncBinary()
+				_ = yym846
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -7378,17 +7419,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym842 := z.EncBinary()
-				_ = yym842
+				yym847 := z.EncBinary()
+				_ = yym847
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym844 := z.EncBinary()
-				_ = yym844
+				yym849 := z.EncBinary()
+				_ = yym849
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -7397,17 +7438,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym845 := z.EncBinary()
-				_ = yym845
+				yym850 := z.EncBinary()
+				_ = yym850
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym847 := z.EncBinary()
-				_ = yym847
+				yym852 := z.EncBinary()
+				_ = yym852
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
@@ -7416,17 +7457,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym848 := z.EncBinary()
-				_ = yym848
+				yym853 := z.EncBinary()
+				_ = yym853
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym850 := z.EncBinary()
-				_ = yym850
+				yym855 := z.EncBinary()
+				_ = yym855
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
@@ -7435,17 +7476,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym851 := z.EncBinary()
-				_ = yym851
+				yym856 := z.EncBinary()
+				_ = yym856
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym853 := z.EncBinary()
-				_ = yym853
+				yym858 := z.EncBinary()
+				_ = yym858
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentEndpointSyncs))
@@ -7454,17 +7495,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentEndpointSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym854 := z.EncBinary()
-				_ = yym854
+				yym859 := z.EncBinary()
+				_ = yym859
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentEndpointSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym856 := z.EncBinary()
-				_ = yym856
+				yym861 := z.EncBinary()
+				_ = yym861
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRSSyncs))
@@ -7473,17 +7514,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentRSSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym857 := z.EncBinary()
-				_ = yym857
+				yym862 := z.EncBinary()
+				_ = yym862
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRSSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym859 := z.EncBinary()
-				_ = yym859
+				yym864 := z.EncBinary()
+				_ = yym864
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRCSyncs))
@@ -7492,17 +7533,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentRCSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym860 := z.EncBinary()
-				_ = yym860
+				yym865 := z.EncBinary()
+				_ = yym865
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRCSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym862 := z.EncBinary()
-				_ = yym862
+				yym867 := z.EncBinary()
+				_ = yym867
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentServiceSyncs))
@@ -7511,17 +7552,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentServiceSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym863 := z.EncBinary()
-				_ = yym863
+				yym868 := z.EncBinary()
+				_ = yym868
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentServiceSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym865 := z.EncBinary()
-				_ = yym865
+				yym870 := z.EncBinary()
+				_ = yym870
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentResourceQuotaSyncs))
@@ -7530,17 +7571,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentResourceQuotaSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym866 := z.EncBinary()
-				_ = yym866
+				yym871 := z.EncBinary()
+				_ = yym871
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentResourceQuotaSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym868 := z.EncBinary()
-				_ = yym868
+				yym873 := z.EncBinary()
+				_ = yym873
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDeploymentSyncs))
@@ -7549,17 +7590,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentDeploymentSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym869 := z.EncBinary()
-				_ = yym869
+				yym874 := z.EncBinary()
+				_ = yym874
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDeploymentSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym871 := z.EncBinary()
-				_ = yym871
+				yym876 := z.EncBinary()
+				_ = yym876
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDaemonSetSyncs))
@@ -7568,17 +7609,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentDaemonSetSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym872 := z.EncBinary()
-				_ = yym872
+				yym877 := z.EncBinary()
+				_ = yym877
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDaemonSetSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym874 := z.EncBinary()
-				_ = yym874
+				yym879 := z.EncBinary()
+				_ = yym879
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentJobSyncs))
@@ -7587,17 +7628,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentJobSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym875 := z.EncBinary()
-				_ = yym875
+				yym880 := z.EncBinary()
+				_ = yym880
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentJobSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym877 := z.EncBinary()
-				_ = yym877
+				yym882 := z.EncBinary()
+				_ = yym882
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentNamespaceSyncs))
@@ -7606,17 +7647,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentNamespaceSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym878 := z.EncBinary()
-				_ = yym878
+				yym883 := z.EncBinary()
+				_ = yym883
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentNamespaceSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym880 := z.EncBinary()
-				_ = yym880
+				yym885 := z.EncBinary()
+				_ = yym885
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentSATokenSyncs))
@@ -7625,17 +7666,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentSATokenSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym881 := z.EncBinary()
-				_ = yym881
+				yym886 := z.EncBinary()
+				_ = yym886
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentSATokenSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym883 := z.EncBinary()
-				_ = yym883
+				yym888 := z.EncBinary()
+				_ = yym888
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRC))
@@ -7644,17 +7685,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForRC"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym884 := z.EncBinary()
-				_ = yym884
+				yym889 := z.EncBinary()
+				_ = yym889
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRC))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym886 := z.EncBinary()
-				_ = yym886
+				yym891 := z.EncBinary()
+				_ = yym891
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRS))
@@ -7663,17 +7704,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForRS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym887 := z.EncBinary()
-				_ = yym887
+				yym892 := z.EncBinary()
+				_ = yym892
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRS))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym889 := z.EncBinary()
-				_ = yym889
+				yym894 := z.EncBinary()
+				_ = yym894
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForDaemonSet))
@@ -7682,43 +7723,16 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForDaemonSet"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym890 := z.EncBinary()
-				_ = yym890
+				yym895 := z.EncBinary()
+				_ = yym895
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForDaemonSet))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy892 := &x.ServiceSyncPeriod
-				yym893 := z.EncBinary()
-				_ = yym893
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy892) {
-				} else if !yym893 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy892)
-				} else {
-					z.EncFallback(yy892)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serviceSyncPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy894 := &x.ServiceSyncPeriod
-				yym895 := z.EncBinary()
-				_ = yym895
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy894) {
-				} else if !yym895 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy894)
-				} else {
-					z.EncFallback(yy894)
-				}
-			}
-			if yyr833 || yy2arr833 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy897 := &x.NodeSyncPeriod
+				yy897 := &x.ServiceSyncPeriod
 				yym898 := z.EncBinary()
 				_ = yym898
 				if false {
@@ -7730,9 +7744,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nodeSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("serviceSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy899 := &x.NodeSyncPeriod
+				yy899 := &x.ServiceSyncPeriod
 				yym900 := z.EncBinary()
 				_ = yym900
 				if false {
@@ -7743,9 +7757,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy899)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy902 := &x.ResourceQuotaSyncPeriod
+				yy902 := &x.NodeSyncPeriod
 				yym903 := z.EncBinary()
 				_ = yym903
 				if false {
@@ -7757,9 +7771,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("resourceQuotaSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("nodeSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy904 := &x.ResourceQuotaSyncPeriod
+				yy904 := &x.NodeSyncPeriod
 				yym905 := z.EncBinary()
 				_ = yym905
 				if false {
@@ -7770,9 +7784,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy904)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy907 := &x.NamespaceSyncPeriod
+				yy907 := &x.ResourceQuotaSyncPeriod
 				yym908 := z.EncBinary()
 				_ = yym908
 				if false {
@@ -7784,9 +7798,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("namespaceSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("resourceQuotaSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy909 := &x.NamespaceSyncPeriod
+				yy909 := &x.ResourceQuotaSyncPeriod
 				yym910 := z.EncBinary()
 				_ = yym910
 				if false {
@@ -7797,9 +7811,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy909)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy912 := &x.PVClaimBinderSyncPeriod
+				yy912 := &x.NamespaceSyncPeriod
 				yym913 := z.EncBinary()
 				_ = yym913
 				if false {
@@ -7811,9 +7825,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("pvClaimBinderSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("namespaceSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy914 := &x.PVClaimBinderSyncPeriod
+				yy914 := &x.NamespaceSyncPeriod
 				yym915 := z.EncBinary()
 				_ = yym915
 				if false {
@@ -7824,9 +7838,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy914)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy917 := &x.MinResyncPeriod
+				yy917 := &x.PVClaimBinderSyncPeriod
 				yym918 := z.EncBinary()
 				_ = yym918
 				if false {
@@ -7838,9 +7852,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("minResyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("pvClaimBinderSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy919 := &x.MinResyncPeriod
+				yy919 := &x.PVClaimBinderSyncPeriod
 				yym920 := z.EncBinary()
 				_ = yym920
 				if false {
@@ -7851,10 +7865,37 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy919)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym922 := z.EncBinary()
-				_ = yym922
+				yy922 := &x.MinResyncPeriod
+				yym923 := z.EncBinary()
+				_ = yym923
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy922) {
+				} else if !yym923 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy922)
+				} else {
+					z.EncFallback(yy922)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("minResyncPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy924 := &x.MinResyncPeriod
+				yym925 := z.EncBinary()
+				_ = yym925
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy924) {
+				} else if !yym925 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy924)
+				} else {
+					z.EncFallback(yy924)
+				}
+			}
+			if yyr838 || yy2arr838 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym927 := z.EncBinary()
+				_ = yym927
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
@@ -7863,43 +7904,16 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("terminatedPodGCThreshold"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym923 := z.EncBinary()
-				_ = yym923
+				yym928 := z.EncBinary()
+				_ = yym928
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy925 := &x.HorizontalPodAutoscalerSyncPeriod
-				yym926 := z.EncBinary()
-				_ = yym926
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy925) {
-				} else if !yym926 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy925)
-				} else {
-					z.EncFallback(yy925)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("horizontalPodAutoscalerSyncPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy927 := &x.HorizontalPodAutoscalerSyncPeriod
-				yym928 := z.EncBinary()
-				_ = yym928
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy927) {
-				} else if !yym928 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy927)
-				} else {
-					z.EncFallback(yy927)
-				}
-			}
-			if yyr833 || yy2arr833 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy930 := &x.DeploymentControllerSyncPeriod
+				yy930 := &x.HorizontalPodAutoscalerSyncPeriod
 				yym931 := z.EncBinary()
 				_ = yym931
 				if false {
@@ -7911,9 +7925,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("deploymentControllerSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("horizontalPodAutoscalerSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy932 := &x.DeploymentControllerSyncPeriod
+				yy932 := &x.HorizontalPodAutoscalerSyncPeriod
 				yym933 := z.EncBinary()
 				_ = yym933
 				if false {
@@ -7924,9 +7938,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy932)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy935 := &x.PodEvictionTimeout
+				yy935 := &x.DeploymentControllerSyncPeriod
 				yym936 := z.EncBinary()
 				_ = yym936
 				if false {
@@ -7938,9 +7952,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("podEvictionTimeout"))
+				r.EncodeString(codecSelferC_UTF81234, string("deploymentControllerSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy937 := &x.PodEvictionTimeout
+				yy937 := &x.DeploymentControllerSyncPeriod
 				yym938 := z.EncBinary()
 				_ = yym938
 				if false {
@@ -7951,10 +7965,37 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy937)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym940 := z.EncBinary()
-				_ = yym940
+				yy940 := &x.PodEvictionTimeout
+				yym941 := z.EncBinary()
+				_ = yym941
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy940) {
+				} else if !yym941 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy940)
+				} else {
+					z.EncFallback(yy940)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("podEvictionTimeout"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy942 := &x.PodEvictionTimeout
+				yym943 := z.EncBinary()
+				_ = yym943
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy942) {
+				} else if !yym943 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy942)
+				} else {
+					z.EncFallback(yy942)
+				}
+			}
+			if yyr838 || yy2arr838 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym945 := z.EncBinary()
+				_ = yym945
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.DeletingPodsQps))
@@ -7963,17 +8004,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("deletingPodsQps"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym941 := z.EncBinary()
-				_ = yym941
+				yym946 := z.EncBinary()
+				_ = yym946
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.DeletingPodsQps))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym943 := z.EncBinary()
-				_ = yym943
+				yym948 := z.EncBinary()
+				_ = yym948
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DeletingPodsBurst))
@@ -7982,44 +8023,44 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("deletingPodsBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym944 := z.EncBinary()
-				_ = yym944
+				yym949 := z.EncBinary()
+				_ = yym949
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DeletingPodsBurst))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy946 := &x.NodeMonitorGracePeriod
-				yym947 := z.EncBinary()
-				_ = yym947
+				yy951 := &x.NodeMonitorGracePeriod
+				yym952 := z.EncBinary()
+				_ = yym952
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy946) {
-				} else if !yym947 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy946)
+				} else if z.HasExtensions() && z.EncExt(yy951) {
+				} else if !yym952 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy951)
 				} else {
-					z.EncFallback(yy946)
+					z.EncFallback(yy951)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeMonitorGracePeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy948 := &x.NodeMonitorGracePeriod
-				yym949 := z.EncBinary()
-				_ = yym949
+				yy953 := &x.NodeMonitorGracePeriod
+				yym954 := z.EncBinary()
+				_ = yym954
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy948) {
-				} else if !yym949 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy948)
+				} else if z.HasExtensions() && z.EncExt(yy953) {
+				} else if !yym954 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy953)
 				} else {
-					z.EncFallback(yy948)
+					z.EncFallback(yy953)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym951 := z.EncBinary()
-				_ = yym951
+				yym956 := z.EncBinary()
+				_ = yym956
 				if false {
 				} else {
 					r.EncodeInt(int64(x.RegisterRetryCount))
@@ -8028,43 +8069,16 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("registerRetryCount"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym952 := z.EncBinary()
-				_ = yym952
+				yym957 := z.EncBinary()
+				_ = yym957
 				if false {
 				} else {
 					r.EncodeInt(int64(x.RegisterRetryCount))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy954 := &x.NodeStartupGracePeriod
-				yym955 := z.EncBinary()
-				_ = yym955
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy954) {
-				} else if !yym955 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy954)
-				} else {
-					z.EncFallback(yy954)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nodeStartupGracePeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy956 := &x.NodeStartupGracePeriod
-				yym957 := z.EncBinary()
-				_ = yym957
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy956) {
-				} else if !yym957 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy956)
-				} else {
-					z.EncFallback(yy956)
-				}
-			}
-			if yyr833 || yy2arr833 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy959 := &x.NodeMonitorPeriod
+				yy959 := &x.NodeStartupGracePeriod
 				yym960 := z.EncBinary()
 				_ = yym960
 				if false {
@@ -8076,9 +8090,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nodeMonitorPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("nodeStartupGracePeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy961 := &x.NodeMonitorPeriod
+				yy961 := &x.NodeStartupGracePeriod
 				yym962 := z.EncBinary()
 				_ = yym962
 				if false {
@@ -8089,10 +8103,37 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy961)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym964 := z.EncBinary()
-				_ = yym964
+				yy964 := &x.NodeMonitorPeriod
+				yym965 := z.EncBinary()
+				_ = yym965
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy964) {
+				} else if !yym965 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy964)
+				} else {
+					z.EncFallback(yy964)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("nodeMonitorPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy966 := &x.NodeMonitorPeriod
+				yym967 := z.EncBinary()
+				_ = yym967
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy966) {
+				} else if !yym967 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy966)
+				} else {
+					z.EncFallback(yy966)
+				}
+			}
+			if yyr838 || yy2arr838 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym969 := z.EncBinary()
+				_ = yym969
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountKeyFile))
@@ -8101,17 +8142,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceAccountKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym965 := z.EncBinary()
-				_ = yym965
+				yym970 := z.EncBinary()
+				_ = yym970
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountKeyFile))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym967 := z.EncBinary()
-				_ = yym967
+				yym972 := z.EncBinary()
+				_ = yym972
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningCertFile))
@@ -8120,17 +8161,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterSigningCertFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym968 := z.EncBinary()
-				_ = yym968
+				yym973 := z.EncBinary()
+				_ = yym973
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningCertFile))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym970 := z.EncBinary()
-				_ = yym970
+				yym975 := z.EncBinary()
+				_ = yym975
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningKeyFile))
@@ -8139,17 +8180,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterSigningKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym971 := z.EncBinary()
-				_ = yym971
+				yym976 := z.EncBinary()
+				_ = yym976
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningKeyFile))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym973 := z.EncBinary()
-				_ = yym973
+				yym978 := z.EncBinary()
+				_ = yym978
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ApproveAllKubeletCSRsForGroup))
@@ -8158,17 +8199,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("approveAllKubeletCSRsForGroup"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym974 := z.EncBinary()
-				_ = yym974
+				yym979 := z.EncBinary()
+				_ = yym979
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ApproveAllKubeletCSRsForGroup))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym976 := z.EncBinary()
-				_ = yym976
+				yym981 := z.EncBinary()
+				_ = yym981
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -8177,17 +8218,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableProfiling"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym977 := z.EncBinary()
-				_ = yym977
+				yym982 := z.EncBinary()
+				_ = yym982
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym979 := z.EncBinary()
-				_ = yym979
+				yym984 := z.EncBinary()
+				_ = yym984
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterName))
@@ -8196,17 +8237,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym980 := z.EncBinary()
-				_ = yym980
+				yym985 := z.EncBinary()
+				_ = yym985
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterName))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym982 := z.EncBinary()
-				_ = yym982
+				yym987 := z.EncBinary()
+				_ = yym987
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterCIDR))
@@ -8215,17 +8256,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym983 := z.EncBinary()
-				_ = yym983
+				yym988 := z.EncBinary()
+				_ = yym988
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterCIDR))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym985 := z.EncBinary()
-				_ = yym985
+				yym990 := z.EncBinary()
+				_ = yym990
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceCIDR))
@@ -8234,17 +8275,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym986 := z.EncBinary()
-				_ = yym986
+				yym991 := z.EncBinary()
+				_ = yym991
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceCIDR))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym988 := z.EncBinary()
-				_ = yym988
+				yym993 := z.EncBinary()
+				_ = yym993
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodeCIDRMaskSize))
@@ -8253,17 +8294,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeCIDRMaskSize"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym989 := z.EncBinary()
-				_ = yym989
+				yym994 := z.EncBinary()
+				_ = yym994
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodeCIDRMaskSize))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym991 := z.EncBinary()
-				_ = yym991
+				yym996 := z.EncBinary()
+				_ = yym996
 				if false {
 				} else {
 					r.EncodeBool(bool(x.AllocateNodeCIDRs))
@@ -8272,17 +8313,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("allocateNodeCIDRs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym992 := z.EncBinary()
-				_ = yym992
+				yym997 := z.EncBinary()
+				_ = yym997
 				if false {
 				} else {
 					r.EncodeBool(bool(x.AllocateNodeCIDRs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym994 := z.EncBinary()
-				_ = yym994
+				yym999 := z.EncBinary()
+				_ = yym999
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ConfigureCloudRoutes))
@@ -8291,17 +8332,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("configureCloudRoutes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym995 := z.EncBinary()
-				_ = yym995
+				yym1000 := z.EncBinary()
+				_ = yym1000
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ConfigureCloudRoutes))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym997 := z.EncBinary()
-				_ = yym997
+				yym1002 := z.EncBinary()
+				_ = yym1002
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RootCAFile))
@@ -8310,17 +8351,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("rootCAFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym998 := z.EncBinary()
-				_ = yym998
+				yym1003 := z.EncBinary()
+				_ = yym1003
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RootCAFile))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1000 := z.EncBinary()
-				_ = yym1000
+				yym1005 := z.EncBinary()
+				_ = yym1005
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
@@ -8329,17 +8370,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1001 := z.EncBinary()
-				_ = yym1001
+				yym1006 := z.EncBinary()
+				_ = yym1006
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1003 := z.EncBinary()
-				_ = yym1003
+				yym1008 := z.EncBinary()
+				_ = yym1008
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -8348,17 +8389,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1004 := z.EncBinary()
-				_ = yym1004
+				yym1009 := z.EncBinary()
+				_ = yym1009
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1006 := z.EncBinary()
-				_ = yym1006
+				yym1011 := z.EncBinary()
+				_ = yym1011
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -8367,66 +8408,66 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1007 := z.EncBinary()
-				_ = yym1007
+				yym1012 := z.EncBinary()
+				_ = yym1012
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1009 := &x.LeaderElection
-				yy1009.CodecEncodeSelf(e)
+				yy1014 := &x.LeaderElection
+				yy1014.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1010 := &x.LeaderElection
-				yy1010.CodecEncodeSelf(e)
+				yy1015 := &x.LeaderElection
+				yy1015.CodecEncodeSelf(e)
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1012 := &x.VolumeConfiguration
-				yy1012.CodecEncodeSelf(e)
+				yy1017 := &x.VolumeConfiguration
+				yy1017.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeConfiguration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1013 := &x.VolumeConfiguration
-				yy1013.CodecEncodeSelf(e)
+				yy1018 := &x.VolumeConfiguration
+				yy1018.CodecEncodeSelf(e)
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1015 := &x.ControllerStartInterval
-				yym1016 := z.EncBinary()
-				_ = yym1016
+				yy1020 := &x.ControllerStartInterval
+				yym1021 := z.EncBinary()
+				_ = yym1021
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1015) {
-				} else if !yym1016 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1015)
+				} else if z.HasExtensions() && z.EncExt(yy1020) {
+				} else if !yym1021 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1020)
 				} else {
-					z.EncFallback(yy1015)
+					z.EncFallback(yy1020)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("controllerStartInterval"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1017 := &x.ControllerStartInterval
-				yym1018 := z.EncBinary()
-				_ = yym1018
+				yy1022 := &x.ControllerStartInterval
+				yym1023 := z.EncBinary()
+				_ = yym1023
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1017) {
-				} else if !yym1018 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1017)
+				} else if z.HasExtensions() && z.EncExt(yy1022) {
+				} else if !yym1023 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1022)
 				} else {
-					z.EncFallback(yy1017)
+					z.EncFallback(yy1022)
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1020 := z.EncBinary()
-				_ = yym1020
+				yym1025 := z.EncBinary()
+				_ = yym1025
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableGarbageCollector))
@@ -8435,17 +8476,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableGarbageCollector"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1021 := z.EncBinary()
-				_ = yym1021
+				yym1026 := z.EncBinary()
+				_ = yym1026
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableGarbageCollector))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1023 := z.EncBinary()
-				_ = yym1023
+				yym1028 := z.EncBinary()
+				_ = yym1028
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentGCSyncs))
@@ -8454,17 +8495,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentGCSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1024 := z.EncBinary()
-				_ = yym1024
+				yym1029 := z.EncBinary()
+				_ = yym1029
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentGCSyncs))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1026 := z.EncBinary()
-				_ = yym1026
+				yym1031 := z.EncBinary()
+				_ = yym1031
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.NodeEvictionRate))
@@ -8473,17 +8514,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeEvictionRate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1027 := z.EncBinary()
-				_ = yym1027
+				yym1032 := z.EncBinary()
+				_ = yym1032
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.NodeEvictionRate))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1029 := z.EncBinary()
-				_ = yym1029
+				yym1034 := z.EncBinary()
+				_ = yym1034
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.SecondaryNodeEvictionRate))
@@ -8492,17 +8533,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secondaryNodeEvictionRate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1030 := z.EncBinary()
-				_ = yym1030
+				yym1035 := z.EncBinary()
+				_ = yym1035
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.SecondaryNodeEvictionRate))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1032 := z.EncBinary()
-				_ = yym1032
+				yym1037 := z.EncBinary()
+				_ = yym1037
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LargeClusterSizeThreshold))
@@ -8511,17 +8552,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("largeClusterSizeThreshold"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1033 := z.EncBinary()
-				_ = yym1033
+				yym1038 := z.EncBinary()
+				_ = yym1038
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LargeClusterSizeThreshold))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1035 := z.EncBinary()
-				_ = yym1035
+				yym1040 := z.EncBinary()
+				_ = yym1040
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.UnhealthyZoneThreshold))
@@ -8530,14 +8571,14 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("unhealthyZoneThreshold"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1036 := z.EncBinary()
-				_ = yym1036
+				yym1041 := z.EncBinary()
+				_ = yym1041
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.UnhealthyZoneThreshold))
 				}
 			}
-			if yyr833 || yy2arr833 {
+			if yyr838 || yy2arr838 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8550,25 +8591,25 @@ func (x *KubeControllerManagerConfiguration) CodecDecodeSelf(d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1037 := z.DecBinary()
-	_ = yym1037
+	yym1042 := z.DecBinary()
+	_ = yym1042
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1038 := r.ContainerType()
-		if yyct1038 == codecSelferValueTypeMap1234 {
-			yyl1038 := r.ReadMapStart()
-			if yyl1038 == 0 {
+		yyct1043 := r.ContainerType()
+		if yyct1043 == codecSelferValueTypeMap1234 {
+			yyl1043 := r.ReadMapStart()
+			if yyl1043 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1038, d)
+				x.codecDecodeSelfFromMap(yyl1043, d)
 			}
-		} else if yyct1038 == codecSelferValueTypeArray1234 {
-			yyl1038 := r.ReadArrayStart()
-			if yyl1038 == 0 {
+		} else if yyct1043 == codecSelferValueTypeArray1234 {
+			yyl1043 := r.ReadArrayStart()
+			if yyl1043 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1038, d)
+				x.codecDecodeSelfFromArray(yyl1043, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8580,12 +8621,12 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1039Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1039Slc
-	var yyhl1039 bool = l >= 0
-	for yyj1039 := 0; ; yyj1039++ {
-		if yyhl1039 {
-			if yyj1039 >= l {
+	var yys1044Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1044Slc
+	var yyhl1044 bool = l >= 0
+	for yyj1044 := 0; ; yyj1044++ {
+		if yyhl1044 {
+			if yyj1044 >= l {
 				break
 			}
 		} else {
@@ -8594,10 +8635,10 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1039Slc = r.DecodeBytes(yys1039Slc, true, true)
-		yys1039 := string(yys1039Slc)
+		yys1044Slc = r.DecodeBytes(yys1044Slc, true, true)
+		yys1044 := string(yys1044Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1039 {
+		switch yys1044 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8716,90 +8757,90 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.ServiceSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1059 := &x.ServiceSyncPeriod
-				yym1060 := z.DecBinary()
-				_ = yym1060
+				yyv1064 := &x.ServiceSyncPeriod
+				yym1065 := z.DecBinary()
+				_ = yym1065
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1059) {
-				} else if !yym1060 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1059)
+				} else if z.HasExtensions() && z.DecExt(yyv1064) {
+				} else if !yym1065 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1064)
 				} else {
-					z.DecFallback(yyv1059, false)
+					z.DecFallback(yyv1064, false)
 				}
 			}
 		case "nodeSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.NodeSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1061 := &x.NodeSyncPeriod
-				yym1062 := z.DecBinary()
-				_ = yym1062
+				yyv1066 := &x.NodeSyncPeriod
+				yym1067 := z.DecBinary()
+				_ = yym1067
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1061) {
-				} else if !yym1062 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1061)
+				} else if z.HasExtensions() && z.DecExt(yyv1066) {
+				} else if !yym1067 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1066)
 				} else {
-					z.DecFallback(yyv1061, false)
+					z.DecFallback(yyv1066, false)
 				}
 			}
 		case "resourceQuotaSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.ResourceQuotaSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1063 := &x.ResourceQuotaSyncPeriod
-				yym1064 := z.DecBinary()
-				_ = yym1064
+				yyv1068 := &x.ResourceQuotaSyncPeriod
+				yym1069 := z.DecBinary()
+				_ = yym1069
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1063) {
-				} else if !yym1064 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1063)
+				} else if z.HasExtensions() && z.DecExt(yyv1068) {
+				} else if !yym1069 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1068)
 				} else {
-					z.DecFallback(yyv1063, false)
+					z.DecFallback(yyv1068, false)
 				}
 			}
 		case "namespaceSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.NamespaceSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1065 := &x.NamespaceSyncPeriod
-				yym1066 := z.DecBinary()
-				_ = yym1066
+				yyv1070 := &x.NamespaceSyncPeriod
+				yym1071 := z.DecBinary()
+				_ = yym1071
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1065) {
-				} else if !yym1066 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1065)
+				} else if z.HasExtensions() && z.DecExt(yyv1070) {
+				} else if !yym1071 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1070)
 				} else {
-					z.DecFallback(yyv1065, false)
+					z.DecFallback(yyv1070, false)
 				}
 			}
 		case "pvClaimBinderSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.PVClaimBinderSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1067 := &x.PVClaimBinderSyncPeriod
-				yym1068 := z.DecBinary()
-				_ = yym1068
+				yyv1072 := &x.PVClaimBinderSyncPeriod
+				yym1073 := z.DecBinary()
+				_ = yym1073
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1067) {
-				} else if !yym1068 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1067)
+				} else if z.HasExtensions() && z.DecExt(yyv1072) {
+				} else if !yym1073 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1072)
 				} else {
-					z.DecFallback(yyv1067, false)
+					z.DecFallback(yyv1072, false)
 				}
 			}
 		case "minResyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.MinResyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1069 := &x.MinResyncPeriod
-				yym1070 := z.DecBinary()
-				_ = yym1070
+				yyv1074 := &x.MinResyncPeriod
+				yym1075 := z.DecBinary()
+				_ = yym1075
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1069) {
-				} else if !yym1070 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1069)
+				} else if z.HasExtensions() && z.DecExt(yyv1074) {
+				} else if !yym1075 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1074)
 				} else {
-					z.DecFallback(yyv1069, false)
+					z.DecFallback(yyv1074, false)
 				}
 			}
 		case "terminatedPodGCThreshold":
@@ -8812,45 +8853,45 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1072 := &x.HorizontalPodAutoscalerSyncPeriod
-				yym1073 := z.DecBinary()
-				_ = yym1073
+				yyv1077 := &x.HorizontalPodAutoscalerSyncPeriod
+				yym1078 := z.DecBinary()
+				_ = yym1078
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1072) {
-				} else if !yym1073 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1072)
+				} else if z.HasExtensions() && z.DecExt(yyv1077) {
+				} else if !yym1078 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1077)
 				} else {
-					z.DecFallback(yyv1072, false)
+					z.DecFallback(yyv1077, false)
 				}
 			}
 		case "deploymentControllerSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1074 := &x.DeploymentControllerSyncPeriod
-				yym1075 := z.DecBinary()
-				_ = yym1075
+				yyv1079 := &x.DeploymentControllerSyncPeriod
+				yym1080 := z.DecBinary()
+				_ = yym1080
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1074) {
-				} else if !yym1075 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1074)
+				} else if z.HasExtensions() && z.DecExt(yyv1079) {
+				} else if !yym1080 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1079)
 				} else {
-					z.DecFallback(yyv1074, false)
+					z.DecFallback(yyv1079, false)
 				}
 			}
 		case "podEvictionTimeout":
 			if r.TryDecodeAsNil() {
 				x.PodEvictionTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv1076 := &x.PodEvictionTimeout
-				yym1077 := z.DecBinary()
-				_ = yym1077
+				yyv1081 := &x.PodEvictionTimeout
+				yym1082 := z.DecBinary()
+				_ = yym1082
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1076) {
-				} else if !yym1077 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1076)
+				} else if z.HasExtensions() && z.DecExt(yyv1081) {
+				} else if !yym1082 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1081)
 				} else {
-					z.DecFallback(yyv1076, false)
+					z.DecFallback(yyv1081, false)
 				}
 			}
 		case "deletingPodsQps":
@@ -8869,15 +8910,15 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.NodeMonitorGracePeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1080 := &x.NodeMonitorGracePeriod
-				yym1081 := z.DecBinary()
-				_ = yym1081
+				yyv1085 := &x.NodeMonitorGracePeriod
+				yym1086 := z.DecBinary()
+				_ = yym1086
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1080) {
-				} else if !yym1081 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1080)
+				} else if z.HasExtensions() && z.DecExt(yyv1085) {
+				} else if !yym1086 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1085)
 				} else {
-					z.DecFallback(yyv1080, false)
+					z.DecFallback(yyv1085, false)
 				}
 			}
 		case "registerRetryCount":
@@ -8890,30 +8931,30 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1083 := &x.NodeStartupGracePeriod
-				yym1084 := z.DecBinary()
-				_ = yym1084
+				yyv1088 := &x.NodeStartupGracePeriod
+				yym1089 := z.DecBinary()
+				_ = yym1089
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1083) {
-				} else if !yym1084 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1083)
+				} else if z.HasExtensions() && z.DecExt(yyv1088) {
+				} else if !yym1089 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1088)
 				} else {
-					z.DecFallback(yyv1083, false)
+					z.DecFallback(yyv1088, false)
 				}
 			}
 		case "nodeMonitorPeriod":
 			if r.TryDecodeAsNil() {
 				x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1085 := &x.NodeMonitorPeriod
-				yym1086 := z.DecBinary()
-				_ = yym1086
+				yyv1090 := &x.NodeMonitorPeriod
+				yym1091 := z.DecBinary()
+				_ = yym1091
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1085) {
-				} else if !yym1086 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1085)
+				} else if z.HasExtensions() && z.DecExt(yyv1090) {
+				} else if !yym1091 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1090)
 				} else {
-					z.DecFallback(yyv1085, false)
+					z.DecFallback(yyv1090, false)
 				}
 			}
 		case "serviceAccountKeyFile":
@@ -9010,29 +9051,29 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv1102 := &x.LeaderElection
-				yyv1102.CodecDecodeSelf(d)
+				yyv1107 := &x.LeaderElection
+				yyv1107.CodecDecodeSelf(d)
 			}
 		case "volumeConfiguration":
 			if r.TryDecodeAsNil() {
 				x.VolumeConfiguration = VolumeConfiguration{}
 			} else {
-				yyv1103 := &x.VolumeConfiguration
-				yyv1103.CodecDecodeSelf(d)
+				yyv1108 := &x.VolumeConfiguration
+				yyv1108.CodecDecodeSelf(d)
 			}
 		case "controllerStartInterval":
 			if r.TryDecodeAsNil() {
 				x.ControllerStartInterval = pkg1_unversioned.Duration{}
 			} else {
-				yyv1104 := &x.ControllerStartInterval
-				yym1105 := z.DecBinary()
-				_ = yym1105
+				yyv1109 := &x.ControllerStartInterval
+				yym1110 := z.DecBinary()
+				_ = yym1110
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1104) {
-				} else if !yym1105 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1104)
+				} else if z.HasExtensions() && z.DecExt(yyv1109) {
+				} else if !yym1110 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1109)
 				} else {
-					z.DecFallback(yyv1104, false)
+					z.DecFallback(yyv1109, false)
 				}
 			}
 		case "enableGarbageCollector":
@@ -9072,9 +9113,9 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 				x.UnhealthyZoneThreshold = float32(r.DecodeFloat(true))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1039)
-		} // end switch yys1039
-	} // end for yyj1039
+			z.DecStructFieldNotFound(-1, yys1044)
+		} // end switch yys1044
+	} // end for yyj1044
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9082,16 +9123,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1112 int
-	var yyb1112 bool
-	var yyhl1112 bool = l >= 0
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	var yyj1117 int
+	var yyb1117 bool
+	var yyhl1117 bool = l >= 0
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9101,13 +9142,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9117,13 +9158,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9133,13 +9174,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9149,13 +9190,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9165,13 +9206,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.CloudProvider = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9181,13 +9222,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.CloudConfigFile = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9197,13 +9238,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentEndpointSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9213,13 +9254,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentRSSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9229,13 +9270,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentRCSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9245,13 +9286,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentServiceSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9261,13 +9302,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentResourceQuotaSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9277,13 +9318,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentDeploymentSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9293,13 +9334,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentDaemonSetSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9309,13 +9350,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentJobSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9325,13 +9366,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentNamespaceSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9341,13 +9382,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentSATokenSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9357,13 +9398,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForRC = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9373,13 +9414,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForRS = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9389,13 +9430,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForDaemonSet = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9403,24 +9444,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ServiceSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1132 := &x.ServiceSyncPeriod
-		yym1133 := z.DecBinary()
-		_ = yym1133
+		yyv1137 := &x.ServiceSyncPeriod
+		yym1138 := z.DecBinary()
+		_ = yym1138
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1132) {
-		} else if !yym1133 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1132)
+		} else if z.HasExtensions() && z.DecExt(yyv1137) {
+		} else if !yym1138 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1137)
 		} else {
-			z.DecFallback(yyv1132, false)
+			z.DecFallback(yyv1137, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9428,24 +9469,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.NodeSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1134 := &x.NodeSyncPeriod
-		yym1135 := z.DecBinary()
-		_ = yym1135
+		yyv1139 := &x.NodeSyncPeriod
+		yym1140 := z.DecBinary()
+		_ = yym1140
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1134) {
-		} else if !yym1135 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1134)
+		} else if z.HasExtensions() && z.DecExt(yyv1139) {
+		} else if !yym1140 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1139)
 		} else {
-			z.DecFallback(yyv1134, false)
+			z.DecFallback(yyv1139, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9453,24 +9494,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ResourceQuotaSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1136 := &x.ResourceQuotaSyncPeriod
-		yym1137 := z.DecBinary()
-		_ = yym1137
+		yyv1141 := &x.ResourceQuotaSyncPeriod
+		yym1142 := z.DecBinary()
+		_ = yym1142
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1136) {
-		} else if !yym1137 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1136)
+		} else if z.HasExtensions() && z.DecExt(yyv1141) {
+		} else if !yym1142 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1141)
 		} else {
-			z.DecFallback(yyv1136, false)
+			z.DecFallback(yyv1141, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9478,24 +9519,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.NamespaceSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1138 := &x.NamespaceSyncPeriod
-		yym1139 := z.DecBinary()
-		_ = yym1139
+		yyv1143 := &x.NamespaceSyncPeriod
+		yym1144 := z.DecBinary()
+		_ = yym1144
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1138) {
-		} else if !yym1139 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1138)
+		} else if z.HasExtensions() && z.DecExt(yyv1143) {
+		} else if !yym1144 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1143)
 		} else {
-			z.DecFallback(yyv1138, false)
+			z.DecFallback(yyv1143, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9503,73 +9544,7 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.PVClaimBinderSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1140 := &x.PVClaimBinderSyncPeriod
-		yym1141 := z.DecBinary()
-		_ = yym1141
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1140) {
-		} else if !yym1141 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1140)
-		} else {
-			z.DecFallback(yyv1140, false)
-		}
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinResyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1142 := &x.MinResyncPeriod
-		yym1143 := z.DecBinary()
-		_ = yym1143
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1142) {
-		} else if !yym1143 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1142)
-		} else {
-			z.DecFallback(yyv1142, false)
-		}
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.TerminatedPodGCThreshold = 0
-	} else {
-		x.TerminatedPodGCThreshold = int32(r.DecodeInt(32))
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1145 := &x.HorizontalPodAutoscalerSyncPeriod
+		yyv1145 := &x.PVClaimBinderSyncPeriod
 		yym1146 := z.DecBinary()
 		_ = yym1146
 		if false {
@@ -9580,21 +9555,21 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 			z.DecFallback(yyv1145, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
+		x.MinResyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1147 := &x.DeploymentControllerSyncPeriod
+		yyv1147 := &x.MinResyncPeriod
 		yym1148 := z.DecBinary()
 		_ = yym1148
 		if false {
@@ -9605,13 +9580,79 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 			z.DecFallback(yyv1147, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.TerminatedPodGCThreshold = 0
+	} else {
+		x.TerminatedPodGCThreshold = int32(r.DecodeInt(32))
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1150 := &x.HorizontalPodAutoscalerSyncPeriod
+		yym1151 := z.DecBinary()
+		_ = yym1151
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1150) {
+		} else if !yym1151 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1150)
+		} else {
+			z.DecFallback(yyv1150, false)
+		}
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1152 := &x.DeploymentControllerSyncPeriod
+		yym1153 := z.DecBinary()
+		_ = yym1153
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1152) {
+		} else if !yym1153 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1152)
+		} else {
+			z.DecFallback(yyv1152, false)
+		}
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9619,24 +9660,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.PodEvictionTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv1149 := &x.PodEvictionTimeout
-		yym1150 := z.DecBinary()
-		_ = yym1150
+		yyv1154 := &x.PodEvictionTimeout
+		yym1155 := z.DecBinary()
+		_ = yym1155
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1149) {
-		} else if !yym1150 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1149)
+		} else if z.HasExtensions() && z.DecExt(yyv1154) {
+		} else if !yym1155 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1154)
 		} else {
-			z.DecFallback(yyv1149, false)
+			z.DecFallback(yyv1154, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9646,13 +9687,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.DeletingPodsQps = float32(r.DecodeFloat(true))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9662,13 +9703,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.DeletingPodsBurst = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9676,73 +9717,7 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.NodeMonitorGracePeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1153 := &x.NodeMonitorGracePeriod
-		yym1154 := z.DecBinary()
-		_ = yym1154
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1153) {
-		} else if !yym1154 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1153)
-		} else {
-			z.DecFallback(yyv1153, false)
-		}
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.RegisterRetryCount = 0
-	} else {
-		x.RegisterRetryCount = int32(r.DecodeInt(32))
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1156 := &x.NodeStartupGracePeriod
-		yym1157 := z.DecBinary()
-		_ = yym1157
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1156) {
-		} else if !yym1157 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1156)
-		} else {
-			z.DecFallback(yyv1156, false)
-		}
-	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
-	} else {
-		yyb1112 = r.CheckBreak()
-	}
-	if yyb1112 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1158 := &x.NodeMonitorPeriod
+		yyv1158 := &x.NodeMonitorGracePeriod
 		yym1159 := z.DecBinary()
 		_ = yym1159
 		if false {
@@ -9753,13 +9728,79 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 			z.DecFallback(yyv1158, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RegisterRetryCount = 0
+	} else {
+		x.RegisterRetryCount = int32(r.DecodeInt(32))
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1161 := &x.NodeStartupGracePeriod
+		yym1162 := z.DecBinary()
+		_ = yym1162
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1161) {
+		} else if !yym1162 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1161)
+		} else {
+			z.DecFallback(yyv1161, false)
+		}
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1163 := &x.NodeMonitorPeriod
+		yym1164 := z.DecBinary()
+		_ = yym1164
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1163) {
+		} else if !yym1164 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1163)
+		} else {
+			z.DecFallback(yyv1163, false)
+		}
+	}
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
+	} else {
+		yyb1117 = r.CheckBreak()
+	}
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9769,13 +9810,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ServiceAccountKeyFile = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9785,13 +9826,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterSigningCertFile = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9801,13 +9842,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterSigningKeyFile = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9817,13 +9858,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ApproveAllKubeletCSRsForGroup = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9833,13 +9874,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.EnableProfiling = bool(r.DecodeBool())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9849,13 +9890,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterName = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9865,13 +9906,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterCIDR = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9881,13 +9922,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ServiceCIDR = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9897,13 +9938,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.NodeCIDRMaskSize = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9913,13 +9954,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.AllocateNodeCIDRs = bool(r.DecodeBool())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9929,13 +9970,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConfigureCloudRoutes = bool(r.DecodeBool())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9945,13 +9986,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.RootCAFile = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9961,13 +10002,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9977,13 +10018,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.KubeAPIQPS = float32(r.DecodeFloat(true))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9993,13 +10034,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10007,16 +10048,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv1175 := &x.LeaderElection
-		yyv1175.CodecDecodeSelf(d)
+		yyv1180 := &x.LeaderElection
+		yyv1180.CodecDecodeSelf(d)
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10024,16 +10065,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.VolumeConfiguration = VolumeConfiguration{}
 	} else {
-		yyv1176 := &x.VolumeConfiguration
-		yyv1176.CodecDecodeSelf(d)
+		yyv1181 := &x.VolumeConfiguration
+		yyv1181.CodecDecodeSelf(d)
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10041,24 +10082,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ControllerStartInterval = pkg1_unversioned.Duration{}
 	} else {
-		yyv1177 := &x.ControllerStartInterval
-		yym1178 := z.DecBinary()
-		_ = yym1178
+		yyv1182 := &x.ControllerStartInterval
+		yym1183 := z.DecBinary()
+		_ = yym1183
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1177) {
-		} else if !yym1178 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1177)
+		} else if z.HasExtensions() && z.DecExt(yyv1182) {
+		} else if !yym1183 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1182)
 		} else {
-			z.DecFallback(yyv1177, false)
+			z.DecFallback(yyv1182, false)
 		}
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10068,13 +10109,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.EnableGarbageCollector = bool(r.DecodeBool())
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10084,13 +10125,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentGCSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10100,13 +10141,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.NodeEvictionRate = float32(r.DecodeFloat(true))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10116,13 +10157,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.SecondaryNodeEvictionRate = float32(r.DecodeFloat(true))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10132,13 +10173,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LargeClusterSizeThreshold = int32(r.DecodeInt(32))
 	}
-	yyj1112++
-	if yyhl1112 {
-		yyb1112 = yyj1112 > l
+	yyj1117++
+	if yyhl1117 {
+		yyb1117 = yyj1117 > l
 	} else {
-		yyb1112 = r.CheckBreak()
+		yyb1117 = r.CheckBreak()
 	}
-	if yyb1112 {
+	if yyb1117 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10149,17 +10190,17 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 		x.UnhealthyZoneThreshold = float32(r.DecodeFloat(true))
 	}
 	for {
-		yyj1112++
-		if yyhl1112 {
-			yyb1112 = yyj1112 > l
+		yyj1117++
+		if yyhl1117 {
+			yyb1117 = yyj1117 > l
 		} else {
-			yyb1112 = r.CheckBreak()
+			yyb1117 = r.CheckBreak()
 		}
-		if yyb1112 {
+		if yyb1117 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1112-1, "")
+		z.DecStructFieldNotFound(yyj1117-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10171,33 +10212,33 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1185 := z.EncBinary()
-		_ = yym1185
+		yym1190 := z.EncBinary()
+		_ = yym1190
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1186 := !z.EncBinary()
-			yy2arr1186 := z.EncBasicHandle().StructToArray
-			var yyq1186 [4]bool
-			_, _, _ = yysep1186, yyq1186, yy2arr1186
-			const yyr1186 bool = false
-			var yynn1186 int
-			if yyr1186 || yy2arr1186 {
+			yysep1191 := !z.EncBinary()
+			yy2arr1191 := z.EncBasicHandle().StructToArray
+			var yyq1191 [4]bool
+			_, _, _ = yysep1191, yyq1191, yy2arr1191
+			const yyr1191 bool = false
+			var yynn1191 int
+			if yyr1191 || yy2arr1191 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1186 = 4
-				for _, b := range yyq1186 {
+				yynn1191 = 4
+				for _, b := range yyq1191 {
 					if b {
-						yynn1186++
+						yynn1191++
 					}
 				}
-				r.EncodeMapStart(yynn1186)
-				yynn1186 = 0
+				r.EncodeMapStart(yynn1191)
+				yynn1191 = 0
 			}
-			if yyr1186 || yy2arr1186 {
+			if yyr1191 || yy2arr1191 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1188 := z.EncBinary()
-				_ = yym1188
+				yym1193 := z.EncBinary()
+				_ = yym1193
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableHostPathProvisioning))
@@ -10206,17 +10247,17 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableHostPathProvisioning"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1189 := z.EncBinary()
-				_ = yym1189
+				yym1194 := z.EncBinary()
+				_ = yym1194
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableHostPathProvisioning))
 				}
 			}
-			if yyr1186 || yy2arr1186 {
+			if yyr1191 || yy2arr1191 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1191 := z.EncBinary()
-				_ = yym1191
+				yym1196 := z.EncBinary()
+				_ = yym1196
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableDynamicProvisioning))
@@ -10225,28 +10266,28 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableDynamicProvisioning"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1192 := z.EncBinary()
-				_ = yym1192
+				yym1197 := z.EncBinary()
+				_ = yym1197
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableDynamicProvisioning))
 				}
 			}
-			if yyr1186 || yy2arr1186 {
+			if yyr1191 || yy2arr1191 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1194 := &x.PersistentVolumeRecyclerConfiguration
-				yy1194.CodecEncodeSelf(e)
+				yy1199 := &x.PersistentVolumeRecyclerConfiguration
+				yy1199.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("persitentVolumeRecyclerConfiguration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1195 := &x.PersistentVolumeRecyclerConfiguration
-				yy1195.CodecEncodeSelf(e)
+				yy1200 := &x.PersistentVolumeRecyclerConfiguration
+				yy1200.CodecEncodeSelf(e)
 			}
-			if yyr1186 || yy2arr1186 {
+			if yyr1191 || yy2arr1191 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1197 := z.EncBinary()
-				_ = yym1197
+				yym1202 := z.EncBinary()
+				_ = yym1202
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FlexVolumePluginDir))
@@ -10255,14 +10296,14 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("flexVolumePluginDir"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1198 := z.EncBinary()
-				_ = yym1198
+				yym1203 := z.EncBinary()
+				_ = yym1203
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FlexVolumePluginDir))
 				}
 			}
-			if yyr1186 || yy2arr1186 {
+			if yyr1191 || yy2arr1191 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10275,25 +10316,25 @@ func (x *VolumeConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1199 := z.DecBinary()
-	_ = yym1199
+	yym1204 := z.DecBinary()
+	_ = yym1204
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1200 := r.ContainerType()
-		if yyct1200 == codecSelferValueTypeMap1234 {
-			yyl1200 := r.ReadMapStart()
-			if yyl1200 == 0 {
+		yyct1205 := r.ContainerType()
+		if yyct1205 == codecSelferValueTypeMap1234 {
+			yyl1205 := r.ReadMapStart()
+			if yyl1205 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1200, d)
+				x.codecDecodeSelfFromMap(yyl1205, d)
 			}
-		} else if yyct1200 == codecSelferValueTypeArray1234 {
-			yyl1200 := r.ReadArrayStart()
-			if yyl1200 == 0 {
+		} else if yyct1205 == codecSelferValueTypeArray1234 {
+			yyl1205 := r.ReadArrayStart()
+			if yyl1205 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1200, d)
+				x.codecDecodeSelfFromArray(yyl1205, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10305,12 +10346,12 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1201Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1201Slc
-	var yyhl1201 bool = l >= 0
-	for yyj1201 := 0; ; yyj1201++ {
-		if yyhl1201 {
-			if yyj1201 >= l {
+	var yys1206Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1206Slc
+	var yyhl1206 bool = l >= 0
+	for yyj1206 := 0; ; yyj1206++ {
+		if yyhl1206 {
+			if yyj1206 >= l {
 				break
 			}
 		} else {
@@ -10319,10 +10360,10 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1201Slc = r.DecodeBytes(yys1201Slc, true, true)
-		yys1201 := string(yys1201Slc)
+		yys1206Slc = r.DecodeBytes(yys1206Slc, true, true)
+		yys1206 := string(yys1206Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1201 {
+		switch yys1206 {
 		case "enableHostPathProvisioning":
 			if r.TryDecodeAsNil() {
 				x.EnableHostPathProvisioning = false
@@ -10339,8 +10380,8 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.PersistentVolumeRecyclerConfiguration = PersistentVolumeRecyclerConfiguration{}
 			} else {
-				yyv1204 := &x.PersistentVolumeRecyclerConfiguration
-				yyv1204.CodecDecodeSelf(d)
+				yyv1209 := &x.PersistentVolumeRecyclerConfiguration
+				yyv1209.CodecDecodeSelf(d)
 			}
 		case "flexVolumePluginDir":
 			if r.TryDecodeAsNil() {
@@ -10349,9 +10390,9 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.FlexVolumePluginDir = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1201)
-		} // end switch yys1201
-	} // end for yyj1201
+			z.DecStructFieldNotFound(-1, yys1206)
+		} // end switch yys1206
+	} // end for yyj1206
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10359,16 +10400,16 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1206 int
-	var yyb1206 bool
-	var yyhl1206 bool = l >= 0
-	yyj1206++
-	if yyhl1206 {
-		yyb1206 = yyj1206 > l
+	var yyj1211 int
+	var yyb1211 bool
+	var yyhl1211 bool = l >= 0
+	yyj1211++
+	if yyhl1211 {
+		yyb1211 = yyj1211 > l
 	} else {
-		yyb1206 = r.CheckBreak()
+		yyb1211 = r.CheckBreak()
 	}
-	if yyb1206 {
+	if yyb1211 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10378,13 +10419,13 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.EnableHostPathProvisioning = bool(r.DecodeBool())
 	}
-	yyj1206++
-	if yyhl1206 {
-		yyb1206 = yyj1206 > l
+	yyj1211++
+	if yyhl1211 {
+		yyb1211 = yyj1211 > l
 	} else {
-		yyb1206 = r.CheckBreak()
+		yyb1211 = r.CheckBreak()
 	}
-	if yyb1206 {
+	if yyb1211 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10394,13 +10435,13 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.EnableDynamicProvisioning = bool(r.DecodeBool())
 	}
-	yyj1206++
-	if yyhl1206 {
-		yyb1206 = yyj1206 > l
+	yyj1211++
+	if yyhl1211 {
+		yyb1211 = yyj1211 > l
 	} else {
-		yyb1206 = r.CheckBreak()
+		yyb1211 = r.CheckBreak()
 	}
-	if yyb1206 {
+	if yyb1211 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10408,16 +10449,16 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	if r.TryDecodeAsNil() {
 		x.PersistentVolumeRecyclerConfiguration = PersistentVolumeRecyclerConfiguration{}
 	} else {
-		yyv1209 := &x.PersistentVolumeRecyclerConfiguration
-		yyv1209.CodecDecodeSelf(d)
+		yyv1214 := &x.PersistentVolumeRecyclerConfiguration
+		yyv1214.CodecDecodeSelf(d)
 	}
-	yyj1206++
-	if yyhl1206 {
-		yyb1206 = yyj1206 > l
+	yyj1211++
+	if yyhl1211 {
+		yyb1211 = yyj1211 > l
 	} else {
-		yyb1206 = r.CheckBreak()
+		yyb1211 = r.CheckBreak()
 	}
-	if yyb1206 {
+	if yyb1211 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10428,17 +10469,17 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.FlexVolumePluginDir = string(r.DecodeString())
 	}
 	for {
-		yyj1206++
-		if yyhl1206 {
-			yyb1206 = yyj1206 > l
+		yyj1211++
+		if yyhl1211 {
+			yyb1211 = yyj1211 > l
 		} else {
-			yyb1206 = r.CheckBreak()
+			yyb1211 = r.CheckBreak()
 		}
-		if yyb1206 {
+		if yyb1211 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1206-1, "")
+		z.DecStructFieldNotFound(yyj1211-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10450,33 +10491,33 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1211 := z.EncBinary()
-		_ = yym1211
+		yym1216 := z.EncBinary()
+		_ = yym1216
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1212 := !z.EncBinary()
-			yy2arr1212 := z.EncBasicHandle().StructToArray
-			var yyq1212 [7]bool
-			_, _, _ = yysep1212, yyq1212, yy2arr1212
-			const yyr1212 bool = false
-			var yynn1212 int
-			if yyr1212 || yy2arr1212 {
+			yysep1217 := !z.EncBinary()
+			yy2arr1217 := z.EncBasicHandle().StructToArray
+			var yyq1217 [7]bool
+			_, _, _ = yysep1217, yyq1217, yy2arr1217
+			const yyr1217 bool = false
+			var yynn1217 int
+			if yyr1217 || yy2arr1217 {
 				r.EncodeArrayStart(7)
 			} else {
-				yynn1212 = 7
-				for _, b := range yyq1212 {
+				yynn1217 = 7
+				for _, b := range yyq1217 {
 					if b {
-						yynn1212++
+						yynn1217++
 					}
 				}
-				r.EncodeMapStart(yynn1212)
-				yynn1212 = 0
+				r.EncodeMapStart(yynn1217)
+				yynn1217 = 0
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1214 := z.EncBinary()
-				_ = yym1214
+				yym1219 := z.EncBinary()
+				_ = yym1219
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaximumRetry))
@@ -10485,17 +10526,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maximumRetry"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1215 := z.EncBinary()
-				_ = yym1215
+				yym1220 := z.EncBinary()
+				_ = yym1220
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaximumRetry))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1217 := z.EncBinary()
-				_ = yym1217
+				yym1222 := z.EncBinary()
+				_ = yym1222
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutNFS))
@@ -10504,17 +10545,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minimumTimeoutNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1218 := z.EncBinary()
-				_ = yym1218
+				yym1223 := z.EncBinary()
+				_ = yym1223
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutNFS))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1220 := z.EncBinary()
-				_ = yym1220
+				yym1225 := z.EncBinary()
+				_ = yym1225
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathNFS))
@@ -10523,17 +10564,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podTemplateFilePathNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1221 := z.EncBinary()
-				_ = yym1221
+				yym1226 := z.EncBinary()
+				_ = yym1226
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathNFS))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1223 := z.EncBinary()
-				_ = yym1223
+				yym1228 := z.EncBinary()
+				_ = yym1228
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutNFS))
@@ -10542,17 +10583,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("incrementTimeoutNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1224 := z.EncBinary()
-				_ = yym1224
+				yym1229 := z.EncBinary()
+				_ = yym1229
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutNFS))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1226 := z.EncBinary()
-				_ = yym1226
+				yym1231 := z.EncBinary()
+				_ = yym1231
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathHostPath))
@@ -10561,17 +10602,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podTemplateFilePathHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1227 := z.EncBinary()
-				_ = yym1227
+				yym1232 := z.EncBinary()
+				_ = yym1232
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathHostPath))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1229 := z.EncBinary()
-				_ = yym1229
+				yym1234 := z.EncBinary()
+				_ = yym1234
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutHostPath))
@@ -10580,17 +10621,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minimumTimeoutHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1230 := z.EncBinary()
-				_ = yym1230
+				yym1235 := z.EncBinary()
+				_ = yym1235
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutHostPath))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1232 := z.EncBinary()
-				_ = yym1232
+				yym1237 := z.EncBinary()
+				_ = yym1237
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutHostPath))
@@ -10599,14 +10640,14 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("incrementTimeoutHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1233 := z.EncBinary()
-				_ = yym1233
+				yym1238 := z.EncBinary()
+				_ = yym1238
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutHostPath))
 				}
 			}
-			if yyr1212 || yy2arr1212 {
+			if yyr1217 || yy2arr1217 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10619,25 +10660,25 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecDecodeSelf(d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1234 := z.DecBinary()
-	_ = yym1234
+	yym1239 := z.DecBinary()
+	_ = yym1239
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1235 := r.ContainerType()
-		if yyct1235 == codecSelferValueTypeMap1234 {
-			yyl1235 := r.ReadMapStart()
-			if yyl1235 == 0 {
+		yyct1240 := r.ContainerType()
+		if yyct1240 == codecSelferValueTypeMap1234 {
+			yyl1240 := r.ReadMapStart()
+			if yyl1240 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1235, d)
+				x.codecDecodeSelfFromMap(yyl1240, d)
 			}
-		} else if yyct1235 == codecSelferValueTypeArray1234 {
-			yyl1235 := r.ReadArrayStart()
-			if yyl1235 == 0 {
+		} else if yyct1240 == codecSelferValueTypeArray1234 {
+			yyl1240 := r.ReadArrayStart()
+			if yyl1240 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1235, d)
+				x.codecDecodeSelfFromArray(yyl1240, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10649,12 +10690,12 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1236Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1236Slc
-	var yyhl1236 bool = l >= 0
-	for yyj1236 := 0; ; yyj1236++ {
-		if yyhl1236 {
-			if yyj1236 >= l {
+	var yys1241Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1241Slc
+	var yyhl1241 bool = l >= 0
+	for yyj1241 := 0; ; yyj1241++ {
+		if yyhl1241 {
+			if yyj1241 >= l {
 				break
 			}
 		} else {
@@ -10663,10 +10704,10 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1236Slc = r.DecodeBytes(yys1236Slc, true, true)
-		yys1236 := string(yys1236Slc)
+		yys1241Slc = r.DecodeBytes(yys1241Slc, true, true)
+		yys1241 := string(yys1241Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1236 {
+		switch yys1241 {
 		case "maximumRetry":
 			if r.TryDecodeAsNil() {
 				x.MaximumRetry = 0
@@ -10710,9 +10751,9 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 				x.IncrementTimeoutHostPath = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1236)
-		} // end switch yys1236
-	} // end for yyj1236
+			z.DecStructFieldNotFound(-1, yys1241)
+		} // end switch yys1241
+	} // end for yyj1241
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10720,16 +10761,16 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1244 int
-	var yyb1244 bool
-	var yyhl1244 bool = l >= 0
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	var yyj1249 int
+	var yyb1249 bool
+	var yyhl1249 bool = l >= 0
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10739,13 +10780,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MaximumRetry = int32(r.DecodeInt(32))
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10755,13 +10796,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MinimumTimeoutNFS = int32(r.DecodeInt(32))
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10771,13 +10812,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.PodTemplateFilePathNFS = string(r.DecodeString())
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10787,13 +10828,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.IncrementTimeoutNFS = int32(r.DecodeInt(32))
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10803,13 +10844,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.PodTemplateFilePathHostPath = string(r.DecodeString())
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10819,13 +10860,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MinimumTimeoutHostPath = int32(r.DecodeInt(32))
 	}
-	yyj1244++
-	if yyhl1244 {
-		yyb1244 = yyj1244 > l
+	yyj1249++
+	if yyhl1249 {
+		yyb1249 = yyj1249 > l
 	} else {
-		yyb1244 = r.CheckBreak()
+		yyb1249 = r.CheckBreak()
 	}
-	if yyb1244 {
+	if yyb1249 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10836,17 +10877,17 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 		x.IncrementTimeoutHostPath = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj1244++
-		if yyhl1244 {
-			yyb1244 = yyj1244 > l
+		yyj1249++
+		if yyhl1249 {
+			yyb1249 = yyj1249 > l
 		} else {
-			yyb1244 = r.CheckBreak()
+			yyb1249 = r.CheckBreak()
 		}
-		if yyb1244 {
+		if yyb1249 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1244-1, "")
+		z.DecStructFieldNotFound(yyj1249-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10856,20 +10897,20 @@ func (x codecSelfer1234) encconfig_ConfigurationMap(v pkg2_config.ConfigurationM
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk1252, yyv1252 := range v {
+	for yyk1257, yyv1257 := range v {
 		z.EncSendContainerState(codecSelfer_containerMapKey1234)
-		yym1253 := z.EncBinary()
-		_ = yym1253
+		yym1258 := z.EncBinary()
+		_ = yym1258
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk1252))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk1257))
 		}
 		z.EncSendContainerState(codecSelfer_containerMapValue1234)
-		yym1254 := z.EncBinary()
-		_ = yym1254
+		yym1259 := z.EncBinary()
+		_ = yym1259
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyv1252))
+			r.EncodeString(codecSelferC_UTF81234, string(yyv1257))
 		}
 	}
 	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10880,63 +10921,63 @@ func (x codecSelfer1234) decconfig_ConfigurationMap(v *pkg2_config.Configuration
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1255 := *v
-	yyl1255 := r.ReadMapStart()
-	yybh1255 := z.DecBasicHandle()
-	if yyv1255 == nil {
-		yyrl1255, _ := z.DecInferLen(yyl1255, yybh1255.MaxInitLen, 32)
-		yyv1255 = make(map[string]string, yyrl1255)
-		*v = yyv1255
+	yyv1260 := *v
+	yyl1260 := r.ReadMapStart()
+	yybh1260 := z.DecBasicHandle()
+	if yyv1260 == nil {
+		yyrl1260, _ := z.DecInferLen(yyl1260, yybh1260.MaxInitLen, 32)
+		yyv1260 = make(map[string]string, yyrl1260)
+		*v = yyv1260
 	}
-	var yymk1255 string
-	var yymv1255 string
-	var yymg1255 bool
-	if yybh1255.MapValueReset {
+	var yymk1260 string
+	var yymv1260 string
+	var yymg1260 bool
+	if yybh1260.MapValueReset {
 	}
-	if yyl1255 > 0 {
-		for yyj1255 := 0; yyj1255 < yyl1255; yyj1255++ {
+	if yyl1260 > 0 {
+		for yyj1260 := 0; yyj1260 < yyl1260; yyj1260++ {
 			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
-				yymk1255 = ""
+				yymk1260 = ""
 			} else {
-				yymk1255 = string(r.DecodeString())
+				yymk1260 = string(r.DecodeString())
 			}
 
-			if yymg1255 {
-				yymv1255 = yyv1255[yymk1255]
+			if yymg1260 {
+				yymv1260 = yyv1260[yymk1260]
 			}
 			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
-				yymv1255 = ""
+				yymv1260 = ""
 			} else {
-				yymv1255 = string(r.DecodeString())
+				yymv1260 = string(r.DecodeString())
 			}
 
-			if yyv1255 != nil {
-				yyv1255[yymk1255] = yymv1255
+			if yyv1260 != nil {
+				yyv1260[yymk1260] = yymv1260
 			}
 		}
-	} else if yyl1255 < 0 {
-		for yyj1255 := 0; !r.CheckBreak(); yyj1255++ {
+	} else if yyl1260 < 0 {
+		for yyj1260 := 0; !r.CheckBreak(); yyj1260++ {
 			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
-				yymk1255 = ""
+				yymk1260 = ""
 			} else {
-				yymk1255 = string(r.DecodeString())
+				yymk1260 = string(r.DecodeString())
 			}
 
-			if yymg1255 {
-				yymv1255 = yyv1255[yymk1255]
+			if yymg1260 {
+				yymv1260 = yyv1260[yymk1260]
 			}
 			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
-				yymv1255 = ""
+				yymv1260 = ""
 			} else {
-				yymv1255 = string(r.DecodeString())
+				yymv1260 = string(r.DecodeString())
 			}
 
-			if yyv1255 != nil {
-				yyv1255[yymk1255] = yymv1255
+			if yyv1260 != nil {
+				yyv1260[yymk1260] = yymv1260
 			}
 		}
 	} // else len==0: TODO: Should we clear map entries?

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -138,6 +138,8 @@ type KubeletConfiguration struct {
 	// readOnlyPort is the read-only port for the Kubelet to serve on with
 	// no authentication/authorization (set to 0 to disable)
 	ReadOnlyPort int32 `json:"readOnlyPort"`
+	// ClientCAFile, if set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+	ClientCAFile string `json:"clientCAFile"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -192,6 +192,8 @@ type KubeletConfiguration struct {
 	// readOnlyPort is the read-only port for the Kubelet to serve on with
 	// no authentication/authorization (set to 0 to disable)
 	ReadOnlyPort int32 `json:"readOnlyPort"`
+	// ClientCAFile, if set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+	ClientCAFile string `json:"clientCAFile"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -178,6 +178,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.CertDirectory = in.CertDirectory
@@ -356,6 +357,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.CertDirectory = in.CertDirectory

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -130,6 +130,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		out.Address = in.Address
 		out.Port = in.Port
 		out.ReadOnlyPort = in.ReadOnlyPort
+		out.ClientCAFile = in.ClientCAFile
 		out.TLSCertFile = in.TLSCertFile
 		out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 		out.CertDirectory = in.CertDirectory

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -203,6 +203,7 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		out.Address = in.Address
 		out.Port = in.Port
 		out.ReadOnlyPort = in.ReadOnlyPort
+		out.ClientCAFile = in.ClientCAFile
 		out.TLSCertFile = in.TLSCertFile
 		out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 		out.CertDirectory = in.CertDirectory


### PR DESCRIPTION
This PR implements TLS cert auth on the kubelet side. Partly resolves https://github.com/kubernetes/kubernetes/issues/11816
and makes impossible to execute this exploit: https://github.com/kayrus/kubelet-exploit

there is also a fix for 1.3.x (https://github.com/kayrus/kubernetes/commit/dd609a7b44f1ddd76abc635aa417022a497f221c), don't know how to create a pull request for stable branch.

following options should be used to implement more secure connection:

kube-apiserver:
- `--kubelet-certificate-authority`
- `--kubelet-client-certificate`
- `--kubelet-client-key`

kubelet:
- `--client-ca-file`

I'm aware that we already have authentication/authorization interfaces to the kubelet (https://github.com/kubernetes/kubernetes/pull/14700). but it still requires lot of work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31562)

<!-- Reviewable:end -->
