### PR TITLE
[Pet Set] Clean up code

### DIFF
--- a/pkg/controller/petset/fakes.go
+++ b/pkg/controller/petset/fakes.go
@@ -151,11 +151,13 @@ func newFakePetClient() *fakePetClient {
 }
 
 type fakePetClient struct {
-	pets                         []*pcb
-	claims                       []api.PersistentVolumeClaim
-	petsCreated, petsDeleted     int
-	claimsCreated, claimsDeleted int
-	recorder                     record.EventRecorder
+	pets          []*pcb
+	claims        []api.PersistentVolumeClaim
+	petsCreated   int
+	petsDeleted   int
+	claimsCreated int
+	claimsDeleted int
+	recorder      record.EventRecorder
 	petHealthChecker
 }
 

--- a/pkg/controller/petset/pet.go
+++ b/pkg/controller/petset/pet.go
@@ -225,18 +225,9 @@ func (p *apiServerPetClient) DeletePVCs(pet *pcb) error {
 	return nil
 }
 
-func (p *apiServerPetClient) getPVC(pvcName, pvcNamespace string) (*api.PersistentVolumeClaim, bool, error) {
-	found := true
+func (p *apiServerPetClient) getPVC(pvcName, pvcNamespace string) (*api.PersistentVolumeClaim, error) {
 	pvc, err := claimClient(p.c, pvcNamespace).Get(pvcName)
-	if errors.IsNotFound(err) {
-		found = false
-	}
-	if !found {
-		return nil, found, nil
-	} else if err != nil {
-		return nil, found, err
-	}
-	return pvc, true, nil
+	return pvc, err
 }
 
 func (p *apiServerPetClient) createPVC(pvc *api.PersistentVolumeClaim) error {
@@ -246,23 +237,25 @@ func (p *apiServerPetClient) createPVC(pvc *api.PersistentVolumeClaim) error {
 
 // SyncPVCs syncs pvcs in the given pcb.
 func (p *apiServerPetClient) SyncPVCs(pet *pcb) error {
-	errMsg := ""
+	errmsg := ""
 	// Create new claims.
 	for i, pvc := range pet.pvcs {
-		_, exists, err := p.getPVC(pvc.Name, pet.parent.Namespace)
-		if !exists {
-			var err error
-			if err = p.createPVC(&pet.pvcs[i]); err != nil {
-				errMsg += fmt.Sprintf("Failed to create %v: %v", pvc.Name, err)
+		_, err := p.getPVC(pvc.Name, pet.parent.Namespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				var err error
+				if err = p.createPVC(&pet.pvcs[i]); err != nil {
+					errmsg += fmt.Sprintf("Failed to create %v: %v", pvc.Name, err)
+				}
+				p.event(pet.parent, "Create", fmt.Sprintf("pvc: %v", pvc.Name), err)
+			} else {
+				errmsg += fmt.Sprintf("Error trying to get pvc %v, %v.", pvc.Name, err)
 			}
-			p.event(pet.parent, "Create", fmt.Sprintf("pvc: %v", pvc.Name), err)
-		} else if err != nil {
-			errMsg += fmt.Sprintf("Error trying to get pvc %v, %v.", pvc.Name, err)
 		}
 		// TODO: Check resource requirements and accessmodes, update if necessary
 	}
-	if len(errMsg) != 0 {
-		return fmt.Errorf("%v", errMsg)
+	if len(errmsg) != 0 {
+		return fmt.Errorf("%v", errmsg)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Clean code of petset, from:

```
func (p *apiServerPetClient) getPVC(pvcName, pvcNamespace string) (*api.PersistentVolumeClaim, bool, error)
```

to:

```
func (p *apiServerPetClient) getPVC(pvcName, pvcNamespace string) (*api.PersistentVolumeClaim, error) 
```

I think the 2nd(bool type) return value of [getPVC](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L228) is unnecessary, as the caller can be responsible for checking the error type and tell if it exists via the [error type](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet.go#L231-L233).

So, I remove the 2nd return value of `getPVC()`.

The benefit of this change is that we can simplify the code of `getPVC()` while don't increase the caller's code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31944)

<!-- Reviewable:end -->
