### PR TITLE
Handle Stream() errors consistently in restclient

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -196,8 +196,10 @@ func StandardErrorMessage(err error) (string, bool) {
 	switch {
 	case isStatus:
 		switch s := status.Status(); {
-		case s.Reason == "Unauthorized":
+		case s.Reason == unversioned.StatusReasonUnauthorized:
 			return fmt.Sprintf("error: You must be logged in to the server (%s)", s.Message), true
+		case len(s.Reason) > 0:
+			return fmt.Sprintf("Error from server (%s): %s", s.Reason, err.Error()), true
 		default:
 			return fmt.Sprintf("Error from server: %s", err.Error()), true
 		}


### PR DESCRIPTION
We should be following the same rules for Stream() as the normal body
request flow.

Also add slightly more output on a server error - in the future we may
want to clean this up but it's potentially hiding bad responses.

Related to #32009 but isn't the fix (so far)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32048)

<!-- Reviewable:end -->
