### PR TITLE
Add new testing library with custom gomega matchers

### DIFF
--- a/test/matchers/matchers.go
+++ b/test/matchers/matchers.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// Convenience function for matching values that can be nil.
+func NilOr(ms ...types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.Or(append(ms, gomega.BeNil())...)
+}
+
+// Check that the actual value is within the expected range.
+// lower and upper must be numeric values.
+func InRange(lower, upper interface{}) types.GomegaMatcher {
+	return gomega.And(gomega.BeNumerically(">=", lower), gomega.BeNumerically("<=", upper))
+}
+
+// Applies the matcher m to the value being pointed to.
+func Ptr(m types.GomegaMatcher) types.GomegaMatcher {
+	return &PtrMatcher{
+		Matcher: m,
+	}
+}
+
+// A matcher that always succeeds.
+func Ignore() types.GomegaMatcher {
+	return gomega.And()
+}
+
+// A matcher that always fails (mostly for development).
+func Fail() types.GomegaMatcher {
+	return gomega.Or()
+}
+
+// A struct matcher where each field must be present and match the expectations.
+func StrictStruct(fields Fields) types.GomegaMatcher {
+	return &StructMatcher{
+		Fields: fields,
+		Strict: true,
+	}
+}
+
+// A struct matcher where present fields must match the expectations, and extra fields are ignored.
+func LooseStruct(fields Fields) types.GomegaMatcher {
+	return &StructMatcher{
+		Fields: fields,
+		Strict: false,
+	}
+}
+
+// A slice matcher where each element identified by the identifier must be present and match the
+// expectations.
+func StrictSlice(identifier Identifier, elements Elements) types.GomegaMatcher {
+	return &SliceMatcher{
+		Identifier: identifier,
+		Elements:   elements,
+		Strict:     true,
+	}
+}
+
+// A slice matcher where present elements identified by the identifier must match the expectations,
+// and extra elements are ignored.
+func LooseSlice(identifier Identifier, elements Elements) types.GomegaMatcher {
+	return &SliceMatcher{
+		Identifier: identifier,
+		Elements:   elements,
+		Strict:     false,
+	}
+}
+
+// A matcher that checks that the actual time was within duration d of Now.
+func Recent(d time.Duration) types.GomegaMatcher {
+	return &RecentMatcher{d}
+}

--- a/test/matchers/nested_error.go
+++ b/test/matchers/nested_error.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/onsi/gomega/types"
+)
+
+// A stateful matcher that nests other matchers within it and preserves the error types of the
+// nested matcher failures.
+type NestingMatcher interface {
+	types.GomegaMatcher
+
+	// Returns the failures of nested matchers.
+	Failures() []error
+}
+
+// An error type for labeling errors on deeply nested matchers.
+type NestedError struct {
+	Path string
+	Err  error
+}
+
+func (e *NestedError) Error() string {
+	// Indent Errors.
+	indented := strings.Replace(e.Err.Error(), "\n", "\n\t", -1)
+	return fmt.Sprintf("%s:\n\t%v", e.Path, indented)
+}
+
+// Create a NestedError with the given path.
+// If err is a NestedError, prepend the path to it.
+// If err is an AggregateError, recursively Nest each error.
+func Nest(path string, err error) error {
+	if ag, ok := err.(errors.Aggregate); ok {
+		var errs []error
+		for _, e := range ag.Errors() {
+			errs = append(errs, Nest(path, e))
+		}
+		return errors.NewAggregate(errs)
+	}
+	if ne, ok := err.(*NestedError); ok {
+		return &NestedError{
+			Path: path + ne.Path,
+			Err:  ne.Err,
+		}
+	}
+	return &NestedError{
+		Path: path,
+		Err:  err,
+	}
+}

