### PR TITLE
Fix for ScheduledJobs failures in GKE

### DIFF
--- a/test/e2e/scheduledjob.go
+++ b/test/e2e/scheduledjob.go
@@ -59,6 +59,11 @@ var _ = framework.KubeDescribe("ScheduledJob", func() {
 	BeforeEach(func() {
 		c = f.Client
 		ns = f.Namespace.Name
+
+		resourceList, err := c.DiscoveryClient.ServerResourcesForGroupVersion("batch/v2alpha1")
+		if err != nil || resourceList.Size() == 0 {
+			framework.Skipf("Could not find ScheduledJobs resource, skipping test: %#v", err)
+		}
 	})
 
 	// multiple jobs running at once


### PR DESCRIPTION
Some environments may not have --runtime-config=batch/v2alpha1 enabled

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32038)

<!-- Reviewable:end -->
