### PR TITLE
return cloudprovider.InstanceNotFound for Instance interface ExternalID()

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -136,6 +136,9 @@ func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
 func (i *Instances) ExternalID(name string) (string, error) {
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
+		if err == ErrNotFound {
+			return "", cloudprovider.InstanceNotFound
+		}
 		return "", err
 	}
 	return srv.ID, nil


### PR DESCRIPTION
Fixes #31615 

@kubernetes/rh-cluster-infra @ncdc @anguslees

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31618)

<!-- Reviewable:end -->
