### PR TITLE
Ensure that we are closing files.

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -612,6 +612,7 @@ func (s *SchedulerServer) Run(hks hyperkube.Interface, _ []string) error {
 		if err != nil {
 			log.Fatalf("Cannot open scheduler config file: %v", err)
 		}
+		defer f.Close()
 
 		err = sc.Read(bufio.NewReader(f))
 		if err != nil {

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -156,6 +156,7 @@ func readInstanceID() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Cannot open %s: %v", metaDataPath, err)
 	}
+	defer file.Close()
 
 	return parseMetaData(file)
 }

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -66,6 +66,7 @@ func readBytesFromFile(t *testing.T, filename string) []byte {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer file.Close()
 
 	data, err := ioutil.ReadAll(file)
 	if err != nil {

--- a/plugin/pkg/admission/imagepolicy/admission_test.go
+++ b/plugin/pkg/admission/imagepolicy/admission_test.go
@@ -242,6 +242,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("failed to read test config: %v", err)
 			}
+			defer configFile.Close()
 
 			_, err = NewImagePolicyWebhook(fake.NewSimpleClientset(), configFile)
 			return err
@@ -402,6 +403,7 @@ func newImagePolicyWebhook(callbackURL string, clientCert, clientKey, ca []byte,
 	if err != nil {
 		return nil, fmt.Errorf("failed to read test config: %v", err)
 	}
+	defer configFile.Close()
 	wh, err := NewImagePolicyWebhook(fake.NewSimpleClientset(), configFile)
 	return wh.(*imagePolicyWebhook), err
 }

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1528,6 +1528,7 @@ func readBytesFromFile(filename string) []byte {
 		framework.Failf(err.Error())
 	}
 	defer file.Close()
+
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
 		framework.Failf(err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**: In several places we are leaking file descriptors. This could be problematic on systems with low ulimits for them.

**Release note**:

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32106)

<!-- Reviewable:end -->
