### PR TITLE
Append "AppArmor enabled" to the Node ready condition message

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -489,6 +489,13 @@ func (kl *Kubelet) setNodeReadyCondition(node *api.Node) {
 		}
 	}
 
+	// Append AppArmor status if it's enabled.
+	// TODO(timstclair): This is a temporary message until node feature reporting is added.
+	if newNodeReadyCondition.Status == api.ConditionTrue &&
+		kl.appArmorValidator != nil && kl.appArmorValidator.ValidateHost() == nil {
+		newNodeReadyCondition.Message = fmt.Sprintf("%s. AppArmor enabled", newNodeReadyCondition.Message)
+	}
+
 	// Record any soft requirements that were not met in the container manager.
 	status := kl.containerManager.Status()
 	if status.SoftRequirements != nil {

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -144,9 +144,9 @@ func getHttpRespBody(resp *http.Response) string {
 	return ""
 }
 
-func NewAppArmorAdmitHandler(runtime string) PodAdmitHandler {
+func NewAppArmorAdmitHandler(validator apparmor.Validator) PodAdmitHandler {
 	return &appArmorAdmitHandler{
-		Validator: apparmor.NewValidator(runtime),
+		Validator: validator,
 	}
 }
 

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -37,6 +37,7 @@ var isDisabledBuild bool
 // Interface for validating that a pod with with an AppArmor profile can be run by a Node.
 type Validator interface {
 	Validate(pod *api.Pod) error
+	ValidateHost() error
 }
 
 func NewValidator(runtime string) Validator {
@@ -64,7 +65,7 @@ func (v *validator) Validate(pod *api.Pod) error {
 		return nil
 	}
 
-	if v.validateHostErr != nil {
+	if v.ValidateHost() != nil {
 		return v.validateHostErr
 	}
 
@@ -85,6 +86,10 @@ func (v *validator) Validate(pod *api.Pod) error {
 	}
 
 	return nil
+}
+
+func (v *validator) ValidateHost() error {
+	return v.validateHostErr
 }
 
 // Verify that the host and runtime is capable of enforcing AppArmor profiles.


### PR DESCRIPTION
As discussed, add a "AppArmor enabled" message to the node ready condition message. This is a temporary solution to surfacing the AppArmor status until node feature reporting is enabled.

Example:

```
$ kubectl get nodes e2e-test-stclair-minion-group-lmvk -o yaml
...
  - lastHeartbeatTime: 2016-08-30T00:52:11Z
    lastTransitionTime: 2016-08-30T00:43:28Z
    message: kubelet is posting ready status. AppArmor enabled
    reason: KubeletReady
    status: "True"
    type: Ready
...
```

---

1.4 justification:
- Risk: Low. This is a small change to append a human readable message.
- Rollback: Nothing depends on this functionality.
- Cost: Not knowing whether AppArmor is actually supported by a node. Although pods should be rejected if it's not enabled, we can't do anything for older (< v1.4) nodes. This positive affirmation provides confirmation that AppArmor is enabled for the current version.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31659)

<!-- Reviewable:end -->