--- a/test/matchers/ptr.go
+++ b/test/matchers/ptr.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+type PtrMatcher struct {
+	Matcher types.GomegaMatcher
+
+	// Failure message.
+	failure string
+}
+
+func (m *PtrMatcher) Match(actual interface{}) (bool, error) {
+	val := reflect.ValueOf(actual)
+
+	// return error if actual's type is incompatible with Transform function's argument type
+	if val.Kind() != reflect.Ptr {
+		return false, fmt.Errorf("PtrMatcher expects a pointer but we have '%s'", val.Kind())
+	}
+
+	if !val.IsValid() || val.IsNil() {
+		m.failure = format.Message(actual, "not to be <nil>")
+		return false, nil
+	}
+
+	// Forward the value.
+	elem := val.Elem().Interface()
+	match, err := m.Matcher.Match(elem)
+	if !match {
+		m.failure = m.Matcher.FailureMessage(elem)
+	}
+	return match, err
+}
+
+func (m *PtrMatcher) FailureMessage(_ interface{}) (message string) {
+	return m.failure
+}
+
+func (m *PtrMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.Matcher.NegatedFailureMessage(actual)
+}

--- a/test/matchers/recent.go
+++ b/test/matchers/recent.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	"github.com/onsi/gomega/format"
+)
+
+type RecentMatcher struct {
+	Duration time.Duration
+}
+
+func (m *RecentMatcher) Match(actual interface{}) (success bool, err error) {
+	if t, ok := actual.(unversioned.Time); ok {
+		return m.Match(t.Time)
+	}
+	t, ok := actual.(time.Time)
+	if !ok {
+		return false, fmt.Errorf("Expected a time.Time. Got:\n%s", format.Object(actual, 1))
+	}
+
+	now := time.Now()
+	if now.Sub(t) > m.Duration {
+		return false, fmt.Errorf("%v is too old! now: %v", t, now)
+	} else if t.After(now) {
+		return false, fmt.Errorf("%v is in the future! now: %v", t, now)
+	}
+
+	return true, nil
+}
+
+func (m *RecentMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to be in the last", m.Duration)
+}
+
+func (m *RecentMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to be in the last", m.Duration)
+}

--- a/test/matchers/slice.go
+++ b/test/matchers/slice.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+
+	errorsutil "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+type SliceMatcher struct {
+	// Matchers for each element.
+	Elements Elements
+	// Whether extra elements are considered an error.
+	Strict bool
+	// Function for identifying a slice element.
+	Identifier Identifier
+
+	// State.
+	failures []error
+}
+
+// Element ID to matcher.
+type Elements map[string]types.GomegaMatcher
+
+// Function for identifying elements of a slice.
+type Identifier func(element interface{}) string
+
+func (m *SliceMatcher) Match(actual interface{}) (success bool, err error) {
+	if reflect.TypeOf(actual).Kind() != reflect.Slice {
+		return false, fmt.Errorf("%v is type %T, expected slice", actual, actual)
+	}
+
+	m.failures = m.matchElements(actual)
+	if len(m.failures) > 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *SliceMatcher) matchElements(actual interface{}) (errs []error) {
+	// Provide more useful error messages in the case of a panic.
+	defer func() {
+		if err := recover(); err != nil {
+			errs = append(errs, fmt.Errorf("panic checking %+v: %v\n%s", actual, err, debug.Stack()))
+		}
+	}()
+
+	val := reflect.ValueOf(actual)
+	elements := map[string]bool{}
+	for i := 0; i < val.Len(); i++ {
+		element := val.Index(i).Interface()
+		id := m.Identifier(element)
+		if elements[id] {
+			errs = append(errs, fmt.Errorf("found duplicate element ID %s", id))
+			continue
+		}
+		elements[id] = true
+
+		matcher, expected := m.Elements[id]
+		if !expected {
+			if m.Strict {
+				errs = append(errs, fmt.Errorf("unexpected element %s", id))
+			}
+			continue
+		}
+
+		match, err := matcher.Match(element)
+		if match {
+			continue
+		}
+
+		if err == nil {
+			if nesting, ok := matcher.(NestingMatcher); ok {
+				err = errorsutil.NewAggregate(nesting.Failures())
+			} else {
+				err = errors.New(matcher.FailureMessage(element))
+			}
+		}
+		errs = append(errs, Nest(fmt.Sprintf("[%s]", id), err))
+	}
+
+	for id := range m.Elements {
+		if !elements[id] {
+			errs = append(errs, fmt.Errorf("missing expected element %s", id))
+		}
+	}
+
+	return errs
+}
+
+func (m *SliceMatcher) FailureMessage(actual interface{}) (message string) {
+	failure := errorsutil.NewAggregate(m.failures)
+	return format.Message(actual, fmt.Sprintf("to match slice matcher: %v", failure))
+}
+
+func (m *SliceMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match slice matcher")
+}
+
+func (m *SliceMatcher) Failures() []error {
+	return m.failures
+}

