### PR TITLE
print Cinder volume source in kubectl describe

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -612,6 +612,8 @@ func describeVolumes(volumes []api.Volume, out io.Writer, space string) {
 			printAzureDiskVolumeSource(volume.VolumeSource.AzureDisk, out)
 		case volume.VolumeSource.VsphereVolume != nil:
 			printVsphereVolumeSource(volume.VolumeSource.VsphereVolume, out)
+		case volume.VolumeSource.Cinder != nil:
+			printCinderVolumeSource(volume.VolumeSource.Cinder, out)
 		default:
 			fmt.Fprintf(out, "  <unknown>\n")
 		}
@@ -746,6 +748,13 @@ func printVsphereVolumeSource(vsphere *api.VsphereVirtualDiskVolumeSource, out i
 		"    FSType:\t%v\n",
 		vsphere.VolumePath, vsphere.FSType)
 }
+func printCinderVolumeSource(cinder *api.CinderVolumeSource, out io.Writer) {
+	fmt.Fprintf(out, "    Type:\tCinder (a Persistent Disk resource in OpenStack)\n"+
+		"    VolumeID:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		cinder.VolumeID, cinder.FSType, cinder.ReadOnly)
+}
 
 type PersistentVolumeDescriber struct {
 	client.Interface
@@ -800,6 +809,8 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string, describerSe
 			printQuobyteVolumeSource(pv.Spec.Quobyte, out)
 		case pv.Spec.VsphereVolume != nil:
 			printVsphereVolumeSource(pv.Spec.VsphereVolume, out)
+		case pv.Spec.Cinder != nil:
+			printCinderVolumeSource(pv.Spec.Cinder, out)
 		}
 
 		if events != nil {

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -537,6 +537,13 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 				},
 			},
 		},
+		"cinder": {
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					Cinder: &api.CinderVolumeSource{},
+				},
+			},
+		},
 	}
 
 	for name, pv := range tests {


### PR DESCRIPTION
with the patch, `kubectl describe` output is

``` console
# kubectl describe pv
Name:       pvc-34069100-6ec5-11e6-97f3-fa163e39e62e
Labels:     <none>
Status:     Bound
Claim:      default/claim1
Reclaim Policy: Delete
Access Modes:   RWO
Capacity:   3Gi
Message:    
Source:
    Type:   Cinder (a Persistent Disk resource in OpenStack)
    VolumeID:   a1bc727a-d1e6-4d6b-92d6-3e5e22bde3fa
    FSType: ext4
    ReadOnly:   false
No events.
```

@kubernetes/sig-storage

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31703)

<!-- Reviewable:end -->
