### PR TITLE
Clarify Docker compatibility message with differentiation between API and runtime versions

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -74,8 +74,10 @@ const (
 	DockerType = "docker"
 
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/
-	// docker version should be at least 1.9.x
+	// Docker API version is used to determine compatibility.
 	minimumDockerAPIVersion = "1.21"
+	// Docker runtime version is required to provide user-friendly message.
+	minimumDockerVersion = "1.9"
 
 	// Remote API version for docker daemon versions
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/
@@ -1067,10 +1069,10 @@ func (dm *DockerManager) checkVersionCompatibility() error {
 	// Verify the docker version.
 	result, err := version.Compare(minimumDockerAPIVersion)
 	if err != nil {
-		return fmt.Errorf("failed to compare current docker version %v with minimum support Docker version %q - %v", version, minimumDockerAPIVersion, err)
+		return fmt.Errorf("failed to compare current docker version %v with minimum support docker version %q - %v", version, minimumDockerAPIVersion, err)
 	}
 	if result < 0 {
-		return fmt.Errorf("container runtime version is older than %s", minimumDockerAPIVersion)
+		return fmt.Errorf("docker API version is older than %s, use docker version %s or newer", minimumDockerAPIVersion, minimumDockerVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
For a new user it may be not that obvious, that kubelet requires different Docker API version to be installed, not Docker runtime version.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32083)

<!-- Reviewable:end -->
