### PR TITLE
[WIP] Add logs in the node e2e test to make it easier for debugging.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -168,7 +168,8 @@ else
   # Test using the host the script was run on
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \
-    --test-flags="--alsologtostderr --v 2 --report-dir=${report} --node-name $(hostname) \
+    --test-flags="--alsologtostderr --v 4 --report-dir=${report} --node-name $(hostname) \
     --start-services=true --stop-services=true $test_args" --build-dependencies=true
   exit $?
 fi
+

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -195,7 +195,7 @@ func RunRemote(archive string, host string, cleanup bool, junitFilePrefix string
 	// Run the tests
 	cmd = getSshCommand(" && ",
 		fmt.Sprintf("cd %s", tmp),
-		fmt.Sprintf("timeout -k 30s %fs ./ginkgo %s ./e2e_node.test -- --logtostderr --v 2 --stop-services=%t --node-name=%s --report-dir=%s/results --report-prefix=%s %s",
+		fmt.Sprintf("timeout -k 30s %fs ./ginkgo %s ./e2e_node.test -- --logtostderr --v 4 --stop-services=%t --node-name=%s --report-dir=%s/results --report-prefix=%s %s",
 			testTimeoutSeconds.Seconds(), ginkgoFlags, cleanup, host, tmp, junitFilePrefix, testArgs),
 	)
 	aggErrs := []error{}

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -347,7 +347,7 @@ func (es *e2eService) startKubeletServer() (*server, error) {
 		cmdArgs = append(cmdArgs, systemdRun, "--unit="+unitName, "--remain-after-exit", build.GetKubeletServerBin())
 		killCommand = exec.Command("sudo", "systemctl", "kill", unitName)
 		restartCommand = exec.Command("sudo", "systemctl", "restart", unitName)
-		es.logFiles["kubelet.log"] = logFileData{
+		es.logFiles["kubelet-journald.log"] = logFileData{
 			journalctlCommand: []string{"-u", unitName},
 		}
 		framework.TestContext.EvictionHard = adjustConfigForSystemd(framework.TestContext.EvictionHard)

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -242,10 +242,14 @@ func (es *e2eService) getLogFiles() {
 			if err != nil {
 				glog.Errorf("failed to get %q from journald: %v, %v", targetFileName, string(out), err)
 			} else {
+				glog.Infof("target link: %s", targetLink)
+				glog.Infof("kubelet log: %s", out)
 				if err = ioutil.WriteFile(targetLink, out, 0755); err != nil {
 					glog.Errorf("failed to write logs to %q: %v", targetLink, err)
 				}
+				glog.Info("after write file, I'm still here")
 			}
+			glog.Info("Finished writing log file %q", targetFileName)
 			continue
 		}
 		for _, file := range logFileData.files {


### PR DESCRIPTION
This helps debug #31537.

I tried to run the test against gci and coreos myself, and journalctl works fine for me.
However, we've no idea what happened to our jenkins ci, because there are few logs in the node e2e test framework.

This PR changes the log level to 4, and add some more logs to help debug the issue.

Mark P0, because currently there is no kubelet log on gci and coreos, which seriously blocks our de-flake work.

@yujuhong

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31749)

<!-- Reviewable:end -->
