### PR TITLE
Feature gate is not stable sorted - docs change each gen

### DIFF
--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -216,6 +216,7 @@ func (f *featureGate) AddFlag(fs *pflag.FlagSet) {
 		}
 		known = append(known, fmt.Sprintf("%s=true|false (%sdefault=%t)", k, pre, v.enabled))
 	}
+	sort.Strings(known)
 	fs.Var(f, flagName, ""+
 		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(known, "\n"))


### PR DESCRIPTION
Also... why are the feature flags defined _in_ pkg/util/config which has nothing to do with general Kube?  Flags should be defined statically in a subpackage of the kubelet (if they are kubelet feature flags) or in pkg/kubernetes/features or something somewhere else generic.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32181)

<!-- Reviewable:end -->
