### PR TITLE
node e2e script: call 'gcloud compute' only if necessary

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -33,9 +33,9 @@ images=${IMAGES:-""}
 hosts=${HOSTS:-""}
 metadata=${INSTANCE_METADATA:-""}
 gubernator=${GUBERNATOR:-"false"}
-gci_image=$(gcloud compute images list --project google-containers \
-    --no-standard-images --regexp="gci-dev.*" --format="table[no-heading](name)")
 if [[ $hosts == "" && $images == "" ]]; then
+  gci_image=$(gcloud compute images list --project google-containers \
+    --no-standard-images --regexp="gci-dev.*" --format="table[no-heading](name)")
   images=$gci_image
   metadata="user-data<${KUBE_ROOT}/test/e2e_node/jenkins/gci-init.yaml"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

The `gcloud compute` is called everytime even if it is not needed.
When runnin node e2e tests on RHEL, the test-e2e-node.sh script is run
the way in which it takes execution path without `gcloud` invocation.

With the current code, `gcloud` is called everytime.
Thus introducing additional runtime dependency.

**Special notes for your reviewer**:

First introduced here: https://github.com/kubernetes/kubernetes/pull/29815

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31588)

<!-- Reviewable:end -->
