### PR TITLE
kubectl edit: Do not add warning header if ftype is json.

### DIFF
--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -133,13 +133,16 @@ func NewCmdEdit(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 func RunEdit(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args []string, options *EditOptions) error {
 	var printer kubectl.ResourcePrinter
 	var ext string
+	var addHeader bool
 	switch format := cmdutil.GetFlagString(cmd, "output"); format {
 	case "json":
 		printer = &kubectl.JSONPrinter{}
 		ext = ".json"
+		addHeader = false
 	case "yaml":
 		printer = &kubectl.YAMLPrinter{}
 		ext = ".yaml"
+		addHeader = true
 	default:
 		return cmdutil.UsageError(cmd, "The flag 'output' must be one of yaml|json")
 	}
@@ -218,7 +221,9 @@ func RunEdit(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args
 				w = crlf.NewCRLFWriter(w)
 			}
 
-			results.header.writeTo(w)
+			if addHeader {
+				results.header.writeTo(w)
+			}
 
 			if !containsError {
 				if err := printer.PrintObj(objToEdit, w); err != nil {


### PR DESCRIPTION
This PR blocks adding warning header if `kubectl edit` is used with `-o json` option.
Fixed header contains comment (what is not supported by json standard) what can break utilities which are using libraries that conforms with http://www.ietf.org/rfc/rfc7159.txt

fixes #29524

/cc @pwittrock 

``` release-note
Removed comments in json config when using kubectl edit with -o json
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31685)

<!-- Reviewable:end -->
