### PR TITLE
Fix make test-integration under OSX

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -208,6 +208,7 @@ test/images/serve_hostname
 test/integration/discoverysummarizer
 test/integration/examples
 test/integration/federation
+test/integration/metrics
 test/integration/openshift
 test/soak/cauldron
 test/soak/serve_hostnames

--- a/test/integration/metrics/doc.go
+++ b/test/integration/metrics/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics


### PR DESCRIPTION
Just throw in a doc.go so there's something compilable in the
test/integration/metrics directory.

Fixes #31587

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31593)

<!-- Reviewable:end -->
