### PR TITLE
gci: verify integrity of cni tarball upon download

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -135,7 +135,8 @@ function install-kube-binary-config {
      [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
     #TODO(andyzheng0831): We should make the cni version number as a k8s env variable.
     local -r cni_tar="cni-9d5e6e60e79491207834ae8439e80c943db65a69.tar.gz"
-    download-or-bust "" "https://storage.googleapis.com/kubernetes-release/network-plugins/${cni_tar}"
+    local -r cni_sha1="a92c2f2b744670d3f0e6b8bc9530f1a68caff9d0"
+    download-or-bust "${cni_sha1}" "https://storage.googleapis.com/kubernetes-release/network-plugins/${cni_tar}"
     local -r cni_dir="${KUBE_HOME}/cni"
     mkdir -p "${cni_dir}"
     tar xzf "${KUBE_HOME}/${cni_tar}" -C "${cni_dir}" --overwrite


### PR DESCRIPTION
This change hard-codes a SHA1 hash for the cni tarball and uses it to
verify the tarball prior to extracting and using it.  This brings it on
par with other artifacts that are downloaded at runtime.

Fixes #31724

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31725)

<!-- Reviewable:end -->
