### PR TITLE
Allow users of logs packages to avoid flag leakage

### DIFF
--- a/pkg/util/logs/logs.go
+++ b/pkg/util/logs/logs.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
+const DefaultLogFlushFreq = 5 * time.Second
 
 // TODO(thockin): This is temporary until we agree on log dirs and put those into each cmd.
 func init() {
@@ -44,10 +44,20 @@ func (writer GlogWriter) Write(data []byte) (n int, err error) {
 
 // InitLogs initializes logs the way we want for kubernetes.
 func InitLogs() {
+	logFlushFreq := pflag.Duration("log-flush-frequency", DefaultLogFlushFreq, "Maximum number of seconds between log flushes")
 	log.SetOutput(GlogWriter{})
 	log.SetFlags(0)
 	// The default glog flush interval is 30 seconds, which is frighteningly long.
 	go wait.Until(glog.Flush, *logFlushFreq, wait.NeverStop)
+}
+
+// InitLogsWithFlushFrequency initializes logs the way we want for kubernetes,
+// without adding a global flag.
+func InitLogsWithFlushFrequency(logFlushFreq time.Duration) {
+	log.SetOutput(GlogWriter{})
+	log.SetFlags(0)
+	// The default glog flush interval is 30 seconds, which is frighteningly long.
+	go wait.Until(glog.Flush, logFlushFreq, wait.NeverStop)
 }
 
 // FlushLogs flushes logs immediately.


### PR DESCRIPTION
**What this PR does / why we need it**:

Including log package currently results in `--log-flush-frequency` flag being added to your program, and it's often undesired, e.g. in `kubeadm`. 

**Which issue this PR fixes**: fixes #21148 (or at least in part)

**Special notes for your reviewer**: This had been attempted in #20713, but didn't make it... My PR simply introduces a new initialiser function, without changes to existing call sites.

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32208)

<!-- Reviewable:end -->
