### PR TITLE
Namespace controller deletes pods last

### DIFF
--- a/pkg/controller/namespace/namespace_controller_utils.go
+++ b/pkg/controller/namespace/namespace_controller_utils.go
@@ -18,6 +18,7 @@ package namespace
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -318,6 +319,8 @@ func deleteAllContent(
 	estimate := int64(0)
 	glog.V(4).Infof("namespace controller - deleteAllContent - namespace: %s, gvrs: %v", namespace, groupVersionResources)
 	// iterate over each group version, and attempt to delete all of its resources
+	// we sort resources to delete in a priority order that deletes pods LAST
+	sort.Sort(sortableGroupVersionResources(groupVersionResources))
 	for _, gvr := range groupVersionResources {
 		gvrEstimate, err := deleteAllContentForGroupVersionResource(kubeClient, clientPool, opCache, gvr, namespace, namespaceDeletedAt)
 		if err != nil {
@@ -452,4 +455,21 @@ func estimateGracefulTerminationForPods(kubeClient clientset.Interface, ns strin
 		}
 	}
 	return estimate, nil
+}
+
+// sortableGroupVersionResources sorts the input set of resources for deletion, and orders pods to always be last.
+// the idea is that the namespace controller will delete all things that spawn pods first in order to reduce the time
+// those controllers spend creating pods only to be told NO in admission and potentially overwhelming cluster especially if they lack rate limiting.
+type sortableGroupVersionResources []unversioned.GroupVersionResource
+
+func (list sortableGroupVersionResources) Len() int {
+	return len(list)
+}
+
+func (list sortableGroupVersionResources) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list sortableGroupVersionResources) Less(i, j int) bool {
+	return list[j].Group == "" && list[j].Resource == "pods"
 }


### PR DESCRIPTION
I think this fixes https://github.com/kubernetes/kubernetes/issues/29308 or at least helps further reduce the incidence.

This PR changes the order in which namespace controller prioritizes resources for deletion.  It deletes all resources before deleting pods.  The rationale for this change is to broadcast deletion of controllers that spawn pods first rather than trip those controllers up into thinking they should spawn more pods which would increase the risk of causing races with the `NamespaceLifecycle` admission plug-in.  Many of those controllers also are not rate-limited in the face of rejection, so rather than promote a situation where they are rejected, we promote a situation that removes those things first.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31917)

<!-- Reviewable:end -->
