### PR TITLE
Update node status instead of node in kubelet

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -107,7 +107,7 @@ func (kl *Kubelet) tryRegisterWithApiServer(node *api.Node) bool {
 		// annotation.
 		requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(node, existingNode)
 		if requiresUpdate {
-			if _, err := kl.kubeClient.Core().Nodes().Update(existingNode); err != nil {
+			if _, err := kl.kubeClient.Core().Nodes().UpdateStatus(existingNode); err != nil {
 				glog.Errorf("Unable to reconcile node %q with API server: error updating node: %v", kl.nodeName, err)
 				return false
 			}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1028,8 +1028,11 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 			// Return an existing (matching) node on get.
 			return true, tc.existingNode, tc.getError
 		})
-		kubeClient.AddReactor("update", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, nil, tc.updateError
+		kubeClient.AddReactor("update", "*", func(action core.Action) (bool, runtime.Object, error) {
+			if action.GetResource().Resource == "nodes" && action.GetSubresource() == "status" {
+				return true, nil, tc.updateError
+			}
+			return true, nil, fmt.Errorf("no reaction implemented for %s", action)
 		})
 		kubeClient.AddReactor("delete", "nodes", func(action core.Action) (bool, runtime.Object, error) {
 			return true, nil, tc.deleteError


### PR DESCRIPTION
#31730 added code for the Kubelet to reconcile the existing and new nodes in order to annotate existing nodes with the annotation for controller-managed attach-detach.  However, it used `Update` instead of `UpdateStatus`, which changes the operations the node's token needs to be permitted to use.  Using `UpdateStatus` is functionally equivalent and maintains the same set of permissions nodes need to have today.

I'm adding this with the 1.4 milestone because it is a follow-on to a 1.4 PR and fixes a downstream bug (which won't surface to Kube).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32000)

<!-- Reviewable:end -->
