### PR TITLE
Vagrant fixups

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -299,8 +299,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Kubernetes node
   $num_node.times do |n|
     node_vm_name = "node-#{n+1}"
-    node_prefix = ENV['INSTANCE_PREFIX'] || 'kubernetes' # must mirror default in cluster/vagrant/config-default.sh
-    node_hostname = "#{node_prefix}-#{node_vm_name}"
 
     config.vm.define node_vm_name do |node|
       customize_vm node, $vm_node_mem

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.proxy.https    = $https_proxy
     config.proxy.no_proxy = $no_proxy
   end
+
+  # this corrects a bug in 1.8.5 where an invalid SSH key is inserted.
+  if Vagrant::VERSION == "1.8.5"
+    config.ssh.insert_key = false
+  end
+
   def setvmboxandurl(config, provider)
     if ENV['KUBERNETES_BOX_NAME'] then
       config.vm.box = ENV['KUBERNETES_BOX_NAME']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Vagrant 1.8.5 contains a bug where it does not insert a newly generated private key into the VM correctly. This prevents usage by both provisioners and the vagrant subsystem itself, essentially bricking the VM.

See https://github.com/mitchellh/vagrant/issues/7760 for some more information.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

I honestly haven't searched; this is something I encountered setting it up.

**Special notes for your reviewer**:

I'm a new contributor so please be kind, happy to do anything that's required though!

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32067)

<!-- Reviewable:end -->
