### PR TITLE
Move CSR helper for nodes out of kubelet

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -104,6 +104,7 @@ pkg/kubelet/container
 pkg/kubelet/envvars
 pkg/kubelet/eviction
 pkg/kubelet/sysctls
+pkg/kubelet/util/csr
 pkg/kubelet/util/format
 pkg/kubelet/util/ioutils
 pkg/kubelet/volume

--- a/pkg/kubelet/util/csr/csr.go
+++ b/pkg/kubelet/util/csr/csr.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csr
+
+import (
+	"crypto/x509/pkix"
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/certificates"
+	unversionedcertificates "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	utilcertificates "k8s.io/kubernetes/pkg/util/certificates"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// RequestNodeCertificate will create a certificate signing request and send it to API server,
+// then it will watch the object's status, once approved by API server, it will return the API
+// server's issued certificate (pem-encoded). If there is any errors, or the watch timeouts,
+// it will return an error. This is intended for use on nodes (kubelet and kubeadm).
+func RequestNodeCertificate(client unversionedcertificates.CertificateSigningRequestInterface, privateKeyData []byte, nodeName string) (certData []byte, err error) {
+	subject := &pkix.Name{
+		Organization: []string{"system:nodes"},
+		CommonName:   fmt.Sprintf("system:node:%s", nodeName),
+	}
+
+	privateKey, err := utilcertificates.ParsePrivateKey(privateKeyData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
+	}
+	csr, err := utilcertificates.NewCertificateRequest(privateKey, subject, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
+	}
+
+	req, err := client.Create(&certificates.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta:   unversioned.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: api.ObjectMeta{GenerateName: "csr-"},
+
+		// TODO: For now, this is a request for a certificate with allowed usage of "TLS Web Client Authentication".
+		// Need to figure out whether/how to surface the allowed usage in the spec.
+		Spec: certificates.CertificateSigningRequestSpec{Request: csr},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create certificate signing request: %v", err)
+
+	}
+
+	// Make a default timeout = 3600s.
+	var defaultTimeoutSeconds int64 = 3600
+	resultCh, err := client.Watch(api.ListOptions{
+		Watch:          true,
+		TimeoutSeconds: &defaultTimeoutSeconds,
+		FieldSelector:  fields.OneTermEqualSelector("metadata.name", req.Name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot watch on the certificate signing request: %v", err)
+	}
+
+	var status certificates.CertificateSigningRequestStatus
+	ch := resultCh.ResultChan()
+
+	for {
+		event, ok := <-ch
+		if !ok {
+			break
+		}
+
+		if event.Type == watch.Modified || event.Type == watch.Added {
+			if event.Object.(*certificates.CertificateSigningRequest).UID != req.UID {
+				continue
+			}
+			status = event.Object.(*certificates.CertificateSigningRequest).Status
+			for _, c := range status.Conditions {
+				if c.Type == certificates.CertificateDenied {
+					return nil, fmt.Errorf("certificate signing request is not approved, reason: %v, message: %v", c.Reason, c.Message)
+				}
+				if c.Type == certificates.CertificateApproved && status.Certificate != nil {
+					return status.Certificate, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("watch channel closed")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Including `cmd/kubelet/app` in kubeadm causes flag leakage.

Namelly, the problem is with `pkg/credentialprovider/gcp`, which
leaks `--google-json-key` and changing the behaviour of `init()`
doesn't sound reasonable, given kubelet is the only one who uses
this packages and obviously the flag is part of the functionality.

The helper is already generic enough, it has already been exported
and works well for kubeadm, so moving it should be fine.

**Special notes for your reviewer**: cc @mikedanese @yifan-gu @gtank

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32209)

<!-- Reviewable:end -->
