### PR TITLE
Add heapster to hyperkube

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -65,6 +65,9 @@ COPY cni-bin/bin /opt/cni/bin
 # Copy overlay configuration to default directory
 COPY cni-conf /etc/cni/net.d
 
+# Copy heapster
+COPY heapster /heapster
+
 # Create symlinks for each hyperkube server
 # TODO: replace manual symlink creation with --make-symlink command once
 # cross-building with qemu supports go binaries. See #28702

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,6 +21,7 @@ REGISTRY?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 CNI_RELEASE=9d5e6e60e79491207834ae8439e80c943db65a69
+HEAPSTER_RELEASE=1.2.0-beta.2
 
 UNAME_S:=$(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -100,6 +101,17 @@ else
 endif
 	# Download CNI
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
+
+	# Download heapster
+	curl -sSL --retry 5 https://github.com/kubernetes/heapster/archive/v${HEAPSTER_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}
+
+	# Build heapster
+	go get github.com/tools/godep
+	mkdir -p ${GOPATH}/src/k8s.io/heapster/
+	rm -rf ${GOPATH}/src/k8s.io/heapster/*
+	cp -R ${TEMP_DIR}/heapster-${HEAPSTER_RELEASE}/* ${GOPATH}/src/k8s.io/heapster/
+	cd ${GOPATH}/src/k8s.io/heapster && godep go build -o heapster -a k8s.io/heapster/metrics
+	cp ${GOPATH}/src/k8s.io/heapster/heapster ${TEMP_DIR}/heapster
 
 	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"

--- a/cluster/images/hyperkube/addons/singlenode/heapster-controller.yaml
+++ b/cluster/images/hyperkube/addons/singlenode/heapster-controller.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster-v1.2.0-beta.2
+  namespace: kube-system
+  labels:
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+    version: v1.2.0-beta.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
+      version: v1.2.0-beta.2
+  template:
+    metadata:
+      labels:
+        k8s-app: heapster
+        version: v1.2.0-beta.2
+    spec:
+      containers:
+        - image: REGISTRY/hyperkube-ARCH:VERSION
+          name: heapster
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - /heapster
+            - --source=kubernetes:'http://$kube-apiserver'

--- a/cluster/images/hyperkube/addons/singlenode/heapster-service.yaml
+++ b/cluster/images/hyperkube/addons/singlenode/heapster-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    k8s-app: heapster
+  ports:
+  - port: 80
+    targetPort: 8082


### PR DESCRIPTION
This PR introduces heapster to hyperkube. The heapster is compiled for desired architecture and stored in hyperkube. It is deployed automatically in cluster.

**Special notes for your reviewer**:
@luxas I wasn't able test it on other architecture but I thing heapster cross compilation should go straight forward

I had to set hepster version to v1.2.0-beta.2 because Horizontal Pod Autoscaling doesn't work with version 1.1.0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31960)

<!-- Reviewable:end -->
