### PR TITLE
Unshare cluster, store in each test suite

### DIFF
--- a/pkg/storage/etcd3/watcher_test.go
+++ b/pkg/storage/etcd3/watcher_test.go
@@ -49,9 +49,6 @@ func TestWatchList(t *testing.T) {
 // - update should trigger Modified event
 // - update that gets filtered should trigger Deleted event
 func testWatch(t *testing.T, recursive bool) {
-	ctx, store, cluster := testSetup(t)
-	defer cluster.Terminate(t)
-
 	podFoo := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	podBar := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "bar"}}
 
@@ -93,6 +90,7 @@ func testWatch(t *testing.T, recursive bool) {
 		trigger: storage.NoTriggerFunc,
 	}}
 	for i, tt := range tests {
+		ctx, store, cluster := testSetup(t)
 		filter := storage.NewSimpleFilter(tt.filter, tt.trigger)
 		w, err := store.watch(ctx, tt.key, "0", filter, recursive)
 		if err != nil {
@@ -124,6 +122,7 @@ func testWatch(t *testing.T, recursive bool) {
 		}
 		w.Stop()
 		testCheckStop(t, i, w)
+		cluster.Terminate(t)
 	}
 }
 


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/31962 and https://github.com/kubernetes/kubernetes/issues/31300.

Just try to unshare it to minimize interface and focus on correctness of logic.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32012)

<!-- Reviewable:end -->
