### PR TITLE
Replace gcloud shelling out with cloudprovider calls.

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -84,7 +84,11 @@ var _ = framework.KubeDescribe("Loadbalancing: L7 [Feature:Ingress]", func() {
 		BeforeEach(func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
 			By("Initializing gce controller")
-			gceController = &GCEIngressController{ns: ns, Project: framework.TestContext.CloudConfig.ProjectID, c: jig.client}
+			gceController = &GCEIngressController{
+				ns:    ns,
+				c:     jig.client,
+				cloud: framework.TestContext.CloudConfig,
+			}
 			gceController.init()
 		})
 


### PR DESCRIPTION
gcloud flakes a lot leading to resource leak. Also fixes https://github.com/kubernetes/kubernetes/issues/16636 by verifying instance-groups, ssl-certs and firewall-rules and cleaned up.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32170)

<!-- Reviewable:end -->
