### PR TITLE
add alias svc for create_service.go

### DIFF
--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -31,9 +31,10 @@ import (
 // NewCmdCreateService is a macro command to create a new namespace
 func NewCmdCreateService(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "service",
-		Short: "Create a service using specified subcommand.",
-		Long:  "Create a service using specified subcommand.",
+		Use:     "service",
+		Aliases: []string{"svc"},
+		Short:   "Create a service using specified subcommand.",
+		Long:    "Create a service using specified subcommand.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},


### PR DESCRIPTION
add alias 'svc' for service in create_service.go so that  alias 'svc'  can be used and also can be seen in help message's Aliases like below:

``` shell
$ kubectl create svc -h
Create a service using specified subcommand.

Aliases:
service, svc

Available Commands:
  clusterip    Create a clusterIP service.
  loadbalancer Create a LoadBalancer service.
  nodeport     Create a NodePort service.

Usage:
  kubectl create service [options]
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32176)

<!-- Reviewable:end -->
