### PR TITLE
Generate versioned client for pvc

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -434,6 +434,8 @@ type PersistentVolumeList struct {
 	Items []PersistentVolume `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// +genclient=true
+
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/core_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/core_client.go
@@ -33,6 +33,7 @@ type CoreInterface interface {
 	NamespacesGetter
 	NodesGetter
 	PersistentVolumesGetter
+	PersistentVolumeClaimsGetter
 	PodsGetter
 	PodTemplatesGetter
 	ReplicationControllersGetter
@@ -77,6 +78,10 @@ func (c *CoreClient) Nodes() NodeInterface {
 
 func (c *CoreClient) PersistentVolumes() PersistentVolumeInterface {
 	return newPersistentVolumes(c)
+}
+
+func (c *CoreClient) PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface {
+	return newPersistentVolumeClaims(c, namespace)
 }
 
 func (c *CoreClient) Pods(namespace string) PodInterface {

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_core_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_core_client.go
@@ -58,6 +58,10 @@ func (c *FakeCore) PersistentVolumes() v1.PersistentVolumeInterface {
 	return &FakePersistentVolumes{c}
 }
 
+func (c *FakeCore) PersistentVolumeClaims(namespace string) v1.PersistentVolumeClaimInterface {
+	return &FakePersistentVolumeClaims{c, namespace}
+}
+
 func (c *FakeCore) Pods(namespace string) v1.PodInterface {
 	return &FakePods{c, namespace}
 }

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePersistentVolumeClaims implements PersistentVolumeClaimInterface
+type FakePersistentVolumeClaims struct {
+	Fake *FakeCore
+	ns   string
+}
+
+var persistentvolumeclaimsResource = unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
+
+func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &v1.PersistentVolumeClaim{})
+
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1.PersistentVolumeClaimList{})
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) Get(name string) (result *v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction(persistentvolumeclaimsResource, c.ns, name), &v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction(persistentvolumeclaimsResource, c.ns, opts), &v1.PersistentVolumeClaimList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1.PersistentVolumeClaimList{}
+	for _, item := range obj.(*v1.PersistentVolumeClaimList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction(persistentvolumeclaimsResource, c.ns, opts))
+
+}
+
+// Patch applies the patch and returns the patched persistentVolumeClaim.
+func (c *FakePersistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, name, data, subresources...), &v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolumeClaim), err
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/generated_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/generated_expansion.go
@@ -28,6 +28,8 @@ type NodeExpansion interface{}
 
 type PersistentVolumeExpansion interface{}
 
+type PersistentVolumeClaimExpansion interface{}
+
 type PodTemplateExpansion interface{}
 
 type ReplicationControllerExpansion interface{}

--- a/pkg/client/clientset_generated/release_1_4/typed/core/v1/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/core/v1/persistentvolumeclaim.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// PersistentVolumeClaimsGetter has a method to return a PersistentVolumeClaimInterface.
+// A group's client should implement this interface.
+type PersistentVolumeClaimsGetter interface {
+	PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface
+}
+
+// PersistentVolumeClaimInterface has methods to work with PersistentVolumeClaim resources.
+type PersistentVolumeClaimInterface interface {
+	Create(*v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
+	Update(*v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
+	UpdateStatus(*v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
+	Delete(name string, options *api.DeleteOptions) error
+	DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error
+	Get(name string) (*v1.PersistentVolumeClaim, error)
+	List(opts api.ListOptions) (*v1.PersistentVolumeClaimList, error)
+	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolumeClaim, err error)
+	PersistentVolumeClaimExpansion
+}
+
+// persistentVolumeClaims implements PersistentVolumeClaimInterface
+type persistentVolumeClaims struct {
+	client *CoreClient
+	ns     string
+}
+
+// newPersistentVolumeClaims returns a PersistentVolumeClaims
+func newPersistentVolumeClaims(c *CoreClient, namespace string) *persistentVolumeClaims {
+	return &persistentVolumeClaims{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *persistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a persistentVolumeClaim and updates it. Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(persistentVolumeClaim.Name).
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
+}
+
+func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(persistentVolumeClaim.Name).
+		SubResource("status").
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.
+func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *persistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&listOptions, api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
+func (c *persistentVolumeClaims) Get(name string) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
+func (c *persistentVolumeClaims) List(opts api.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
+	result = &v1.PersistentVolumeClaimList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *persistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched persistentVolumeClaim.
+func (c *persistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}


### PR DESCRIPTION
I noticed while trying to use client-go that there is no way to get PVC with versioned clientset. I don't know why it is excluded, I cannot find any discussion about this, so I am creating this assuming it is just an oversight...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31834)

<!-- Reviewable:end -->
