### PR TITLE
release lock before panic to prevent dead lock

### DIFF
--- a/vendor/github.com/prometheus/client_golang/prometheus/summary.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/summary.go
@@ -264,7 +264,6 @@ func (s *summary) Desc() *Desc {
 
 func (s *summary) Observe(v float64) {
 	s.bufMtx.Lock()
-	defer s.bufMtx.Unlock()
 
 	now := time.Now()
 	if now.After(s.hotBufExpTime) {
@@ -274,6 +273,7 @@ func (s *summary) Observe(v float64) {
 	if len(s.hotBuf) == cap(s.hotBuf) {
 		s.asyncFlush(now)
 	}
+	s.bufMtx.Unlock()
 }
 
 func (s *summary) Write(out *dto.Metric) error {
@@ -362,6 +362,9 @@ func (s *summary) flushColdBuf() {
 // swapBufs needs mtx AND bufMtx locked, coldBuf must be empty.
 func (s *summary) swapBufs(now time.Time) {
 	if len(s.coldBuf) != 0 {
+		//here we release the lock
+		s.mux.Unlock()
+		s.bufMtx.Unlock()
 		panic("coldBuf is not empty")
 	}
 	s.hotBuf, s.coldBuf = s.coldBuf, s.hotBuf


### PR DESCRIPTION
As func swapBufs( may panic, then the locks it held does not release, we should do this, or will effect other goroutines

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31852)

<!-- Reviewable:end -->
