### PR TITLE
fixes upgrade tests for kubectl skew from 1.3 to master

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -541,24 +541,48 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 
 			By("Waiting for Redis master to start.")
 			waitForOrFailWithDebug(1)
+
 			// Pod
-			forEachPod(func(pod api.Pod) {
-				output := framework.RunKubectlOrDie("describe", "pod", pod.Name, nsFlag)
-				requiredStrings := [][]string{
-					{"Name:", "redis-master-"},
-					{"Namespace:", ns},
-					{"Node:"},
-					{"Labels:", "app=redis"},
-					{"role=master"},
-					{"Status:", "Running"},
-					{"IP:"},
-					{"Controllers:", "ReplicationController/redis-master"},
-					{"Image:", redisImage},
-					{"State:", "Running"},
-					{"QoS Class:", "BestEffort"},
-				}
-				checkOutput(output, requiredStrings)
-			})
+			// this is terrible but we want 1.4.0 alpha to count as well
+			classVersion, err := framework.KubectlVersionGTE(version.MustParse("v1.4.0-alpha"))
+			Expect(err).NotTo(HaveOccurred())
+			if classVersion {
+				forEachPod(func(pod api.Pod) {
+					output := framework.RunKubectlOrDie("describe", "pod", pod.Name, nsFlag)
+					requiredStrings := [][]string{
+						{"Name:", "redis-master-"},
+						{"Namespace:", ns},
+						{"Node:"},
+						{"Labels:", "app=redis"},
+						{"role=master"},
+						{"Status:", "Running"},
+						{"IP:"},
+						{"Controllers:", "ReplicationController/redis-master"},
+						{"Image:", redisImage},
+						{"State:", "Running"},
+						{"QoS Class:", "BestEffort"},
+					}
+					checkOutput(output, requiredStrings)
+				})
+			} else {
+				forEachPod(func(pod api.Pod) {
+					output := framework.RunKubectlOrDie("describe", "pod", pod.Name, nsFlag)
+					requiredStrings := [][]string{
+						{"Name:", "redis-master-"},
+						{"Namespace:", ns},
+						{"Node:"},
+						{"Labels:", "app=redis"},
+						{"role=master"},
+						{"Status:", "Running"},
+						{"IP:"},
+						{"Controllers:", "ReplicationController/redis-master"},
+						{"Image:", redisImage},
+						{"State:", "Running"},
+						{"QoS Tier:", "BestEffort"},
+					}
+					checkOutput(output, requiredStrings)
+				})
+			}
 
 			// Rc
 			output := framework.RunKubectlOrDie("describe", "rc", "redis-master", nsFlag)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

This PR modified the output from "QoS Tier" to "QoS Class" which broke the kubectl skew upgrade test from 1.3 to 1.4 https://github.com/kubernetes/kubernetes/pull/27749

this fixes that

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31642)

<!-- Reviewable:end -->
