### PR TITLE
Fix Bash script

### DIFF
--- a/cluster/mesos/docker/socat/build.sh
+++ b/cluster/mesos/docker/socat/build.sh
@@ -18,7 +18,9 @@
 
 set -o errexit
 set -o nounset
-set -o pipefailscript_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
+set -o pipefail
+
+script_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
 
 cd "${script_dir}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: `cluster/mesos/docker/socat/build.sh` had two lines mixed together.

Old command output:

```
$ ./cluster/mesos/docker/socat/build.sh 
./cluster/mesos/docker/socat/build.sh: line 21: set: pipefailscript_dir=/home/rodolfo/src/k8s.io/kubernetes/cluster/mesos/docker/socat: invalid option name
```

**Special notes for your reviewer**: probably nobody is using that script? @sttts PTAL.

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31609)

<!-- Reviewable:end -->
