### PR TITLE
Add extensive set of tests for federation API server init TLS generation.

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -88,16 +88,28 @@ func Run(s *options.CMServer) error {
 	} else {
 		glog.Errorf("unable to register configz: %s", err)
 	}
+
+	// If s.Kubeconfig flag is empty, try with the deprecated name in 1.4.
+	// TODO(madhusudancs): Remove this in 1.5.
+	var restClientCfg *restclient.Config
+	var err error
+	if len(s.Kubeconfig) <= 0 {
+		restClientCfg, err = restClientConfigFromSecret(s.Master)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Create the config to talk to federation-apiserver.
-	restClientCfg, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
+	restClientCfg, err = clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil || restClientCfg == nil {
 		// Retry with the deprecated name in 1.4.
 		// TODO(madhusudancs): Remove this in 1.5.
-		var depErr error
-		kubeconfigGetter := util.KubeconfigGetterForSecret(DeprecatedKubeconfigSecretName)
-		restClientCfg, depErr = clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
-		if depErr != nil {
-			return fmt.Errorf("failed to find the secret containing Federation API server kubeconfig, tried the secret name %s and the deprecated name %s: %v, %v", KubeconfigSecretName, DeprecatedKubeconfigSecretName, err, depErr)
+		glog.V(2).Infof("Couldn't build the rest client config from flags: %v", err)
+		glog.V(2).Infof("Trying with deprecated secret: %s", DeprecatedKubeconfigSecretName)
+		restClientCfg, err = restClientConfigFromSecret(s.Master)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -170,4 +182,15 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 	}
 
 	select {}
+}
+
+// TODO(madhusudancs): Remove this in 1.5. This is only temporary to give an
+// upgrade path in 1.4.
+func restClientConfigFromSecret(master string) (*restclient.Config, error) {
+	kubeconfigGetter := util.KubeconfigGetterForSecret(DeprecatedKubeconfigSecretName)
+	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(master, kubeconfigGetter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find the Federation API server kubeconfig, tried the flags and the deprecated secret %s: %v", DeprecatedKubeconfigSecretName, err)
+	}
+	return restClientCfg, nil
 }

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -50,10 +50,6 @@ import (
 )
 
 const (
-	// TODO(madhusudancs): Consider making this configurable via a flag.
-	// "federation-apiserver-kubeconfig" is a reserved secret name which
-	// stores the kubeconfig for federation-apiserver.
-	KubeconfigSecretName = "federation-apiserver-kubeconfig"
 	// "federation-apiserver-secret" was the old name we used to store
 	// Federation API server kubeconfig secret. Unfortunately, this name
 	// is very close to "federation-apiserver-secrets" and causes a lot
@@ -93,8 +89,7 @@ func Run(s *options.CMServer) error {
 		glog.Errorf("unable to register configz: %s", err)
 	}
 	// Create the config to talk to federation-apiserver.
-	kubeconfigGetter := util.KubeconfigGetterForSecret(KubeconfigSecretName)
-	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
+	restClientCfg, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil || restClientCfg == nil {
 		// Retry with the deprecated name in 1.4.
 		// TODO(madhusudancs): Remove this in 1.5.

--- a/federation/deploy/init/Dockerfile
+++ b/federation/deploy/init/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+MAINTAINER "Madhusudan C.S. <madhusudancs@google.com>"
+
+ARG VERSION
+
+ADD init /
+
+ENTRYPOINT ["/init"]

--- a/federation/deploy/init/Makefile
+++ b/federation/deploy/init/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE_NAME?=gcr.io/madhusudancs-containers/federation/init
+IMAGE_VERSION?=v0.9.0
+
+.PHONY: all
+all: build push
+
+.PHONY: build
+build:
+	# Setting CGO_ENABLED=0 builds a static binary
+	CGO_ENABLED=0 go build init.go
+	docker build \
+	  -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+	rm init
+
+
+.PHONY: push
+push:
+	gcloud docker push $(IMAGE_NAME):$(IMAGE_VERSION)
+

--- a/federation/deploy/init/Makefile
+++ b/federation/deploy/init/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME?=gcr.io/madhusudancs-containers/federation/init
+IMAGE_NAME?=gcr.kubernetes.io/federation/init
 IMAGE_VERSION?=v0.9.0
 
 .PHONY: all

--- a/federation/deploy/init/init.go
+++ b/federation/deploy/init/init.go
@@ -16,7 +16,8 @@ limitations under the License.
 
 // This program implements the initialization code required to start a
 // federation API server. This code is intended to be run inside an init
-// container in the federation API server pod.
+// container (http://kubernetes.io/docs/user-guide/production-pods/#handling-initialization)
+// in the federation API server pod.
 //
 // Federation API server is deployed as a Kubernetes Deployment resource and
 // hence the number of Deployment pod replicas can be scaled up and down. This
@@ -91,9 +92,9 @@ var (
 	namespace    = flag.String("namespace", "federation", "namespace of the federation control plane components")
 	secretName   = flag.String("secret", "federation-apiserver-credentials", "name of the secret where the federation API server user credentials are stored")
 	cmSecretName = flag.String("controllermanager-kubeconfig-secret", "federation-controller-manager-kubeconfig", "name of the secret where the federation controller manager kubeconfig is stored")
-	svcName      = flag.String("service", "federation-apiserver", "namespace of the federation control plane components")
+	svcName      = flag.String("service", "federation-apiserver", "name of the federation API server service")
 	timeout      = flag.Duration("timeout", 5*time.Minute, "duration to wait to obtain the federation API server's loadbalancer name/address before timing out")
-	certValidity = flag.Duration("cert-validity", 365*24*time.Hour, "Certificate validity duration")
+	certValidity = flag.Duration("cert-validity", 365*24*time.Hour, "certificate validity duration")
 )
 
 type certKey struct {

--- a/federation/deploy/init/init.go
+++ b/federation/deploy/init/init.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	flag "github.com/spf13/pflag"
+	release_1_4 "k8s.io/client-go/1.4/kubernetes"
+	api "k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/errors"
+	corev1 "k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/1.4/pkg/watch"
+	"k8s.io/client-go/1.4/rest"
+)
+
+const (
+	orgName        = "Kubernetes Cluster Federation"
+	cmName         = "federation-controller-manager"
+	kubeconfigName = "kubeconfig"
+)
+
+var (
+	namespace    = flag.String("namespace", "federation", "namespace of the federation control plane components")
+	secretName   = flag.String("secret", "federation-apiserver-secrets", "name of the federation ")
+	svcName      = flag.String("service", "federation-apiserver", "namespace of the federation control plane components")
+	timeout      = flag.Duration("timeout", 5*time.Minute, "duration to wait to obtain the federation API server's loadbalancer name/address before timing out")
+	certValidity = flag.Duration("cert-validity", 365*24*time.Hour, "Certificate validity duration")
+)
+
+type certKey struct {
+	cert []byte
+	key  []byte
+}
+
+func main() {
+	flag.Parse()
+
+	ccfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatal("Failed to obtain in-cluster client config")
+	}
+	clientset := release_1_4.NewForConfigOrDie(ccfg)
+
+	exists, err := secretExists(clientset, *namespace, *secretName)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"namespace": *namespace,
+			"error":     err,
+		}).Fatal("Failed to check whether federation certificates secret already exists")
+	}
+	if exists {
+		log.WithFields(log.Fields{
+			"namespace": *namespace,
+			"secret":    *secretName,
+		}).Info("Secret already exists, nothing to do here. Exiting")
+		return
+	}
+
+	ips, hostnames, err := lbTargets(clientset, *namespace, *svcName, *timeout)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"namespace": *namespace,
+			"error":     err,
+		}).Fatal("Failed to retrieve federation API server load balancer IP addresses and/or hostnames")
+	}
+
+	cks, err := certs(*svcName, *certValidity, ips, hostnames)
+	if err != nil {
+		log.WithField("error", err).
+			Fatal("Failed to generate certificates")
+	}
+
+	if err := createSecret(clientset, *namespace, *secretName, cks); err != nil {
+		log.WithField("error", err).
+			Fatal("Failed to create a secret")
+	}
+
+	// DEBUG: Remove before submission
+	time.Sleep(5 * time.Minute)
+}
+
+func secretExists(clientset *release_1_4.Clientset, namespace, secretName string) (bool, error) {
+	secret, err := clientset.Core().Secrets(namespace).Get(secretName)
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get secret: %v", err)
+	}
+	return secret != nil && secret.Name == secretName, nil
+}
+
+func lbTargets(clientset *release_1_4.Clientset, namespace, svcName string, timeout time.Duration) ([]string, []string, error) {
+	ips := []string{}
+	hostnames := []string{}
+
+	listOptions := api.SingleObject(api.ObjectMeta{
+		Name: svcName,
+	})
+	w, err := clientset.Core().Services(namespace).Watch(listOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to set a watch on federation control plane services")
+	}
+
+	_, err = watch.Until(timeout, w, func(e watch.Event) (bool, error) {
+		switch e.Type {
+		case watch.Added, watch.Modified:
+			svc, ok := e.Object.(*corev1.Service)
+			if !ok {
+				log.WithFields(log.Fields{
+					"namespace": namespace,
+					"type":      fmt.Sprintf("%T", svc),
+				}).Warn("Expected events for Services")
+				return false, nil
+			}
+
+			// This has a potential problem when a service loadbalancer cloud
+			// provider implementation populates both IPs and Hostnames, and
+			// particularly when it populates multiple of such entries. We get
+			// notified when the very first address/name is added and we
+			// process it and return. If a new address/name is added later, we
+			// can't process them.
+			// TODO(madhusudancs): Provide a way to specify which of the IPs
+			// or hostnames to wait for and for how long to wait.
+			if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+				for _, ing := range svc.Status.LoadBalancer.Ingress {
+					if len(ing.IP) > 0 {
+						ips = append(ips, ing.IP)
+					}
+					if len(ing.Hostname) > 0 {
+						hostnames = append(hostnames, ing.Hostname)
+					}
+				}
+			}
+
+			log.WithFields(log.Fields{
+				"namespace": namespace,
+				"service":   svc.Name,
+				"IPs":       ips,
+				"Hostnames": hostnames,
+			}).Info("Added/Modified")
+
+			if len(ips)+len(hostnames) > 0 {
+				return true, nil
+			}
+
+			return false, nil
+		case watch.Deleted:
+			svc, ok := e.Object.(*corev1.Service)
+			if !ok {
+				log.WithFields(log.Fields{
+					"namespace": namespace,
+					"type":      fmt.Sprintf("%T", svc),
+				}).Warn("Expected events for Services")
+				return false, nil
+			}
+			log.WithFields(log.Fields{
+				"namespace": namespace,
+				"service":   svc.Name,
+			}).Info("Deleted")
+			return false, nil
+		case watch.Error:
+			// Handle error and return with an error.
+			log.WithFields(log.Fields{
+				"namespace": namespace,
+			}).Info("Error event")
+			return false, fmt.Errorf("received watch error: %+v", e.Object)
+		default:
+			return false, nil
+		}
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to watch federation control plane services")
+	}
+
+	return ips, hostnames, nil
+}
+
+func certs(svcName string, certValidity time.Duration, ips, hostnames []string) (map[string]*certKey, error) {
+	template := x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(certValidity),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, ip := range ips {
+		addr := net.ParseIP(ip)
+		if addr == nil {
+			log.WithField("ip", ip).
+				Warn("Failed to parse IP")
+			continue
+		}
+		template.IPAddresses = append(template.IPAddresses, addr)
+	}
+	for _, hn := range hostnames {
+		template.DNSNames = append(template.DNSNames, hn)
+	}
+
+	// Arbitrarily choose the first federation API server IP address or
+	// the hostname as the CA common name.
+	caCN := ""
+	if len(ips) > 0 {
+		caCN = ips[0]
+	} else if len(hostnames) > 0 {
+		caCN = hostnames[0]
+	} else {
+		return nil, fmt.Errorf("at least one IP address or hostname must be specified")
+	}
+	caCN = fmt.Sprintf("%s@%d", template.NotBefore.Unix())
+
+	// CA
+	caCertKey, err := cert(caCN, template, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a CA certificate: %v", err)
+	}
+
+	caCertObj, err := x509.ParseCertificate(caCertKey.cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the CA certificate: %v", err)
+	}
+
+	// Server
+	serverCertKey, err := cert(svcName, template, caCertObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a server certificate: %v", err)
+	}
+
+	// TODO(madhusudancs): Ideally these clients (Controller Manager and Admin
+	// kubeconfig) should generate their own private keys and a CSR, submit
+	// that CSR to the server for signing and retrieve the signed certificate
+	// for their use. This process is being automated/simplified by the TLS
+	// bootstrap proposal. Once that proposal is implemented in federation API
+	// Server, we should just switch to that instead of generating the client
+	// keys and certificates in this federation API server's init process and
+	// passing it down to the clients.
+
+	// Controller Manager
+	cmCertKey, err := cert(cmName, template, caCertObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a client certificate for controller manager: %v", err)
+	}
+
+	// Admin kubeconfig
+	kubeconfigCertKey, err := cert(kubeconfigName, template, caCertObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a client certificate for admin kubeconfig: %v", err)
+	}
+
+	return map[string]*certKey{
+		"ca":                 caCertKey,
+		"server":             serverCertKey,
+		"controller-manager": cmCertKey,
+		"kubeconfig":         kubeconfigCertKey,
+	}, nil
+}
+
+// cert generates a certificate/key pair for a given template.
+// Args:
+//   name: the common name of the entity for which the certificate/key pair
+//         must be generated.
+//   template: a template for which a certificate/key pair must be produced. It
+//             must be passed by-value because it is modified in this function.
+//   caCert: An optional CA certificate. If it is supplied, then that
+//           certificate will be used to sign the generated certificate. If it
+//           is nil, then it will be assumed that this certificate is for a new
+//           CA and a self-signed CA certificate will be generated.
+func cert(name string, template x509.Certificate, caCert *x509.Certificate) (*certKey, error) {
+	var parent *x509.Certificate
+	if caCert == nil {
+		parent = &template
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	} else {
+		parent = caCert
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %v", err)
+	}
+	template.SerialNumber = serialNumber
+
+	template.Subject.CommonName = name
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %v", err)
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, &template, parent, &privKey.PublicKey, privKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %v", err)
+	}
+	priv, err := x509.MarshalECPrivateKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal ECDSA private key: %v", err)
+	}
+	return &certKey{cert, priv}, nil
+}
+
+func createSecret(clientset *release_1_4.Clientset, namespace, secretName string, cks map[string]*certKey) error {
+	buf := &bytes.Buffer{}
+
+	cksPemBase64 := make(map[string][]byte)
+	for name, ck := range cks {
+		ckPemBase64, err := encodeCertKey(buf, ck)
+		if err != nil {
+			return fmt.Errorf("%s pair failed to encode: %v", name, err)
+		}
+		cksPemBase64[fmt.Sprintf("%s.crt", name)] = ckPemBase64.cert
+		cksPemBase64[fmt.Sprintf("%s.key", name)] = ckPemBase64.key
+	}
+
+	// Intentionally using the default secret type - `SecretTypeOpaque` (not
+	// set, but it will be defaulted) instead of `SecretTypeTLS` or other
+	// types because this secret will hold tokens and other credentials along
+	// with certificate/key pairs.
+	secret := &corev1.Secret{
+		ObjectMeta: corev1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: cksPemBase64,
+	}
+
+	_, err := clientset.Core().Secrets(namespace).Create(secret)
+	if errors.IsAlreadyExists(err) {
+		log.WithFields(log.Fields{
+			"namespace": namespace,
+			"secret":    secretName,
+		}).Info("Secret already exists, shouldn't be overwritten")
+		return nil
+	}
+	return err
+}
+
+func encodeCertKey(buf *bytes.Buffer, ck *certKey) (*certKey, error) {
+	certPemBase64, err := encodeToPemBase64(buf, ck.cert, "CERTIFICATE")
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the certificate: %v", err)
+	}
+	keyPemBase64, err := encodeToPemBase64(buf, ck.key, "EC PRIVATE KEY")
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the key: %v", err)
+	}
+	return &certKey{certPemBase64, keyPemBase64}, nil
+}
+
+func encodeToPemBase64(buf *bytes.Buffer, derBytes []byte, btype string) ([]byte, error) {
+	buf.Reset()
+	enc := base64.NewEncoder(base64.StdEncoding, buf)
+
+	_, err := enc.Write(pem.EncodeToMemory(&pem.Block{Type: btype, Bytes: derBytes}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close and flush the base64 encoder: %v", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/federation/deploy/init/init_test.go
+++ b/federation/deploy/init/init_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const (
+	testSvcName      = "test-service"
+	testCertValidity = 1 * time.Hour
+)
+
+func TestCerts(t *testing.T) {
+	testCases := []struct {
+		cAddr     string
+		ips       []net.IP
+		hostnames []string
+	}{
+		{
+			// Unfortunately, due to the limitation in the way Go
+			// net/http/httptest package sets up the test HTTPS/TLS server,
+			// 127.0.0.1 is the only accepted server address. So, we need to
+			// generate certificates for this address.
+			cAddr:     "127.0.0.1",
+			ips:       []net.IP{net.ParseIP("127.0.0.1")},
+			hostnames: []string{},
+		},
+	}
+
+	for i, tc := range testCases {
+		cks, err := certs(testSvcName, testCertValidity, tc.cAddr, tc.ips, tc.hostnames)
+		if err != nil {
+			t.Errorf("[%d] unexpected error generating certs: %v", i, err)
+		}
+
+		caPemCK := encodeCertKey(cks["ca"])
+		roots := x509.NewCertPool()
+		if ok := roots.AppendCertsFromPEM(caPemCK.cert); !ok {
+			t.Errorf("[%d] failed to parse root certificate", i)
+		}
+
+		serverPemCK := encodeCertKey(cks["server"])
+		s, err := fakeTLSServer(roots, serverPemCK)
+		if err != nil {
+			t.Errorf("[%d] unexpected error starting TLS server: %v", i, err)
+		}
+		defer s.Close()
+
+		// Setup HTTPS client
+		kcfgPemCK := encodeCertKey(cks["kubeconfig"])
+		kcfgCert, err := tls.X509KeyPair(kcfgPemCK.cert, kcfgPemCK.key)
+		if err != nil {
+			t.Errorf("[%d] unexpected error parsing kubeconfig certificates: %v", i, err)
+		}
+		tlsCfg := &tls.Config{
+			Certificates: []tls.Certificate{kcfgCert},
+			RootCAs:      roots,
+		}
+		tlsCfg.BuildNameToCertificate()
+		tr := &http.Transport{
+			TLSClientConfig: tlsCfg,
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(s.URL)
+		if err != nil {
+			t.Errorf("[%d] unexpected error while sending GET request to the server: %v", i, err)
+		}
+		defer resp.Body.Close()
+
+		greeting, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("[%d] unexpected error reading server response: %v", i, err)
+		}
+		if want := "Hello, certificate test!\n"; string(greeting) != want {
+			t.Errorf("[%d] want %q, got %q", i, want, greeting)
+		}
+	}
+}
+
+func fakeTLSServer(roots *x509.CertPool, serverCK *certKey) (*httptest.Server, error) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, certificate test!")
+	}))
+
+	serverCert, err := tls.X509KeyPair(serverCK.cert, serverCK.key)
+	if err != nil {
+		return nil, err
+	}
+
+	s.TLS.Certificates = []tls.Certificate{serverCert}
+	s.TLS.RootCAs = roots
+	s.TLS.ClientAuth = tls.RequireAndVerifyClientCert
+	s.TLS.ClientCAs = roots
+	s.TLS.InsecureSkipVerify = false
+	return s, nil
+}

