### PR TITLE
Don't return an error if a file doesn't exist for IsPathDevice(...)

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -208,6 +208,9 @@ func exclusiveOpenFailsOnDevice(pathname string) (bool, error) {
 
 func pathIsDevice(pathname string) (bool, error) {
 	finfo, err := os.Stat(pathname)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
 	// err in call to os.Stat
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/30455

@saad-ali @thockin fyi, since linux devices and storage.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32097)

<!-- Reviewable:end -->
