### PR TITLE
Check the length of portReference.StrVal first in resovlePort func

### DIFF
--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -92,15 +92,19 @@ func resolvePort(portReference intstr.IntOrString, container *api.Container) (in
 		return portReference.IntValue(), nil
 	}
 	portName := portReference.StrVal
-	port, err := strconv.Atoi(portName)
-	if err == nil {
-		return port, nil
-	}
-	for _, portSpec := range container.Ports {
-		if portSpec.Name == portName {
-			return int(portSpec.ContainerPort), nil
+
+	if len(portName) > 0 {
+		port, err := strconv.Atoi(portName)
+		if err == nil {
+			return port, nil
+		}
+		for _, portSpec := range container.Ports {
+			if portSpec.Name == portName {
+				return int(portSpec.ContainerPort), nil
+			}
 		}
 	}
+
 	return -1, fmt.Errorf("couldn't find port: %v in %v", portReference, container)
 }
 


### PR DESCRIPTION
while the length of portReference.StrVal is zero, the code below has no necessary to run

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31963)

<!-- Reviewable:end -->