--- a/federation/deploy/init/init_test.go
+++ b/federation/deploy/init/init_test.go
@@ -20,10 +20,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -31,14 +34,165 @@ import (
 const (
 	testSvcName      = "test-service"
 	testCertValidity = 1 * time.Hour
+
+	helloMsg = "Hello, certificate test!"
 )
 
-func TestCerts(t *testing.T) {
+type clientServerTLSConfigs struct {
+	server *tls.Config
+	client *tls.Config
+}
+
+type certParams struct {
+	cAddr     string
+	ips       []net.IP
+	hostnames []string
+}
+
+// TestCertsTLS tests TLS handshake with client authentication for any server
+// name. There is a separate test below to test the certificate generation
+// end-to-end over HTTPS.
+// TODO(madhusudancs): Consider using a deterministic random number generator
+// for generating certificates in tests.
+func TestCertsTLS(t *testing.T) {
+	params := []certParams{
+		{
+			cAddr:     "10.1.2.3",
+			ips:       []net.IP{net.ParseIP("10.1.2.3"), net.ParseIP("10.2.3.4")},
+			hostnames: []string{"federation.test", "federation2.test"},
+		},
+		{
+			cAddr:     "10.10.20.30",
+			ips:       []net.IP{net.ParseIP("10.20.30.40"), net.ParseIP("10.64.128.4")},
+			hostnames: []string{"tls.federation.test"},
+		},
+	}
+
+	tlsCfgs, err := tlsConfigs(params)
+	if err != nil {
+		t.Errorf("failed to generate tls configs: %v", err)
+		// No point in proceeding further
+		return
+	}
+
 	testCases := []struct {
-		cAddr     string
-		ips       []net.IP
-		hostnames []string
+		serverName string
+		sCfg       *tls.Config
+		cCfg       *tls.Config
+		failType   string
 	}{
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "10.2.3.4",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "federation.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "10.20.30.40",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[1].client,
+		},
+		{
+			serverName: "tls.federation.test",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[1].client,
+		},
+		{
+			serverName: "10.100.200.50",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "noexist.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "10.64.128.4",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "tls.federation.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[1].client,
+			failType:   "UnknownAuthorityError",
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[1].client,
+			failType:   "UnknownAuthorityError",
+		},
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+	}
+
+	for i, tc := range testCases {
+		// Make a copy of the client config before modifying it.
+		cCfgCopy := *tc.cCfg
+		cCfg := &cCfgCopy
+		cCfg.ServerName = tc.serverName
+		cCfg.BuildNameToCertificate()
+
+		err := tlsHandshake(t, tc.sCfg, cCfg)
+		if len(tc.failType) > 0 {
+			switch tc.failType {
+			case "HostnameError":
+				if _, ok := err.(x509.HostnameError); !ok {
+					t.Errorf("[%d] unexpected error: want x509.HostnameError, got: %T", i, err)
+				}
+			case "UnknownAuthorityError":
+				if _, ok := err.(x509.UnknownAuthorityError); !ok {
+					t.Errorf("[%d] unexpected error: want x509.UnknownAuthorityError, got: %T", i, err)
+				}
+			default:
+				t.Errorf("cannot handle error type: %s", tc.failType)
+
+			}
+		} else if err != nil {
+			t.Errorf("[%d] unexpected error: %v", i, err)
+		}
+	}
+}
+
+// TestCertsHTTPS cannot test client authentication for non-localhost server
+// names, but it tests TLS handshake end-to-end over HTTPS.
+func TestCertsHTTPS(t *testing.T) {
+	params := []certParams{
 		{
 			// Unfortunately, due to the limitation in the way Go
 			// net/http/httptest package sets up the test HTTPS/TLS server,
@@ -48,72 +202,199 @@ func TestCerts(t *testing.T) {
 			ips:       []net.IP{net.ParseIP("127.0.0.1")},
 			hostnames: []string{},
 		},
+		{
+			// Unfortunately, due to the limitation in the way Go
+			// net/http/httptest package sets up the test HTTPS/TLS server,
+			// 127.0.0.1 is the only accepted server address. So, we need to
+			// generate certificates for this address.
+			cAddr:     "localhost",
+			ips:       []net.IP{net.ParseIP("127.0.0.1")},
+			hostnames: []string{"localhost"},
+		},
+	}
+
+	tlsCfgs, err := tlsConfigs(params)
+	if err != nil {
+		t.Errorf("failed to generate tls configs: %v", err)
+		// No point in proceeding further
+		return
+	}
+
+	testCases := []struct {
+		sCfg *tls.Config
+		cCfg *tls.Config
+		fail bool
+	}{
+		{
+			sCfg: tlsCfgs[0].server,
+			cCfg: tlsCfgs[0].client,
+			fail: false,
+		},
+		{
+			sCfg: tlsCfgs[0].server,
+			cCfg: tlsCfgs[1].client,
+			fail: true,
+		},
+		{
+			sCfg: tlsCfgs[1].server,
+			cCfg: tlsCfgs[0].client,
+			fail: true,
+		},
 	}
 
 	for i, tc := range testCases {
-		cks, err := certs(testSvcName, testCertValidity, tc.cAddr, tc.ips, tc.hostnames)
-		if err != nil {
-			t.Errorf("[%d] unexpected error generating certs: %v", i, err)
-		}
+		// Make a copy of the client config before modifying it.
+		cCfgCopy := *tc.cCfg
+		cCfg := &cCfgCopy
+		cCfg.BuildNameToCertificate()
 
-		caPemCK := encodeCertKey(cks["ca"])
-		roots := x509.NewCertPool()
-		if ok := roots.AppendCertsFromPEM(caPemCK.cert); !ok {
-			t.Errorf("[%d] failed to parse root certificate", i)
-		}
-
-		serverPemCK := encodeCertKey(cks["server"])
-		s, err := fakeTLSServer(roots, serverPemCK)
+		s, err := fakeHTTPSServer(tc.sCfg)
 		if err != nil {
 			t.Errorf("[%d] unexpected error starting TLS server: %v", i, err)
+			// No point in proceeding
+			continue
 		}
 		defer s.Close()
 
-		// Setup HTTPS client
-		kcfgPemCK := encodeCertKey(cks["kubeconfig"])
-		kcfgCert, err := tls.X509KeyPair(kcfgPemCK.cert, kcfgPemCK.key)
-		if err != nil {
-			t.Errorf("[%d] unexpected error parsing kubeconfig certificates: %v", i, err)
-		}
-		tlsCfg := &tls.Config{
-			Certificates: []tls.Certificate{kcfgCert},
-			RootCAs:      roots,
-		}
-		tlsCfg.BuildNameToCertificate()
 		tr := &http.Transport{
-			TLSClientConfig: tlsCfg,
+			TLSClientConfig: cCfg,
 		}
 		client := &http.Client{Transport: tr}
 		resp, err := client.Get(s.URL)
-		if err != nil {
-			t.Errorf("[%d] unexpected error while sending GET request to the server: %v", i, err)
+		if tc.fail {
+			_, ok := err.(*url.Error)
+			if !ok || !strings.HasSuffix(err.Error(), "x509: certificate signed by unknown authority") {
+				t.Errorf("[%d] unexpected error: want x509.HostnameError, got: %T", i, err)
+			}
+			// We are done for this test.
+			continue
+		} else if err != nil {
+			t.Errorf("[%d] unexpected error while sending GET request to the server: %T", i, err)
+			// No point in proceeding
+			continue
 		}
 		defer resp.Body.Close()
 
-		greeting, err := ioutil.ReadAll(resp.Body)
+		got, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("[%d] unexpected error reading server response: %v", i, err)
-		}
-		if want := "Hello, certificate test!\n"; string(greeting) != want {
-			t.Errorf("[%d] want %q, got %q", i, want, greeting)
+		} else if string(got) != helloMsg {
+			t.Errorf("[%d] want %q, got %q", i, helloMsg, got)
 		}
 	}
 }
 
-func fakeTLSServer(roots *x509.CertPool, serverCK *certKey) (*httptest.Server, error) {
-	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, certificate test!")
-	}))
-
-	serverCert, err := tls.X509KeyPair(serverCK.cert, serverCK.key)
+func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {
+	// Tried to use net.Pipe() instead of TCP. But the connections returned by
+	// net.Pipe() do a fully-synchronous reads and writes on both the ends.
+	// So if a TLS handshake fails, they can't return the error until the
+	// other side reads the message which it did not expect. Since the other
+	// side does not read the message it did not expect, the server and
+	// clients hang. Since TCP is non-blocking we use that as transport
+	// instead. One could have as well used a Unix Domain Socket, but TCP is
+	// more portable.
+	s, err := tls.Listen("tcp", "", sCfg)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to create a test TLS server: %v", err)
+	}
+	defer s.Close()
+
+	errCh := make(chan error)
+	go func() {
+		for {
+			conn, err := s.Accept()
+			if err != nil {
+				errCh <- fmt.Errorf("failed to accept a TLS connection: %v", err)
+				return
+			}
+			gotByte := make([]byte, len(helloMsg))
+			_, err = conn.Read(gotByte)
+			if err != nil && err != io.EOF {
+				errCh <- fmt.Errorf("failed to read input: %v", err)
+			} else if got := string(gotByte); got != helloMsg {
+				errCh <- fmt.Errorf("got %q, want %q", got, helloMsg)
+			}
+			errCh <- nil
+			return
+		}
+	}()
+
+	c, err := tls.Dial("tcp", s.Addr().String(), cCfg)
+	if err != nil {
+		// Intentionally not serializing the error received because we want to
+		// test for the failure case in the caller test function.
+		return err
+	}
+	defer c.Close()
+	if _, err := c.Write([]byte(helloMsg)); err != nil {
+		return fmt.Errorf("failed to write to server: %v", err)
 	}
 
