### PR TITLE
Create a file from data stored in gobindata to fix kubectl-based exam…

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -301,14 +301,16 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Liveness", func() {
 		It("liveness pods should be automatically restarted", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "test/fixtures/doc-yaml/user-guide/liveness", file)
+				path := filepath.Join("test/fixtures/doc-yaml/user-guide/liveness", file)
+				ExpectNoError(framework.CreateFileForGoBinData(path, path))
+				return path
 			}
 			execYaml := mkpath("exec-liveness.yaml")
 			httpYaml := mkpath("http-liveness.yaml")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
-			framework.RunKubectlOrDie("create", "-f", execYaml, nsFlag)
-			framework.RunKubectlOrDie("create", "-f", httpYaml, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", filepath.Join(framework.TestContext.OutputDir, execYaml), nsFlag)
+			framework.RunKubectlOrDie("create", "-f", filepath.Join(framework.TestContext.OutputDir, httpYaml), nsFlag)
 
 			// Since both containers start rapidly, we can easily run this test in parallel.
 			var wg sync.WaitGroup
@@ -351,16 +353,19 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Secret", func() {
 		It("should create a pod that reads a secret", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "test/fixtures/doc-yaml/user-guide/secrets", file)
+				path := filepath.Join("test/fixtures/doc-yaml/user-guide/secrets", file)
+				ExpectNoError(framework.CreateFileForGoBinData(path, path))
+				return path
 			}
 			secretYaml := mkpath("secret.yaml")
 			podYaml := mkpath("secret-pod.yaml")
+
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podName := "secret-test-pod"
 
 			By("creating secret and pod")
-			framework.RunKubectlOrDie("create", "-f", secretYaml, nsFlag)
-			framework.RunKubectlOrDie("create", "-f", podYaml, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", filepath.Join(framework.TestContext.OutputDir, secretYaml), nsFlag)
+			framework.RunKubectlOrDie("create", "-f", filepath.Join(framework.TestContext.OutputDir, podYaml), nsFlag)
 			err := framework.WaitForPodNoLongerRunningInNamespace(c, podName, ns, "")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -373,14 +378,16 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Downward API", func() {
 		It("should create a pod that prints his name and namespace", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "test/fixtures/doc-yaml/user-guide/downward-api", file)
+				path := filepath.Join("test/fixtures/doc-yaml/user-guide/downward-api", file)
+				ExpectNoError(framework.CreateFileForGoBinData(path, path))
+				return path
 			}
 			podYaml := mkpath("dapi-pod.yaml")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podName := "dapi-test-pod"
 
 			By("creating the pod")
-			framework.RunKubectlOrDie("create", "-f", podYaml, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", filepath.Join(framework.TestContext.OutputDir, podYaml), nsFlag)
 			err := framework.WaitForPodNoLongerRunningInNamespace(c, podName, ns, "")
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -5074,4 +5075,21 @@ func GetMasterAndWorkerNodesOrDie(c *client.Client) (sets.String, *api.NodeList)
 		}
 	}
 	return masters, nodes
+}
+
+func CreateFileForGoBinData(gobindataPath, outputFilename string) error {
+	data := ReadOrDie(gobindataPath)
+	if len(data) == 0 {
+		return fmt.Errorf("Failed to read gobindata from %v", gobindataPath)
+	}
+	fullPath := filepath.Join(TestContext.OutputDir, outputFilename)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0777)
+	if err != nil {
+		return fmt.Errorf("Error while creating directory %v: %v", filepath.Dir(fullPath), err)
+	}
+	err = ioutil.WriteFile(fullPath, data, 0644)
+	if err != nil {
+		return fmt.Errorf("Error while trying to write to file %v: %v", fullPath, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Fix #31539

Adding 1.4 milestone as this fixes P0 flake issue (test completely broken by moving to gobindata). @pwittrock 

cc @jayunit100

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31883)

<!-- Reviewable:end -->
