### PR TITLE
always clean gce resources in service e2e

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1446,6 +1446,14 @@ func (gce *GCECloud) deleteForwardingRule(name, region string) error {
 	return nil
 }
 
+func (gce *GCECloud) DeleteForwardingRule(name string) error {
+	region, err := GetGCERegion(gce.localZone)
+	if err != nil {
+		return err
+	}
+	return gce.deleteForwardingRule(name, region)
+}
+
 // DeleteTargetPool deletes the given target pool.
 func (gce *GCECloud) DeleteTargetPool(name string, hc *compute.HttpHealthCheck) error {
 	region, err := GetGCERegion(gce.localZone)

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1446,6 +1446,15 @@ func (gce *GCECloud) deleteForwardingRule(name, region string) error {
 	return nil
 }
 
+// DeleteTargetPool deletes the given target pool.
+func (gce *GCECloud) DeleteTargetPool(name string, hc *compute.HttpHealthCheck) error {
+	region, err := GetGCERegion(gce.localZone)
+	if err != nil {
+		return err
+	}
+	return gce.deleteTargetPool(name, region, hc)
+}
+
 func (gce *GCECloud) deleteTargetPool(name, region string, hc *compute.HttpHealthCheck) error {
 	op, err := gce.service.TargetPools.Delete(gce.projectID, region, name).Do()
 	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4582,3 +4582,16 @@ func (p *E2ETestNodePreparer) CleanupNodes() error {
 	}
 	return encounteredError
 }
+
+func CleanupGCEResources(loadBalancerName string) (err error) {
+	gceCloud, ok := TestContext.CloudConfig.Provider.(*gcecloud.GCECloud)
+	if !ok {
+		return fmt.Errorf("failed to convert CloudConfig.Provider to GCECloud: %#v", TestContext.CloudConfig.Provider)
+	}
+	gceCloud.DeleteFirewall(loadBalancerName)
+	gceCloud.DeleteGlobalForwardingRule(loadBalancerName)
+	gceCloud.DeleteGlobalStaticIP(loadBalancerName)
+	hc, _ := gceCloud.GetHttpHealthCheck(loadBalancerName)
+	gceCloud.DeleteTargetPool(loadBalancerName, hc)
+	return nil
+}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4589,7 +4589,7 @@ func CleanupGCEResources(loadBalancerName string) (err error) {
 		return fmt.Errorf("failed to convert CloudConfig.Provider to GCECloud: %#v", TestContext.CloudConfig.Provider)
 	}
 	gceCloud.DeleteFirewall(loadBalancerName)
-	gceCloud.DeleteGlobalForwardingRule(loadBalancerName)
+	gceCloud.DeleteForwardingRule(loadBalancerName)
 	gceCloud.DeleteGlobalStaticIP(loadBalancerName)
 	hc, _ := gceCloud.GetHttpHealthCheck(loadBalancerName)
 	gceCloud.DeleteTargetPool(loadBalancerName, hc)


### PR DESCRIPTION
@bprashanth the previous PR was closed when I squashed my commits.
Here is the new change set, please help to review again.
1). only the following two It() create, I created a string array to persist the LB name so that they can be cleaned in AfterEach(), and the string array was reset after clean up.

```
"should be able to change the type and ports of a service [Slow]"
"should be able to create services of type LoadBalancer and externalTraffic=localOnly"
```

2). Directly call gce api to delete the resource and ignore any error returned.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32183)

<!-- Reviewable:end -->