-	s.TLS.Certificates = []tls.Certificate{serverCert}
-	s.TLS.RootCAs = roots
-	s.TLS.ClientAuth = tls.RequireAndVerifyClientCert
-	s.TLS.ClientCAs = roots
-	s.TLS.InsecureSkipVerify = false
+	return <-errCh
+}
+
+func fakeHTTPSServer(sCfg *tls.Config) (*httptest.Server, error) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helloMsg)
+	}))
+
+	s.TLS.Certificates = sCfg.Certificates
+	s.TLS.RootCAs = sCfg.RootCAs
+	s.TLS.ClientAuth = sCfg.ClientAuth
+	s.TLS.ClientCAs = sCfg.ClientCAs
+	s.TLS.InsecureSkipVerify = sCfg.InsecureSkipVerify
 	return s, nil
+}
+
+func tlsConfigs(params []certParams) ([]clientServerTLSConfigs, error) {
+	tlsCfgs := []clientServerTLSConfigs{}
+	for i, p := range params {
+		sCfg, cCfg, err := genServerClientTLSConfigs(testSvcName, testCertValidity, p.cAddr, p.ips, p.hostnames)
+		if err != nil {
+			return nil, fmt.Errorf("[%d] failed to generate tls configs: %v", i, err)
+		}
+		tlsCfgs = append(tlsCfgs, clientServerTLSConfigs{sCfg, cCfg})
+	}
+	return tlsCfgs, nil
+}
+
+func genServerClientTLSConfigs(svcName string, certValidity time.Duration, canonicalAddress string, ips []net.IP, hostnames []string) (*tls.Config, *tls.Config, error) {
+	cks, err := certs(svcName, certValidity, canonicalAddress, ips, hostnames)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected error generating certs: %v", err)
+	}
+
+	caPemCK := encodeCertKey(cks["ca"])
+	roots := x509.NewCertPool()
+	if ok := roots.AppendCertsFromPEM(caPemCK.cert); !ok {
+		return nil, nil, fmt.Errorf("failed to parse root certificate")
+	}
+
+	serverPemCK := encodeCertKey(cks["server"])
+	serverCert, err := tls.X509KeyPair(serverPemCK.cert, serverPemCK.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected error parsing server certificate: %v", err)
+	}
+
+	// Setup HTTPS client
+	kcfgPemCK := encodeCertKey(cks["kubeconfig"])
+	kcfgCert, err := tls.X509KeyPair(kcfgPemCK.cert, kcfgPemCK.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected error parsing kubeconfig certificates: %v", err)
+	}
+
+	sCfg := &tls.Config{
+		Certificates:       []tls.Certificate{serverCert},
+		RootCAs:            roots,
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ClientCAs:          roots,
+		InsecureSkipVerify: false,
+	}
+
+	cCfg := &tls.Config{
+		Certificates: []tls.Certificate{kcfgCert},
+		RootCAs:      roots,
+	}
+
+	return sCfg, cCfg, nil
 }

