### PR TITLE
Make ExponentialFailureRateLimiter slightly slower and cap the backof…

### DIFF
--- a/pkg/util/workqueue/default_rate_limiters_test.go
+++ b/pkg/util/workqueue/default_rate_limiters_test.go
@@ -27,16 +27,16 @@ func TestItemExponentialFailureRateLimiter(t *testing.T) {
 	if e, a := 1*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 10*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 2*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 100*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 4*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 1*time.Second, limiter.When("one"); e != a {
+	if e, a := 8*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 1*time.Second, limiter.When("one"); e != a {
+	if e, a := 16*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 5, limiter.NumRequeues("one"); e != a {
@@ -46,7 +46,7 @@ func TestItemExponentialFailureRateLimiter(t *testing.T) {
 	if e, a := 1*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 10*time.Millisecond, limiter.When("two"); e != a {
+	if e, a := 2*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 2, limiter.NumRequeues("two"); e != a {
@@ -68,7 +68,7 @@ func TestItemExponentialFailureRateLimiterOverFlow(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		limiter.When("one")
 	}
-	if e, a := 100000*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 32*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -83,7 +83,7 @@ func TestItemExponentialFailureRateLimiterOverFlow(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		limiter.When("two")
 	}
-	if e, a := 100*time.Minute, limiter.When("two"); e != a {
+	if e, a := 4*time.Minute, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -147,10 +147,10 @@ func TestMaxOfRateLimiter(t *testing.T) {
 	if e, a := 5*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 10*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 5*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 100*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 5*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 3*time.Second, limiter.When("one"); e != a {
@@ -166,7 +166,7 @@ func TestMaxOfRateLimiter(t *testing.T) {
 	if e, a := 5*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 10*time.Millisecond, limiter.When("two"); e != a {
+	if e, a := 5*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 2, limiter.NumRequeues("two"); e != a {

--- a/pkg/util/workqueue/rate_limitting_queue_test.go
+++ b/pkg/util/workqueue/rate_limitting_queue_test.go
@@ -44,7 +44,7 @@ func TestRateLimitingQueue(t *testing.T) {
 	}
 	queue.AddRateLimited("one")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 10*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 2*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 2, queue.NumRequeues("one"); e != a {
@@ -58,7 +58,7 @@ func TestRateLimitingQueue(t *testing.T) {
 	}
 	queue.AddRateLimited("two")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 10*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 2*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 


### PR DESCRIPTION
Fix #27503

cc @deads2k @derekwaynecarr @ncdc @wojtek-t

For the context of this change see: https://github.com/kubernetes/kubernetes/issues/27503#issuecomment-244741161

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32082)

<!-- Reviewable:end -->
