### PR TITLE
Backport vsphere cluster as failure zone

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -126,10 +126,12 @@ func TestVSphereLogin(t *testing.T) {
 func TestZones(t *testing.T) {
 	cfg := VSphereConfig{}
 	cfg.Global.Datacenter = "myDatacenter"
+	failureZone := "myCluster"
 
 	// Create vSphere configuration object
 	vs := VSphere{
-		cfg: &cfg,
+		cfg:         &cfg,
+		clusterName: failureZone,
 	}
 
 	z, ok := vs.Zones()
@@ -144,6 +146,10 @@ func TestZones(t *testing.T) {
 
 	if zone.Region != vs.cfg.Global.Datacenter {
 		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
+	}
+
+	if zone.FailureDomain != failureZone {
+		t.Fatalf("GetZone() returned wrong Failure Zone (%s)", zone.FailureDomain)
 	}
 }
 


### PR DESCRIPTION
In 1.3, the vsphere provider does not report anything for FailureDomain when it should.  We should be treating a Cluster as the failure domain.

This is a backport of the following PR:
#30935

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32147)

<!-- Reviewable:end -->
