### PR TITLE
LRUExpireCache#Get requires write lock

### DIFF
--- a/pkg/util/cache/lruexpirecache.go
+++ b/pkg/util/cache/lruexpirecache.go
@@ -25,7 +25,7 @@ import (
 
 type LRUExpireCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
+	lock  sync.Mutex
 }
 
 func NewLRUExpireCache(maxSize int) *LRUExpireCache {
@@ -46,8 +46,8 @@ func (c *LRUExpireCache) Add(key lru.Key, value interface{}, ttl time.Duration) 
 }
 
 func (c *LRUExpireCache) Get(key lru.Key) (interface{}, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	e, ok := c.cache.Get(key)
 	if !ok {
 		return nil, false


### PR DESCRIPTION
**What this PR does / why we need it**:

[LRUExpireCache#Get](https://github.com/kubernetes/kubernetes/blob/dbfad789e35979083b8d4b35a4cb405c324cc485/pkg/util/cache/lruexpirecache.go#L48) requires write lock since [groupcache/lru#Get](https://github.com/golang/groupcache/blob/a6b377e3400b08991b80d6805d627f347f983866/lru/lru.go#L74) needs to manipulate its list to track recently used item. Currently it uses read lock so it may introduce race condition.
- [test code which introduces race condition with current LRUExpireCache#Get](https://gist.github.com/tksm/17c7a610ed0574c165e6f6edeca351b7#file-lru_race_test-go)

**Which issue this PR fixes** #31081

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32244)

<!-- Reviewable:end -->
