### PR TITLE
Use secrets for glusterfs provisioning passwords

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -109,17 +109,22 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
-  restuserkey: "password"
+  secretNamespace: "default"
+  secretName: "heketi-secret"
 ```
 
 * `endpoint`: `glusterfs-cluster` is the endpoint name which includes GlusterFS trusted pool IP addresses. This parameter is mandatory. We need to also create a service for this endpoint, so that the endpoint will be persisted. This service can be without a selector to tell Kubernetes we want to add its endpoints manually.  Please note that, glusterfs plugin looks for the endpoint in the pod namespace, so it is mandatory that the endpoint and service have to be created in Pod's namespace for successful mount of gluster volumes in the pod.
 * `resturl` : Gluster REST service/Heketi service url which provision gluster volumes on demand. The general format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner. If Heketi service is exposed as a routable service in openshift/kubernetes setup, this can have a format similar to
 `http://heketi-storage-project.cloudapps.mystorage.com` where the fqdn is a resolvable heketi service url.
-* `restauthenabled` : Gluster REST service authentication boolean is required if the authentication is enabled on the REST server. If this value is 'true', 'restuser' and 'restuserkey' have to be filled.
+* `restauthenabled` : Gluster REST service authentication boolean that enables authentication to the REST server. If this value is 'true', `restuser` and `restuserkey` or `secretNamespace` + `secretName` have to be filled. This option is deprecated, authentication is enabled when any of `restuser`, `restuserkey`, `secretName` or `secretNamespace` is specified.
 * `restuser` : Gluster REST service/Heketi user who has access to create volumes in the Gluster Trusted Pool.
-* `restuserkey` : Gluster REST service/Heketi user's password which will be used for authentication to the REST server.
+* `restuserkey` : Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of `secretNamespace` + `secretName`.
+* `secretNamespace` + `secretName` : Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both `secretNamespace` and `secretName` are omitted.
+
+When both `restuserkey` and `secretNamespace` + `secretName` is specified, the secret will be used.
+
+Example of a secret can be found in [glusterfs-provisioning-secret.yaml](glusterfs-provisioning-secret.yaml).
 
 Reference : ([How to configure Heketi](https://github.com/heketi/heketi/wiki/Setting-up-the-topology))
 
@@ -170,7 +175,7 @@ parameters:
 ```yaml
   apiVersion: storage.k8s.io/v1beta1
   kind: StorageClass
-  metadata: 
+  metadata:
     name: fast
     provisioner: kubernetes.io/rbd
     parameters:
@@ -392,7 +397,7 @@ Claim:		myns/claim1
 Reclaim Policy:	Delete
 Access Modes:	RWO
 Capacity:	3Gi
-Message:	
+Message:
 Source:
     Type:		RBD (a Rados Block Device mount on the host that shares a pod's lifetime)
     CephMonitors:	[10.16.153.105:6789]

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -6,6 +6,6 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
-  restuserkey: "password"
+  secretNamespace: "default"
+  secretName: "heketi-secret"

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: heketi-secret
+  namespace: default
+data:
+  # base64 encoded password. E.g.: echo -n "mypassword" | base64
+  key: bXlwYXNzd29yZA==

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -236,3 +236,63 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		t.Errorf("Expected true for mounter.IsReadOnly")
 	}
 }
+
+func TestAnnotations(t *testing.T) {
+	// Pass a provisioningConfigs through paramToAnnotations and back through
+	// annotationsToParam and check it did not change in the process.
+	tests := []provisioningConfig{
+		{
+		// Everything empty
+		},
+		{
+			// Everything with a value
+			url:             "http://localhost",
+			user:            "admin",
+			secretNamespace: "default",
+			secretName:      "gluster-secret",
+			userKey:         "mykey",
+		},
+		{
+			// No secret
+			url:             "http://localhost",
+			user:            "admin",
+			secretNamespace: "",
+			secretName:      "",
+			userKey:         "",
+		},
+	}
+
+	for i, test := range tests {
+		provisioner := &glusterfsVolumeProvisioner{
+			provisioningConfig: test,
+		}
+		deleter := &glusterfsVolumeDeleter{}
+
+		pv := &api.PersistentVolume{
+			ObjectMeta: api.ObjectMeta{
+				Name: "pv",
+			},
+		}
+
+		provisioner.paramToAnnotations(pv)
+		err := deleter.annotationsToParam(pv)
+		if err != nil {
+			t.Errorf("test %d failed: %v", i, err)
+		}
+		if test.url != deleter.url {
+			t.Errorf("test %d failed: expected url %q, got %q", i, test.url, deleter.url)
+		}
+		if test.user != deleter.user {
+			t.Errorf("test %d failed: expected user %q, got %q", i, test.user, deleter.user)
+		}
+		if test.userKey != deleter.userKey {
+			t.Errorf("test %d failed: expected userKey %q, got %q", i, test.userKey, deleter.userKey)
+		}
+		if test.secretNamespace != deleter.secretNamespace {
+			t.Errorf("test %d failed: expected secretNamespace %q, got %q", i, test.secretNamespace, deleter.secretNamespace)
+		}
+		if test.secretName != deleter.secretName {
+			t.Errorf("test %d failed: expected secretName %q, got %q", i, test.secretName, deleter.secretName)
+		}
+	}
+}


### PR DESCRIPTION
- no plain password in StorageClass!
- fix the style along the way
- use PV annotations to pass the configuration from provisioners to deleters, inspired by Ceph RBD provisioning.

~~Proposing 1.4:~~

~~\- GlusterFS provisioning is a new 1.4 feature~~
~~\- if we release GlusterFS provisioner as it is now, we need to support it's API (i.e. plaintext passwords) until 2.0~~
~~\- it can break only GlusterFS provisioning, nothing else~~
~~\- it's easy to revert~~

@kubernetes/sig-storage

fixes #31871

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31869)

<!-- Reviewable:end -->
