### PR TITLE
Set Job's labels from PodTemplateSpec if none are specified

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -65,6 +65,8 @@ pkg/apis/authentication/install
 pkg/apis/authorization/install
 pkg/apis/autoscaling/install
 pkg/apis/batch/install
+pkg/apis/batch/v1
+pkg/apis/batch/v2alpha1
 pkg/apis/certificates/install
 pkg/apis/componentconfig/install
 pkg/apis/extensions/install

--- a/pkg/apis/batch/v1/defaults.go
+++ b/pkg/apis/batch/v1/defaults.go
@@ -39,4 +39,8 @@ func SetDefaults_Job(obj *Job) {
 		obj.Spec.Parallelism = new(int32)
 		*obj.Spec.Parallelism = 1
 	}
+	labels := obj.Spec.Template.Labels
+	if labels != nil && len(obj.Labels) == 0 {
+		obj.Labels = labels
+	}
 }

--- a/pkg/apis/batch/v1/defaults_test.go
+++ b/pkg/apis/batch/v1/defaults_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api/install"
+	"k8s.io/kubernetes/pkg/api/v1"
+	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	. "k8s.io/kubernetes/pkg/apis/batch/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestSetDefaultJob(t *testing.T) {
+	defaultLabels := map[string]string{"default": "default"}
+	tests := map[string]struct {
+		original     *Job
+		expected     *Job
+		expectLabels bool
+	}{
+		"both unspecified -> sets both to 1": {
+			original: &Job{
+				Spec: JobSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(1),
+					Parallelism: newInt32(1),
+				},
+			},
+			expectLabels: true,
+		},
+		"both unspecified -> sets both to 1 and no default labels": {
+			original: &Job{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"mylabel": "myvalue"},
+				},
+				Spec: JobSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(1),
+					Parallelism: newInt32(1),
+				},
+			},
+		},
+		"WQ: Parallelism explicitly 0 and completions unset -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+				},
+			},
+			expectLabels: true,
+		},
+		"WQ: Parallelism explicitly 2 and completions unset -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+				},
+			},
+			expectLabels: true,
+		},
+		"Completions explicitly 2 and parallelism unset -> parallelism is defaulted": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+					Parallelism: newInt32(1),
+				},
+			},
+			expectLabels: true,
+		},
+		"Both set -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expectLabels: true,
+		},
+		"Both set, flipped -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+				},
+			},
+			expectLabels: true,
+		},
+	}
+
+	for name, test := range tests {
+		original := test.original
+		expected := test.expected
+		obj2 := roundTrip(t, runtime.Object(original))
+		actual, ok := obj2.(*Job)
+		if !ok {
+			t.Errorf("%s: unexpected object: %v", name, actual)
+			t.FailNow()
+		}
+		if (actual.Spec.Completions == nil) != (expected.Spec.Completions == nil) {
+			t.Errorf("%s: got different *completions than expected: %v %v", name, actual.Spec.Completions, expected.Spec.Completions)
+		}
+		if actual.Spec.Completions != nil && expected.Spec.Completions != nil {
+			if *actual.Spec.Completions != *expected.Spec.Completions {
+				t.Errorf("%s: got different completions than expected: %d %d", name, *actual.Spec.Completions, *expected.Spec.Completions)
+			}
+		}
+		if (actual.Spec.Parallelism == nil) != (expected.Spec.Parallelism == nil) {
+			t.Errorf("%s: got different *Parallelism than expected: %v %v", name, actual.Spec.Parallelism, expected.Spec.Parallelism)
+		}
+		if actual.Spec.Parallelism != nil && expected.Spec.Parallelism != nil {
+			if *actual.Spec.Parallelism != *expected.Spec.Parallelism {
+				t.Errorf("%s: got different parallelism than expected: %d %d", name, *actual.Spec.Parallelism, *expected.Spec.Parallelism)
+			}
+		}
+		if test.expectLabels != reflect.DeepEqual(actual.Labels, actual.Spec.Template.Labels) {
+			if test.expectLabels {
+				t.Errorf("%s: expected: %v, got: %v", name, actual.Spec.Template.Labels, actual.Labels)
+			} else {
+				t.Errorf("%s: unexpected equality: %v", name, actual.Labels)
+			}
+		}
+
+	}
+}
+
+func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
+	data, err := runtime.Encode(api.Codecs.LegacyCodec(SchemeGroupVersion), obj)
+	if err != nil {
+		t.Errorf("%v\n %#v", err, obj)
+		return nil
+	}
+	obj2, err := runtime.Decode(api.Codecs.UniversalDecoder(), data)
+	if err != nil {
+		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
+		return nil
+	}
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = api.Scheme.Convert(obj2, obj3, nil)
+	if err != nil {
+		t.Errorf("%v\nSource: %#v", err, obj2)
+		return nil
+	}
+	return obj3
+}
+
+func newInt32(val int32) *int32 {
+	p := new(int32)
+	*p = val
+	return p
+}

--- a/pkg/apis/batch/v2alpha1/defaults.go
+++ b/pkg/apis/batch/v2alpha1/defaults.go
@@ -40,6 +40,10 @@ func SetDefaults_Job(obj *Job) {
 		obj.Spec.Parallelism = new(int32)
 		*obj.Spec.Parallelism = 1
 	}
