### PR TITLE
increase resource usage limit in node e2e test

### DIFF
--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -79,7 +79,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				podsNr:   10,
 				interval: 0 * time.Millisecond,
 				cpuLimits: framework.ContainersCPUSummary{
-					stats.SystemContainerKubelet: {0.50: 0.25, 0.95: 0.40},
+					stats.SystemContainerKubelet: {0.50: 0.30, 0.95: 0.50},
 					stats.SystemContainerRuntime: {0.50: 0.40, 0.95: 0.60},
 				},
 				memLimits: framework.ResourceUsagePerContainer{
@@ -177,7 +177,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				podsNr:   10,
 				bgPodsNr: 50,
 				cpuLimits: framework.ContainersCPUSummary{
-					stats.SystemContainerKubelet: {0.50: 0.25, 0.95: 0.40},
+					stats.SystemContainerKubelet: {0.50: 0.30, 0.95: 0.50},
 					stats.SystemContainerRuntime: {0.50: 0.40, 0.95: 0.60},
 				},
 				memLimits: framework.ResourceUsagePerContainer{


### PR DESCRIPTION
This PR increases the resource limit of node e2e density test according to previous measurements.

Fixed https://github.com/kubernetes/kubernetes/issues/31877 and fixed https://github.com/kubernetes/kubernetes/issues/30523

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31982)

<!-- Reviewable:end -->
