### PR TITLE
Deepcopy: fix generic pointer case

### DIFF
--- a/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
+++ b/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
@@ -609,7 +609,7 @@ func (g *genDeepCopy) doPointer(t *types.Type, sw *generator.SnippetWriter) {
 		sw.Do("if newVal, err := c.DeepCopy(*in); err != nil {\n", nil)
 		sw.Do("return err\n", nil)
 		sw.Do("} else {\n", nil)
-		sw.Do("*out = newVal.($.|raw$)\n", t.Elem)
+		sw.Do("*out = newVal.($.|raw$)\n", t)
 		sw.Do("}\n", nil)
 	}
 }


### PR DESCRIPTION
The changed code path is not used by Kubernetes, but by downstream. It was leading to a type error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32064)

<!-- Reviewable:end -->
