### PR TITLE
AWS: Fix unbound SSH_CIDR

### DIFF
--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -78,6 +78,8 @@ NON_MASQUERADE_CIDR="${NON_MASQUERADE_CIDR:-10.0.0.0/8}" # Traffic to IPs outsid
 SERVICE_CLUSTER_IP_RANGE="${SERVICE_CLUSTER_IP_RANGE:-10.0.0.0/16}"  # formerly PORTAL_NET
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
+SSH_CIDR="${SSH_CIDR:-0.0.0.0/0}" # IP to restrict ssh access to nodes/master
+HTTP_API_CIDR="${HTTP_API_CIDR:-0.0.0.0/0}" # IP to restrict HTTP API access
 # If set to an Elastic IP address, the master instance will be associated with this IP.
 # Otherwise a new Elastic IP will be acquired
 # (We used to accept 'auto' to mean 'allocate elastic ip', but that is now the default)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes "unbound `SSH_CIDR` errors in e2e

**Which issue this PR fixes** fixes code in #27061

**Special notes for your reviewer**: Not tested, I'm still OOO

Another e2e bug, this one injected by https://github.com/kubernetes/kubernetes/pull/27061

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31666)

<!-- Reviewable:end -->
