### PR TITLE
Skip gofmt for staging/ directory

### DIFF
--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -34,6 +34,7 @@ find_files() {
         -o -wholename './_output' \
         -o -wholename './_gopath' \
         -o -wholename './release' \
+        -o -wholename './staging' \
         -o -wholename './target' \
         -o -wholename '*/third_party/*' \
         -o -wholename '*/vendor/*' \


### PR DESCRIPTION
Don't run gofmt for example on:
staging/src/k8s.io/client-go/1.4/_vendor

Fixes #31875

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31882)

<!-- Reviewable:end -->