--- a/test/matchers/slice_test.go
+++ b/test/matchers/slice_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+func TestSliceMatcher(t *testing.T) {
+	allElements := []string{"a", "b"}
+	missingElements := []string{"a"}
+	extraElements := []string{"a", "b", "c"}
+	empty := []string{}
+
+	strict := StrictSlice(id, Elements{
+		"b": gomega.Equal("b"),
+		"a": gomega.Equal("a"),
+	})
+	strictFail := StrictSlice(id, Elements{
+		"a": gomega.Equal("a"),
+		"b": gomega.Equal("fail"),
+	})
+	strictEmpty := StrictSlice(id, Elements{})
+	loose := LooseSlice(id, Elements{
+		"b": gomega.Equal("b"),
+		"a": gomega.Equal("a"),
+	})
+	looseFail := LooseSlice(id, Elements{
+		"a": gomega.Equal("a"),
+		"b": gomega.Equal("fail"),
+	})
+
+	tests := []struct {
+		actual      interface{}
+		matcher     types.GomegaMatcher
+		expectMatch bool
+		msg         string
+	}{
+		{allElements, strict, true, "StrictSlice should match all elements"},
+		{missingElements, strict, false, "StrictSlice should fail with missing elements"},
+		{extraElements, strict, false, "StrictSlice should fail with extra elements"},
+		{allElements, strictFail, false, "StrictSlice should fail with fail"},
+		{empty, strictEmpty, true, "StrictSlice should handle empty slices"},
+		{allElements, loose, true, "LooseSlice should match all elements"},
+		{missingElements, loose, false, "LooseSlice should fail with missing elements"},
+		{extraElements, loose, true, "LooseSlice should ignore extra elements"},
+		{allElements, looseFail, false, "LooseSlice should fail with fail"},
+	}
+
+	for i, test := range tests {
+		match, err := test.matcher.Match(test.actual)
+		assert.NoError(t, err, "[%d] %s", i, test.msg)
+		assert.Equal(t, test.expectMatch, match,
+			"[%d] %s: %s", i, test.msg, test.matcher.FailureMessage(test.actual))
+	}
+}
+
+func id(element interface{}) string {
+	return element.(string)
+}

