### PR TITLE
remove call to compinit in zsh completion output

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -234,7 +234,6 @@ __kubectl_quote() {
     fi
 }
 
-autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed


### PR DESCRIPTION
**Release note**:

``` release-note
release-note-none
```

Fixes: https://github.com/kubernetes/kubernetes/issues/32029
Fixes:
https://github.com/kubernetes/kubernetes/issues/27538#issuecomment-238574035

The zsh completion output makes a call to "compinit" which causes the
zsh completion system to re-initialize every time `<root_cmd> completion zsh`
is sourced, overwriting any settings already applied to other commands.
This in-turn caused other commands' completions to break (such as git,
gcloud, vim) causing an error "function definition file not found" to
be returned any time a tab-completion was attempted.

This patch removes the call to `compinit` in the zsh completion output,
causing no behavioral changes to the existing `completion` command, but
fixing any issues that were caused after sourcing its output.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32142)

<!-- Reviewable:end -->
