### PR TITLE
Allow missing keys in jsonpath

### DIFF
--- a/pkg/util/jsonpath/jsonpath.go
+++ b/pkg/util/jsonpath/jsonpath.go
@@ -34,6 +34,8 @@ type JSONPath struct {
 	beginRange int
 	inRange    int
 	endRange   int
+
+	allowMissingKeys bool
 }
 
 func New(name string) *JSONPath {
@@ -43,6 +45,13 @@ func New(name string) *JSONPath {
 		inRange:    0,
 		endRange:   0,
 	}
+}
+
+// AllowMissingKeys allows a caller to specify whether they want an error if a field or map key
+// cannot be located, or simply an empty result. The receiver is returned for chaining.
+func (j *JSONPath) AllowMissingKeys(allow bool) *JSONPath {
+	j.allowMissingKeys = allow
+	return j
 }
 
 // Parse parse the given template, return error
@@ -305,7 +314,7 @@ func (j *JSONPath) findFieldInValue(value *reflect.Value, node *FieldNode) (refl
 	return value.FieldByName(node.Value), nil
 }
 
-// evalField evaluates filed of struct or key of map.
+// evalField evaluates field of struct or key of map.
 func (j *JSONPath) evalField(input []reflect.Value, node *FieldNode) ([]reflect.Value, error) {
 	results := []reflect.Value{}
 	// If there's no input, there's no output
@@ -338,6 +347,9 @@ func (j *JSONPath) evalField(input []reflect.Value, node *FieldNode) ([]reflect.
 		}
 	}
 	if len(results) == 0 {
+		if j.allowMissingKeys {
+			return results, nil
+		}
 		return results, fmt.Errorf("%s is not found", node.Value)
 	}
 	return results, nil


### PR DESCRIPTION
It is common in constrained circumstances to prefer an empty string
result from JSONPath templates for missing keys over an error. Several
other implementations provide this (the canonical JS and PHP, as well as
the Java implementation).  This also mirrors gotemplate, which allows
Options("missingkey=zero").

Added simple check and simple test case.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31714)

<!-- Reviewable:end -->
