### PR TITLE
[BUG FIX] Fix bug of UT in Pet Set

### DIFF
--- a/pkg/controller/petset/fakes.go
+++ b/pkg/controller/petset/fakes.go
@@ -246,7 +246,7 @@ func (f *fakePetClient) deletePetAtIndex(index int) {
 }
 
 func (f *fakePetClient) setHealthy(index int) error {
-	if len(f.pets) < index {
+	if len(f.pets) <= index {
 		return fmt.Errorf("Index out of range, len %v index %v", len(f.pets), index)
 	}
 	f.pets[index].pod.Status.Phase = api.PodRunning
@@ -268,7 +268,7 @@ func (f *fakePetClient) isHealthy(pod *api.Pod) bool {
 }
 
 func (f *fakePetClient) setDeletionTimestamp(index int) error {
-	if len(f.pets) < index {
+	if len(f.pets) <= index {
 		return fmt.Errorf("Index out of range, len %v index %v", len(f.pets), index)
 	}
 	f.pets[index].pod.DeletionTimestamp = &unversioned.Time{Time: time.Now()}

--- a/pkg/controller/petset/pet_set_test.go
+++ b/pkg/controller/petset/pet_set_test.go
@@ -73,7 +73,7 @@ func scalePetSet(t *testing.T, ps *apps.PetSet, psc *PetSetController, fc *fakeP
 	for i := 0; i < scale; i++ {
 		pl := fc.getPodList()
 		if len(pl) != i {
-			t.Errorf("Unexpected number of pets, expected %d found %d", i, len(fc.pets))
+			t.Errorf("Unexpected number of pets, expected %d found %d", i, len(pl))
 		}
 		if _, syncErr := psc.syncPetSet(ps, pl); syncErr != nil {
 			errs = append(errs, syncErr)
@@ -120,7 +120,7 @@ func TestPetSetControllerDeletes(t *testing.T) {
 	knownPods := fc.getPodList()
 	for i := replicas - 1; i >= 0; i-- {
 		if len(fc.pets) != i+1 {
-			t.Errorf("Unexpected number of pets, expected %d found %d", i, len(fc.pets))
+			t.Errorf("Unexpected number of pets, expected %d found %d", i+1, len(fc.pets))
 		}
 		if _, syncErr := psc.syncPetSet(ps, knownPods); syncErr != nil {
 			errs = append(errs, syncErr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Fix bug of UT in Pet Set.

[1] https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet_set_test.go#L74-L75, 

I think`len(pl)` is not equal to `len(fc.pets)`, see [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/fakes.go#L229-L233)

[2] https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/fakes.go#L249

I think should change to 

```
if len(f.pets) <= index {
```

because when `len(f.pets)==index`, then [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/fakes.go#L252-L254) will cause `index out of range` panic!

[3] https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/fakes.go#L271

same reason with [2]

[4] https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/pet_set_test.go#L79

which doesn't make use of the error returned by [setHealthy](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/petset/fakes.go#L248) and has a risk of letting the error out.

Should we catch the error and use `t.Errorf()` to stop the test?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32027)

<!-- Reviewable:end -->
