### PR TITLE
Allow to use ./cluster/kube-push.sh with warning

### DIFF
--- a/cluster/kube-push.sh
+++ b/cluster/kube-push.sh
@@ -23,8 +23,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "kube-push.sh is currently broken; see https://github.com/kubernetes/kubernetes/issues/17397"
-exit 1
+USAGE_TEXT="kube-push.sh may not work with your provider; see https://github.com/kubernetes/kubernetes/issues/17397.
+we recommend to use it only for development; proceed?
+"
+
+while true; do
+    read -p "${USAGE_TEXT}" yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit;;
+        * ) echo "Answer Y/n.";;
+    esac
+done
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 


### PR DESCRIPTION
I think the benefits are obvious, cause kube-push allows not to redeploy cluster from scratch
when you need to update binaries or change configuration for certain components.

I am using it with vagrant provider.

related: https://github.com/kubernetes/kubernetes/issues/17397

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32069)

<!-- Reviewable:end -->
