### PR TITLE
DeltaFIFO should not report HasSynced until deletes are reported

### DIFF
--- a/pkg/client/cache/delta_fifo.go
+++ b/pkg/client/cache/delta_fifo.go
@@ -437,11 +437,6 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 	defer f.lock.Unlock()
 	keys := make(sets.String, len(list))
 
-	if !f.populated {
-		f.populated = true
-		f.initialPopulationCount = len(list)
-	}
-
 	for _, item := range list {
 		key, err := f.KeyOf(item)
 		if err != nil {
@@ -467,6 +462,12 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 				return err
 			}
 		}
+
+		if !f.populated {
+			f.populated = true
+			f.initialPopulationCount = len(list)
+		}
+
 		return nil
 	}
 
@@ -474,6 +475,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 	// TODO(lavalamp): This may be racy-- we aren't properly locked
 	// with knownObjects. Unproven.
 	knownKeys := f.knownObjects.ListKeys()
+	queuedDeletions := 0
 	for _, k := range knownKeys {
 		if keys.Has(k) {
 			continue
@@ -487,10 +489,17 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 			deletedObj = nil
 			glog.Infof("Key %v does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", k)
 		}
+		queuedDeletions++
 		if err := f.queueActionLocked(Deleted, DeletedFinalStateUnknown{k, deletedObj}); err != nil {
 			return err
 		}
 	}
+
+	if !f.populated {
+		f.populated = true
+		f.initialPopulationCount = len(list) + queuedDeletions
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Deletions identified by knownObjects on the initial sync replace
(immediately after the List from a reflector) should be considered part
of the initial sync since we have the information available at the time
we do the deletion.

An error during Replace() can result in Populated not being set, but it
was incorrect before (population would be wrong) and queueActionLocked
does not error except on "my cache is broken because I gave an incorrect
keyFunc".

@lavalamp @deads2k hit this while trying to use DeltaFIFO to implement an "external" controller (one that uses the knownObjects as provided by a call to a remote system of record).

Not 1.4

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31755)

<!-- Reviewable:end -->
