### PR TITLE
Default HTTP2 on, post fixes from #29001

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -251,6 +251,9 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 			secureServer.TLSConfig.ClientAuth = tls.RequestClientCert
 			// Specify allowed CAs for client certificates
 			secureServer.TLSConfig.ClientCAs = clientCAs
+			// "h2" NextProtos is necessary for enabling HTTP2 for go's 1.7 HTTP Server
+			secureServer.TLSConfig.NextProtos = []string{"h2"}
+
 		}
 
 		glog.Infof("Serving securely on %s", secureLocation)

--- a/pkg/util/net/http.go
+++ b/pkg/util/net/http.go
@@ -77,8 +77,10 @@ func SetOldTransportDefaults(t *http.Transport) *http.Transport {
 // for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
 func SetTransportDefaults(t *http.Transport) *http.Transport {
 	t = SetOldTransportDefaults(t)
-	// Allow HTTP2 clients but default off for now
-	if s := os.Getenv("ENABLE_HTTP2"); len(s) > 0 {
+	// Allow clients to disable http2 if needed.
+	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
+		glog.Infof("HTTP2 has been explicitly disabled")
+	} else {
 		if err := http2.ConfigureTransport(t); err != nil {
 			glog.Warningf("Transport failed http2 configuration: %v", err)
 		}


### PR DESCRIPTION
This reverts commit 8cb799c7897c029863cd9051b8e033991d29fe88.

Enables HTTP2 on by default post fixes from https://github.com/kubernetes/kubernetes/issues/29001 for 1.5 

NOTE:  We are nearing lb connection limits at current thresholds. 

/cc @bradfitz @lavalamp @smarterclayton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32231)

<!-- Reviewable:end -->
