### PR TITLE
Automated Docker Validation: Change wrong name in perf config.

### DIFF
--- a/test/e2e_node/jenkins/docker_validation/perf-config.yaml
+++ b/test/e2e_node/jenkins/docker_validation/perf-config.yaml
@@ -1,55 +1,55 @@
 ---
 images:
-  containervm-density1:
+  density1:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-1
     tests:
       - '.*create 35 pods with 0s? interval \[Benchmark\]'
-  containervm-density2:
+  density2:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-1
     tests:
       - '.*create 105 pods with 0s? interval \[Benchmark\]'
-  containervm-density3:
+  density3:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-2
     tests:
       - '.*create 105 pods with 0s? interval \[Benchmark\]'
-  containervm-density4:
+  density4:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-1
     tests:
       - '.*create 35 pods with 100ms interval \[Benchmark\]'
-  containervm-density5:
+  density5:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-1
     tests:
       - '.*create 105 pods with 100ms interval \[Benchmark\]'
-  containervm-density6:
+  density6:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-2
     tests:
       - '.*create 105 pods with 100ms interval \[Benchmark\]'
-  containervm-density7:
+  density7:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"
     machine: n1-standard-1
     tests:
       - '.*create 105 pods with 300ms interval \[Benchmark\]'
-  containervm-density8:
+  density8:
     image: "{{IMAGE}}"
     project: "{{IMAGE_PROJECT}}"
     metadata: "{{METADATA}}"


### PR DESCRIPTION
The config key `containervm-density*` is improper, remove it.

/cc @coufon

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32003)

<!-- Reviewable:end -->
