### PR TITLE
Add memory requests to apiserver, scheduler, cm, remove limits from r…

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -31,7 +31,8 @@
     "image": "gcr.io/google_containers/etcd:{{ pillar.get('etcd_docker_tag', '3.0.4') }}",
     "resources": {
       "requests": {
-        "cpu": {{ cpulimit }}
+        "cpu": {{ cpulimit }},
+        "memory": "300Mi"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -185,7 +185,8 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "250m"
+        "cpu": "250m",
+        "memory": "500Mi"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -106,7 +106,8 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "200m"
+        "cpu": "200m",
+        "memory": "375Mi"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -41,7 +41,8 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "100m"
+        "cpu": "100m",
+        "memory": "250Mi"
       }
     },
     "command": [


### PR DESCRIPTION
Current limits make rescheduler crashlooping on big clusters. The same thing might happen for cluster autoscaler. Adding requests for main master components to prevent it from being killed first by the OOM killer.

cc @mwielgus @piosz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32189)

<!-- Reviewable:end -->
