### PR TITLE
Make error more useful when failing to list node e2e images

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -392,7 +392,7 @@ func (a byCreationTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func getGCEImages(imageRegex, project string, previousImages int) ([]string, error) {
 	ilc, err := computeService.Images.List(project).Do()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to list images in project %q and zone %q", project, zone)
+		return nil, fmt.Errorf("Failed to list images in project %q: %v", project, err)
 	}
 	imageObjs := []imageObj{}
 	imageRe := regexp.MustCompile(imageRegex)


### PR DESCRIPTION
To help investigate https://github.com/kubernetes/kubernetes/issues/31694 if it happens again.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32169)

<!-- Reviewable:end -->
