### PR TITLE
Redundant code process for container_mananger start

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -468,13 +468,14 @@ func (cm *containerManagerImpl) Start(node *api.Node) error {
 		return err
 	}
 	// Don't run a background thread if there are no ensureStateFuncs.
-	numEnsureStateFuncs := 0
+	hasEnsureStateFuncs := false
 	for _, cont := range cm.systemContainers {
 		if cont.ensureStateFunc != nil {
-			numEnsureStateFuncs++
+			hasEnsureStateFuncs = true
+			break
 		}
 	}
-	if numEnsureStateFuncs >= 0 {
+	if hasEnsureStateFuncs {
 		// Run ensure state functions every minute.
 		go wait.Until(func() {
 			for _, cont := range cm.systemContainers {


### PR DESCRIPTION
1. need not sum the total numEnsureStateFuncs
2. numEnsureStateFuncs should > 0, otherwise, calculate numEnsureStateFuncs would be not neccessary

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31958)

<!-- Reviewable:end -->
