### PR TITLE
Wrong cron job date in scheduledjob.md

### DIFF
--- a/docs/proposals/scheduledjob.md
+++ b/docs/proposals/scheduledjob.md
@@ -207,7 +207,7 @@ In the above example:
 
 * `--restart=OnFailure` implies creating a job instead of replicationController.
 * `--runAt="0 14 21 7 *"` implies the schedule with which the job should be run, here
-  July 7th, 2pm.  This value will be validated according to the same rules which
+  July 21, 2pm.  This value will be validated according to the same rules which
   apply to `.spec.schedule`.
 
 ## Fields Added to Job Template


### PR DESCRIPTION
It seems we wrote a wrong date? 

`"0 14 21 7 *"` is July 21.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32130)

<!-- Reviewable:end -->
