### PR TITLE
Check for the changed files from the root of the source tree.

### DIFF
--- a/federation/develop/develop.sh
+++ b/federation/develop/develop.sh
@@ -69,7 +69,7 @@ function dirty_sha() {
   mkdir -p "${tmp_objects_dir}"
   cp "${index}" "${tmp_index}"
 
-  local -r files=$(git ls-files -m -o -d --exclude-standard)
+  local -r files="$(git ls-files $(git rev-parse --show-toplevel) -m -o -d --exclude-standard)"
   GIT_INDEX_FILE="${tmp_index}" git add ${files}
   GIT_ALTERNATE_OBJECT_DIRECTORIES="${objects_dir}" GIT_OBJECT_DIRECTORY="${tmp_objects_dir}" GIT_INDEX_FILE="${tmp_index}" git write-tree
 }


### PR DESCRIPTION
git ls-files by default checks for the specified files only in the current directory and in all its descendents. So if a developer invokes in this command in a non-root directory then the modified files in the other directory are ignored. So change this behavior to look for all changed files from the root directory and downwards.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31748)

<!-- Reviewable:end -->
