### PR TITLE
Support graceful termination in kube-dns

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -125,12 +125,12 @@ func (server *KubeDNSServer) setupHealthzHandlers() {
 }
 
 // setupSignalHandlers runs a goroutine that waits on SIGINT or SIGTERM and logs it
-// before exiting.
+// program will be terminated by SIGKILL when grace period ends.
 func setupSignalHandlers() {
 	sigChan := make(chan os.Signal)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		glog.Fatalf("Received signal: %s", <-sigChan)
+		glog.Infof("Received signal: %s, will exit when the grace period ends", <-sigChan)
 	}()
 }
 


### PR DESCRIPTION
Fix #31807 

kube-dns used to trap SIGINT and SIGTERM and call glog.Fatalf() when signal received.
Let the program keep running when signal occur to support graceful termination. It will be terminated by SIGKILL when grace period ends.

@thockin @girishkalele

``` release-note
Support graceful termination in kube-dns
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31894)

<!-- Reviewable:end -->
