### PR TITLE
Move nginx ingress e2e to slow

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -146,7 +146,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7 [Feature:Ingress]", func() {
 	})
 
 	// Time: borderline 5m, slow by design
-	framework.KubeDescribe("Nginx [Slow] [Feature: Ingress]", func() {
+	framework.KubeDescribe("Nginx [Slow]", func() {
 		var nginxController *NginxIngressController
 
 		BeforeEach(func() {


### PR DESCRIPTION
Normal GCE L7 e2e takes ~15m and runs in a feature private suite. This e2e ensure that the api isn't broken, by creating an nginx controller. I plan to write a really slimmed down version for presubmit, but I need to shave off a minute to get it below 5m. 

Fixes https://github.com/kubernetes/kubernetes/issues/23416

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32173)

<!-- Reviewable:end -->
