### PR TITLE
rkt: Refactor host file mounts for host network.

### DIFF
--- a/examples/pod
+++ b/examples/pod
@@ -6,6 +6,9 @@ metadata:
   labels:
     name: nginx
 spec:
+  initcontainers: 
+    name: busybox
+    image: busybox
   containers:
   - name: nginx
     image: nginx

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -133,6 +133,9 @@ const (
 
 	// defaultRequestTimeout is the default timeout of rkt requests.
 	defaultRequestTimeout = 2 * time.Minute
+
+	etcHostsPath      = "/etc/hosts"
+	etcResolvConfPath = "/etc/resolv.conf"
 )
 
 // Runtime implements the Containerruntime for rkt. The implementation
@@ -657,27 +660,42 @@ func copyfile(src, dst string) error {
 
 // TODO(yifan): Can make rkt handle this when '--net=host'. See https://github.com/coreos/rkt/issues/2430.
 func makeHostNetworkMount(opts *kubecontainer.RunContainerOptions) (*kubecontainer.Mount, *kubecontainer.Mount, error) {
-	hostsPath := filepath.Join(opts.PodContainerDir, "etc-hosts")
-	resolvPath := filepath.Join(opts.PodContainerDir, "etc-resolv-conf")
+	mountHosts, mountResolvConf := true, true
+	for _, mnt := range opts.Mounts {
+		switch mnt.ContainerPath {
+		case etcHostsPath:
+			mountHosts = false
+		case etcResolvConfPath:
+			mountResolvConf = false
+		}
+	}
 
-	if err := copyfile("/etc/hosts", hostsPath); err != nil {
-		return nil, nil, err
-	}
-	if err := copyfile("/etc/resolv.conf", resolvPath); err != nil {
-		return nil, nil, err
+	var hostsMount, resolvMount kubecontainer.Mount
+	if mountHosts {
+		hostsPath := filepath.Join(opts.PodContainerDir, "etc-hosts")
+		if err := copyfile(etcHostsPath, hostsPath); err != nil {
+			return nil, nil, err
+		}
+		hostsMount = kubecontainer.Mount{
+			Name:          "kubernetes-hostnetwork-hosts-conf",
+			ContainerPath: etcHostsPath,
+			HostPath:      hostsPath,
+		}
+		opts.Mounts = append(opts.Mounts, hostsMount)
 	}
 
-	hostsMount := kubecontainer.Mount{
-		Name:          "kubernetes-hostnetwork-hosts-conf",
-		ContainerPath: "/etc/hosts",
-		HostPath:      hostsPath,
+	if mountResolvConf {
+		resolvPath := filepath.Join(opts.PodContainerDir, "etc-resolv-conf")
+		if err := copyfile(etcResolvConfPath, resolvPath); err != nil {
+			return nil, nil, err
+		}
+		resolvMount = kubecontainer.Mount{
+			Name:          "kubernetes-hostnetwork-resolv-conf",
+			ContainerPath: etcResolvConfPath,
+			HostPath:      resolvPath,
+		}
+		opts.Mounts = append(opts.Mounts, resolvMount)
 	}
-	resolvMount := kubecontainer.Mount{
-		Name:          "kubernetes-hostnetwork-resolv-conf",
-		ContainerPath: "/etc/resolv.conf",
-		HostPath:      resolvPath,
-	}
-	opts.Mounts = append(opts.Mounts, hostsMount, resolvMount)
 	return &hostsMount, &resolvMount, nil
 }
 


### PR DESCRIPTION
Do not mount /etc/hosts/ /etc/resolv.conf if they are already mounted.

Ref https://github.com/coreos/rkt/issues/2430#issuecomment-244343576

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32148)

<!-- Reviewable:end -->
