### PR TITLE
Fixes the master messaging

### DIFF
--- a/cluster/juju/layers/kubernetes/reactive/k8s.py
+++ b/cluster/juju/layers/kubernetes/reactive/k8s.py
@@ -307,7 +307,7 @@ def start_cadvisor():
 
 
 @when('kubelet.available', 'kubeconfig.created')
-@when_any('proxy.available', 'cadvisor.available', 'skydns.available')
+@when_any('proxy.available', 'cadvisor.available', 'kubedns.available')
 def final_message():
     '''Issue some final messages when the services are started. '''
     # TODO: Run a simple/quick health checks before issuing this message.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Corrects the master unit messaging state to correctly reflect that kubernetes is active

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #32010

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
None
```

Proof: ![](https://www.evernote.com/l/AX74r1GLG3dNG504sJrDOPkb5_nYpkO_DUQB/image.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32011)

<!-- Reviewable:end -->
