### PR TITLE
Node E2E: Move host info around test result.

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -259,17 +259,24 @@ func main() {
 	for i := 0; i < running; i++ {
 		tr := <-results
 		host := tr.host
-		fmt.Printf("%s================================================================%s\n", blue, noColour)
+		fmt.Println() // Print an empty line
+		fmt.Printf("%s>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>%s\n", blue, noColour)
+		fmt.Printf("%s>                              START TEST                                >%s\n", blue, noColour)
+		fmt.Printf("%s>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>%s\n", blue, noColour)
+		fmt.Printf("Start Test Suite on Host %s\n", host)
+		fmt.Printf("%s\n", tr.output)
 		if tr.err != nil {
 			errCount++
-			fmt.Printf("Failure Finished Host %s Test Suite\n%s\n%v\n", host, tr.output, tr.err)
+			fmt.Printf("Failure Finished Test Suite on Host %s\n%v\n", host, tr.err)
 		} else {
-			fmt.Printf("Success Finished Host %s Test Suite\n%s\n", host, tr.output)
+			fmt.Printf("Success Finished Test Suite on Host %s\n", host)
 		}
 		exitOk = exitOk && tr.exitOk
-		fmt.Printf("%s================================================================%s\n", blue, noColour)
+		fmt.Printf("%s<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<%s\n", blue, noColour)
+		fmt.Printf("%s<                              FINISH TEST                               <%s\n", blue, noColour)
+		fmt.Printf("%s<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<%s\n", blue, noColour)
+		fmt.Println() // Print an empty line
 	}
-
 	// Set the exit code if there were failures
 	if !exitOk {
 		fmt.Printf("Failure: %d errors encountered.", errCount)


### PR DESCRIPTION
Discussed offline with @yujuhong and @dchen1107. Currently, the node e2e result is organized as:

```
================================================================
Success Finished Host tmp-node-e2e-b6c375c7-e2e-node-containervm-v20160321-image Test Suite
{ginkgo-output}
{framework-error}
================================================================
```

This makes it painful to find which image the test is failing on. The `{ginkgo-output}` is usually quite long, so we have to scroll mouse up and down to find the host name.
This PR changes the test result to:

```
================================================================
Start Host tmp-node-e2e-b6c375c7-e2e-node-containervm-v20160321-image Test Suite
{ginkgo-output}
Success Finished Host tmp-node-e2e-b6c375c7-e2e-node-containervm-v20160321-image Test Suite
{framework-error}
================================================================
```

This is not perfect, but much better than before. We can easily find the host name under the ginkgo test result, like this:

```
================================================================
Start Host test-gci-dev-54-8743-3-0 Test Suite
Running Suite: E2eNode Suite
============================
Random Seed: 1472511489 - Will randomize all specs
Will run 0 of 131 specs

Running in parallel across 8 nodes

I0829 22:58:13.727764    1143 e2e_node_suite_test.go:98] Pre-pulling images so that they are cached for the tests.
I0829 22:58:28.562459    1143 e2e_node_suite_test.go:111] Node services started.  Running tests...
I0829 22:58:28.562477    1143 e2e_node_suite_test.go:116] Wait for the node to be ready

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
I0829 22:58:29.742596    1143 e2e_node_suite_test.go:136] Stopping node services...
I0829 22:58:29.742650    1143 services.go:673] Killing process 1423 (services) with -TERM
I0829 22:58:29.860893    1143 e2e_node_suite_test.go:141] Tests Finished


Ran 0 of 131 Specs in 16.185 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 131 Skipped 

Ginkgo ran 1 suite in 19.939034297s
Test Suite Passed

Success Finished Host test-gci-dev-54-8743-3-0 Test Suite
================================================================
```

In a following PR, I'll print the test result from different images into different files to make it more clear for debugging. Mark v1.4 because this helps us de-flake test.

/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31651)

<!-- Reviewable:end -->
