### PR TITLE
Pick a specific GCI version by default on GCE.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -41,6 +41,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 # containervm. If you are updating the containervm version, update this
 # variable.
 CVM_VERSION=container-v1-3-v20160604
+GCI_VERSION="gci-dev-54-8743-3-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -42,6 +42,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 # containervm. If you are updating the containervm version, update this
 # variable.
 CVM_VERSION=container-v1-3-v20160604
+GCI_VERSION="gci-dev-54-8743-3-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -37,29 +37,10 @@ else
   exit 1
 fi
 
-function get_latest_gci_image() {
-  # GCI milestone to use
-  GCI_MILESTONE="53"
-
-  # First try to find an active (non-deprecated) image on this milestone.
-  gci_images=( $(gcloud compute images list --project google-containers \
-      --no-standard-images --sort-by="~creationTimestamp" \
-      --regexp="gci-[a-z]+-${GCI_MILESTONE}-.*" --format="table[no-heading](name)") )
-
-  # If no active image is available, search across all deprecated images.
-  if [[ ${#gci_images[@]} == 0 ]] ; then
-    gci_images=( $(gcloud compute images list --project google-containers \
-        --no-standard-images --show-deprecated --sort-by="~creationTimestamp" \
-        --regexp="gci-[a-z]+-${GCI_MILESTONE}-.*" --format="table[no-heading](name)") )
-  fi
-
-  echo "${gci_images[0]}"
-}
-
 if [[ "${MASTER_OS_DISTRIBUTION}" == "gci" ]]; then
   # If the master image is not set, we use the latest GCI image.
   # Otherwise, we respect whatever is set by the user.
-  MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-"$(get_latest_gci_image)"}
+  MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-${GCI_VERSION}}
   MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 elif [[ "${MASTER_OS_DISTRIBUTION}" == "debian" ]]; then
   MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-${CVM_VERSION}}
@@ -69,7 +50,7 @@ fi
 if [[ "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
   # If the node image is not set, we use the latest GCI image.
   # Otherwise, we respect whatever is set by the user.
-  NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-"$(get_latest_gci_image)"}
+  NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}
   NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
 elif [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
   NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -16,6 +16,6 @@ images:
     image: e2e-node-containervm-v20160321-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-dev-.*
+    image_regex: gci-dev-54-8743-3-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"


### PR DESCRIPTION
Prior to this change, a K8s branch (master as well as release) was
pinned to a GCI milestone.  It would pick up the latest GCI release on
that milestone at the time of cluster creation.  The rationale was the
K8s users would automatically get the bug fixes in newer versions of
GCI.  However in practice, it makes the runtime environment
non-deterministic, and lack of continuous e2e tests mean we would run
into breakages sooner or later.

With this change, each K8s release will pick a specific version
of GCI by default (similar to how the Debian-based container-vm gets used).
Users can override the default version through KUBE_GCE_MASTER_IMAGE and
KUBE_GCE_NODE_IMAGE environment variables.

We expect the default GCI version will be updated relatively frequently stay
updated with newer GCI releases.  We can also automate the process to
automatically bump the hard-coded GCI version in future.

@vishh @adityakali can you please review?

cc @kubernetes/goog-image FYI

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31830)

<!-- Reviewable:end -->
