### PR TITLE
vSphere Cloud provider null pointer exception

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -570,6 +570,9 @@ func getVirtualMachineDevices(cfg *VSphereConfig, ctx context.Context, c *govmom
 
 // Removes SCSI controller which is latest attached to VM.
 func cleanUpController(newSCSIController types.BaseVirtualDevice, vmDevices object.VirtualDeviceList, vm *object.VirtualMachine, ctx context.Context) error {
+	if newSCSIController == nil || vmDevices == nil || vm == nil {
+		return nil
+	}
 	ctls := vmDevices.SelectByType(newSCSIController)
 	if len(ctls) < 1 {
 		return ErrNoDevicesFound


### PR DESCRIPTION
This PR addresses issue #31823.

SelectByType function in govmomi will panic if deviceType is not Array,
Chan, Map, Ptr, or Slice.  Also checking if vmDevices or vm are nil,
there is nothing to cleanup.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31979)

<!-- Reviewable:end -->
