### PR TITLE
generated DeepCopy without a function on a struct pointer is wrong

### DIFF
--- a/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
+++ b/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
@@ -609,7 +609,7 @@ func (g *genDeepCopy) doPointer(t *types.Type, sw *generator.SnippetWriter) {
 		sw.Do("if newVal, err := c.DeepCopy(*in); err != nil {\n", nil)
 		sw.Do("return err\n", nil)
 		sw.Do("} else {\n", nil)
-		sw.Do("*out = newVal.($.|raw$)\n", t.Elem)
+		sw.Do("*out = newVal.(*$.|raw$)\n", t.Elem)
 		sw.Do("}\n", nil)
 	}
 }


### PR DESCRIPTION
in and out are both pointers to pointers, so *in has to be cast to
*Type, not Type.

@sttts hit this while debugging something else (most everything should be generated, but in this case the type is wrong)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32049)

<!-- Reviewable:end -->
