### PR TITLE
Prevent loadbalancer creation failures during node failures

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -412,10 +412,15 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *api.Ser
 
 		for _, host := range hosts {
 			addr, err := getAddressByName(lbaas.compute, host)
-			if err != nil && err != ErrNotFound {
-				// cleanup what was created so far
-				_ = lbaas.EnsureLoadBalancerDeleted(clusterName, apiService)
+			if err != nil {
+				if err == ErrNotFound {
+					// Node failure, do not create member
+					continue
+				} else {
+					// cleanup what was created so far
+					_ = lbaas.EnsureLoadBalancerDeleted(clusterName, apiService)
 				return nil, err
+				}
 			}
 
 			_, err = v2_pools.CreateAssociateMember(lbaas.network, pool.ID, v2_pools.MemberCreateOpts{

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -412,7 +412,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *api.Ser
 
 		for _, host := range hosts {
 			addr, err := getAddressByName(lbaas.compute, host)
-			if err != nil {
+			if err != nil && err != ErrNotFound {
 				// cleanup what was created so far
 				_ = lbaas.EnsureLoadBalancerDeleted(clusterName, apiService)
 				return nil, err


### PR DESCRIPTION
Currently, during node failures EnsureLoadBalancer fails because `getAddressByName(lbaas.compute, host)` gets `ErrNotFound`. As a result, all services are unreachable.

This pull request makes EnsureLoadBalancer skip member creation on nodes that are down at creation time.

Steps to reproduce: shut down controller-manager master (verified steps) or shut down a node and boot controller-manager (in my guess would also work).

Service event output during node failure:

```
Events:
  FirstSeen     LastSeen        Count   From            SubobjectPath   Type        Reason              Message
  ---------     --------        -----   ----            -------------   --------        ------              -------
  22m       22m         1       {service-controller }           Normal      CreatingLoadBalancer        Creating load balancer
  21m       21m         1       {service-controller }           Normal      CreatedLoadBalancer         Created load balancer
  17m       44s         14      {service-controller }           Normal      CreatingLoadBalancer        Creating load balancer
  17m       23s         14      {service-controller }           Warning     CreatingLoadBalancerFailed      Error creating load balancer (will retry): Failed to create load balancer for service default/app: Failed to find object

floating-network-id={{ os_stack_floating_pool }}
```

Logs (From logging that I added temporarily):

```
getAddressByName(lbaas.compute, host) error: &errors.errorString{s:"Failed to find object"}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31786)

<!-- Reviewable:end -->
