### PR TITLE
Node Problem Detector: Use the right waiting time for eventually in NPD node e2e

### DIFF
--- a/test/e2e/node_problem_detector.go
+++ b/test/e2e/node_problem_detector.go
@@ -202,7 +202,7 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 			By("Make sure the default node condition is generated")
 			Eventually(func() error {
 				return verifyCondition(c.Nodes(), node.Name, condition, api.ConditionFalse, defaultReason, defaultMessage)
-			}, pollConsistent, pollInterval).Should(Succeed())
+			}, pollTimeout, pollInterval).Should(Succeed())
 
 			num := 3
 			By(fmt.Sprintf("Inject %d temporary errors", num))


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/29656.
The `Eventually` check changed in this PR is used to make sure NPD generating default node condition after it starts. Mostly it should happen very fast, but sometimes it may take some time.

In the test, we should use `pollTimeout`(`1m`) for eventually check which is long enough, but we used `pollConsistent`(`5s`) by mistake.

This PR changed the eventually check to use `pollTimeout`(`1m`).

Mark P1 to match the corresponding test flake.

/cc @krousey @pwittrock

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32016)

<!-- Reviewable:end -->
