### PR TITLE
Make image-puller work on GCI nodes.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -943,6 +943,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${salt_dir}/kube-addons/kube-addon-manager.yaml" "${dst_dir}"
   cp "${salt_dir}/l7-gcp/glbc.manifest" "${dst_dir}"
   cp "${salt_dir}/rescheduler/rescheduler.manifest" "${dst_dir}/"
+  cp "${salt_dir}/e2e-image-puller/e2e-image-puller.manifest" "${dst_dir}/"
   cp "${KUBE_ROOT}/cluster/gce/trusty/configure-helper.sh" "${dst_dir}/trusty-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -37,9 +37,6 @@ PREEMPTIBLE_MASTER=${PREEMPTIBLE_MASTER:-false}
 
 MASTER_OS_DISTRIBUTION=${KUBE_MASTER_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
-# By default a cluster will be started with the master on GCI and nodes on
-# containervm. If you are updating the containervm version, update this
-# variable.
 CVM_VERSION=container-v1-3-v20160604
 GCI_VERSION="gci-dev-54-8743-3-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -38,9 +38,6 @@ PREEMPTIBLE_MASTER=${PREEMPTIBLE_MASTER:-false}
 
 MASTER_OS_DISTRIBUTION=${KUBE_MASTER_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
-# By default a cluster will be started with the master on GCI and nodes on
-# containervm. If you are updating the containervm version, update this
-# variable.
 CVM_VERSION=container-v1-3-v20160604
 GCI_VERSION="gci-dev-54-8743-3-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1080,10 +1080,23 @@ function start-fluentd {
   fi
 }
 
+# Starts an image-puller - used in test clusters.
+function start-image-puller {
+  echo "Start image-puller"
+  cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/e2e-image-puller.manifest" \
+    /etc/kubernetes/manifests/
+}
+
+# Starts kube-registry proxy
+function start-kube-registry-proxy {
+  echo "Start kube-registry-proxy"
+  cp "${KUBE_HOME}/kube-manifests/kubernetes/kube-registry-proxy.yaml" /etc/kubernetes/manifests
+}
+
 # Starts a l7 loadbalancing controller for ingress.
 function start-lb-controller {
   if [[ "${ENABLE_L7_LOADBALANCING:-}" == "glbc" ]]; then
-    echo "Starting GCE L7 pod"
+    echo "Start GCE L7 pod"
     prepare-log-file /var/log/glbc.log
     setup-addon-manifests "addons" "cluster-loadbalancing/glbc"
     cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/glbc.manifest" \
@@ -1094,7 +1107,7 @@ function start-lb-controller {
 # Starts rescheduler.
 function start-rescheduler {
   if [[ "${ENABLE_RESCHEDULER:-}" == "true" ]]; then
-    echo "Starting Rescheduler"
+    echo "Start Rescheduler"
     prepare-log-file /var/log/rescheduler.log
     cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/rescheduler.manifest" \
        /etc/kubernetes/manifests/
@@ -1188,8 +1201,11 @@ else
   start-kube-proxy
   # Kube-registry-proxy.
   if [[ "${ENABLE_CLUSTER_REGISTRY:-}" == "true" ]]; then
-    cp "${KUBE_HOME}/kube-manifests/kubernetes/kube-registry-proxy.yaml" /etc/kubernetes/manifests
-	fi
+    start-kube-registry-proxy
+  fi
+  if [[ "${PREPULL_E2E_IMAGES:-}" == "true" ]]; then
+    start-image-puller
+  fi
 fi
 start-fluentd
 reset-motd


### PR DESCRIPTION
Currently image-puller works only on debian nodes. This will make our test more flaky after we switch to the GCI by default. This PR ports the image-puller to the GCI-based Nodes.

cc @vishh @wonderfly @dchen1107

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32197)

<!-- Reviewable:end -->
