### PR TITLE
re-enable provisioning test

### DIFF
--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -115,8 +115,6 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 	framework.KubeDescribe("DynamicProvisioner", func() {
 		It("should create and delete persistent volumes [Slow]", func() {
-			// added until the GKE startup includes storage.k8s.io/v1beta1
-			framework.SkipIfProviderIs("gke")
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke")
 
 			By("creating a StorageClass")


### PR DESCRIPTION
Reverts https://github.com/kubernetes/kubernetes/pull/32199 for when the gke control plane is updated.  This should be merged AFTER gke is ready.

@kubernetes/sig-storage @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32200)

<!-- Reviewable:end -->
