### PR TITLE
add logging for enabled/disabled API Groups

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -51,7 +51,7 @@ The name of a StorageClass object is significant, and is how users can request a
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs
@@ -71,7 +71,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd
@@ -86,7 +86,7 @@ parameters:
 #### GLUSTERFS
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: slow
@@ -109,7 +109,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: gold
 provisioner: kubernetes.io/cinder

--- a/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
+++ b/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs

--- a/examples/experimental/persistent-volume-provisioning/gce-pd.yaml
+++ b/examples/experimental/persistent-volume-provisioning/gce-pd.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: slow

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -297,13 +297,16 @@ func (m *Master) InstallAPIs(c *Config) {
 	// TODO find a better way to configure priority of groups
 	for _, group := range sets.StringKeySet(c.RESTStorageProviders).List() {
 		if !c.APIResourceConfigSource.AnyResourcesForGroupEnabled(group) {
+			glog.V(1).Infof("Skipping disabled API group %q.", group)
 			continue
 		}
 		restStorageBuilder := c.RESTStorageProviders[group]
 		apiGroupInfo, enabled := restStorageBuilder.NewRESTStorage(c.APIResourceConfigSource, restOptionsGetter)
 		if !enabled {
+			glog.Warningf("Problem initializing API group %q, skipping.", group)
 			continue
 		}
+		glog.V(1).Infof("Enabling API group %q.", group)
 
 		// This is here so that, if the policy group is present, the eviction
 		// subresource handler wil be able to find poddisruptionbudgets


### PR DESCRIPTION
Adds logging to the apiserver to indicate which API groups are enabled and disabled as go through.  This will make it easier to identify what's gone wrong in cases where the API server is down during diagnoses and the config is inaccessible, like in GKE tests.  For example https://github.com/kubernetes/kubernetes/issues/32185#issuecomment-245255700 .

@wojtek-t This may have made the problem more obvious.

``` release-note
Add logging for enabled/disabled API Groups
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32198)

<!-- Reviewable:end -->
