### PR TITLE
Increase logging level for e2e node services

### DIFF
--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -88,6 +88,7 @@ func (e *E2EServices) Start() error {
 		"--manifest-path", framework.TestContext.ManifestPath,
 		"--eviction-hard", framework.TestContext.EvictionHard,
 		"--logtostderr",
+		"--vmodule=*=4",
 	)
 	e.services = newServer("services", startCmd, nil, nil, getHealthCheckURLs(), servicesLogFile, false)
 	return e.services.start()


### PR DESCRIPTION
Without this change, the apiserver logs are non existent for node e2e tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32005)

<!-- Reviewable:end -->