--- a/test/matchers/struct.go
+++ b/test/matchers/struct.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+	"strings"
+
+	errorsutil "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+type StructMatcher struct {
+	// Matchers for each field.
+	Fields Fields
+	// Whether extra fields are considered an error.
+	Strict bool
+
+	// State.
+	failures []error
+}
+
+// Field name to matcher.
+type Fields map[string]types.GomegaMatcher
+
+func (m *StructMatcher) Match(actual interface{}) (success bool, err error) {
+	if reflect.TypeOf(actual).Kind() != reflect.Struct {
+		return false, fmt.Errorf("%v is type %T, expected struct", actual, actual)
+	}
+
+	m.failures = m.matchFields(actual)
+	if len(m.failures) > 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *StructMatcher) matchFields(actual interface{}) (errs []error) {
+	val := reflect.ValueOf(actual)
+	typ := val.Type()
+	fields := map[string]bool{}
+	for i := 0; i < val.NumField(); i++ {
+		fieldName := typ.Field(i).Name
+		fields[fieldName] = true
+
+		err := func() (err error) {
+			// This test relies heavily on reflect, which tends to panic.
+			// Recover here to provide more useful error messages in that case.
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic checking %+v: %v\n%s", actual, r, debug.Stack())
+				}
+			}()
+
+			matcher, expected := m.Fields[fieldName]
+			if !expected {
+				if m.Strict {
+					return fmt.Errorf("unexpected field %s: %+v", fieldName, actual)
+				}
+				return nil
+			}
+
+			var field interface{}
+			if val.Field(i).IsValid() {
+				field = val.Field(i).Interface()
+			} else {
+				field = reflect.Zero(typ.Field(i).Type)
+			}
+
+			match, err := matcher.Match(field)
+			if err != nil {
+				return err
+			} else if !match {
+				if nesting, ok := matcher.(NestingMatcher); ok {
+					return errorsutil.NewAggregate(nesting.Failures())
+				}
+				return errors.New(matcher.FailureMessage(field))
+			}
+			return nil
+		}()
+		if err != nil {
+			errs = append(errs, Nest("."+fieldName, err))
+		}
+	}
+
+	for field := range m.Fields {
+		if !fields[field] {
+			errs = append(errs, fmt.Errorf("missing expected field %s", field))
+		}
+	}
+
+	return errs
+}
+
+func (m *StructMatcher) FailureMessage(actual interface{}) (message string) {
+	failures := make([]string, len(m.failures))
+	for i := range m.failures {
+		failures[i] = m.failures[i].Error()
+	}
+	return format.Message(reflect.TypeOf(actual).Name(),
+		fmt.Sprintf("to match struct matcher: {\n%v\n}\n", strings.Join(failures, "\n")))
+}
+
+func (m *StructMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match struct matcher")
+}
+
+func (m *StructMatcher) Failures() []error {
+	return m.failures
+}

--- a/test/matchers/struct_test.go
+++ b/test/matchers/struct_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matchers
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructMatcher(t *testing.T) {
+	allFields := struct{ A, B string }{"a", "b"}
+	missingFields := struct{ A string }{"a"}
+	extraFields := struct{ A, B, C string }{"a", "b", "c"}
+	emptyFields := struct{ A, B string }{}
+
+	strict := StrictStruct(Fields{
+		"B": gomega.Equal("b"),
+		"A": gomega.Equal("a"),
+	})
+	strictFail := StrictStruct(Fields{
+		"A": gomega.Equal("a"),
+		"B": gomega.Equal("fail"),
+	})
+	strictIgnore := StrictStruct(Fields{
+		"A": Ignore(),
+		"B": Ignore(),
+	})
+	loose := LooseStruct(Fields{
+		"B": gomega.Equal("b"),
+		"A": gomega.Equal("a"),
+	})
+	looseFail := LooseStruct(Fields{
+		"A": gomega.Equal("a"),
+		"B": gomega.Equal("fail"),
+	})
+
+	tests := []struct {
+		actual      interface{}
+		matcher     types.GomegaMatcher
+		expectMatch bool
+		msg         string
+	}{
+		{allFields, strict, true, "StrictStruct should match all fields"},
+		{missingFields, strict, false, "StrictStruct should fail with missing fields"},
+		{extraFields, strict, false, "StrictStruct should fail with extra fields"},
+		{allFields, strictFail, false, "StrictStruct should fail with fail"},
+		{emptyFields, strictIgnore, true, "StrictStruct should handle empty fields"},
+		{allFields, loose, true, "LooseStruct should match all fields"},
+		{missingFields, loose, false, "LooseStruct should fail with missing fields"},
+		{extraFields, loose, true, "LooseStruct should ignore extra fields"},
+		{allFields, looseFail, false, "LooseStruct should fail with fail"},
+	}
+
+	for i, test := range tests {
+		match, err := test.matcher.Match(test.actual)
+		assert.NoError(t, err, "[%d] %s", i, test.msg)
+		assert.Equal(t, test.expectMatch, match,
+			"[%d] %s: %s", i, test.msg, test.matcher.FailureMessage(test.actual))
+	}
+}


### PR DESCRIPTION
To make it easier to validate large objects. For a big example, see how the summary metrics test was rewritten with this library in (WIP) https://github.com/kubernetes/kubernetes/pull/29479.

I think we can move a lot of the conditionals from `test/e2e/framework` into this library eventually too.

/cc @kubernetes/sig-testing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31831)

<!-- Reviewable:end -->
