### PR TITLE
Set DefaultCluster in config overrides

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -83,7 +83,7 @@ func newKubeClient(dnsConfig *options.KubeDNSConfig) (clientset.Interface, error
 		//  3) neither flag
 		// In any case, the logic is the same.  If (3), this will automatically
 		// fall back on the service account token.
-		overrides := &kclientcmd.ConfigOverrides{}
+		overrides := &kclientcmd.ConfigOverrides{ClusterDefaults: kclientcmd.DefaultCluster}  // need this because ClientConfig would not set DefaultCluster now
 		overrides.ClusterInfo.Server = dnsConfig.KubeMasterURL                                // might be "", but that is OK
 		rules := &kclientcmd.ClientConfigLoadingRules{ExplicitPath: dnsConfig.KubeConfigFile} // might be "", but that is OK
 		if config, err = kclientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig(); err != nil {


### PR DESCRIPTION
Attempt to fix #31910 

Due to this commit 06cbb29e9e9b10c371347d2457ff8708f4a9e9f5, ClientConfig would not default to http://localhost:8080 now. Add DefaultCluster in kube-dns config overrides to fix.

@smarterclayton @girishkalele @thockin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31940)

<!-- Reviewable:end -->
