### PR TITLE
make setupDataDirs do completely

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -83,6 +83,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/clock"
 	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/integer"
@@ -1053,17 +1054,18 @@ type Kubelet struct {
 // 2.  the pods directory
 // 3.  the plugins directory
 func (kl *Kubelet) setupDataDirs() error {
+	errors := []error{}
 	kl.rootDirectory = path.Clean(kl.rootDirectory)
 	if err := os.MkdirAll(kl.getRootDir(), 0750); err != nil {
-		return fmt.Errorf("error creating root directory: %v", err)
+		errors = append(errors, fmt.Errorf("error creating root directory: %v", err))
 	}
 	if err := os.MkdirAll(kl.getPodsDir(), 0750); err != nil {
-		return fmt.Errorf("error creating pods directory: %v", err)
+		errors = append(errors, fmt.Errorf("error creating pods directory: %v", err))
 	}
 	if err := os.MkdirAll(kl.getPluginsDir(), 0750); err != nil {
-		return fmt.Errorf("error creating plugins directory: %v", err)
+		errors = append(errors, fmt.Errorf("error creating plugins directory: %v", err))
 	}
-	return nil
+	return utilerrors.NewAggregate(errors)
 }
 
 // Get a list of pods that have data directories.


### PR DESCRIPTION
Since setup the three dirs has no dependency, so we do not return as of someone error, return errors in the last.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32058)

<!-- Reviewable:end -->
