### PR TITLE
Add a check in ConfirmUsable() to validate the contextName

### DIFF
--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -263,6 +263,21 @@ func (config *DirectClientConfig) ConfigAccess() ConfigAccess {
 // but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
 func (config *DirectClientConfig) ConfirmUsable() error {
 	validationErrors := make([]error, 0)
+
+	var contextName string
+	if len(config.contextName) != 0 {
+		contextName = config.contextName
+	} else {
+		contextName = config.config.CurrentContext
+	}
+
+	if len(contextName) > 0 {
+		_, exists := config.config.Contexts[contextName]
+		if !exists {
+			validationErrors = append(validationErrors, &errContextNotFound{contextName})
+		}
+	}
+
 	validationErrors = append(validationErrors, validateAuthInfo(config.getAuthInfoName(), config.getAuthInfo())...)
 	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
 	// when direct client config is specified, and our only error is that no server is defined, we should

--- a/pkg/client/unversioned/clientcmd/client_config_test.go
+++ b/pkg/client/unversioned/clientcmd/client_config_test.go
@@ -20,10 +20,10 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/imdario/mergo"
-	"k8s.io/kubernetes/pkg/client/restclient"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
@@ -357,22 +357,20 @@ func TestCreateMissingContextNoDefault(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
+
 func TestCreateMissingContext(t *testing.T) {
-	const expectedErrorContains = "Context was not found for specified context"
+	const expectedErrorContains = "context was not found for specified context: not-present"
 	config := createValidTestConfig()
 	clientBuilder := NewNonInteractiveClientConfig(*config, "not-present", &ConfigOverrides{
 		ClusterDefaults: DefaultCluster,
 	}, nil)
 
-	clientConfig, err := clientBuilder.ClientConfig()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	_, err := clientBuilder.ClientConfig()
+	if err == nil {
+		t.Fatalf("Expected error: %v", expectedErrorContains)
 	}
-
-	expectedConfig := &restclient.Config{Host: clientConfig.Host}
-
-	if !reflect.DeepEqual(expectedConfig, clientConfig) {
-		t.Errorf("Expected %#v, got %#v", expectedConfig, clientConfig)
+	if !strings.Contains(err.Error(), expectedErrorContains) {
+		t.Fatalf("Expected error: %v, but got %v", expectedErrorContains, err)
 	}
 }
 

--- a/test/integration/kubectl/kubectl_test.go
+++ b/test/integration/kubectl/kubectl_test.go
@@ -49,12 +49,13 @@ func TestKubectlValidation(t *testing.T) {
 	// Enable swagger api on master.
 	components.KubeMaster.InstallSwaggerAPI()
 	cluster := clientcmdapi.NewCluster()
+
 	cluster.Server = components.ApiServer.URL
 	cluster.InsecureSkipTLSVerify = true
+	cfg.Contexts = map[string]*clientcmdapi.Context{"test": ctx}
+	cfg.CurrentContext = "test"
 	overrides := clientcmd.ConfigOverrides{
-		ClusterInfo:    *cluster,
-		Context:        *ctx,
-		CurrentContext: "test",
+		ClusterInfo: *cluster,
 	}
 	cmdConfig := clientcmd.NewNonInteractiveClientConfig(*cfg, "test", &overrides, nil)
 	factory := util.NewFactory(cmdConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
When a context name is provided, but can't be found (miss spelling), it currently
uses the defaults. This PR will cause the command to fail, to prevent unexpected side effects
of using the wrong configuration.

**Which issue this PR fixes**
fixes #21062

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
Error if a contextName is provided but not found in the kubeconfig.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31767)

<!-- Reviewable:end -->