+	labels := obj.Spec.Template.Labels
+	if labels != nil && len(obj.Labels) == 0 {
+		obj.Labels = labels
+	}
 }
 
 func SetDefaults_ScheduledJob(obj *ScheduledJob) {

--- a/pkg/apis/batch/v2alpha1/defaults_test.go
+++ b/pkg/apis/batch/v2alpha1/defaults_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1_test
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api/install"
+	"k8s.io/kubernetes/pkg/api/v1"
+	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	. "k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestSetDefaultJob(t *testing.T) {
+	defaultLabels := map[string]string{"default": "default"}
+	tests := map[string]struct {
+		original     *Job
+		expected     *Job
+		expectLabels bool
+	}{
+		"both unspecified -> sets both to 1": {
+			original: &Job{
+				Spec: JobSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(1),
+					Parallelism: newInt32(1),
+				},
+			},
+			expectLabels: true,
+		},
+		"both unspecified -> sets both to 1 and no default labels": {
+			original: &Job{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"mylabel": "myvalue"},
+				},
+				Spec: JobSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(1),
+					Parallelism: newInt32(1),
+				},
+			},
+		},
+		"WQ: Parallelism explicitly 0 and completions unset -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+				},
+			},
+			expectLabels: true,
+		},
+		"WQ: Parallelism explicitly 2 and completions unset -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+				},
+			},
+			expectLabels: true,
+		},
+		"Completions explicitly 2 and parallelism unset -> parallelism is defaulted": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+					Parallelism: newInt32(1),
+				},
+			},
+			expectLabels: true,
+		},
+		"Both set -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expectLabels: true,
+		},
+		"Both set, flipped -> no change": {
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: defaultLabels},
+					},
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+				},
+			},
+			expectLabels: true,
+		},
+	}
+
+	for name, test := range tests {
+		original := test.original
+		expected := test.expected
+		obj2 := roundTrip(t, runtime.Object(original))
+		actual, ok := obj2.(*Job)
+		if !ok {
+			t.Errorf("%s: unexpected object: %v", name, actual)
+			t.FailNow()
+		}
+		if (actual.Spec.Completions == nil) != (expected.Spec.Completions == nil) {
+			t.Errorf("%s: got different *completions than expected: %v %v", name, actual.Spec.Completions, expected.Spec.Completions)
+		}
+		if actual.Spec.Completions != nil && expected.Spec.Completions != nil {
+			if *actual.Spec.Completions != *expected.Spec.Completions {
+				t.Errorf("%s: got different completions than expected: %d %d", name, *actual.Spec.Completions, *expected.Spec.Completions)
+			}
+		}
+		if (actual.Spec.Parallelism == nil) != (expected.Spec.Parallelism == nil) {
+			t.Errorf("%s: got different *Parallelism than expected: %v %v", name, actual.Spec.Parallelism, expected.Spec.Parallelism)
+		}
+		if actual.Spec.Parallelism != nil && expected.Spec.Parallelism != nil {
+			if *actual.Spec.Parallelism != *expected.Spec.Parallelism {
+				t.Errorf("%s: got different parallelism than expected: %d %d", name, *actual.Spec.Parallelism, *expected.Spec.Parallelism)
+			}
+		}
+		if test.expectLabels != reflect.DeepEqual(actual.Labels, actual.Spec.Template.Labels) {
+			if test.expectLabels {
+				t.Errorf("%s: expected: %v, got: %v", name, actual.Spec.Template.Labels, actual.Labels)
+			} else {
+				t.Errorf("%s: unexpected equality: %v", name, actual.Labels)
+			}
+		}
+
+	}
+}
+
+func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
+	data, err := runtime.Encode(api.Codecs.LegacyCodec(SchemeGroupVersion), obj)
+	if err != nil {
+		t.Errorf("%v\n %#v", err, obj)
+		return nil
+	}
+	obj2, err := runtime.Decode(api.Codecs.UniversalDecoder(), data)
+	if err != nil {
+		t.Errorf("%v\nData: %s\nSource: %#v", err, string(data), obj)
+		return nil
+	}
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = api.Scheme.Convert(obj2, obj3, nil)
+	if err != nil {
+		t.Errorf("%v\nSource: %#v", err, obj2)
+		return nil
+	}
+	return obj3
+}
+
+func newInt32(val int32) *int32 {
+	p := new(int32)
+	*p = val
+	return p
+}

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -49,14 +49,8 @@ func ValidateGeneratedSelector(obj *batch.Job) field.ErrorList {
 		allErrs = append(allErrs, field.Required(field.NewPath("metadata").Child("uid"), ""))
 	}
 
-	// If somehow uid was unset then we would get "controller-uid=" as the selector
-	// which is bad.
-	if obj.ObjectMeta.UID == "" {
-		allErrs = append(allErrs, field.Required(field.NewPath("metadata").Child("uid"), ""))
-	}
-
 	// If selector generation was requested, then expected labels must be
-	// present on pod template, and much match job's uid and name.  The
+	// present on pod template, and must match job's uid and name.  The
 	// generated (not-manual) selectors/labels ensure no overlap with other
 	// controllers.  The manual mode allows orphaning, adoption,
 	// backward-compatibility, and experimentation with new


### PR DESCRIPTION
Fixes #31009 and replaces #32033.

@AdoHe I've picked your changes, added the additional ones for 'batch/v2alpha1' and most importantly added tests for job's defaulting. ptal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32110)

<!-- Reviewable:end -->
