### PR TITLE
Removing the Storage plugin from the juju cluster master.json manifest file

### DIFF
--- a/cluster/juju/layers/kubernetes/templates/master.json
+++ b/cluster/juju/layers/kubernetes/templates/master.json
@@ -38,7 +38,7 @@
               "--etcd-certfile={{ etcd_cert }}",
               {%- endif %}
               "--etcd-servers={{ connection_string }}",
-              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,DefaultStorageClass,ResourceQuota",
+              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
               "--client-ca-file=/srv/kubernetes/ca.crt",
               "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
               "--min-request-timeout=300",


### PR DESCRIPTION
**What this PR does / why we need it**: The Juju cluster fails to bring up the apiserver. Using the docker logs I see the API server complaining about a fatal error.

```
F0830 17:04:16.922997       1 plugins.go:143] Unknown admission plugin: DefaultStorageClass
```

**Which issue this PR fixes** : fixes #31726

**Special notes for your reviewer**: This is specifically for the Juju cluster provider.

**Release note**:

```
release-note-none
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31727)

<!-- Reviewable:end -->
