### PR TITLE
Automated Docker Validation: Add automated docker performance validation.

### DIFF
--- a/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
@@ -1,18 +1,22 @@
+#!/bin/bash
 GCI_IMAGE_PROJECT=container-vm-image-staging
 GCI_IMAGE_FAMILY=gci-canary-test
 GCI_IMAGE=$(gcloud compute images describe-from-family ${GCI_IMAGE_FAMILY} --project=${GCI_IMAGE_PROJECT} --format="value(name)")
 DOCKER_VERSION=$(curl -fsSL --retry 3 https://api.github.com/repos/docker/docker/releases | tac | tac | grep -m 1 "\"tag_name\"\:" | grep -Eo "[0-9\.rc-]+")
 GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
 
+# Render the test config file
+GCE_IMAGE_CONFIG_PATH=`mktemp`
+CONFIG_FILE=test/e2e_node/jenkins/docker_validation/perf-config.yaml
+cp $CONFIG_FILE $GCE_IMAGE_CONFIG_PATH
+sed -i -e "s@{{IMAGE}}@${GCI_IMAGE}@g" $GCE_IMAGE_CONFIG_PATH
+sed -i -e "s@{{IMAGE_PROJECT}}@${GCI_IMAGE_PROJECT}@g" $GCE_IMAGE_CONFIG_PATH
+sed -i -e "s@{{METADATA}}@user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}@g" $GCE_IMAGE_CONFIG_PATH
+
 GCE_HOSTS=
-GCE_IMAGES=${GCI_IMAGE}
-GCE_IMAGE_PROJECT=${GCI_IMAGE_PROJECT}
 GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
-# user-data is the GCI cloud init config file.
-# gci-docker-version specifies docker version in GCI image.
-GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"
 CLEANUP=true
-# TODO(random-liu): Run performance test in docker validation test.
-GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
+GINKGO_FLAGS='--skip="\[Flaky\]"'
 SETUP_NODE=true
+PARALLELISM=1

--- a/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
@@ -1,0 +1,17 @@
+GCI_IMAGE_PROJECT=container-vm-image-staging
+GCI_IMAGE_FAMILY=gci-canary-test
+GCI_IMAGE=$(gcloud compute images describe-from-family ${GCI_IMAGE_FAMILY} --project=${GCI_IMAGE_PROJECT} --format="value(name)")
+DOCKER_VERSION=$(curl -fsSL --retry 3 https://api.github.com/repos/docker/docker/releases | tac | tac | grep -m 1 "\"tag_name\"\:" | grep -Eo "[0-9\.rc-]+")
+GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
+
+GCE_HOSTS=
+GCE_IMAGES=${GCI_IMAGE}
+GCE_IMAGE_PROJECT=${GCI_IMAGE_PROJECT}
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+# user-data is the GCI cloud init config file.
+# gci-docker-version specifies docker version in GCI image.
+GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
+SETUP_NODE=true

--- a/test/e2e_node/jenkins/docker_validation/perf-config.yaml
+++ b/test/e2e_node/jenkins/docker_validation/perf-config.yaml
@@ -1,0 +1,58 @@
+---
+images:
+  containervm-density1:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-1
+    tests:
+      - '.*create 35 pods with 0s? interval \[Benchmark\]'
+  containervm-density2:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-1
+    tests:
+      - '.*create 105 pods with 0s? interval \[Benchmark\]'
+  containervm-density3:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-2
+    tests:
+      - '.*create 105 pods with 0s? interval \[Benchmark\]'
+  containervm-density4:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-1
+    tests:
+      - '.*create 35 pods with 100ms interval \[Benchmark\]'
+  containervm-density5:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-1
+    tests:
+      - '.*create 105 pods with 100ms interval \[Benchmark\]'
+  containervm-density6:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-2
+    tests:
+      - '.*create 105 pods with 100ms interval \[Benchmark\]'
+  containervm-density7:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-1
+    tests:
+      - '.*create 105 pods with 300ms interval \[Benchmark\]'
+  containervm-density8:
+    image: "{{IMAGE}}"
+    project: "{{IMAGE_PROJECT}}"
+    metadata: "{{METADATA}}"
+    machine: n1-standard-2
+    tests:
+      - '.*create 105 pods with 300ms interval \[Benchmark\]'


### PR DESCRIPTION
Use the node e2e performance benchmark to automatically validate newest docker release.
And it can also help us validate docker 1.12 this release.

@dchen1107 @coufon

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31933)

<!-- Reviewable:end -->
