### PR TITLE
Back porting critical vSphere bug fixes to release 1.3

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1873,78 +1873,78 @@
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/find",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/list",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/object",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/property",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/session",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/task",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/debug",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/methods",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/mo",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/progress",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/soap",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/types",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/xml",
-			"Comment": "v0.6.2",
-			"Rev": "9051bd6b44125d9472e0c148b5965692ab283d4a"
+			"Comment": "v0.8.0-9-gb5ee639",
+			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -59,6 +59,7 @@ func ProbeAttachableVolumePlugins(config componentconfig.VolumeConfiguration) []
 	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, cinder.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(config.FlexVolumePluginDir)...)
+	allPlugins = append(allPlugins, vsphere_volume.ProbeVolumePlugins()...)
 	return allPlugins
 }
 

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/vmware/govmomi"
@@ -75,24 +76,35 @@ type VSphere struct {
 
 type VSphereConfig struct {
 	Global struct {
-		User         string `gcfg:"user"`
-		Password     string `gcfg:"password"`
-		VCenterIP    string `gcfg:"server"`
-		VCenterPort  string `gcfg:"port"`
-		InsecureFlag bool   `gcfg:"insecure-flag"`
-		Datacenter   string `gcfg:"datacenter"`
-		Datastore    string `gcfg:"datastore"`
-		WorkingDir   string `gcfg:"working-dir"`
+		// vCenter username.
+		User string `gcfg:"user"`
+		// vCenter password in clear text.
+		Password string `gcfg:"password"`
+		// vCenter IP.
+		VCenterIP string `gcfg:"server"`
+		// vCenter port.
+		VCenterPort string `gcfg:"port"`
+		// True if vCenter uses self-signed cert.
+		InsecureFlag bool `gcfg:"insecure-flag"`
+		// Datacenter in which VMs are located.
+		Datacenter string `gcfg:"datacenter"`
+		// Datastore in which vmdks are stored.
+		Datastore string `gcfg:"datastore"`
+		// WorkingDir is path where VMs can be found.
+		WorkingDir string `gcfg:"working-dir"`
 	}
 
 	Network struct {
+		// PublicNetwork is name of the network the VMs are joined to.
 		PublicNetwork string `gcfg:"public-network"`
 	}
 	Disk struct {
+		// SCSIControllerType defines SCSI controller to be used.
 		SCSIControllerType string `dcfg:"scsicontrollertype"`
 	}
 }
 
+// Parses vSphere cloud config file and stores it into VSphereConfig.
 func readConfig(config io.Reader) (VSphereConfig, error) {
 	if config == nil {
 		err := fmt.Errorf("no vSphere cloud provider config file given")
@@ -114,6 +126,9 @@ func init() {
 	})
 }
 
+// Returns the name of the VM on which this code is running.
+// This is done by searching for the name of virtual machine by current IP.
+// Prerequisite: this code assumes VMWare vmtools or open-vm-tools to be installed in the VM.
 func readInstanceID(cfg *VSphereConfig) (string, error) {
 	cmd := exec.Command("bash", "-c", `dmidecode -t 1 | grep UUID | tr -d ' ' | cut -f 2 -d ':'`)
 	var out bytes.Buffer
@@ -150,6 +165,7 @@ func readInstanceID(cfg *VSphereConfig) (string, error) {
 	s := object.NewSearchIndex(c.Client)
 
 	svm, err := s.FindByUuid(ctx, dc, strings.ToLower(strings.TrimSpace(out.String())), true, nil)
+
 	var vm mo.VirtualMachine
 	err = s.Properties(ctx, svm.Reference(), []string{"name"}, &vm)
 	if err != nil {
@@ -180,6 +196,7 @@ func newVSphere(cfg VSphereConfig) (*VSphere, error) {
 	return &vs, nil
 }
 
+// Returns if the given controller type is supported by the plugin
 func checkControllerSupported(ctrlType string) bool {
 	for _, c := range supportedSCSIControllerType {
 		if ctrlType == c {
@@ -189,8 +206,9 @@ func checkControllerSupported(ctrlType string) bool {
 	return false
 }
 
+// Returns a client which communicates with vCenter.
+// This client can used to perform further vCenter operations.
 func vsphereLogin(cfg *VSphereConfig, ctx context.Context) (*govmomi.Client, error) {
-
 	// Parse URL from string
 	u, err := url.Parse(fmt.Sprintf("https://%s:%s/sdk", cfg.Global.VCenterIP, cfg.Global.VCenterPort))
 	if err != nil {
@@ -208,6 +226,7 @@ func vsphereLogin(cfg *VSphereConfig, ctx context.Context) (*govmomi.Client, err
 	return c, nil
 }
 
+// Returns vSphere object `virtual machine` by its name.
 func getVirtualMachineByName(cfg *VSphereConfig, ctx context.Context, c *govmomi.Client, name string) (*object.VirtualMachine, error) {
 	// Create a new finder
 	f := find.NewFinder(c.Client, true)
@@ -242,6 +261,7 @@ func getVirtualMachineManagedObjectReference(ctx context.Context, c *govmomi.Cli
 	return nil
 }
 
+// Returns names of running VMs inside VM folder.
 func getInstances(cfg *VSphereConfig, ctx context.Context, c *govmomi.Client, filter string) ([]string, error) {
 	f := find.NewFinder(c.Client, true)
 	dc, err := f.Datacenter(ctx, cfg.Global.Datacenter)
@@ -293,7 +313,7 @@ func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
 	return &Instances{vs.cfg, vs.localInstanceID}, true
 }
 
-// List is an implementation of Instances.List.
+// List returns names of VMs (inside vm folder) by applying filter and which are currently running.
 func (i *Instances) List(filter string) ([]string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -480,40 +500,40 @@ func (vs *VSphere) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 	return nameservers, searches
 }
 
-func getVirtualMachineDevices(cfg *VSphereConfig, ctx context.Context, c *govmomi.Client, name string) (*object.VirtualMachine, object.VirtualDeviceList, *object.Datastore, error) {
-
+// Returns vSphere objects virtual machine, virtual device list, datastore and datacenter.
+func getVirtualMachineDevices(cfg *VSphereConfig, ctx context.Context, c *govmomi.Client, name string) (*object.VirtualMachine, object.VirtualDeviceList, *object.Datastore, *object.Datacenter, error) {
 	// Create a new finder
 	f := find.NewFinder(c.Client, true)
 
 	// Fetch and set data center
 	dc, err := f.Datacenter(ctx, cfg.Global.Datacenter)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	f.SetDatacenter(dc)
 
 	// Find datastores
 	ds, err := f.Datastore(ctx, cfg.Global.Datastore)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	vmRegex := cfg.Global.WorkingDir + name
 
 	vm, err := f.VirtualMachine(ctx, vmRegex)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	// Get devices from VM
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return vm, vmDevices, ds, nil
+	return vm, vmDevices, ds, dc, nil
 }
 
-//cleaning up the controller
+// Removes SCSI controller which is latest attached to VM.
 func cleanUpController(newSCSIController types.BaseVirtualDevice, vmDevices object.VirtualDeviceList, vm *object.VirtualMachine, ctx context.Context) error {
 	ctls := vmDevices.SelectByType(newSCSIController)
 	if len(ctls) < 1 {
@@ -549,7 +569,7 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, nodeName string) (diskID string
 	}
 
 	// Get VM device list
-	vm, vmDevices, ds, err := getVirtualMachineDevices(vs.cfg, ctx, c, vSphereInstance)
+	vm, vmDevices, ds, _, err := getVirtualMachineDevices(vs.cfg, ctx, c, vSphereInstance)
 	if err != nil {
 		return "", "", err
 	}
@@ -594,7 +614,7 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, nodeName string) (diskID string
 		// verify scsi controller in virtual machine
 		vmDevices, err = vm.Device(ctx)
 		if err != nil {
-			//cannot cleanup if there is no device list
+			// cannot cleanup if there is no device list
 			return "", "", err
 		}
 
@@ -735,33 +755,77 @@ func getAvailableSCSIController(scsiControllers []*types.VirtualController) *typ
 	return nil
 }
 
+// Returns formatted UUID for a virtual disk device.
 func getVirtualDiskUUID(newDevice types.BaseVirtualDevice) (string, error) {
 	vd := newDevice.GetVirtualDevice()
 
 	if b, ok := vd.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-		uuidWithNoHypens := strings.Replace(b.Uuid, "-", "", -1)
-		return strings.ToLower(uuidWithNoHypens), nil
+		uuid := formatVirtualDiskUUID(b.Uuid)
+		return uuid, nil
 	}
 	return "", ErrNoDiskUUIDFound
 }
 
-func getVirtualDiskID(volPath string, vmDevices object.VirtualDeviceList) (string, error) {
+func formatVirtualDiskUUID(uuid string) string {
+	uuidwithNoSpace := strings.Replace(uuid, " ", "", -1)
+	uuidWithNoHypens := strings.Replace(uuidwithNoSpace, "-", "", -1)
+	return strings.ToLower(uuidWithNoHypens)
+}
+
+// Gets virtual disk UUID by datastore (namespace) path
+//
+// volPath can be namespace path (e.g. "[vsanDatastore] volumes/test.vmdk") or
+// uuid path (e.g. "[vsanDatastore] 59427457-6c5a-a917-7997-0200103eedbc/test.vmdk").
+// `volumes` in this case would be a symlink to
+// `59427457-6c5a-a917-7997-0200103eedbc`.
+//
+// We want users to use namespace path. It is good for attaching the disk,
+// but for detaching the API requires uuid path.  Hence, to detach the right
+// device we have to convert the namespace path to uuid path.
+func getVirtualDiskUUIDByPath(volPath string, dc *object.Datacenter, client *govmomi.Client) (string, error) {
+	if len(volPath) > 0 && filepath.Ext(volPath) != ".vmdk" {
+		volPath += ".vmdk"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// VirtualDiskManager provides a way to manage and manipulate virtual disks on vmware datastores.
+	vdm := object.NewVirtualDiskManager(client.Client)
+	// Returns uuid of vmdk virtual disk
+	diskUUID, err := vdm.QueryVirtualDiskUuid(ctx, volPath, dc)
+
+	if err != nil {
+		return "", ErrNoDiskUUIDFound
+	}
+
+	diskUUID = formatVirtualDiskUUID(diskUUID)
+
+	return diskUUID, nil
+}
+
+// Returns a device id which is internal vSphere API identifier for the attached virtual disk.
+func getVirtualDiskID(volPath string, vmDevices object.VirtualDeviceList, dc *object.Datacenter, client *govmomi.Client) (string, error) {
+	volumeUUID, err := getVirtualDiskUUIDByPath(volPath, dc, client)
+
+	if err != nil {
+		glog.Warningf("disk uuid not found for %v ", volPath)
+		return "", err
+	}
+
 	// filter vm devices to retrieve disk ID for the given vmdk file
 	for _, device := range vmDevices {
 		if vmDevices.TypeName(device) == "VirtualDisk" {
-			d := device.GetVirtualDevice()
-			if b, ok := d.Backing.(types.BaseVirtualDeviceFileBackingInfo); ok {
-				fileName := b.GetVirtualDeviceFileBackingInfo().FileName
-				if fileName == volPath {
-					return vmDevices.Name(device), nil
-				}
+			diskUUID, _ := getVirtualDiskUUID(device)
+			if diskUUID == volumeUUID {
+				return vmDevices.Name(device), nil
 			}
 		}
 	}
 	return "", ErrNoDiskIDFound
 }
 
-// Detaches given virtual disk volume from the compute running kubelet.
+// DetachDisk detaches given virtual disk volume from the compute running kubelet.
 func (vs *VSphere) DetachDisk(volPath string, nodeName string) error {
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -782,23 +846,24 @@ func (vs *VSphere) DetachDisk(volPath string, nodeName string) error {
 		vSphereInstance = nodeName
 	}
 
-	vm, vmDevices, _, err := getVirtualMachineDevices(vs.cfg, ctx, c, vSphereInstance)
+	vm, vmDevices, _, dc, err := getVirtualMachineDevices(vs.cfg, ctx, c, vSphereInstance)
 	if err != nil {
 		return err
 	}
 
-	diskID, err := getVirtualDiskID(volPath, vmDevices)
+	diskID, err := getVirtualDiskID(volPath, vmDevices, dc, c)
 	if err != nil {
 		glog.Warningf("disk ID not found for %v ", volPath)
 		return err
 	}
 
-	// Remove disk from VM
+	// Gets virtual disk device
 	device := vmDevices.Find(diskID)
 	if device == nil {
 		return fmt.Errorf("device '%s' not found", diskID)
 	}
 
+	// Detach disk from VM
 	err = vm.RemoveDevice(ctx, true, device)
 	if err != nil {
 		return err
@@ -807,7 +872,7 @@ func (vs *VSphere) DetachDisk(volPath string, nodeName string) error {
 	return nil
 }
 
-// Create a volume of given size (in KiB).
+// CreateVolume creates a volume of given size (in KiB).
 func (vs *VSphere) CreateVolume(name string, size int, tags *map[string]string) (volumePath string, err error) {
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -853,7 +918,7 @@ func (vs *VSphere) CreateVolume(name string, size int, tags *map[string]string) 
 	return vmDiskPath, nil
 }
 
-// Deletes a volume given volume name.
+// DeleteVolume deletes a volume given volume name.
 func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere_volume
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/keymutex"
+	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+type vsphereVMDKAttacher struct {
+	host           volume.VolumeHost
+	vsphereVolumes vsphere.Volumes
+}
+
+var _ volume.Attacher = &vsphereVMDKAttacher{}
+var _ volume.AttachableVolumePlugin = &vsphereVolumePlugin{}
+
+// Singleton key mutex for keeping attach operations for the same host atomic
+var attachdetachMutex = keymutex.NewKeyMutex()
+
+func (plugin *vsphereVolumePlugin) NewAttacher() (volume.Attacher, error) {
+	vsphereCloud, err := getCloudProvider(plugin.host.GetCloudProvider())
+	if err != nil {
+		return nil, err
+	}
+
+	return &vsphereVMDKAttacher{
+		host:           plugin.host,
+		vsphereVolumes: vsphereCloud,
+	}, nil
+}
+
+// Attaches the volume specified by the given spec to the given host.
+// On success, returns the device path where the device was attached on the
+// node.
+// Callers are responsible for retryinging on failure.
+// Callers are responsible for thread safety between concurrent attach and
+// detach operations.
+func (attacher *vsphereVMDKAttacher) Attach(spec *volume.Spec, hostName string) (string, error) {
+	volumeSource, _, err := getVolumeSource(spec)
+	if err != nil {
+		return "", err
+	}
+
+	glog.V(4).Infof("vSphere: Attach disk called for host %s", hostName)
+
+	// Keeps concurrent attach operations to same host atomic
+	attachdetachMutex.LockKey(hostName)
+	defer attachdetachMutex.UnlockKey(hostName)
+
+	// vsphereCloud.AttachDisk checks if disk is already attached to host and
+	// succeeds in that case, so no need to do that separately.
+	_, diskUUID, err := attacher.vsphereVolumes.AttachDisk(volumeSource.VolumePath, hostName)
+	if err != nil {
+		glog.Errorf("Error attaching volume %q: %+v", volumeSource.VolumePath, err)
+		return "", err
+	}
+
+	return path.Join(diskByIDPath, diskSCSIPrefix+diskUUID), nil
+}
+
+func (attacher *vsphereVMDKAttacher) WaitForAttach(spec *volume.Spec, devicePath string, timeout time.Duration) (string, error) {
+	volumeSource, _, err := getVolumeSource(spec)
+	if err != nil {
+		return "", err
+	}
+
+	if devicePath == "" {
+		return "", fmt.Errorf("WaitForAttach failed for VMDK %q: devicePath is empty.", volumeSource.VolumePath)
+	}
+
+	ticker := time.NewTicker(checkSleepDuration)
+	defer ticker.Stop()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			glog.V(5).Infof("Checking VMDK %q is attached", volumeSource.VolumePath)
+			path, err := verifyDevicePath(devicePath)
+			if err != nil {
+				// Log error, if any, and continue checking periodically. See issue #11321
+				glog.Warningf("Error verifying VMDK (%q) is attached: %v", volumeSource.VolumePath, err)
+			} else if path != "" {
+				// A device path has successfully been created for the VMDK
+				glog.Infof("Successfully found attached VMDK %q.", volumeSource.VolumePath)
+				return path, nil
+			}
+		case <-timer.C:
+			return "", fmt.Errorf("Could not find attached VMDK %q. Timeout waiting for mount paths to be created.", volumeSource.VolumePath)
+		}
+	}
+}
+
+// GetDeviceMountPath returns a path where the device should
+// point which should be bind mounted for individual volumes.
+func (attacher *vsphereVMDKAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error) {
+	volumeSource, _, err := getVolumeSource(spec)
+	if err != nil {
+		return "", err
+	}
+
+	return makeGlobalPDPath(attacher.host, volumeSource.VolumePath), nil
+}
+
+// GetMountDeviceRefs finds all other references to the device referenced
+// by deviceMountPath; returns a list of paths.
+func (plugin *vsphereVolumePlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {
+	mounter := plugin.host.GetMounter()
+	return mount.GetMountRefs(mounter, deviceMountPath)
+}
+
+// MountDevice mounts device to global mount point.
+func (attacher *vsphereVMDKAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+	mounter := attacher.host.GetMounter()
+	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(deviceMountPath, 0750); err != nil {
+				glog.Errorf("Failed to create directory at %#v. err: %s", deviceMountPath, err)
+				return err
+			}
+			notMnt = true
+		} else {
+			return err
+		}
+	}
+
+	volumeSource, _, err := getVolumeSource(spec)
+	if err != nil {
+		return err
+	}
+
+	options := []string{}
+
+	if notMnt {
+		diskMounter := &mount.SafeFormatAndMount{Interface: mounter, Runner: exec.New()}
+		err = diskMounter.FormatAndMount(devicePath, deviceMountPath, volumeSource.FSType, options)
+		if err != nil {
+			os.Remove(deviceMountPath)
+			return err
+		}
+		glog.V(4).Infof("formatting spec %v devicePath %v deviceMountPath %v fs %v with options %+v", spec.Name(), devicePath, deviceMountPath, volumeSource.FSType, options)
+	}
+	return nil
+}
+
+type vsphereVMDKDetacher struct {
+	mounter        mount.Interface
+	vsphereVolumes vsphere.Volumes
+}
+
+var _ volume.Detacher = &vsphereVMDKDetacher{}
+
+func (plugin *vsphereVolumePlugin) NewDetacher() (volume.Detacher, error) {
+	vsphereCloud, err := getCloudProvider(plugin.host.GetCloudProvider())
+	if err != nil {
+		return nil, err
+	}
+
+	return &vsphereVMDKDetacher{
+		mounter:        plugin.host.GetMounter(),
+		vsphereVolumes: vsphereCloud,
+	}, nil
+}
+
+// Detach the given device from the given host.
+func (detacher *vsphereVMDKDetacher) Detach(deviceMountPath string, hostName string) error {
+
+	volPath := getVolPathfromDeviceMountPath(deviceMountPath)
+	attached, err := detacher.vsphereVolumes.DiskIsAttached(volPath, hostName)
+	if err != nil {
+		// Log error and continue with detach
+		glog.Errorf(
+			"Error checking if volume (%q) is already attached to current node (%q). Will continue and try detach anyway. err=%v",
+			volPath, hostName, err)
+	}
+
+	if err == nil && !attached {
+		// Volume is already detached from node.
+		glog.Infof("detach operation was successful. volume %q is already detached from node %q.", volPath, hostName)
+		return nil
+	}
+
+	attachdetachMutex.LockKey(hostName)
+	defer attachdetachMutex.UnlockKey(hostName)
+	if err := detacher.vsphereVolumes.DetachDisk(volPath, hostName); err != nil {
+		glog.Errorf("Error detaching volume %q: %v", volPath, err)
+		return err
+	}
+	return nil
+}
+
+func (detacher *vsphereVMDKDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
+	ticker := time.NewTicker(checkSleepDuration)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			glog.V(5).Infof("Checking device %q is detached.", devicePath)
+			if pathExists, err := volumeutil.PathExists(devicePath); err != nil {
+				return fmt.Errorf("Error checking if device path exists: %v", err)
+			} else if !pathExists {
+				return nil
+			}
+		case <-timer.C:
+			return fmt.Errorf("Timeout reached; Device %v is still attached", devicePath)
+		}
+	}
+}
+
+func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error {
+	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
+}

--- a/pkg/volume/vsphere_volume/attacher_test.go
+++ b/pkg/volume/vsphere_volume/attacher_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere_volume
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/volume"
+	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+
+	"github.com/golang/glog"
+)
+
+func TestGetDeviceName_Volume(t *testing.T) {
+	plugin := newPlugin()
+	volPath := "[local] volumes/test"
+	spec := createVolSpec(volPath)
+
+	deviceName, err := plugin.GetVolumeName(spec)
+	if err != nil {
+		t.Errorf("GetDeviceName error: %v", err)
+	}
+	if deviceName != volPath {
+		t.Errorf("GetDeviceName error: expected %s, got %s", volPath, deviceName)
+	}
+}
+
+func TestGetDeviceName_PersistentVolume(t *testing.T) {
+	plugin := newPlugin()
+	volPath := "[local] volumes/test"
+	spec := createPVSpec(volPath)
+
+	deviceName, err := plugin.GetVolumeName(spec)
+	if err != nil {
+		t.Errorf("GetDeviceName error: %v", err)
+	}
+	if deviceName != volPath {
+		t.Errorf("GetDeviceName error: expected %s, got %s", volPath, deviceName)
+	}
+}
+
+// One testcase for TestAttachDetach table test below
+type testcase struct {
+	name string
+	// For fake vSphere:
+	attach         attachCall
+	detach         detachCall
+	diskIsAttached diskIsAttachedCall
+	t              *testing.T
+
+	// Actual test to run
+	test func(test *testcase) (string, error)
+	// Expected return of the test
+	expectedDevice string
+	expectedError  error
+}
+
+func TestAttachDetach(t *testing.T) {
+	uuid := "00000000000000"
+	diskName := "[local] volumes/test"
+	hostName := "host"
+	spec := createVolSpec(diskName)
+	attachError := errors.New("Fake attach error")
+	detachError := errors.New("Fake detach error")
+	diskCheckError := errors.New("Fake DiskIsAttached error")
+	tests := []testcase{
+		// Successful Attach call
+		{
+			name:   "Attach_Positive",
+			attach: attachCall{diskName, hostName, uuid, nil},
+			test: func(testcase *testcase) (string, error) {
+				attacher := newAttacher(testcase)
+				return attacher.Attach(spec, hostName)
+			},
+			expectedDevice: "/dev/disk/by-id/wwn-0x" + uuid,
+		},
+
+		// Attach call fails
+		{
+			name:   "Attach_Negative",
+			attach: attachCall{diskName, hostName, "", attachError},
+			test: func(testcase *testcase) (string, error) {
+				attacher := newAttacher(testcase)
+				return attacher.Attach(spec, hostName)
+			},
+			expectedError: attachError,
+		},
+
+		// Detach succeeds
+		{
+			name:           "Detach_Positive",
+			diskIsAttached: diskIsAttachedCall{diskName, hostName, true, nil},
+			detach:         detachCall{diskName, hostName, nil},
+			test: func(testcase *testcase) (string, error) {
+				detacher := newDetacher(testcase)
+				return "", detacher.Detach(diskName, hostName)
+			},
+		},
+
+		// Disk is already detached
+		{
+			name:           "Detach_Positive_AlreadyDetached",
+			diskIsAttached: diskIsAttachedCall{diskName, hostName, false, nil},
+			test: func(testcase *testcase) (string, error) {
+				detacher := newDetacher(testcase)
+				return "", detacher.Detach(diskName, hostName)
+			},
+		},
+
+		// Detach succeeds when DiskIsAttached fails
+		{
+			name:           "Detach_Positive_CheckFails",
+			diskIsAttached: diskIsAttachedCall{diskName, hostName, false, diskCheckError},
+			detach:         detachCall{diskName, hostName, nil},
+			test: func(testcase *testcase) (string, error) {
+				detacher := newDetacher(testcase)
+				return "", detacher.Detach(diskName, hostName)
+			},
+		},
+
+		// Detach fails
+		{
+			name:           "Detach_Negative",
+			diskIsAttached: diskIsAttachedCall{diskName, hostName, false, diskCheckError},
+			detach:         detachCall{diskName, hostName, detachError},
+			test: func(testcase *testcase) (string, error) {
+				detacher := newDetacher(testcase)
+				return "", detacher.Detach(diskName, hostName)
+			},
+			expectedError: detachError,
+		},
+	}
+
+	for _, testcase := range tests {
+		testcase.t = t
+		device, err := testcase.test(&testcase)
+		if err != testcase.expectedError {
+			t.Errorf("%s failed: expected err=%q, got %q", testcase.name, testcase.expectedError.Error(), err.Error())
+		}
+		if device != testcase.expectedDevice {
+			t.Errorf("%s failed: expected device=%q, got %q", testcase.name, testcase.expectedDevice, device)
+		}
+		t.Logf("Test %q succeeded", testcase.name)
+	}
+}
+
+// newPlugin creates a new vsphereVolumePlugin with fake cloud, NewAttacher
+// and NewDetacher won't work.
+func newPlugin() *vsphereVolumePlugin {
+	host := volumetest.NewFakeVolumeHost("/tmp", nil, nil, "")
+	plugins := ProbeVolumePlugins()
+	plugin := plugins[0]
+	plugin.Init(host)
+	return plugin.(*vsphereVolumePlugin)
+}
+
+func newAttacher(testcase *testcase) *vsphereVMDKAttacher {
+	return &vsphereVMDKAttacher{
+		host:           nil,
+		vsphereVolumes: testcase,
+	}
+}
+
+func newDetacher(testcase *testcase) *vsphereVMDKDetacher {
+	return &vsphereVMDKDetacher{
+		vsphereVolumes: testcase,
+	}
+}
+
+func createVolSpec(name string) *volume.Spec {
+	return &volume.Spec{
+		Volume: &api.Volume{
+			VolumeSource: api.VolumeSource{
+				VsphereVolume: &api.VsphereVirtualDiskVolumeSource{
+					VolumePath: name,
+				},
+			},
+		},
+	}
+}
+
+func createPVSpec(name string) *volume.Spec {
+	return &volume.Spec{
+		PersistentVolume: &api.PersistentVolume{
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					VsphereVolume: &api.VsphereVirtualDiskVolumeSource{
+						VolumePath: name,
+					},
+				},
+			},
+		},
+	}
+}
+
+// Fake vSphere implementation
+
+type attachCall struct {
+	diskName      string
+	hostName      string
+	retDeviceUUID string
+	ret           error
+}
+
+type detachCall struct {
+	diskName string
+	hostName string
+	ret      error
+}
+
+type diskIsAttachedCall struct {
+	diskName, hostName string
+	isAttached         bool
+	ret                error
+}
+
+func (testcase *testcase) AttachDisk(diskName string, hostName string) (string, string, error) {
+	expected := &testcase.attach
+
+	if expected.diskName == "" && expected.hostName == "" {
+		// testcase.attach looks uninitialized, test did not expect to call
+		// AttachDisk
+		testcase.t.Errorf("Unexpected AttachDisk call!")
+		return "", "", errors.New("Unexpected AttachDisk call!")
+	}
+
+	if expected.diskName != diskName {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected diskName %s, got %s", expected.diskName, diskName)
+		return "", "", errors.New("Unexpected AttachDisk call: wrong diskName")
+	}
+
+	if expected.hostName != hostName {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected hostName %s, got %s", expected.hostName, hostName)
+		return "", "", errors.New("Unexpected AttachDisk call: wrong hostName")
+	}
+
+	glog.V(4).Infof("AttachDisk call: %s, %s, returning %q, %v", diskName, hostName, expected.retDeviceUUID, expected.ret)
+
+	return "", expected.retDeviceUUID, expected.ret
+}
+
+func (testcase *testcase) DetachDisk(diskName string, hostName string) error {
+	expected := &testcase.detach
+
+	if expected.diskName == "" && expected.hostName == "" {
+		// testcase.detach looks uninitialized, test did not expect to call
+		// DetachDisk
+		testcase.t.Errorf("Unexpected DetachDisk call!")
+		return errors.New("Unexpected DetachDisk call!")
+	}
+
+	if expected.diskName != diskName {
+		testcase.t.Errorf("Unexpected DetachDisk call: expected diskName %s, got %s", expected.diskName, diskName)
+		return errors.New("Unexpected DetachDisk call: wrong diskName")
+	}
+
+	if expected.hostName != hostName {
+		testcase.t.Errorf("Unexpected DetachDisk call: expected hostname %s, got %s", expected.hostName, hostName)
+		return errors.New("Unexpected DetachDisk call: wrong hostname")
+	}
+
+	glog.V(4).Infof("DetachDisk call: %s, %s, returning %v", diskName, hostName, expected.ret)
+
+	return expected.ret
+}
+
+func (testcase *testcase) DiskIsAttached(diskName, hostName string) (bool, error) {
+	expected := &testcase.diskIsAttached
+
+	if expected.diskName == "" && expected.hostName == "" {
+		// testcase.diskIsAttached looks uninitialized, test did not expect to
+		// call DiskIsAttached
+		testcase.t.Errorf("Unexpected DiskIsAttached call!")
+		return false, errors.New("Unexpected DiskIsAttached call!")
+	}
+
+	if expected.diskName != diskName {
+		testcase.t.Errorf("Unexpected DiskIsAttached call: expected diskName %s, got %s", expected.diskName, diskName)
+		return false, errors.New("Unexpected DiskIsAttached call: wrong diskName")
+	}
+
+	if expected.hostName != hostName {
+		testcase.t.Errorf("Unexpected DiskIsAttached call: expected hostName %s, got %s", expected.hostName, hostName)
+		return false, errors.New("Unexpected DiskIsAttached call: wrong hostName")
+	}
+
+	glog.V(4).Infof("DiskIsAttached call: %s, %s, returning %v, %v", diskName, hostName, expected.isAttached, expected.ret)
+
+	return expected.isAttached, expected.ret
+}
+
+func (testcase *testcase) CreateVolume(name string, size int, tags *map[string]string) (volumePath string, err error) {
+	return "", errors.New("Not implemented")
+}
+
+func (testcase *testcase) DeleteVolume(vmDiskPath string) error {
+	return errors.New("Not implemented")
+}

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -304,11 +304,13 @@ func (v *vsphereVolumeUnmounter) TearDownAt(dir string) error {
 		return fmt.Errorf("directory %s is not mounted", dir)
 	}
 
+	mountPath := refs[0]
+	// Assumption: No file or folder is named starting with '[' in datastore
+	volumePath := mountPath[strings.LastIndex(mountPath, "["):]
 	// space between datastore and vmdk name in volumePath is encoded as '\040' when returned by GetMountRefs().
 	// volumePath eg: "[local] xxx.vmdk" provided to attach/mount
 	// replacing \040 with space to match the actual volumePath
-	mountPath := strings.Replace(path.Base(refs[0]), "\\040", " ", -1)
-	v.volPath = mountPath
+	v.volPath = strings.Replace(volumePath, "\\040", " ", -1)
 	glog.V(4).Infof("Found volume %s mounted to %s", v.volPath, dir)
 
 	// Reload list of references, there might be SetUpAt finished in the meantime

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -17,16 +17,13 @@ limitations under the License.
 package vsphere_volume
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -121,20 +118,6 @@ func (plugin *vsphereVolumePlugin) newUnmounterInternal(volName string, podUID t
 		}}, nil
 }
 
-func (plugin *vsphereVolumePlugin) getCloudProvider() (*vsphere.VSphere, error) {
-	cloud := plugin.host.GetCloudProvider()
-	if cloud == nil {
-		glog.Errorf("Cloud provider not initialized properly")
-		return nil, errors.New("Cloud provider not initialized properly")
-	}
-
-	vs := cloud.(*vsphere.VSphere)
-	if vs == nil {
-		return nil, errors.New("Invalid cloud provider: expected vSphere")
-	}
-	return vs, nil
-}
-
 func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	vsphereVolume := &api.Volume{
 		Name: volumeName,
@@ -149,10 +132,6 @@ func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath str
 
 // Abstract interface to disk operations.
 type vdManager interface {
-	// Attaches the disk to the kubelet's host machine.
-	AttachDisk(mounter *vsphereVolumeMounter, globalPDPath string) error
-	// Detaches the disk from the kubelet's host machine.
-	DetachDisk(unmounter *vsphereVolumeUnmounter) error
 	// Creates a volume
 	CreateVolume(provisioner *vsphereVolumeProvisioner) (vmDiskPath string, volumeSizeGB int, err error)
 	// Deletes a volume
@@ -177,13 +156,6 @@ type vsphereVolume struct {
 	diskMounter mount.Interface
 	plugin      *vsphereVolumePlugin
 	volume.MetricsNil
-}
-
-func detachDiskLogError(vv *vsphereVolume) {
-	err := vv.manager.DetachDisk(&vsphereVolumeUnmounter{vv})
-	if err != nil {
-		glog.Warningf("Failed to detach disk: %v (%v)", vv, err)
-	}
 }
 
 var _ volume.Mounter = &vsphereVolumeMounter{}
@@ -219,23 +191,16 @@ func (b *vsphereVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		glog.V(4).Infof("Something is already mounted to target %s", dir)
 		return nil
 	}
-	globalPDPath := makeGlobalPDPath(b.plugin.host, b.volPath)
-	if err := b.manager.AttachDisk(b, globalPDPath); err != nil {
-		glog.V(3).Infof("AttachDisk failed: %v", err)
+
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		glog.V(4).Infof("Could not create directory %s: %v", dir, err)
 		return err
 	}
-	glog.V(3).Infof("vSphere volume %s attached", b.volPath)
 
 	options := []string{"bind"}
 
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		// TODO: we should really eject the attach/detach out into its own control loop.
-		glog.V(4).Infof("Could not create directory %s: %v", dir, err)
-		detachDiskLogError(b.vsphereVolume)
-		return err
-	}
-
 	// Perform a bind mount to the full path to allow duplicate mounts of the same PD.
+	globalPDPath := makeGlobalPDPath(b.plugin.host, b.volPath)
 	err = b.mounter.Mount(globalPDPath, dir, "", options)
 	if err != nil {
 		notmnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
@@ -259,7 +224,6 @@ func (b *vsphereVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 			}
 		}
 		os.Remove(dir)
-		detachDiskLogError(b.vsphereVolume)
 		return err
 	}
 	glog.V(3).Infof("vSphere volume %s mounted to %s", b.volPath, dir)
@@ -283,69 +247,25 @@ func (v *vsphereVolumeUnmounter) TearDown() error {
 // resource was the last reference to that disk on the kubelet.
 func (v *vsphereVolumeUnmounter) TearDownAt(dir string) error {
 	glog.V(5).Infof("vSphere Volume TearDown of %s", dir)
-	notmnt, err := v.mounter.IsLikelyNotMountPoint(dir)
+	notMnt, err := v.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {
-		glog.V(4).Infof("Error checking if mountpoint ", dir, ": ", err)
 		return err
 	}
-	if notmnt {
-		glog.V(4).Infof("Not mount point,deleting")
+	if notMnt {
 		return os.Remove(dir)
 	}
-
-	// Find vSphere volumeID to lock the right volume
-	refs, err := mount.GetMountRefs(v.mounter, dir)
-	if err != nil {
-		glog.V(4).Infof("Error getting mountrefs for ", dir, ": ", err)
-		return err
-	}
-	if len(refs) == 0 {
-		glog.V(4).Infof("Directory %s is not mounted", dir)
-		return fmt.Errorf("directory %s is not mounted", dir)
-	}
-
-	mountPath := refs[0]
-	// Assumption: No file or folder is named starting with '[' in datastore
-	volumePath := mountPath[strings.LastIndex(mountPath, "["):]
-	// space between datastore and vmdk name in volumePath is encoded as '\040' when returned by GetMountRefs().
-	// volumePath eg: "[local] xxx.vmdk" provided to attach/mount
-	// replacing \040 with space to match the actual volumePath
-	v.volPath = strings.Replace(volumePath, "\\040", " ", -1)
-	glog.V(4).Infof("Found volume %s mounted to %s", v.volPath, dir)
-
-	// Reload list of references, there might be SetUpAt finished in the meantime
-	refs, err = mount.GetMountRefs(v.mounter, dir)
-	if err != nil {
-		glog.V(4).Infof("GetMountRefs failed: %v", err)
-		return err
-	}
 	if err := v.mounter.Unmount(dir); err != nil {
-		glog.V(4).Infof("Unmount failed: %v", err)
 		return err
 	}
-	glog.V(3).Infof("Successfully unmounted: %s\n", dir)
-
-	// If refCount is 1, then all bind mounts have been removed, and the
-	// remaining reference is the global mount. It is safe to detach.
-	if len(refs) == 1 {
-		if err := v.manager.DetachDisk(v); err != nil {
-			glog.V(4).Infof("DetachDisk failed: %v", err)
-			return err
-		}
-		glog.V(3).Infof("Volume %s detached", v.volPath)
-	}
-	notmnt, mntErr := v.mounter.IsLikelyNotMountPoint(dir)
+	notMnt, mntErr := v.mounter.IsLikelyNotMountPoint(dir)
 	if mntErr != nil {
 		glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 		return err
 	}
-	if notmnt {
-		if err := os.Remove(dir); err != nil {
-			glog.V(4).Infof("Failed to remove directory after unmount: %v", err)
-			return err
-		}
+	if notMnt {
+		return os.Remove(dir)
 	}
-	return nil
+	return fmt.Errorf("Failed to unmount volume dir")
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, devName string) string {

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,5 +1,35 @@
 # changelog
 
+### 0.8.0 (2016-06-30)
+
+* Add session.Manager.AcquireLocalTicket
+
+* Include StoragePod in Finder.FolderList
+
+* Add Finder methods for finding by ManagedObjectReference: Element, ObjectReference
+
+* Add mo.ManagedObjectReference methods: Reference, String, FromString
+
+* Add support using SessionManagerGenericServiceTicket.HostName for Datastore HTTP access
+
+### 0.7.1 (2016-06-03)
+
+* Fix object.ObjectName method
+
+### 0.7.0 (2016-06-02)
+
+* Move InventoryPath field to object.Common
+
+* Add HostDatastoreSystem.CreateLocalDatastore method
+
+* Add DatastoreNamespaceManager methods: CreateDirectory, DeleteDirectory
+
+* Add HostServiceSystem
+
+* Add HostStorageSystem methods: MarkAsSdd, MarkAsNonSdd, MarkAsLocal, MarkAsNonLocal
+
+* Add HostStorageSystem.RescanAllHba method
+
 ### 0.6.2 (2016-05-11)
 
 * Get complete file details in Datastore.Stat

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
@@ -9,10 +9,8 @@ Change _$USER_ below to your github username if they are not the same.
 
 ``` shell
 export GOPATH=$HOME/govmomi
-mkdir -p $GOPATH/src/github.com/vmware
-cd $GOPATH/src/github.com/vmware
-git clone git@github.com:vmware/govmomi.git
-cd govmomi
+go get github.com/vmware/govmomi
+cd $GOPATH/src/github.com/vmware/govmomi
 git config push.default nothing # anything to avoid pushing to vmware/govmomi by default
 git remote rename origin vmware
 git remote add $USER git@github.com:$USER/govmomi.git
@@ -26,6 +24,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Create a topic branch from where you want to base your work.
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
+- Update CHANGELOG.md and/or govc/CHANGELOG.md when appropriate.
 - Push your changes to a topic branch in your fork of the repository.
 - Submit a pull request to vmware/govmomi.
 

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -10,10 +10,12 @@ Arran Walker <arran.walker@zopa.com>
 Austin Parker <aparker@apprenda.com>
 Bob Killen <killen.bob@gmail.com>
 Bruce Downs <bdowns@vmware.com>
-Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
 Cédric Blomart <cblomart@gmail.com>
+Christian Höltje <docwhat@gerf.org>
+Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
 Danny Lockard <danny.lockard@banno.com>
 Dave Tucker <dave@dtucker.co.uk>
+David Stark <dave@davidstark.name>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eric Yutao <eric.yutao@gmail.com>
@@ -31,8 +33,8 @@ Pieter Noordhuis <pnoordhuis@vmware.com> <pcnoordhuis@gmail.com>
 runner.mei <runner.mei@gmail.com>
 S.Çağlar Onur <conur@vmware.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
-Takaaki Furukawa <takaaki.frkw@gmail.com> <takaaki.furukawa@mail.rakuten.com>
 Steve Purcell <steve@sanityinc.com>
+Takaaki Furukawa <takaaki.frkw@gmail.com> <takaaki.furukawa@mail.rakuten.com>
 Yang Yang <yangy@vmware.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
 Zach Tucker <ztucker@vmware.com>

--- a/vendor/github.com/vmware/govmomi/Makefile
+++ b/vendor/github.com/vmware/govmomi/Makefile
@@ -4,21 +4,17 @@ all: check test
 
 check: goimports govet
 
-vendor:
-	go get golang.org/x/tools/cmd/goimports
-	go get github.com/davecgh/go-spew/spew
-	go get golang.org/x/net/context
-
-goimports: vendor
+goimports:
 	@echo checking go imports...
+	@go get golang.org/x/tools/cmd/goimports
 	@! goimports -d . 2>&1 | egrep -v '^$$'
 
 govet:
 	@echo checking go vet...
 	@go tool vet -structtags=false -methods=false .
 
-test: vendor
+test:
 	go test -v $(TEST_OPTS) ./...
 
-install: vendor
+install:
 	go install github.com/vmware/govmomi/govc

--- a/vendor/github.com/vmware/govmomi/find/finder.go
+++ b/vendor/github.com/vmware/govmomi/find/finder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 
@@ -192,6 +193,48 @@ func (f *Finder) managedObjectList(ctx context.Context, path string, tl bool) ([
 	return f.find(ctx, fn, tl, path)
 }
 
+// Element returns an Element for the given ManagedObjectReference
+// This method is only useful for looking up the InventoryPath of a ManagedObjectReference.
+func (f *Finder) Element(ctx context.Context, ref types.ManagedObjectReference) (*list.Element, error) {
+	rl := func(_ context.Context) (object.Reference, error) {
+		return ref, nil
+	}
+
+	e, err := f.find(ctx, rl, false, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(e) == 0 {
+		return nil, &NotFoundError{ref.Type, ref.Value}
+	}
+
+	if len(e) > 1 {
+		panic("ManagedObjectReference must be unique")
+	}
+
+	return &e[0], nil
+}
+
+// ObjectReference converts the given ManagedObjectReference to a type from the object package via object.NewReference
+// with the object.Common.InventoryPath field set.
+func (f *Finder) ObjectReference(ctx context.Context, ref types.ManagedObjectReference) (object.Reference, error) {
+	e, err := f.Element(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	r := object.NewReference(f.client, ref)
+
+	type common interface {
+		SetInventoryPath(string)
+	}
+
+	r.(common).SetInventoryPath(e.Path)
+
+	return r, nil
+}
+
 func (f *Finder) ManagedObjectList(ctx context.Context, path string) ([]list.Element, error) {
 	return f.managedObjectList(ctx, path, false)
 }
@@ -210,7 +253,9 @@ func (f *Finder) DatacenterList(ctx context.Context, path string) ([]*object.Dat
 	for _, e := range es {
 		ref := e.Object.Reference()
 		if ref.Type == "Datacenter" {
-			dcs = append(dcs, object.NewDatacenter(f.client, ref))
+			dc := object.NewDatacenter(f.client, ref)
+			dc.InventoryPath = e.Path
+			dcs = append(dcs, dc)
 		}
 	}
 
@@ -772,7 +817,7 @@ func (f *Finder) FolderList(ctx context.Context, path string) ([]*object.Folder,
 
 	for _, e := range es {
 		switch o := e.Object.(type) {
-		case mo.Folder:
+		case mo.Folder, mo.StoragePod:
 			folder := object.NewFolder(f.client, o.Reference())
 			folder.InventoryPath = e.Path
 			folders = append(folders, folder)

--- a/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
@@ -25,8 +25,6 @@ import (
 
 type ClusterComputeResource struct {
 	ComputeResource
-
-	InventoryPath string
 }
 
 func NewClusterComputeResource(c *vim25.Client, ref types.ManagedObjectReference) *ClusterComputeResource {

--- a/vendor/github.com/vmware/govmomi/object/compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/object/compute_resource.go
@@ -29,8 +29,6 @@ import (
 
 type ComputeResource struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewComputeResource(c *vim25.Client, ref types.ManagedObjectReference) *ComputeResource {

--- a/vendor/github.com/vmware/govmomi/object/datastore.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"path"
 	"strings"
 
@@ -57,18 +58,12 @@ func (e DatastoreNoSuchFileError) Error() string {
 
 type Datastore struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewDatastore(c *vim25.Client, ref types.ManagedObjectReference) *Datastore {
 	return &Datastore{
 		Common: NewCommon(c, ref),
 	}
-}
-
-func (d Datastore) Name() string {
-	return path.Base(d.InventoryPath)
 }
 
 func (d Datastore) Path(path string) string {
@@ -116,6 +111,42 @@ func (d Datastore) Browser(ctx context.Context) (*HostDatastoreBrowser, error) {
 	return NewHostDatastoreBrowser(d.c, do.Browser), nil
 }
 
+func (d Datastore) useServiceTicketHostName(name string) bool {
+	// No need if talking directly to ESX.
+	if !d.c.IsVC() {
+		return false
+	}
+
+	// If version happens to be < 5.1
+	if name == "" {
+		return false
+	}
+
+	// If the HostSystem is using DHCP on a network without dynamic DNS,
+	// HostSystem.Config.Network.DnsConfig.HostName is set to "localhost" by default.
+	// This resolves to "localhost.localdomain" by default via /etc/hosts on ESX.
+	// In that case, we will stick with the HostSystem.Name which is the IP address that
+	// was used to connect the host to VC.
+	if name == "localhost.localdomain" {
+		return false
+	}
+
+	// Still possible to have HostName that don't resolve via DNS,
+	// so we default to false.
+	key := "GOVMOMI_USE_SERVICE_TICKET_HOSTNAME"
+
+	val := d.c.URL().Query().Get(key)
+	if val == "" {
+		val = os.Getenv(key)
+	}
+
+	if val == "1" || val == "true" {
+		return true
+	}
+
+	return false
+}
+
 // ServiceTicket obtains a ticket via AcquireGenericServiceTicket and returns it an http.Cookie with the url.URL
 // that can be used along with the ticket cookie to access the given path.
 func (d Datastore) ServiceTicket(ctx context.Context, path string, method string) (*url.URL, *http.Cookie, error) {
@@ -142,7 +173,7 @@ func (d Datastore) ServiceTicket(ctx context.Context, path string, method string
 
 		// Pick a random attached host
 		host := hosts[rand.Intn(len(hosts))]
-		name, err := host.Name(ctx)
+		name, err := host.ObjectName(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -165,6 +196,10 @@ func (d Datastore) ServiceTicket(ctx context.Context, path string, method string
 	cookie := &http.Cookie{
 		Name:  "vmware_cgi_ticket",
 		Value: ticket.Id,
+	}
+
+	if d.useServiceTicketHostName(ticket.HostName) {
+		u.Host = ticket.HostName
 	}
 
 	return u, cookie, nil

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
@@ -17,8 +17,6 @@ limitations under the License.
 package object
 
 import (
-	"path"
-
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -27,17 +25,12 @@ import (
 
 type DistributedVirtualPortgroup struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectReference) *DistributedVirtualPortgroup {
 	return &DistributedVirtualPortgroup{
 		Common: NewCommon(c, ref),
 	}
-}
-func (p DistributedVirtualPortgroup) Name() string {
-	return path.Base(p.InventoryPath)
 }
 
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this DistributedVirtualPortgroup

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
@@ -25,8 +25,6 @@ import (
 
 type DistributedVirtualSwitch struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewDistributedVirtualSwitch(c *vim25.Client, ref types.ManagedObjectReference) *DistributedVirtualSwitch {

--- a/vendor/github.com/vmware/govmomi/object/folder.go
+++ b/vendor/github.com/vmware/govmomi/object/folder.go
@@ -26,8 +26,6 @@ import (
 
 type Folder struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewFolder(c *vim25.Client, ref types.ManagedObjectReference) *Folder {
@@ -111,6 +109,20 @@ func (f Folder) CreateFolder(ctx context.Context, name string) (*Folder, error) 
 	}
 
 	return NewFolder(f.c, res.Returnval), err
+}
+
+func (f Folder) CreateStoragePod(ctx context.Context, name string) (*StoragePod, error) {
+	req := types.CreateStoragePod{
+		This: f.Reference(),
+		Name: name,
+	}
+
+	res, err := methods.CreateStoragePod(ctx, f.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewStoragePod(f.c, res.Returnval), err
 }
 
 func (f Folder) AddStandaloneHost(ctx context.Context, spec types.HostConnectSpec, addConnected bool, license *string, compResSpec *types.BaseComputeResourceConfigSpec) (*Task, error) {

--- a/vendor/github.com/vmware/govmomi/object/host_config_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/host_config_manager.go
@@ -120,3 +120,14 @@ func (m HostConfigManager) OptionManager(ctx context.Context) (*OptionManager, e
 
 	return NewOptionManager(m.c, *h.ConfigManager.AdvancedOption), nil
 }
+
+func (m HostConfigManager) ServiceSystem(ctx context.Context) (*HostServiceSystem, error) {
+	var h mo.HostSystem
+
+	err := m.Properties(ctx, m.Reference(), []string{"configManager.serviceSystem"}, &h)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewHostServiceSystem(m.c, *h.ConfigManager.ServiceSystem), nil
+}

--- a/vendor/github.com/vmware/govmomi/object/host_datastore_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_datastore_system.go
@@ -33,6 +33,21 @@ func NewHostDatastoreSystem(c *vim25.Client, ref types.ManagedObjectReference) *
 	}
 }
 
+func (s HostDatastoreSystem) CreateLocalDatastore(ctx context.Context, name string, path string) (*Datastore, error) {
+	req := types.CreateLocalDatastore{
+		This: s.Reference(),
+		Name: name,
+		Path: path,
+	}
+
+	res, err := methods.CreateLocalDatastore(ctx, s.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDatastore(s.Client(), res.Returnval), nil
+}
+
 func (s HostDatastoreSystem) CreateNasDatastore(ctx context.Context, spec types.HostNasVolumeSpec) (*Datastore, error) {
 	req := types.CreateNasDatastore{
 		This: s.Reference(),

--- a/vendor/github.com/vmware/govmomi/object/host_service_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_service_system.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type HostServiceSystem struct {
+	Common
+}
+
+func NewHostServiceSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostServiceSystem {
+	return &HostServiceSystem{
+		Common: NewCommon(c, ref),
+	}
+}
+
+func (s HostServiceSystem) Service(ctx context.Context) ([]types.HostService, error) {
+	var ss mo.HostServiceSystem
+
+	err := s.Properties(ctx, s.Reference(), []string{"serviceInfo.service"}, &ss)
+	if err != nil {
+		return nil, err
+	}
+
+	return ss.ServiceInfo.Service, nil
+}
+
+func (s HostServiceSystem) Start(ctx context.Context, id string) error {
+	req := types.StartService{
+		This: s.Reference(),
+		Id:   id,
+	}
+
+	_, err := methods.StartService(ctx, s.Client(), &req)
+	return err
+}
+
+func (s HostServiceSystem) Stop(ctx context.Context, id string) error {
+	req := types.StopService{
+		This: s.Reference(),
+		Id:   id,
+	}
+
+	_, err := methods.StopService(ctx, s.Client(), &req)
+	return err
+}
+
+func (s HostServiceSystem) Restart(ctx context.Context, id string) error {
+	req := types.RestartService{
+		This: s.Reference(),
+		Id:   id,
+	}
+
+	_, err := methods.RestartService(ctx, s.Client(), &req)
+	return err
+}
+
+func (s HostServiceSystem) UpdatePolicy(ctx context.Context, id string, policy string) error {
+	req := types.UpdateServicePolicy{
+		This:   s.Reference(),
+		Id:     id,
+		Policy: policy,
+	}
+
+	_, err := methods.UpdateServicePolicy(ctx, s.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/object/host_storage_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_storage_system.go
@@ -78,3 +78,68 @@ func (s HostStorageSystem) UpdateDiskPartitionInfo(ctx context.Context, devicePa
 	_, err := methods.UpdateDiskPartitions(ctx, s.c, &req)
 	return err
 }
+
+func (s HostStorageSystem) RescanAllHba(ctx context.Context) error {
+	req := types.RescanAllHba{
+		This: s.Reference(),
+	}
+
+	_, err := methods.RescanAllHba(ctx, s.c, &req)
+	return err
+}
+
+func (s HostStorageSystem) MarkAsSsd(ctx context.Context, uuid string) (*Task, error) {
+	req := types.MarkAsSsd_Task{
+		This:         s.Reference(),
+		ScsiDiskUuid: uuid,
+	}
+
+	res, err := methods.MarkAsSsd_Task(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.c, res.Returnval), nil
+}
+
+func (s HostStorageSystem) MarkAsNonSsd(ctx context.Context, uuid string) (*Task, error) {
+	req := types.MarkAsNonSsd_Task{
+		This:         s.Reference(),
+		ScsiDiskUuid: uuid,
+	}
+
+	res, err := methods.MarkAsNonSsd_Task(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.c, res.Returnval), nil
+}
+
+func (s HostStorageSystem) MarkAsLocal(ctx context.Context, uuid string) (*Task, error) {
+	req := types.MarkAsLocal_Task{
+		This:         s.Reference(),
+		ScsiDiskUuid: uuid,
+	}
+
+	res, err := methods.MarkAsLocal_Task(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.c, res.Returnval), nil
+}
+
+func (s HostStorageSystem) MarkAsNonLocal(ctx context.Context, uuid string) (*Task, error) {
+	req := types.MarkAsNonLocal_Task{
+		This:         s.Reference(),
+		ScsiDiskUuid: uuid,
+	}
+
+	res, err := methods.MarkAsNonLocal_Task(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.c, res.Returnval), nil
+}

--- a/vendor/github.com/vmware/govmomi/object/host_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_system.go
@@ -29,32 +29,12 @@ import (
 
 type HostSystem struct {
 	Common
-
-	InventoryPath string
-}
-
-func (h HostSystem) String() string {
-	if h.InventoryPath == "" {
-		return h.Common.String()
-	}
-	return fmt.Sprintf("%v @ %v", h.Common, h.InventoryPath)
 }
 
 func NewHostSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostSystem {
 	return &HostSystem{
 		Common: NewCommon(c, ref),
 	}
-}
-
-func (h HostSystem) Name(ctx context.Context) (string, error) {
-	var mh mo.HostSystem
-
-	err := h.Properties(ctx, h.Reference(), []string{"name"}, &mh)
-	if err != nil {
-		return "", err
-	}
-
-	return mh.Name, nil
 }
 
 func (h HostSystem) ConfigManager() *HostConfigManager {

--- a/vendor/github.com/vmware/govmomi/object/namespace_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/namespace_manager.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type DatastoreNamespaceManager struct {
+	Common
+}
+
+func NewDatastoreNamespaceManager(c *vim25.Client) *DatastoreNamespaceManager {
+	n := DatastoreNamespaceManager{
+		Common: NewCommon(c, *c.ServiceContent.DatastoreNamespaceManager),
+	}
+
+	return &n
+}
+
+// CreateDirectory creates a top-level directory on the given vsan datastore, using
+// the given user display name hint and opaque storage policy.
+func (nm DatastoreNamespaceManager) CreateDirectory(ctx context.Context, ds *Datastore, displayName string, policy string) (string, error) {
+
+	req := &types.CreateDirectory{
+		This:        nm.Reference(),
+		Datastore:   ds.Reference(),
+		DisplayName: displayName,
+		Policy:      policy,
+	}
+
+	resp, err := methods.CreateDirectory(ctx, nm.c, req)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Returnval, nil
+}
+
+// DeleteDirectory deletes the given top-level directory from a vsan datastore.
+func (nm DatastoreNamespaceManager) DeleteDirectory(ctx context.Context, dc *Datacenter, datastorePath string) error {
+
+	req := &types.DeleteDirectory{
+		This:          nm.Reference(),
+		DatastorePath: datastorePath,
+	}
+
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	if _, err := methods.DeleteDirectory(ctx, nm.c, req); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/object/network.go
+++ b/vendor/github.com/vmware/govmomi/object/network.go
@@ -17,8 +17,6 @@ limitations under the License.
 package object
 
 import (
-	"path"
-
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
@@ -26,18 +24,12 @@ import (
 
 type Network struct {
 	Common
-
-	InventoryPath string
 }
 
 func NewNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Network {
 	return &Network{
 		Common: NewCommon(c, ref),
 	}
-}
-
-func (n Network) Name() string {
-	return path.Base(n.InventoryPath)
 }
 
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network

--- a/vendor/github.com/vmware/govmomi/object/resource_pool.go
+++ b/vendor/github.com/vmware/govmomi/object/resource_pool.go
@@ -17,43 +17,20 @@ limitations under the License.
 package object
 
 import (
-	"fmt"
-
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 
 type ResourcePool struct {
 	Common
-
-	InventoryPath string
-}
-
-func (p ResourcePool) String() string {
-	if p.InventoryPath == "" {
-		return p.Common.String()
-	}
-	return fmt.Sprintf("%v @ %v", p.Common, p.InventoryPath)
 }
 
 func NewResourcePool(c *vim25.Client, ref types.ManagedObjectReference) *ResourcePool {
 	return &ResourcePool{
 		Common: NewCommon(c, ref),
 	}
-}
-
-func (p ResourcePool) Name(ctx context.Context) (string, error) {
-	var o mo.ResourcePool
-
-	err := p.Properties(ctx, p.Reference(), []string{"name"}, &o)
-	if err != nil {
-		return "", err
-	}
-
-	return o.Name, nil
 }
 
 func (p ResourcePool) ImportVApp(ctx context.Context, spec types.BaseImportSpec, folder *Folder, host *HostSystem) (*HttpNfcLease, error) {

--- a/vendor/github.com/vmware/govmomi/object/virtual_app.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_app.go
@@ -17,13 +17,10 @@ limitations under the License.
 package object
 
 import (
-	"fmt"
-
 	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -35,24 +32,6 @@ func NewVirtualApp(c *vim25.Client, ref types.ManagedObjectReference) *VirtualAp
 	return &VirtualApp{
 		ResourcePool: NewResourcePool(c, ref),
 	}
-}
-
-func (p VirtualApp) String() string {
-	if p.InventoryPath == "" {
-		return p.Common.String()
-	}
-	return fmt.Sprintf("%v @ %v", p.Common, p.InventoryPath)
-}
-
-func (p VirtualApp) Name(ctx context.Context) (string, error) {
-	var o mo.VirtualApp
-
-	err := p.Properties(ctx, p.Reference(), []string{"name"}, &o)
-	if err != nil {
-		return "", err
-	}
-
-	return o.Name, nil
 }
 
 func (p VirtualApp) CreateChildVM_Task(ctx context.Context, config types.VirtualMachineConfigSpec, host *HostSystem) (*Task, error) {

--- a/vendor/github.com/vmware/govmomi/object/virtual_disk_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_disk_manager.go
@@ -143,3 +143,27 @@ func (m VirtualDiskManager) DeleteVirtualDisk(ctx context.Context, name string, 
 
 	return NewTask(m.c, res.Returnval), nil
 }
+
+// Queries virtual disk uuid
+func (m VirtualDiskManager) QueryVirtualDiskUuid(ctx context.Context, name string, dc *Datacenter) (string, error) {
+	req := types.QueryVirtualDiskUuid{
+		This: m.Reference(),
+		Name: name,
+	}
+
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	res, err := methods.QueryVirtualDiskUuid(ctx, m.c, &req)
+	if err != nil {
+		return "", err
+	}
+
+	if res == nil {
+		return "", nil
+	}
+
+	return res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/object/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_machine.go
@@ -18,7 +18,6 @@ package object
 
 import (
 	"errors"
-	"fmt"
 	"net"
 
 	"github.com/vmware/govmomi/property"
@@ -35,32 +34,12 @@ const (
 
 type VirtualMachine struct {
 	Common
-
-	InventoryPath string
-}
-
-func (v VirtualMachine) String() string {
-	if v.InventoryPath == "" {
-		return v.Common.String()
-	}
-	return fmt.Sprintf("%v @ %v", v.Common, v.InventoryPath)
 }
 
 func NewVirtualMachine(c *vim25.Client, ref types.ManagedObjectReference) *VirtualMachine {
 	return &VirtualMachine{
 		Common: NewCommon(c, ref),
 	}
-}
-
-func (v VirtualMachine) Name(ctx context.Context) (string, error) {
-	var o mo.VirtualMachine
-
-	err := v.Properties(ctx, v.Reference(), []string{"name"}, &o)
-	if err != nil {
-		return "", err
-	}
-
-	return o.Name, nil
 }
 
 func (v VirtualMachine) PowerState(ctx context.Context) (types.VirtualMachinePowerState, error) {

--- a/vendor/github.com/vmware/govmomi/session/manager.go
+++ b/vendor/github.com/vmware/govmomi/session/manager.go
@@ -161,3 +161,17 @@ func (sm *Manager) AcquireGenericServiceTicket(ctx context.Context, spec types.B
 
 	return &res.Returnval, nil
 }
+
+func (sm *Manager) AcquireLocalTicket(ctx context.Context, userName string) (*types.SessionManagerLocalTicket, error) {
+	req := types.AcquireLocalTicket{
+		This:     sm.Reference(),
+		UserName: userName,
+	}
+
+	res, err := methods.AcquireLocalTicket(ctx, sm.client, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/vim25/mo/extra.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/extra.go
@@ -36,6 +36,10 @@ func (m DistributedVirtualSwitch) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }
 
+func (m DistributedVirtualPortgroup) GetManagedEntity() ManagedEntity {
+	return m.ManagedEntity
+}
+
 func (m Folder) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }

--- a/vendor/github.com/vmware/govmomi/vim25/soap/soap.go
+++ b/vendor/github.com/vmware/govmomi/vim25/soap/soap.go
@@ -36,7 +36,7 @@ type Fault struct {
 	Code    string   `xml:"faultcode"`
 	String  string   `xml:"faultstring"`
 	Detail  struct {
-		Fault types.AnyType `xml:",any"`
+		Fault types.AnyType `xml:",any,typeattr"`
 	} `xml:"detail"`
 }
 

--- a/vendor/github.com/vmware/govmomi/vim25/types/helpers.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/helpers.go
@@ -16,10 +16,33 @@ limitations under the License.
 
 package types
 
+import "strings"
+
 func NewBool(v bool) *bool {
 	return &v
 }
 
 func NewReference(r ManagedObjectReference) *ManagedObjectReference {
 	return &r
+}
+
+func (r ManagedObjectReference) Reference() ManagedObjectReference {
+	return r
+}
+
+func (r ManagedObjectReference) String() string {
+	return strings.Join([]string{r.Type, r.Value}, ":")
+}
+
+func (r *ManagedObjectReference) FromString(o string) bool {
+	s := strings.SplitN(o, ":", 2)
+
+	if len(s) < 2 {
+		return false
+	}
+
+	r.Type = s[0]
+	r.Value = s[1]
+
+	return true
 }


### PR DESCRIPTION
vSphere cloud provider plugin was first introduced in Kubernetes 1.3.0.  The two PRs listed below contain critical volume attach/detach related fixes.  Without these fixes, vSphere in 1.3 lacks the ability to consistently attach/detach volumes correctly especially in a busy cluster.

These changes only affect the vSphere cloud provider.
- https://github.com/kubernetes/kubernetes/pull/29172
- https://github.com/kubernetes/kubernetes/pull/30535

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31993)

<!-- Reviewable:end -->
