### PR TITLE
AppArmor was flipped to beta, update feature gate

### DIFF
--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -50,7 +50,7 @@ var (
 	knownFeatures = map[string]featureSpec{
 		allAlphaGate:              {false, alpha},
 		externalTrafficLocalOnly:  {false, alpha},
-		appArmor:                  {true, alpha},
+		appArmor:                  {true, beta},
 		dynamicKubeletConfig:      {false, alpha},
 		dynamicVolumeProvisioning: {true, alpha},
 	}
@@ -93,7 +93,7 @@ type FeatureGate interface {
 	// MyFeature() bool
 
 	// owner: @timstclair
-	// alpha: v1.4
+	// beta: v1.4
 	AppArmor() bool
 
 	// owner: @girishkalele


### PR DESCRIPTION
/cc @dchen1107

---

1.4 Justification:
- Risk: Low. Change is small & contained.
- Rollback: Nothing else should touch this code path or depend on its functionality.
- Cost: AppArmor is beta, but the feature gate thinks it's alpha.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31625)

<!-- Reviewable:end -->
