### PR TITLE
Clean user agent to reduce metrics cardinality

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -104,8 +104,15 @@ func InstrumentRouteFunc(verb, resource string, routeFunc restful.RouteFunction)
 		if verb == "LIST" && strings.ToLower(request.QueryParameter("watch")) == "true" {
 			verb = "WATCH"
 		}
-		Monitor(&verb, &resource, utilnet.GetHTTPClient(request.Request), rw.Header().Get("Content-Type"), delegate.status, now)
+		Monitor(&verb, &resource, cleanUserAgent(utilnet.GetHTTPClient(request.Request)), rw.Header().Get("Content-Type"), delegate.status, now)
 	})
+}
+
+func cleanUserAgent(ua string) string {
+	if strings.HasPrefix(ua, "Mozilla/") {
+		return "Browser"
+	}
+	return ua
 }
 
 type responseWriterDelegator struct {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "testing"
+
+func TestCleanUserAgent(t *testing.T) {
+	for _, tc := range []struct {
+		In  string
+		Out string
+	}{
+		{
+			In:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36",
+			Out: "Browser",
+		},
+		{
+			In:  "kubectl/v1.2.4",
+			Out: "kubectl/v1.2.4",
+		},
+	} {
+		if cleanUserAgent(tc.In) != tc.Out {
+			t.Errorf("Failed to clean User-Agent: %s", tc.In)
+		}
+	}
+}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -16250,6 +16250,13 @@ go_library(
     tags = ["automanaged"],
 )
 
+go_test(
+    name = "k8s.io/apiserver/pkg/endpoints/metrics_test",
+    srcs = ["k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go"],
+    library = ":k8s.io/apiserver/pkg/endpoints/metrics",
+    tags = ["automanaged"],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is an example implementation for my issue #31781.

``` release-note
```

This commit cleans common browser user-agents to reduce the metrics
cardinality in exported prometheus metrics.

Resolves kubernetes/kubernetes#31781

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31783)

<!-- Reviewable:end -->
