### PR TITLE
fix problem verifying volume-snapshotting.md

### DIFF
--- a/docs/design/volume-snapshotting.md
+++ b/docs/design/volume-snapshotting.md
@@ -18,6 +18,11 @@
 If you are using a released version of Kubernetes, you should
 refer to the docs that go with that version.
 
+<!-- TAG RELEASE_LINK, added by the munger automatically -->
+<strong>
+The latest release of this document can be found
+[here](http://releases.k8s.io/release-1.4/docs/design/volume-snapshotting.md).
+
 Documentation for other releases can be found at
 [releases.k8s.io](http://releases.k8s.io).
 </strong>


### PR DESCRIPTION
Fix problem in volume-snapshotting.md introduced in https://github.com/kubernetes/kubernetes/commit/3a28c09efb81a2c8e836d9cc415e3ad0017728f1

```
+++ [0906 18:27:26] Building go targets for linux/amd64:
    cmd/mungedocs
/go/src/k8s.io/kubernetes/docs/design/volume-snapshotting.md
----
unversioned-warning:
not printing failed chunk: too many lines
contents were modified

FAIL: changes needed but not made due to --verify
/go/src/k8s.io/kubernetes/docs/ is out of date. Please run hack/update-munge-docs.sh
FAILED   hack/make-rules/../../hack/verify-munge-docs.sh    5s
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32175)

<!-- Reviewable:end -->
