### PR TITLE
Juju automated charm testing shouldn't bootstrap

### DIFF
--- a/cluster/juju/layers/kubernetes/tests/tests.yaml
+++ b/cluster/juju/layers/kubernetes/tests/tests.yaml
@@ -1,1 +1,5 @@
 tests: "*kubernetes*"
+bootstrap: false
+reset: false
+python_packages:
+  - tox


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**: This controls the tooling around our test automation. This is a low impact change to the k8s codebase, that will have a big impact on our CI infrastructure.

**Release note**:

``` release-note
release-note-none
```

Juju bootstrapping is an act of cost. This should be an explicit action
by the tooling surrounding bundle-tester when testing a charm. Setting
bootstrap:false will allow us to get faster feedback at lower cost when
running the kubernetes charm under ci.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31736)

<!-- Reviewable:end -->
