### PR TITLE
add alias deploy for deployment

### DIFF
--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -40,7 +40,7 @@ var (
 func NewCmdCreateDeployment(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "deployment NAME --image=image [--dry-run]",
-		Aliases: []string{"dep"},
+		Aliases: []string{"deploy"},
 		Short:   "Create a deployment with the specified name.",
 		Long:    deploymentLong,
 		Example: deploymentExample,


### PR DESCRIPTION
deploy is also alias of deployment. add alias deploy for deployment so the help can see deploy in the Aliases like below:

``` sh
k8s@k8s-node1:~/go/workspace/src/k8s.io/kubernetes/cmd/kubectl$ ./kubectl create dep -h
Create a deployment with the specified name.

Aliases:
deployment, dep, deploy
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32060)

<!-- Reviewable:end -->
