### PR TITLE
Allow IP addresses to be used as node names

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3435,9 +3435,11 @@ func validateEndpointAddress(address *api.EndpointAddress, fldPath *field.Path, 
 	if len(address.Hostname) > 0 {
 		allErrs = append(allErrs, ValidateDNS1123Label(address.Hostname, fldPath.Child("hostname"))...)
 	}
-	// During endpoint update, validate NodeName is DNS1123 compliant and transition rules allow the update
+	// During endpoint update, verify that NodeName is a DNS subdomain and transition rules allow the update
 	if address.NodeName != nil {
-		allErrs = append(allErrs, ValidateDNS1123Label(*address.NodeName, fldPath.Child("nodeName"))...)
+		for _, msg := range ValidateNodeName(*address.NodeName, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeName"), *address.NodeName, msg))
+		}
 	}
 	allErrs = append(allErrs, validateEpAddrNodeNameTransition(address, ipToNodeName, fldPath.Child("nodeName"))...)
 	if len(allErrs) > 0 {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -8023,11 +8023,19 @@ func TestEndpointAddressNodeNameUpdateRestrictions(t *testing.T) {
 	}
 }
 
-func TestEndpointAddressNodeNameInvalidDNS1123(t *testing.T) {
+func TestEndpointAddressNodeNameInvalidDNSSubdomain(t *testing.T) {
 	// Check NodeName DNS validation
-	endpoint := newNodeNameEndpoint("illegal.nodename")
+	endpoint := newNodeNameEndpoint("illegal*.nodename")
 	errList := ValidateEndpoints(endpoint)
 	if len(errList) == 0 {
 		t.Error("Endpoint should reject invalid NodeName")
+	}
+}
+
+func TestEndpointAddressNodeNameCanBeAnIPAddress(t *testing.T) {
+	endpoint := newNodeNameEndpoint("10.10.1.1")
+	errList := ValidateEndpoints(endpoint)
+	if len(errList) != 0 {
+		t.Error("Endpoint should accept a NodeName that is an IP address")
 	}
 }


### PR DESCRIPTION
Fixes #32050

In `pkg/api/validation/validation.go`, there's already `ValidateNodeName()`, so using `ValidateDNS1123Label()` was ujustified. Also, it broke service endpoints in `hack/local-up-cluster.sh` and some other software that doesn't want to do extra work to provide resolvable hostnames for the nodes of test clusters, e.g.
https://github.com/metral/nanokube
https://github.com/sttts/kubernetes-dind-cluster
And probably others.

On affected installs, service latency e2e test hangs, see e.g. https://github.com/kubernetes/kubernetes/issues/30632#issuecomment-244431797

DNS1123Label suggestion is by @thockin, see [here](https://github.com/kubernetes/kubernetes/pull/30301#issuecomment-239602268). I think it's wrong though for aforementioned reasons :(

PR that broke node names: #31311

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32052)

<!-- Reviewable:end -->
