### PR TITLE
Namespace certificates API group

### DIFF
--- a/api/swagger-spec/certificates.k8s.io.json
+++ b/api/swagger-spec/certificates.k8s.io.json
@@ -2,14 +2,14 @@
   "swaggerVersion": "1.2",
   "apiVersion": "",
   "basePath": "https://10.10.10.10:6443",
-  "resourcePath": "/apis/certificates",
+  "resourcePath": "/apis/certificates.k8s.io",
   "info": {
    "title": "",
    "description": ""
   },
   "apis": [
    {
-    "path": "/apis/certificates",
+    "path": "/apis/certificates.k8s.io",
     "description": "get information of a group",
     "operations": [
      {

--- a/api/swagger-spec/certificates.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/certificates.k8s.io_v1alpha1.json
@@ -1,16 +1,16 @@
 {
   "swaggerVersion": "1.2",
-  "apiVersion": "certificates/v1alpha1",
+  "apiVersion": "certificates.k8s.io/v1alpha1",
   "basePath": "https://10.10.10.10:6443",
-  "resourcePath": "/apis/certificates/v1alpha1",
+  "resourcePath": "/apis/certificates.k8s.io/v1alpha1",
   "info": {
    "title": "",
    "description": ""
   },
   "apis": [
    {
-    "path": "/apis/certificates/v1alpha1/certificatesigningrequests",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/certificatesigningrequests",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "v1alpha1.CertificateSigningRequestList",
@@ -196,8 +196,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1/watch/certificatesigningrequests",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/watch/certificatesigningrequests",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "*versioned.Event",
@@ -274,8 +274,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1/certificatesigningrequests/{name}",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "v1alpha1.CertificateSigningRequest",
@@ -478,8 +478,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1/watch/certificatesigningrequests/{name}",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/watch/certificatesigningrequests/{name}",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "*versioned.Event",
@@ -564,8 +564,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1/certificatesigningrequests/{name}/approval",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/approval",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "v1alpha1.CertificateSigningRequest",
@@ -617,8 +617,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1/certificatesigningrequests/{name}/status",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/status",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "v1alpha1.CertificateSigningRequest",
@@ -670,8 +670,8 @@
     ]
    },
    {
-    "path": "/apis/certificates/v1alpha1",
-    "description": "API at /apis/certificates/v1alpha1",
+    "path": "/apis/certificates.k8s.io/v1alpha1",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1",
     "operations": [
      {
       "type": "unversioned.APIResourceList",

--- a/api/swagger-spec/resourceListing.json
+++ b/api/swagger-spec/resourceListing.json
@@ -66,11 +66,11 @@
     "description": "get information of a group"
    },
    {
-    "path": "/apis/certificates/v1alpha1",
-    "description": "API at /apis/certificates/v1alpha1"
+    "path": "/apis/certificates.k8s.io/v1alpha1",
+    "description": "API at /apis/certificates.k8s.io/v1alpha1"
    },
    {
-    "path": "/apis/certificates",
+    "path": "/apis/certificates.k8s.io",
     "description": "get information of a group"
    },
    {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -455,7 +455,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 	go attachDetachController.Run(wait.NeverStop)
 	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 
-	groupVersion = "certificates/v1alpha1"
+	groupVersion = "certificates.k8s.io/v1alpha1"
 	resources, found = resourceMap[groupVersion]
 	glog.Infof("Attempting to start certificates, full resource map %+v", resourceMap)
 	if containsVersion(versions, groupVersion) && found {

--- a/docs/api-reference/certificates.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/certificates.k8s.io/v1alpha1/definitions.html
@@ -1311,7 +1311,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-08-23 17:35:27 UTC
+Last updated 2016-09-01 18:34:11 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/certificates.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/certificates.k8s.io/v1alpha1/operations.html
@@ -371,7 +371,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_get_available_resources">get available resources</h3>
 <div class="listingblock">
 <div class="content">
-<pre>GET /apis/certificates/v1alpha1</pre>
+<pre>GET /apis/certificates.k8s.io/v1alpha1</pre>
 </div>
 </div>
 <div class="sect3">
@@ -436,7 +436,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -446,7 +446,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_list_or_watch_objects_of_kind_certificatesigningrequest">list or watch objects of kind CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>GET /apis/certificates/v1alpha1/certificatesigningrequests</pre>
+<pre>GET /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests</pre>
 </div>
 </div>
 <div class="sect3">
@@ -579,7 +579,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -589,7 +589,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_delete_collection_of_certificatesigningrequest">delete collection of CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>DELETE /apis/certificates/v1alpha1/certificatesigningrequests</pre>
+<pre>DELETE /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests</pre>
 </div>
 </div>
 <div class="sect3">
@@ -722,7 +722,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -732,7 +732,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_create_a_certificatesigningrequest">create a CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>POST /apis/certificates/v1alpha1/certificatesigningrequests</pre>
+<pre>POST /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests</pre>
 </div>
 </div>
 <div class="sect3">
@@ -833,7 +833,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -843,7 +843,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_read_the_specified_certificatesigningrequest">read the specified CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>GET /apis/certificates/v1alpha1/certificatesigningrequests/{name}</pre>
+<pre>GET /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}</pre>
 </div>
 </div>
 <div class="sect3">
@@ -960,7 +960,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -970,7 +970,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_replace_the_specified_certificatesigningrequest">replace the specified CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>PUT /apis/certificates/v1alpha1/certificatesigningrequests/{name}</pre>
+<pre>PUT /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1079,7 +1079,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1089,7 +1089,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_delete_a_certificatesigningrequest">delete a CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>DELETE /apis/certificates/v1alpha1/certificatesigningrequests/{name}</pre>
+<pre>DELETE /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1198,7 +1198,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1208,7 +1208,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_partially_update_the_specified_certificatesigningrequest">partially update the specified CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>PATCH /apis/certificates/v1alpha1/certificatesigningrequests/{name}</pre>
+<pre>PATCH /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1323,7 +1323,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1333,7 +1333,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_replace_approval_of_the_specified_certificatesigningrequest">replace approval of the specified CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>PUT /apis/certificates/v1alpha1/certificatesigningrequests/{name}/approval</pre>
+<pre>PUT /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/approval</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1442,7 +1442,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1452,7 +1452,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_replace_status_of_the_specified_certificatesigningrequest">replace status of the specified CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>PUT /apis/certificates/v1alpha1/certificatesigningrequests/{name}/status</pre>
+<pre>PUT /apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/status</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1561,7 +1561,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1571,7 +1571,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_watch_individual_changes_to_a_list_of_certificatesigningrequest">watch individual changes to a list of CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>GET /apis/certificates/v1alpha1/watch/certificatesigningrequests</pre>
+<pre>GET /apis/certificates.k8s.io/v1alpha1/watch/certificatesigningrequests</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1707,7 +1707,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1717,7 +1717,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <h3 id="_watch_changes_to_an_object_of_kind_certificatesigningrequest">watch changes to an object of kind CertificateSigningRequest</h3>
 <div class="listingblock">
 <div class="content">
-<pre>GET /apis/certificates/v1alpha1/watch/certificatesigningrequests/{name}</pre>
+<pre>GET /apis/certificates.k8s.io/v1alpha1/watch/certificatesigningrequests/{name}</pre>
 </div>
 </div>
 <div class="sect3">
@@ -1861,7 +1861,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
-<p>apiscertificatesv1alpha1</p>
+<p>apiscertificates.k8s.iov1alpha1</p>
 </li>
 </ul>
 </div>
@@ -1872,7 +1872,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-07-29 20:29:11 UTC
+Last updated 2016-09-01 18:34:11 UTC
 </div>
 </div>
 </body>

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -293,6 +293,7 @@ kube::util::analytics-link() {
 # * default behavior: extensions/v1beta1 -> apis/extensions/v1beta1
 # * default behavior for only a group: experimental -> apis/experimental
 # * Special handling for empty group: v1 -> api/v1, unversioned -> api/unversioned
+# * Special handling for groups suffixed with ".k8s.io": foo.k8s.io/v1 -> apis/foo/v1
 # * Very special handling for when both group and version are "": / -> api
 kube::util::group-version-to-pkg-path() {
   local group_version="$1"
@@ -309,6 +310,12 @@ kube::util::group-version-to-pkg-path() {
       ;;
     unversioned)
       echo "api/unversioned"
+      ;;
+    *.k8s.io)
+      echo "apis/${group_version%.k8s.io}"
+      ;;
+    *.k8s.io/*)
+      echo "apis/${group_version/.k8s.io/}"
       ;;
     *)
       echo "apis/${group_version%__internal}"

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -27,7 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,extensions/v1beta1"}
 # FIXME: due to current implementation of a test client (see: pkg/api/testapi/testapi.go)
 # ONLY the last version is tested in each group.
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,apps/v1alpha1,policy/v1alpha1,extensions/v1beta1,rbac.authorization.k8s.io/v1alpha1,certificates/v1alpha1"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,apps/v1alpha1,policy/v1alpha1,extensions/v1beta1,rbac.authorization.k8s.io/v1alpha1,certificates.k8s.io/v1alpha1"}
 
 # Give integration tests longer to run
 # TODO: allow a larger value to be passed in

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -66,7 +66,7 @@ KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # "v1,compute/v1alpha1,experimental/v1alpha2;v1,compute/v2,experimental/v1alpha3"
 # FIXME: due to current implementation of a test client (see: pkg/api/testapi/testapi.go)
 # ONLY the last version is tested in each group.
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,apps/v1alpha1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1alpha1,extensions/v1beta1,federation/v1beta1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1,imagepolicy.k8s.io/v1alpha1"}
 # once we have multiple group supports
 # Create a junit-style XML test report in this directory if set.
 KUBE_JUNIT_REPORT_DIR=${KUBE_JUNIT_REPORT_DIR:-}

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -34,7 +34,7 @@ OUTPUT=${1:-${DEFAULT_OUTPUT}}
 
 SWAGGER_SPEC_PATH="${REPO_DIR}/api/swagger-spec"
 
-GROUP_VERSIONS=("v1" "extensions/v1beta1" "batch/v1" "autoscaling/v1" "certificates/v1alpha1")
+GROUP_VERSIONS=("v1" "extensions/v1beta1" "batch/v1" "autoscaling/v1" "certificates.k8s.io/v1alpha1")
 GV_DIRS=()
 for gv in "${GROUP_VERSIONS[@]}"; do
   GV_DIRS+=("${REPO_DIR}/pkg/$(kube::util::group-version-to-pkg-path "${gv}")")

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -73,7 +73,7 @@ APISERVER_PID=$!
 kube::util::wait_for_url "${API_HOST}:${API_PORT}/healthz" "apiserver: "
 
 SWAGGER_API_PATH="${API_HOST}:${API_PORT}/swaggerapi/"
-DEFAULT_GROUP_VERSIONS="v1 apps/v1alpha1 authentication.k8s.io/v1beta1 authorization.k8s.io/v1beta1 autoscaling/v1 batch/v1 batch/v2alpha1 extensions/v1beta1 certificates/v1alpha1 policy/v1alpha1 rbac.authorization.k8s.io/v1alpha1"
+DEFAULT_GROUP_VERSIONS="v1 apps/v1alpha1 authentication.k8s.io/v1beta1 authorization.k8s.io/v1beta1 autoscaling/v1 batch/v1 batch/v2alpha1 extensions/v1beta1 certificates.k8s.io/v1alpha1 policy/v1alpha1 rbac.authorization.k8s.io/v1alpha1"
 VERSIONS=${VERSIONS:-$DEFAULT_GROUP_VERSIONS}
 
 kube::log::status "Updating " ${SWAGGER_ROOT_DIR}

--- a/pkg/apis/certificates/doc.go
+++ b/pkg/apis/certificates/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
 
+// +groupName=certificates.k8s.io
 package certificates // import "k8s.io/kubernetes/pkg/apis/certificates"

--- a/pkg/apis/certificates/register.go
+++ b/pkg/apis/certificates/register.go
@@ -28,7 +28,7 @@ var (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "certificates"
+const GroupName = "certificates.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/apis/certificates/v1alpha1/doc.go
+++ b/pkg/apis/certificates/v1alpha1/doc.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +groupName=certificates.k8s.io
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
 

--- a/pkg/apis/certificates/v1alpha1/register.go
+++ b/pkg/apis/certificates/v1alpha1/register.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "certificates"
+const GroupName = "certificates.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificates_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificates_client.go
@@ -66,7 +66,7 @@ func New(c *restclient.RESTClient) *CertificatesClient {
 
 func setConfigDefaults(config *restclient.Config) error {
 	// if certificates group is not registered, return an error
-	g, err := registered.Group("certificates")
+	g, err := registered.Group("certificates.k8s.io")
 	if err != nil {
 		return err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificatesigningrequest.go
@@ -30,7 +30,7 @@ type FakeCertificateSigningRequests struct {
 	Fake *FakeCertificates
 }
 
-var certificatesigningrequestsResource = unversioned.GroupVersionResource{Group: "certificates", Version: "", Resource: "certificatesigningrequests"}
+var certificatesigningrequestsResource = unversioned.GroupVersionResource{Group: "certificates.k8s.io", Version: "", Resource: "certificatesigningrequests"}
 
 func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/doc.go
+++ b/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/doc.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +groupName=certificates.k8s.io
 // +k8s:deepcopy-gen=package,register
 
 package certificates

--- a/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/register.go
+++ b/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/register.go
@@ -28,7 +28,7 @@ var (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "certificates"
+const GroupName = "certificates.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/v1alpha1/doc.go
+++ b/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/v1alpha1/doc.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +groupName=certificates.k8s.io
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
 

--- a/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/v1alpha1/register.go
+++ b/staging/src/k8s.io/client-go/1.4/pkg/apis/certificates/v1alpha1/register.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "certificates"
+const GroupName = "certificates.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}


### PR DESCRIPTION
New API groups should follow best-practices for naming, including using DNS names within the k8s.io namespace

``` release-note
The certificates API group has been renamed to certificates.k8s.io
```

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31887)

<!-- Reviewable:end -->
