### PR TITLE
[Pet Set] Fix Get(pcb) logical breaking

### DIFF
--- a/pkg/controller/petset/pet.go
+++ b/pkg/controller/petset/pet.go
@@ -169,9 +169,11 @@ func (p *apiServerPetClient) Get(pet *pcb) (*pcb, bool, error) {
 	found := true
 	ns := pet.parent.Namespace
 	pod, err := podClient(p.c, ns).Get(pet.pod.Name)
-	if errors.IsNotFound(err) {
+	if err != nil {
 		found = false
-		err = nil
+		if errors.IsNotFound(err) {
+			err = nil
+		}
 	}
 	if err != nil || !found {
 		return nil, found, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
- 1

Consider this [code block](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L169-L177), I think there is a logical breaking. 

It set `found` to `false` **only if** client receive an "Not Found" error, while keep `found` to `true` if client receive other type errors(such as `403`). 

In other words, I think [this function](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L168)'s 2nd returned value should **always be false** when [err](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L171) is not nil, which means we didn't **find** what we want when `Get` request failed. 

Besides, I think it's not a good way to reset the error to nil by hand [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L176-L177).
- 2,

I think return values of [this func](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L168) can be simplified. We can remove the 2nd bool type return value. It means change the declaration of 

```
func (p *apiServerPetClient) Get(pet *pcb) (*pcb, bool, error)
```

to

```
func (p *apiServerPetClient) Get(pet *pcb) (*pcb, error)
```

Then the caller will be responsible for distinguishing the error type.

The benefit of this change is make the `func (p *apiServerPetClient) Get(pet * pcb)` more simple while do not increase the caller's complexity.

Thank!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31789)

<!-- Reviewable:end -->
