### PR TITLE
add deploy for deployment in kubectl expose help text

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -42,7 +42,7 @@ type ExposeOptions struct {
 var (
 	expose_resources = dedent.Dedent(`
 		pod (po), service (svc), replicationcontroller (rc),
-		deployment, replicaset (rs)
+		deployment (deploy), replicaset (rs)
 	`)
 
 	expose_long = dedent.Dedent(`


### PR DESCRIPTION
add shorthand deploy for  deployment

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31764)

<!-- Reviewable:end -->
