### PR TITLE
Refactor volume controller parameters into a structure

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -425,19 +425,16 @@ func StartControllers(s *options.CMServer, kubeconfig *restclient.Config, stop <
 	if err != nil {
 		glog.Fatalf("An backward-compatible provisioner could not be created: %v, but one was expected. Provisioning will not work. This functionality is considered an early Alpha version.", err)
 	}
-	volumeController := persistentvolumecontroller.NewPersistentVolumeController(
-		client("persistent-volume-binder"),
-		s.PVClaimBinderSyncPeriod.Duration,
-		alphaProvisioner,
-		ProbeControllerVolumePlugins(cloud, s.VolumeConfiguration),
-		cloud,
-		s.ClusterName,
-		nil, // volumeSource
-		nil, // claimSource
-		nil, // classSource
-		nil, // eventRecorder
-		s.VolumeConfiguration.EnableDynamicProvisioning,
-	)
+	params := persistentvolumecontroller.ControllerParameters{
+		KubeClient:                client("persistent-volume-binder"),
+		SyncPeriod:                s.PVClaimBinderSyncPeriod.Duration,
+		AlphaProvisioner:          alphaProvisioner,
+		VolumePlugins:             ProbeControllerVolumePlugins(cloud, s.VolumeConfiguration),
+		Cloud:                     cloud,
+		ClusterName:               s.ClusterName,
+		EnableDynamicProvisioning: s.VolumeConfiguration.EnableDynamicProvisioning,
+	}
+	volumeController := persistentvolumecontroller.NewController(params)
 	volumeController.Run(wait.NeverStop)
 	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -294,19 +294,16 @@ func (s *CMServer) Run(_ []string) error {
 	if err != nil {
 		glog.Fatalf("An backward-compatible provisioner could not be created: %v, but one was expected. Provisioning will not work. This functionality is considered an early Alpha version.", err)
 	}
-	volumeController := persistentvolumecontroller.NewPersistentVolumeController(
-		clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "persistent-volume-binder")),
-		s.PVClaimBinderSyncPeriod.Duration,
-		alphaProvisioner,
-		kubecontrollermanager.ProbeControllerVolumePlugins(cloud, s.VolumeConfiguration),
-		cloud,
-		s.ClusterName,
-		nil, // volumeSource
-		nil, // claimSource
-		nil, // classSource
-		nil, // eventRecorder
-		s.VolumeConfiguration.EnableDynamicProvisioning,
-	)
+	params := persistentvolumecontroller.ControllerParameters{
+		KubeClient:                clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "persistent-volume-binder")),
+		SyncPeriod:                s.PVClaimBinderSyncPeriod.Duration,
+		AlphaProvisioner:          alphaProvisioner,
+		VolumePlugins:             kubecontrollermanager.ProbeControllerVolumePlugins(cloud, s.VolumeConfiguration),
+		Cloud:                     cloud,
+		ClusterName:               s.ClusterName,
+		EnableDynamicProvisioning: s.VolumeConfiguration.EnableDynamicProvisioning,
+	}
+	volumeController := persistentvolumecontroller.NewController(params)
 	volumeController.Run(wait.NeverStop)
 
 	var rootCA []byte

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -594,19 +594,18 @@ func newTestController(kubeClient clientset.Interface, volumeSource, claimSource
 	if classSource == nil {
 		classSource = fcache.NewFakeControllerSource()
 	}
-	ctrl := NewPersistentVolumeController(
-		kubeClient,
-		5*time.Second,        // sync period
-		nil,                  // alpha provisioner
-		[]vol.VolumePlugin{}, // recyclers
-		nil,                  // cloud
-		"",
-		volumeSource,
-		claimSource,
-		classSource,
-		record.NewFakeRecorder(1000), // event recorder
-		enableDynamicProvisioning,
-	)
+
+	params := ControllerParameters{
+		KubeClient:                kubeClient,
+		SyncPeriod:                5 * time.Second,
+		VolumePlugins:             []vol.VolumePlugin{},
+		VolumeSource:              volumeSource,
+		ClaimSource:               claimSource,
+		ClassSource:               classSource,
+		EventRecorder:             record.NewFakeRecorder(1000),
+		EnableDynamicProvisioning: enableDynamicProvisioning,
+	}
+	ctrl := NewController(params)
 
 	// Speed up the test
 	ctrl.createProvisionedPVInterval = 5 * time.Millisecond

--- a/test/integration/persistentvolumes/persistent_volumes_test.go
+++ b/test/integration/persistentvolumes/persistent_volumes_test.go
@@ -1124,20 +1124,14 @@ func createClients(ns *api.Namespace, t *testing.T, s *httptest.Server, syncPeri
 	}
 	plugins := []volume.VolumePlugin{plugin}
 	cloud := &fake_cloud.FakeCloud{}
-
-	syncPeriod = getSyncPeriod(syncPeriod)
-	ctrl := persistentvolumecontroller.NewPersistentVolumeController(
-		binderClient,
-		syncPeriod,
-		nil, // alpha provisioner
-		plugins,
-		cloud,
-		"",   // cluster name
-		nil,  // volumeSource
-		nil,  // claimSource
-		nil,  // classSource
-		nil,  // eventRecorder
-		true) // enableDynamicProvisioning
+	ctrl := persistentvolumecontroller.NewController(
+		persistentvolumecontroller.ControllerParameters{
+			KubeClient:    binderClient,
+			SyncPeriod:    getSyncPeriod(syncPeriod),
+			VolumePlugins: plugins,
+			Cloud:         cloud,
+			EnableDynamicProvisioning: true,
+		})
 
 	watchPV, err := testClient.PersistentVolumes().Watch(api.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
`persistentvolumecontroller.NewPersistentVolumeController` has 11 arguments now,
put them into a structure.

Also, rename `NewPersistentVolumeController` to `NewController`, `persistentvolume`
is already name of the package.

Fixes #30219

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32129)

<!-- Reviewable:end -->
