### PR TITLE
Mount GCP credentials to federation deployment container for GKE clusters.

### DIFF
--- a/federation/deploy/deploy.sh
+++ b/federation/deploy/deploy.sh
@@ -91,6 +91,10 @@ function federation_action() {
   kube::log::status "Action: ${action} federation components"
   docker run \
     -m 12G \
+    # For non-GKE clusters just mounting kubeconfig is sufficient. But we need
+    # gcloud credentials for GKE clusters, so we pass both kubeconfig and
+    # gcloud credentials
+    -v "${GOOGLE_APPLICATION_CREDENTIALS}:/root/.config/gcloud/application_default_credentials.json:ro" \
     -v "${KUBE_CONFIG}:/root/.kube/config:ro" \
     -v "${FEDERATION_OUTPUT_ROOT}:/_output" \
     "${KUBE_ANYWHERE_FEDERATION_CHARTS_IMAGE}:${KUBE_ANYWHERE_FEDERATION_CHARTS_VERSION}" \


### PR DESCRIPTION
GKE clusters use GCP credentials and hence require them for deploying federation components on to those clusters.

cc @kubernetes/sig-cluster-federation

``` release-note
Fixed an issue that caused a credential error when deploying federation control plane onto a GKE cluster.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31747)

<!-- Reviewable:end -->
