### PR TITLE
cluster/gce: Update master root disk size

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -673,7 +673,7 @@ function create-network() {
 #   MASTER_ROOT_DISK_SIZE
 function get-master-root-disk-size() {
   if [[ "${NUM_NODES}" -le "1000" ]]; then
-    export MASTER_ROOT_DISK_SIZE="10"
+    export MASTER_ROOT_DISK_SIZE="20"
   else
     export MASTER_ROOT_DISK_SIZE="50"
   fi


### PR DESCRIPTION
As part of #29213, the hyperkube image will be deployed alongside
existing dependencies.

This ends up just running over the root disk size of 10 during
extraction.

cc @yifan-gu @aaronlevy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32155)

<!-- Reviewable:end -->
