### PR TITLE
fix deleteClaim

### DIFF
--- a/pkg/controller/volume/persistentvolume/controller_base.go
+++ b/pkg/controller/volume/persistentvolume/controller_base.go
@@ -413,7 +413,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(obj interface{}) {
 		}
 	}
 
-	if !ok || claim == nil {
+	if claim == nil {
 		return
 	}
 	glog.V(4).Infof("claim %q deleted", claimToClaimKey(claim))


### PR DESCRIPTION
`ok` is not in same variable socpe
like https://github.com/kubernetes/kubernetes/pull/31416

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31885)

<!-- Reviewable:end -->
