### PR TITLE
Improve the get output for completed pods

### DIFF
--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -166,7 +166,7 @@ func (t *testPrinter) HandledResources() []string {
 	return []string{}
 }
 
-func (t *testPrinter) FinishPrint(output io.Writer, res string) error {
+func (t *testPrinter) AfterPrint(output io.Writer, res string) error {
 	return nil
 }
 

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -235,7 +235,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 			if err := printer.PrintObj(obj, out); err != nil {
 				return fmt.Errorf("unable to output the provided object: %v", err)
 			}
-			printer.FinishPrint(errOut, mapping.Resource)
+			printer.AfterPrint(errOut, mapping.Resource)
 		}
 
 		// print watched changes
@@ -253,7 +253,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 			}
 			err := printer.PrintObj(e.Object, out)
 			if err == nil {
-				printer.FinishPrint(errOut, mapping.Resource)
+				printer.AfterPrint(errOut, mapping.Resource)
 			}
 			return err
 		})
@@ -315,7 +315,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		if err := printer.PrintObj(obj, out); err != nil {
 			allErrs = append(allErrs, err)
 		}
-		printer.FinishPrint(errOut, res)
+		printer.AfterPrint(errOut, res)
 		return utilerrors.NewAggregate(allErrs)
 	}
 
@@ -382,7 +382,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		if printer == nil || lastMapping == nil || mapping == nil || mapping.Resource != lastMapping.Resource {
 			if printer != nil {
 				w.Flush()
-				printer.FinishPrint(errOut, lastMapping.Resource)
+				printer.AfterPrint(errOut, lastMapping.Resource)
 			}
 			printer, err = f.PrinterForMapping(cmd, mapping, allNamespaces)
 			if err != nil {
@@ -422,7 +422,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	}
 	w.Flush()
 	if printer != nil {
-		printer.FinishPrint(errOut, lastMapping.Resource)
+		printer.AfterPrint(errOut, lastMapping.Resource)
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/custom_column_printer.go
+++ b/pkg/kubectl/custom_column_printer.go
@@ -155,7 +155,7 @@ type CustomColumnsPrinter struct {
 	NoHeaders bool
 }
 
-func (s *CustomColumnsPrinter) FinishPrint(w io.Writer, res string) error {
+func (s *CustomColumnsPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -150,7 +150,7 @@ type ResourcePrinter interface {
 	HandledResources() []string
 	//Can be used to print out warning/clarifications if needed
 	//after all objects were printed
-	FinishPrint(io.Writer, string) error
+	AfterPrint(io.Writer, string) error
 }
 
 // ResourcePrinterFunc is a function that can print objects
@@ -166,7 +166,7 @@ func (fn ResourcePrinterFunc) HandledResources() []string {
 	return []string{}
 }
 
-func (fn ResourcePrinterFunc) FinishPrint(io.Writer, string) error {
+func (fn ResourcePrinterFunc) AfterPrint(io.Writer, string) error {
 	return nil
 }
 
@@ -187,7 +187,7 @@ func NewVersionedPrinter(printer ResourcePrinter, converter runtime.ObjectConver
 	}
 }
 
-func (p *VersionedPrinter) FinishPrint(w io.Writer, res string) error {
+func (p *VersionedPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
@@ -214,7 +214,7 @@ type NamePrinter struct {
 	Typer   runtime.ObjectTyper
 }
 
-func (p *NamePrinter) FinishPrint(w io.Writer, res string) error {
+func (p *NamePrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
@@ -266,7 +266,7 @@ func (p *NamePrinter) HandledResources() []string {
 type JSONPrinter struct {
 }
 
-func (p *JSONPrinter) FinishPrint(w io.Writer, res string) error {
+func (p *JSONPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
@@ -300,7 +300,7 @@ type YAMLPrinter struct {
 	converter runtime.ObjectConvertor
 }
 
-func (p *YAMLPrinter) FinishPrint(w io.Writer, res string) error {
+func (p *YAMLPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
@@ -447,9 +447,9 @@ func (h *HumanReadablePrinter) HandledResources() []string {
 	return keys
 }
 
-func (h *HumanReadablePrinter) FinishPrint(output io.Writer, res string) error {
+func (h *HumanReadablePrinter) AfterPrint(output io.Writer, res string) error {
 	if !h.options.NoHeaders && !h.options.ShowAll && h.hiddenObjNum > 0 {
-		_, err := fmt.Fprintf(output, "  info: %d completed object(s) was(were) not shown in %s list. Pass --show-all to see all objects.\n\n", h.hiddenObjNum, res)
+		_, err := fmt.Fprintf(output, "\ninfo: %d completed %s were not shown in the list. Pass --show-all to see all.\n\n", h.hiddenObjNum, res)
 		return err
 	}
 	return nil
@@ -2256,7 +2256,7 @@ func NewTemplatePrinter(tmpl []byte) (*TemplatePrinter, error) {
 	}, nil
 }
 
-func (p *TemplatePrinter) FinishPrint(w io.Writer, res string) error {
+func (p *TemplatePrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
@@ -2407,7 +2407,7 @@ func NewJSONPathPrinter(tmpl string) (*JSONPathPrinter, error) {
 	return &JSONPathPrinter{tmpl, j}, nil
 }
 
-func (j *JSONPathPrinter) FinishPrint(w io.Writer, res string) error {
+func (j *JSONPathPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 

--- a/pkg/kubectl/sorting_printer.go
+++ b/pkg/kubectl/sorting_printer.go
@@ -40,7 +40,7 @@ type SortingPrinter struct {
 	Decoder   runtime.Decoder
 }
 
-func (s *SortingPrinter) FinishPrint(w io.Writer, res string) error {
+func (s *SortingPrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- rename FinishPrint() to AfterPrint()
- add a newline to separate it from the table
- remove the "objects" and ()
- assume plural

**Which issue this PR fixes** 
fixes #31160

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
Improve the get output for completed pods
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32092)

<!-- Reviewable:end -->
