### PR TITLE
Adding clusters to the list of valid resources printed by kubectl help

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -158,7 +158,9 @@ __custom_func() {
 
 	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
 	// and add a short forms entry in expandResourceShortcut() when appropriate.
+	// TODO: This should be populated using the discovery information from apiserver.
 	valid_resources = `Valid resource types include:
+   * clusters (valid only for federation apiservers)
    * componentstatuses (aka 'cs')
    * configmaps (aka 'cm')
    * daemonsets (aka 'ds')


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/25592

Adding clusters to the list of valid resources printed by kubectl help with a clear message that it only works when talking to federation apiserver.
In future, we should replace the hard coded list with a dynamic list generated using APIServer's discovery API.

``` release-note
Adding clusters to the list of valid resources printed by kubectl help
```

cc @kubernetes/kubectl @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31719)

<!-- Reviewable:end -->
