### PR TITLE
Store startupscript from GKE clusters too

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -59,7 +59,7 @@ function save-logs() {
     local -r node_name="${1}"
     local -r dir="${2}"
     local files="${3} ${common_logfiles}"
-    if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
+    if [[ "${KUBERNETES_PROVIDER}" == "gce" || "${KUBERNETES_PROVIDER}" == "gke" ]]; then
         files="${files} ${gce_logfiles}"
     fi
     if [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/31215

@kubernetes/goog-gke  Is there any reason why we don't want to do it?

@kubernetes/test-infra-maintainers

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31872)

<!-- Reviewable:end -->
