### PR TITLE
Disallow users from updating selector or template labels in kubectl apply

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1541,8 +1541,6 @@ func readReplicationControllerFromString(contents string) *api.ReplicationContro
 func modifyReplicationControllerConfiguration(contents string) io.Reader {
 	rc := readReplicationControllerFromString(contents)
 	rc.Labels[applyTestLabel] = "ADDED"
-	rc.Spec.Selector[applyTestLabel] = "ADDED"
-	rc.Spec.Template.Labels[applyTestLabel] = "ADDED"
 	data, err := json.Marshal(rc)
 	if err != nil {
 		framework.Failf("json marshal failed: %s\n", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Ref https://github.com/kubernetes/kubernetes/issues/26202#issuecomment-245114043 -- updating selectors / pod template labels is as dangerous as updating name, and should be disallowed. In this PR we only disallow this in `kubectl apply`, and we should do more in the future PRs. 

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

@kubernetes/kubectl @kubernetes/sig-apps @mwielgus @pwittrock @bgrant0607 @ghodss @AdoHe @lavalamp @erictune 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32228)

<!-- Reviewable:end -->
