### PR TITLE
Inline and unroll MergeFieldsSets in PodToSelectableFields to improve…

### DIFF
--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -192,12 +192,10 @@ func NodeNameTriggerFunc(obj runtime.Object) []storage.MatchValue {
 // TODO: fields are not labels, and the validation rules for them do not apply.
 func PodToSelectableFields(pod *api.Pod) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&pod.ObjectMeta, true)
-	podSpecificFieldsSet := fields.Set{
-		"spec.nodeName":      pod.Spec.NodeName,
-		"spec.restartPolicy": string(pod.Spec.RestartPolicy),
-		"status.phase":       string(pod.Status.Phase),
-	}
-	return generic.MergeFieldsSets(objectMetaFieldsSet, podSpecificFieldsSet)
+	objectMetaFieldsSet["spec.nodeName"] = pod.Spec.NodeName
+  objectMetaFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
+  objectMetaFieldsSet["status.phase"] = string(pod.Status.Phase)
+	return objectMetaFieldsSet
 }
 
 // ResourceGetter is an interface for retrieving resources by ResourceLocation.


### PR DESCRIPTION
PodToSelectableFields seems to consume a lot CPU in API server profiles (30%) 60% of which can be accounted to memory management. This PR removes two map creations, which should improve performance.

cc @lavalamp

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32136)

<!-- Reviewable:end -->
