### PR TITLE
Bump ClusterAutoscaler to 0.3.0-beta6

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.3.0-beta5",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.3.0-beta6",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
Contains https://github.com/kubernetes/contrib/pull/1685.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/31998)

<!-- Reviewable:end -->
