### PR TITLE
Adding namespaces/finalizer subresource to federation apiserver

### DIFF
--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -2821,7 +2821,7 @@
      },
      "flexVolume": {
       "$ref": "v1.FlexVolumeSource",
-      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plugin. This is an alpha feature and may change in future."
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future."
      },
      "cinder": {
       "$ref": "v1.CinderVolumeSource",
@@ -3160,7 +3160,7 @@
    },
    "v1.FlexVolumeSource": {
     "id": "v1.FlexVolumeSource",
-    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plugin. This is an alpha feature and may change in future.",
+    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
     "required": [
      "driver"
     ],
@@ -3352,7 +3352,7 @@
       "items": {
        "type": "string"
       },
-      "description": "Required: FC target world wide names (WWNs)"
+      "description": "Required: FC target worldwide names (WWNs)"
      },
      "lun": {
       "type": "integer",

--- a/federation/apis/swagger-spec/v1.json
+++ b/federation/apis/swagger-spec/v1.json
@@ -1346,6 +1346,59 @@
     ]
    },
    {
+    "path": "/api/v1/namespaces/{name}/finalize",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.Namespace",
+      "method": "PUT",
+      "summary": "replace finalize of the specified Namespace",
+      "nickname": "replaceNamespaceFinalize",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.Namespace",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Namespace"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1/namespaces/{name}/status",
     "description": "API at /api/v1",
     "operations": [

--- a/federation/cmd/federation-apiserver/app/core.go
+++ b/federation/cmd/federation-apiserver/app/core.go
@@ -42,16 +42,17 @@ import (
 
 func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
 	serviceStore, serviceStatusStore := serviceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("service")))
-	namespaceStore, namespaceStatusStore, _ := namespaceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("namespaces")))
+	namespaceStore, namespaceStatusStore, namespaceFinalizeStore := namespaceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("namespaces")))
 	secretStore := secretetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("secrets")))
 	eventStore := eventetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("events")), uint64(s.EventTTL.Seconds()))
 	coreResources := map[string]rest.Storage{
-		"secrets":           secretStore,
-		"services":          serviceStore,
-		"services/status":   serviceStatusStore,
-		"namespaces":        namespaceStore,
-		"namespaces/status": namespaceStatusStore,
-		"events":            eventStore,
+		"secrets":             secretStore,
+		"services":            serviceStore,
+		"services/status":     serviceStatusStore,
+		"namespaces":          namespaceStore,
+		"namespaces/status":   namespaceStatusStore,
+		"namespaces/finalize": namespaceFinalizeStore,
+		"events":              eventStore,
 	}
 	coreGroupMeta := registered.GroupOrDie(core.GroupName)
 	apiGroupInfo := genericapiserver.APIGroupInfo{

--- a/test/integration/federation/server_test.go
+++ b/test/integration/federation/server_test.go
@@ -283,8 +283,8 @@ func testCoreResourceList(t *testing.T) {
 	}
 	assert.Equal(t, "", apiResourceList.APIVersion)
 	assert.Equal(t, v1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
-	// Assert that there are exactly 6 resources.
-	assert.Equal(t, 6, len(apiResourceList.APIResources))
+	// Assert that there are exactly 7 resources.
+	assert.Equal(t, 7, len(apiResourceList.APIResources))
 
 	// Verify services.
 	found := findResource(apiResourceList.APIResources, "services")
@@ -299,6 +299,9 @@ func testCoreResourceList(t *testing.T) {
 	assert.NotNil(t, found)
 	assert.False(t, found.Namespaced)
 	found = findResource(apiResourceList.APIResources, "namespaces/status")
+	assert.NotNil(t, found)
+	assert.False(t, found.Namespaced)
+	found = findResource(apiResourceList.APIResources, "namespaces/finalize")
 	assert.NotNil(t, found)
 	assert.False(t, found.Namespaced)
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/31077

cc @kubernetes/sig-cluster-federation @mwielgus 

Verified manually that I can delete federation namespaces now.
Will update federation-namespace e2e test to verify that namespace is deleted fine

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31925)

<!-- Reviewable:end -->
