### PR TITLE
Typos and englishify pkg/cloudprovider + pkg/dns + pkg/kubectl

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1014,7 +1014,7 @@ func (c *Cloud) List(filter string) ([]string, error) {
 // It currently involves querying all instances
 func (c *Cloud) getAllZones() (sets.String, error) {
 	// We don't currently cache this; it is currently used only in volume
-	// creation which is expected to be a comparatively rare occurence.
+	// creation which is expected to be a comparatively rare occurrence.
 
 	// TODO: Caching / expose api.Nodes to the cloud provider?
 	// TODO: We could also query for subnets, I think

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -218,7 +218,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 
 				// NOTE The documentation for the AWS API indicates we could get an HTTP 400
 				// back if a policy of the same name already exists. However, the aws-sdk does not
-				// seem to return an error to us in these cases. Therefore this will issue an API
+				// seem to return an error to us in these cases. Therefore, this will issue an API
 				// request every time.
 				err := c.createProxyProtocolPolicy(loadBalancerName)
 				if err != nil {

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_test.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_test.go
@@ -74,7 +74,7 @@ func configFromEnv() (*CSConfig, bool) {
 	cfg.Global.Zone = os.Getenv("CS_ZONE")
 
 	// It is save to ignore the error here. If the input cannot be parsed SSLNoVerify
-	// will still be a bool with it's zero value (false) which is the expected default.
+	// will still be a bool with its zero value (false) which is the expected default.
 	cfg.Global.SSLNoVerify, _ = strconv.ParseBool(os.Getenv("CS_SSL_NO_VERIFY"))
 
 	// Check if we have the minimum required info to be able to connect to CloudStack.

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -2596,7 +2596,7 @@ func (gce *GCECloud) getDiskByNameUnknownZone(diskName string) (*gceDisk, error)
 
 // GetGCERegion returns region of the gce zone. Zone names
 // are of the form: ${region-name}-${ix}.
-// For example "us-central1-b" has a region of "us-central1".
+// For example, "us-central1-b" has a region of "us-central1".
 // So we look for the last '-' and trim to just before that.
 func GetGCERegion(zone string) (string, error) {
 	ix := strings.LastIndex(zone, "-")

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -129,7 +129,7 @@ func (os *OpenStack) getVolume(diskName string) (volumes.Volume, error) {
 		return false, errors.New(errmsg)
 	})
 	if err != nil {
-		glog.Errorf("Error occured getting volume: %s", diskName)
+		glog.Errorf("Error occurred getting volume: %s", diskName)
 		return volume, err
 	}
 	return volume, err

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -563,7 +563,7 @@ func (rs *Rackspace) getVolume(diskName string) (volumes.Volume, error) {
 		return false, errors.New(errmsg)
 	})
 	if err != nil {
-		glog.Errorf("Error occured getting volume: %s", diskName)
+		glog.Errorf("Error occurred getting volume: %s", diskName)
 	}
 	return volume, err
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -742,7 +742,7 @@ func getNextUnitNumber(devices object.VirtualDeviceList, c types.BaseVirtualCont
 			return int32(unitNumber), nil
 		}
 	}
-	return -1, fmt.Errorf("SCSI Controller with key=%d does not have any avaiable slots (LUN).", key)
+	return -1, fmt.Errorf("SCSI Controller with key=%d does not have any available slots (LUN).", key)
 }
 
 func getSCSIController(vmDevices object.VirtualDeviceList, scsiType string) *types.VirtualController {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -99,7 +99,7 @@ type KubeDNS struct {
 	// Map of cluster IP to service object. Headless services are not part of this map.
 	// Used to get a service when given its cluster IP.
 	// Access to this is coordinated using cacheLock. We use the same lock for cache and this map
-	// to ensure that they dont get out of sync.
+	// to ensure that they don't get out of sync.
 	clusterIPServiceMap map[string]*kapi.Service
 
 	// caller is responsible for using the cacheLock before invoking methods on cache
@@ -253,7 +253,7 @@ func (kd *KubeDNS) newService(obj interface{}) {
 			return
 		}
 		if len(service.Spec.Ports) == 0 {
-			glog.Warningf("Unexpected service with no ports, this should not have happend: %v", service)
+			glog.Warningf("Unexpected service with no ports, this should not have happened: %v", service)
 		}
 		kd.newPortalService(service)
 	}

--- a/pkg/dns/treecache.go
+++ b/pkg/dns/treecache.go
@@ -53,7 +53,7 @@ func (cache *TreeCache) Serialize() (string, error) {
 func (cache *TreeCache) setEntry(key string, val *skymsg.Service, fqdn string, path ...string) {
 	// TODO: Consolidate setEntry and setSubCache into a single method with a
 	// type switch.
-	// TODO: Insted of passing the fqdn as an argument, we can reconstruct
+	// TODO: Instead of passing the fqdn as an argument, we can reconstruct
 	// it from the path, provided callers always pass the full path to the
 	// object. This is currently *not* the case, since callers first create
 	// a new, empty node, populate it, then parent it under the right path.

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1779,7 +1779,7 @@ func extractCSRStatus(csr *certificates.CertificateSigningRequest) (string, erro
 		case certificates.CertificateDenied:
 			denied = true
 		default:
-			return "", fmt.Errorf("unknown csr conditon %q", c)
+			return "", fmt.Errorf("unknown csr condition %q", c)
 		}
 	}
 	var status string

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -367,7 +367,7 @@ func (reaper *PetSetReaper) Stop(namespace, name string, timeout time.Duration, 
 	}
 
 	// TODO: Cleanup volumes? We don't want to accidentally delete volumes from
-	// stop, so just leave this up to the the petset.
+	// stop, so just leave this up to the petset.
 	return petsets.Delete(name, nil)
 }
 

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -766,7 +766,7 @@ func TestDeploymentNotFoundError(t *testing.T) {
 		return true, list, nil
 	})
 	fake.AddReactor("get", "replicasets", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, ScaleError{ActualError: errors.NewNotFound(api.Resource("replicaset"), "doesnt-matter")}
+		return true, nil, ScaleError{ActualError: errors.NewNotFound(api.Resource("replicaset"), "doesn't-matter")}
 	})
 
 	reaper := DeploymentReaper{fake, time.Millisecond, time.Millisecond}


### PR DESCRIPTION
**What this PR does / why we need it**: Just fixed some typos + "englishify" in pkg/cloudprovider + pkg/dns + pkg/kubectl

**Which issue this PR fixes** : None

**Special notes for your reviewer**: It's just fixes typos

**Release note**: `NONE`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31773)

<!-- Reviewable:end -->
