### PR TITLE
update `kubectl expose` output to UsageError

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -147,7 +147,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		Do()
 	err = r.Err()
 	if err != nil {
-		return err
+		return cmdutil.UsageError(cmd, err.Error())
 	}
 
 	// Get the generator, setup and validate all required parameters


### PR DESCRIPTION
**Release note**:

``` release-note
NONE
```

This patch updates `kubectl expose` output (with no resources provided)
to a UsageError so that the `kubectl expose -h` suggestion is displayed.
##### Before

`$ kubectl expose`

```
error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   'pods my-pod'
   'services'
```
##### After

```
error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   'pods my-pod'
   'services'
See 'kubectl expose -h' for help and examples.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32230)

<!-- Reviewable:end -->