--- a/federation/manifests/federation-controller-manager-deployment.yaml
+++ b/federation/manifests/federation-controller-manager-deployment.yaml
@@ -17,16 +17,23 @@ spec:
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs
+      - name: kubeconfig
+        secret:
+          secretName: federation-apiserver-kubeconfig
       containers:
       - name: controller-manager
         volumeMounts:
         - name: ssl-certs
           readOnly: true
           mountPath: /etc/ssl/certs
+        - name: kubeconfig
+          readOnly: true
+          mountPath: "/etc/federation/controller-manager",
         image: {{.FEDERATION_CONTROLLER_MANAGER_IMAGE_REPO}}:{{.FEDERATION_CONTROLLER_MANAGER_IMAGE_TAG}}
         command:
         - /usr/local/bin/federation-controller-manager
         - --master=https://{{.FEDERATION_APISERVER_DEPLOYMENT_NAME}}:443
+        - --kubeconfig=/etc/federation/controller-manager/kubeconfig
         - --dns-provider={{.FEDERATION_DNS_PROVIDER}}
         - --dns-provider-config={{.FEDERATION_DNS_PROVIDER_CONFIG}}
         - --federation-name={{.FEDERATION_NAME}}


### PR DESCRIPTION
This depends on PR #30615. Please review only the last commit here.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31856)

<!-- Reviewable:end -->
