### PR TITLE
move '(master)' to end of message for uniformity

### DIFF
--- a/cluster/juju/layers/kubernetes/reactive/k8s.py
+++ b/cluster/juju/layers/kubernetes/reactive/k8s.py
@@ -468,7 +468,7 @@ def render_files(reldata=None):
 def status_set(level, message):
     '''Output status message with leadership information.'''
     if is_leader():
-        message = '(master) {0}'.format(message)
+        message = '{0} (master) '.format(message)
     hookenv.status_set(level, message)
 
 


### PR DESCRIPTION
**What this PR does / why we need it**: This is a small polish operation on the kubernetes charm wrt juju status output.

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

This changes the status output from:

```
kubernetes/0  active    idle   3        172.27.24.54    8088/tcp
Kubernetes running.
kubernetes/1  active    idle   4        172.27.24.55    6443/tcp
(master) Kubernetes services started
```

 to this:

```
 kubernetes/0  active    idle   3        172.27.24.54    8088/tcp
 Kubernetes running.
 kubernetes/1  active    idle   4        172.27.24.55    6443/tcp
 Kubernetes services started (master)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31794)

<!-- Reviewable:end -->
