### PR TITLE
Don't git clean in hack/jenkins/build.sh

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -53,7 +53,6 @@ export KUBE_RELEASE_RUN_TESTS RELEASE_INFRA_PUSH FEDERATION SET_NOMOCK_FLAG
 # state.
 rm -rf ~/.kube*
 make clean
-git clean -fdx
 
 # Uncomment if you want to purge the Docker cache completely each
 # build. It costs about 150s each build to pull the golang image and


### PR DESCRIPTION
We go through [all the effort](https://github.com/kubernetes/test-infra/pull/521) of activating a service account but then immediately wipe it away in the build script.

We do a full workspace cleanup anyway, so we don't need the `git clean`. We could probably remove the other cleanup lines in this script, too, but I wanted to keep this change as small as possible for now.

Maybe actually fixes https://github.com/kubernetes/test-infra/issues/470?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32162)

<!-- Reviewable:end -->
