### PR TITLE
PetSet returns valid replica count in status

### DIFF
--- a/pkg/controller/petset/fakes.go
+++ b/pkg/controller/petset/fakes.go
@@ -248,7 +248,7 @@ func (f *fakePetClient) deletePetAtIndex(index int) {
 }
 
 func (f *fakePetClient) setHealthy(index int) error {
-	if len(f.pets) < index {
+	if len(f.pets) <= index {
 		return fmt.Errorf("Index out of range, len %v index %v", len(f.pets), index)
 	}
 	f.pets[index].pod.Status.Phase = api.PodRunning

--- a/pkg/controller/petset/pet_set.go
+++ b/pkg/controller/petset/pet_set.go
@@ -348,7 +348,14 @@ func (psc *PetSetController) syncPetSet(ps *apps.PetSet, pets []*api.Pod) (int, 
 		case deletePet:
 			err = petManager.Delete(pet)
 		}
-		if err != nil {
+		switch err.(type) {
+		case errUnhealthyPet:
+			// We are not passing this error up, but we don't increment numPets if we encounter it,
+			// since numPets directly translates to petset.status.replicas
+			continue
+		case nil:
+			continue
+		default:
 			it.errs = append(it.errs, err)
 		}
 	}

--- a/pkg/controller/petset/pet_set_test.go
+++ b/pkg/controller/petset/pet_set_test.go
@@ -267,3 +267,13 @@ func TestPetSetBlockingPetIsCleared(t *testing.T) {
 		t.Errorf("Unexpected blocking pet, err %v: %+v", err, p)
 	}
 }
+
+// TODO(mkwiek): test if the petset.Status.Replicas is actually correct
+func TestPetSetReplicaCount(t *testing.T) {
+	psc, fc := newFakePetSetController()
+	ps := newPetSet(3)
+	i, _ := psc.syncPetSet(ps, fc.getPodList())
+	if i != len(fc.getPodList()) {
+		t.Errorf("syncPetSet should return actual amount of pods")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: It prevents the PetSet replica count to be invalid regardless of pods not being created due to 

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #31965

**Special notes for your reviewer**:

**Release note**:

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32117)

<!-- Reviewable:end -->
