### PR TITLE
Increase cache size for RCs

### DIFF
--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -85,6 +85,7 @@ func InitializeWatchCacheSizes(expectedRAMCapacityMB int) {
 	// is supposed to have non-default value.
 	//
 	// TODO: Figure out which resource we should have non-default value.
+	watchCacheSizes[Controllers] = maxInt(5*clusterSize, 100)
 	watchCacheSizes[Endpoints] = maxInt(10*clusterSize, 1000)
 	watchCacheSizes[Nodes] = maxInt(3*clusterSize, 1000)
 	watchCacheSizes[Pods] = maxInt(10*clusterSize, 1000)


### PR DESCRIPTION
Ref #31589

[This should also help with failures of kubemark-scale.]

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31599)

<!-- Reviewable:end -->
