### PR TITLE
Increase registry cache size for services to handle big clusters

### DIFF
--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -89,6 +89,7 @@ func InitializeWatchCacheSizes(expectedRAMCapacityMB int) {
 	watchCacheSizes[Endpoints] = maxInt(10*clusterSize, 1000)
 	watchCacheSizes[Nodes] = maxInt(3*clusterSize, 1000)
 	watchCacheSizes[Pods] = maxInt(10*clusterSize, 1000)
+	watchCacheSizes[Services] = maxInt(5*clusterSize, 1000)
 }
 
 func SetWatchCacheSizes(cacheSizes []string) {


### PR DESCRIPTION
We noticed a problem with too small cache in a load test on a big cluster. This PR will slightly increase apiserver memory footprint, but it's safe otherwise. This should get in v1.4. @pwittrock

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31870)

<!-- Reviewable:end -->
