### PR TITLE
Ignore troublesome paths that cause coverage to fail

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -224,13 +224,21 @@ runTests() {
   # must make sure the output from PARALLEL runs is not mixed. To achieve this,
   # we spawn a subshell for each PARALLEL process, redirecting the output to
   # separate files.
-  # cmd/libs/go2idl/generator is fragile when run under coverage, so ignore it for now.
-  # see: https://github.com/kubernetes/kubernetes/issues/24967
+
+  # ignore paths:
+  # cmd/libs/go2idl/generator: is fragile when run under coverage, so ignore it for now.
+  #                            https://github.com/kubernetes/kubernetes/issues/24967
+  # vendor/k8s.io/client-go/1.4/rest: causes cover internal errors
+  #                            https://github.com/golang/go/issues/16540
+  cover_ignore_dirs="cmd/libs/go2idl/generator|vendor/k8s.io/client-go/1.4/rest"
+  for path in $(echo $cover_ignore_dirs | sed 's/|/ /g'); do
+      echo -e "skipped\tk8s.io/kubernetes/$path"
+  done
   #
   # `go test` does not install the things it builds. `go test -i` installs
   # the build artifacts but doesn't run the tests.  The two together provide
   # a large speedup for tests that do not need to be rebuilt.
-  printf "%s\n" "${@}" | grep -v "cmd/libs/go2idl/generator"| xargs -I{} -n1 -P${KUBE_COVERPROCS} \
+  printf "%s\n" "${@}" | grep -Ev $cover_ignore_dirs | xargs -I{} -n1 -P${KUBE_COVERPROCS} \
     bash -c "set -o pipefail; _pkg=\"{}\"; _pkg_out=\${_pkg//\//_}; \
         go test -i ${goflags[@]:+${goflags[@]}} \
           ${KUBE_RACE} \

--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -901,10 +901,11 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 	}
 
 	if glog.V(8) {
-		switch {
-		case bytes.IndexFunc(body, func(r rune) bool { return r < 0x0a }) != -1:
+		if bytes.IndexFunc(body, func(r rune) bool {
+			return r < 0x0a
+		}) != -1 {
 			glog.Infof("Response Body:\n%s", hex.Dump(body))
-		default:
+		} else {
 			glog.Infof("Response Body: %s", string(body))
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
`KUBE_COVER=y make check` currently fails, this patch fixes it.

**Which issue this PR fixes** 
fixes #31691

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
NONE
```

This avoids the whole command failing because of errors like the following:

```
# cover k8s.io/kubernetes/pkg/client/restclient
cover: internal error: block 268 overlaps block 270
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31949)

<!-- Reviewable:end -->
