### PR TITLE
kubectl version -c has been deprecated, use --client instead

### DIFF
--- a/build/util.sh
+++ b/build/util.sh
@@ -23,7 +23,7 @@ function kube::release::semantic_version() {
   # Client Version: version.Info{Major:"1", Minor:"1+", GitVersion:"v1.1.0-alpha.0.2328+3c0a05de4a38e3", GitCommit:"3c0a05de4a38e355d147dbfb4d85bad6d2d73bb9", GitTreeState:"clean"}
   # and spits back the GitVersion piece in a way that is somewhat
   # resilient to the other fields changing (we hope)
-  ${KUBE_ROOT}/cluster/kubectl.sh version -c | sed "s/, */\\
+  ${KUBE_ROOT}/cluster/kubectl.sh version --client | sed "s/, */\\
 /g" | egrep "^GitVersion:" | cut -f2 -d: | cut -f2 -d\"
 }
 


### PR DESCRIPTION
```
Flag shorthand -c has been deprecated, please use --client instead.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32164)

<!-- Reviewable:end -->
