### PR TITLE
Node E2E: Fix wrong permission bit for log file.

### DIFF
--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -238,7 +238,7 @@ func (es *e2eService) getLogFiles() {
 			if err != nil {
 				glog.Errorf("failed to get %q from journald: %v, %v", targetFileName, string(out), err)
 			} else {
-				if err = ioutil.WriteFile(targetLink, out, 0755); err != nil {
+				if err = ioutil.WriteFile(targetLink, out, 0644); err != nil {
 					glog.Errorf("failed to write logs to %q: %v", targetLink, err)
 				}
 			}


### PR DESCRIPTION
When creating log for logs from journald, we use `0755` which is weird to me.
This PR changes it to `0666`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31769)

<!-- Reviewable:end -->
