### PR TITLE
[Pet Set] Sleep between petset update retries

### DIFF
--- a/pkg/controller/petset/pet.go
+++ b/pkg/controller/petset/pet.go
@@ -19,6 +19,7 @@ package petset
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
@@ -45,6 +46,9 @@ const (
 	// pet has finished initializing itself.
 	// TODO: Replace this with init container status.
 	PetSetInitAnnotation = "pod.alpha.kubernetes.io/initialized"
+	// The amount of time the PetSet controller should sleep between retrying
+	// PetSet updates
+	retrySleepTime = 20 * time.Millisecond
 )
 
 // pcb is the control block used to transmit all updates about a single pet.
@@ -216,6 +220,7 @@ func (p *apiServerPetClient) Update(pet *pcb, expectedPet *pcb) (updateErr error
 		if p, getErr = pc.Get(pod.Name); getErr != nil {
 			return getErr
 		}
+		time.Sleep(retrySleepTime)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Sleep 20ms between petset update retries.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32121)

<!-- Reviewable:end -->
