### PR TITLE
Finished pods can be drained

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -260,6 +260,11 @@ func (o *DrainOptions) getPodCreator(pod api.Pod) (*api.SerializedReference, err
 }
 
 func (o *DrainOptions) unreplicatedFilter(pod api.Pod) (bool, *warning, *fatal) {
+	// any finished pod can be removed
+	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
+		return true, nil, nil
+	}
+
 	sr, err := o.getPodCreator(pod)
 	if err != nil {
 		return false, nil, &fatal{err.Error()}


### PR DESCRIPTION
fixes #26080

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31763)

<!-- Reviewable:end -->

``` release-note
Kubectl drain will now drain finished Pods
```
