### PR TITLE
Update federation controllers to use release 1.5 clientset

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -26,7 +26,7 @@ import (
 	"net/http/pprof"
 	"strconv"
 
-	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	clustercontroller "k8s.io/kubernetes/federation/pkg/federation-controller/cluster"

--- a/federation/pkg/federation-controller/cluster/clustercontroller.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	cluster_cache "k8s.io/kubernetes/federation/client/cache"
-	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/controller"

--- a/federation/pkg/federation-controller/cluster/clustercontroller_test.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	controller_util "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"

--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	federation_api "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fake_federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fake_fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	. "k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	extensions_v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
-	fake_kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	fake_kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +45,7 @@ func TestIngressController(t *testing.T) {
 	cfg2 := NewConfigMap("bar") // Different UID from cfg1, so that we can check that they get reconciled.
 
 	t.Log("Creating fake infrastructure")
-	fedClient := &fake_federation_release_1_4.Clientset{}
+	fedClient := &fake_fedclientset.Clientset{}
 	RegisterFakeList("clusters", &fedClient.Fake, &fakeClusterList)
 	RegisterFakeList("ingresses", &fedClient.Fake, &extensions_v1beta1.IngressList{Items: []extensions_v1beta1.Ingress{}})
 	fedIngressWatch := RegisterFakeWatch("ingresses", &fedClient.Fake)
@@ -53,7 +53,7 @@ func TestIngressController(t *testing.T) {
 	fedClusterUpdateChan := RegisterFakeCopyOnUpdate("clusters", &fedClient.Fake, clusterWatch)
 	fedIngressUpdateChan := RegisterFakeCopyOnUpdate("ingresses", &fedClient.Fake, fedIngressWatch)
 
-	cluster1Client := &fake_kube_release_1_4.Clientset{}
+	cluster1Client := &fake_kubeclientset.Clientset{}
 	RegisterFakeList("ingresses", &cluster1Client.Fake, &extensions_v1beta1.IngressList{Items: []extensions_v1beta1.Ingress{}})
 	RegisterFakeList("configmaps", &cluster1Client.Fake, &fakeConfigMapList1)
 	cluster1IngressWatch := RegisterFakeWatch("ingresses", &cluster1Client.Fake)
@@ -61,7 +61,7 @@ func TestIngressController(t *testing.T) {
 	cluster1IngressCreateChan := RegisterFakeCopyOnCreate("ingresses", &cluster1Client.Fake, cluster1IngressWatch)
 	cluster1IngressUpdateChan := RegisterFakeCopyOnUpdate("ingresses", &cluster1Client.Fake, cluster1IngressWatch)
 
-	cluster2Client := &fake_kube_release_1_4.Clientset{}
+	cluster2Client := &fake_kubeclientset.Clientset{}
 	RegisterFakeList("ingresses", &cluster2Client.Fake, &extensions_v1beta1.IngressList{Items: []extensions_v1beta1.Ingress{}})
 	RegisterFakeList("configmaps", &cluster2Client.Fake, &fakeConfigMapList2)
 	cluster2IngressWatch := RegisterFakeWatch("ingresses", &cluster2Client.Fake)
@@ -69,7 +69,7 @@ func TestIngressController(t *testing.T) {
 	cluster2IngressCreateChan := RegisterFakeCopyOnCreate("ingresses", &cluster2Client.Fake, cluster2IngressWatch)
 	cluster2ConfigMapUpdateChan := RegisterFakeCopyOnUpdate("configmaps", &cluster2Client.Fake, cluster2ConfigMapWatch)
 
-	clientFactoryFunc := func(cluster *federation_api.Cluster) (kube_release_1_4.Interface, error) {
+	clientFactoryFunc := func(cluster *federation_api.Cluster) (kubeclientset.Interface, error) {
 		switch cluster.Name {
 		case cluster1.Name:
 			return cluster1Client, nil

--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -22,14 +22,14 @@ import (
 	"time"
 
 	federation_api "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/eventsink"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/cache"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/controller"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
@@ -64,7 +64,7 @@ type NamespaceController struct {
 	namespaceInformerController cache.ControllerInterface
 
 	// Client to federated api server.
-	federatedApiClient federation_release_1_4.Interface
+	federatedApiClient federationclientset.Interface
 
 	// Backoff manager for namespaces
 	namespaceBackoff *flowcontrol.Backoff
@@ -79,7 +79,7 @@ type NamespaceController struct {
 }
 
 // NewNamespaceController returns a new namespace controller
-func NewNamespaceController(client federation_release_1_4.Interface) *NamespaceController {
+func NewNamespaceController(client federationclientset.Interface) *NamespaceController {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(eventsink.NewFederatedEventSink(client))
 	recorder := broadcaster.NewRecorder(api.EventSource{Component: "federated-namespace-controller"})
@@ -115,7 +115,7 @@ func NewNamespaceController(client federation_release_1_4.Interface) *NamespaceC
 	// Federated informer on namespaces in members of federation.
 	nc.namespaceFederatedInformer = util.NewFederatedInformer(
 		client,
-		func(cluster *federation_api.Cluster, targetClient kube_release_1_4.Interface) (cache.Store, cache.ControllerInterface) {
+		func(cluster *federation_api.Cluster, targetClient kubeclientset.Interface) (cache.Store, cache.ControllerInterface) {
 			return cache.NewInformer(
 				&cache.ListWatch{
 					ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
@@ -144,17 +144,17 @@ func NewNamespaceController(client federation_release_1_4.Interface) *NamespaceC
 
 	// Federated updeater along with Create/Update/Delete operations.
 	nc.federatedUpdater = util.NewFederatedUpdater(nc.namespaceFederatedInformer,
-		func(client kube_release_1_4.Interface, obj pkg_runtime.Object) error {
+		func(client kubeclientset.Interface, obj pkg_runtime.Object) error {
 			namespace := obj.(*api_v1.Namespace)
 			_, err := client.Core().Namespaces().Create(namespace)
 			return err
 		},
-		func(client kube_release_1_4.Interface, obj pkg_runtime.Object) error {
+		func(client kubeclientset.Interface, obj pkg_runtime.Object) error {
 			namespace := obj.(*api_v1.Namespace)
 			_, err := client.Core().Namespaces().Update(namespace)
 			return err
 		},
-		func(client kube_release_1_4.Interface, obj pkg_runtime.Object) error {
+		func(client kubeclientset.Interface, obj pkg_runtime.Object) error {
 			namespace := obj.(*api_v1.Namespace)
 			err := client.Core().Namespaces().Delete(namespace.Name, &api.DeleteOptions{})
 			return err

--- a/federation/pkg/federation-controller/namespace/namespace_controller_test.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller_test.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	federation_api "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fake_federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fake_fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	. "k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
-	fake_kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	fake_kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/runtime"
 
@@ -45,19 +45,19 @@ func TestNamespaceController(t *testing.T) {
 		},
 	}
 
-	fakeClient := &fake_federation_release_1_4.Clientset{}
+	fakeClient := &fake_fedclientset.Clientset{}
 	RegisterFakeList("clusters", &fakeClient.Fake, &federation_api.ClusterList{Items: []federation_api.Cluster{*cluster1}})
 	RegisterFakeList("namespaces", &fakeClient.Fake, &api_v1.NamespaceList{Items: []api_v1.Namespace{}})
 	namespaceWatch := RegisterFakeWatch("namespaces", &fakeClient.Fake)
 	clusterWatch := RegisterFakeWatch("clusters", &fakeClient.Fake)
 
-	cluster1Client := &fake_kube_release_1_4.Clientset{}
+	cluster1Client := &fake_kubeclientset.Clientset{}
 	cluster1Watch := RegisterFakeWatch("namespaces", &cluster1Client.Fake)
 	RegisterFakeList("namespaces", &cluster1Client.Fake, &api_v1.NamespaceList{Items: []api_v1.Namespace{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("namespaces", &cluster1Client.Fake, cluster1Watch)
 	cluster1UpdateChan := RegisterFakeCopyOnUpdate("namespaces", &cluster1Client.Fake, cluster1Watch)
 
-	cluster2Client := &fake_kube_release_1_4.Clientset{}
+	cluster2Client := &fake_kubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("namespaces", &cluster2Client.Fake)
 	RegisterFakeList("namespaces", &cluster2Client.Fake, &api_v1.NamespaceList{Items: []api_v1.Namespace{}})
 	cluster2CreateChan := RegisterFakeCopyOnCreate("namespaces", &cluster2Client.Fake, cluster2Watch)
@@ -87,7 +87,7 @@ func TestNamespaceController(t *testing.T) {
 
 	namespaceController := NewNamespaceController(fakeClient)
 	informer := ToFederatedInformerForTestOnly(namespaceController.namespaceFederatedInformer)
-	informer.SetClientFactory(func(cluster *federation_api.Cluster) (kube_release_1_4.Interface, error) {
+	informer.SetClientFactory(func(cluster *federation_api.Cluster) (kubeclientset.Interface, error) {
 		switch cluster.Name {
 		case cluster1.Name:
 			return cluster1Client, nil

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -28,7 +28,7 @@ import (
 
 	fed "k8s.io/kubernetes/federation/apis/federation"
 	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	planner "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset/planner"
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/eventsink"
@@ -36,7 +36,7 @@ import (
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/cache"
-	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/runtime"

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller_test.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller_test.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fedclientfake "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fedclientfake "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	"k8s.io/kubernetes/pkg/api/meta"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
-	kubeclientfake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	kubeclientfake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -97,7 +97,7 @@ func TestReplicaSetController(t *testing.T) {
 	kube2Podwatch := watch.NewFake()
 	kube2clientset.PrependWatchReactor("pods", core.DefaultWatchReactor(kube2Podwatch, nil))
 
-	fedInformerClientFactory := func(cluster *fedv1.Cluster) (kube_release_1_4.Interface, error) {
+	fedInformerClientFactory := func(cluster *fedv1.Cluster) (kubeclientset.Interface, error) {
 		switch cluster.Name {
 		case "k8s-1":
 			return kube1clientset, nil

--- a/federation/pkg/federation-controller/secret/secret_controller_test.go
+++ b/federation/pkg/federation-controller/secret/secret_controller_test.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	federation_api "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fake_federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fake_fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	. "k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
-	fake_kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	fake_kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
@@ -37,26 +37,26 @@ func TestSecretController(t *testing.T) {
 	cluster1 := NewCluster("cluster1", api_v1.ConditionTrue)
 	cluster2 := NewCluster("cluster2", api_v1.ConditionTrue)
 
-	fakeClient := &fake_federation_release_1_4.Clientset{}
+	fakeClient := &fake_fedclientset.Clientset{}
 	RegisterFakeList("clusters", &fakeClient.Fake, &federation_api.ClusterList{Items: []federation_api.Cluster{*cluster1}})
 	RegisterFakeList("secrets", &fakeClient.Fake, &api_v1.SecretList{Items: []api_v1.Secret{}})
 	secretWatch := RegisterFakeWatch("secrets", &fakeClient.Fake)
 	clusterWatch := RegisterFakeWatch("clusters", &fakeClient.Fake)
 
-	cluster1Client := &fake_kube_release_1_4.Clientset{}
+	cluster1Client := &fake_kubeclientset.Clientset{}
 	cluster1Watch := RegisterFakeWatch("secrets", &cluster1Client.Fake)
 	RegisterFakeList("secrets", &cluster1Client.Fake, &api_v1.SecretList{Items: []api_v1.Secret{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("secrets", &cluster1Client.Fake, cluster1Watch)
 	cluster1UpdateChan := RegisterFakeCopyOnUpdate("secrets", &cluster1Client.Fake, cluster1Watch)
 
-	cluster2Client := &fake_kube_release_1_4.Clientset{}
+	cluster2Client := &fake_kubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("secrets", &cluster2Client.Fake)
 	RegisterFakeList("secrets", &cluster2Client.Fake, &api_v1.SecretList{Items: []api_v1.Secret{}})
 	cluster2CreateChan := RegisterFakeCopyOnCreate("secrets", &cluster2Client.Fake, cluster2Watch)
 
 	secretController := NewSecretController(fakeClient)
 	informer := ToFederatedInformerForTestOnly(secretController.secretFederatedInformer)
-	informer.SetClientFactory(func(cluster *federation_api.Cluster) (kube_release_1_4.Interface, error) {
+	informer.SetClientFactory(func(cluster *federation_api.Cluster) (kubeclientset.Interface, error) {
 		switch cluster.Name {
 		case cluster1.Name:
 			return cluster1Client, nil

--- a/federation/pkg/federation-controller/service/cluster_helper.go
+++ b/federation/pkg/federation-controller/service/cluster_helper.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	cache "k8s.io/kubernetes/pkg/client/cache"
-	release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -37,7 +37,7 @@ import (
 )
 
 type clusterCache struct {
-	clientset *release_1_4.Clientset
+	clientset *kubeclientset.Clientset
 	cluster   *v1beta1.Cluster
 	// A store of services, populated by the serviceController
 	serviceStore cache.StoreToServiceLister
@@ -196,10 +196,10 @@ func (cc *clusterClientCache) addToClientMap(obj interface{}) {
 	}
 }
 
-func newClusterClientset(c *v1beta1.Cluster) (*release_1_4.Clientset, error) {
+func newClusterClientset(c *v1beta1.Cluster) (*kubeclientset.Clientset, error) {
 	clusterConfig, err := util.BuildClusterConfig(c)
 	if clusterConfig != nil {
-		clientset := release_1_4.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, UserAgentName))
+		clientset := kubeclientset.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, UserAgentName))
 		return clientset, nil
 	}
 	return nil, err

--- a/federation/pkg/federation-controller/service/endpoint_helper.go
+++ b/federation/pkg/federation-controller/service/endpoint_helper.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	cache "k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/controller"
@@ -75,7 +75,7 @@ ForLoop:
 
 // Whenever there is change on endpoint, the federation service should be updated
 // key is the namespaced name of endpoint
-func (cc *clusterClientCache) syncEndpoint(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient federation_release_1_4.Interface, serviceController *ServiceController) error {
+func (cc *clusterClientCache) syncEndpoint(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient fedclientset.Interface, serviceController *ServiceController) error {
 	cachedService, ok := serviceCache.get(key)
 	if !ok {
 		// here we filtered all non-federation services

--- a/federation/pkg/federation-controller/service/service_helper.go
+++ b/federation/pkg/federation-controller/service/service_helper.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/pkg/api/errors"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	cache "k8s.io/kubernetes/pkg/client/cache"
@@ -77,7 +77,7 @@ ForLoop:
 }
 
 // Whenever there is change on service, the federation service should be updated
-func (cc *clusterClientCache) syncService(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient federation_release_1_4.Interface, sc *ServiceController) error {
+func (cc *clusterClientCache) syncService(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient fedclientset.Interface, sc *ServiceController) error {
 	// obj holds the latest service info from apiserver, return if there is no federation cache for the service
 	cachedService, ok := serviceCache.get(key)
 	if !ok {
@@ -257,7 +257,7 @@ func (cc *clusterClientCache) processServiceUpdate(cachedService *cachedService,
 	return needUpdate
 }
 
-func (cc *clusterClientCache) persistFedServiceUpdate(cachedService *cachedService, fedClient federation_release_1_4.Interface) error {
+func (cc *clusterClientCache) persistFedServiceUpdate(cachedService *cachedService, fedClient fedclientset.Interface) error {
 	service := cachedService.lastState
 	glog.V(5).Infof("Persist federation service status %s/%s", service.Namespace, service.Name)
 	var err error

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -26,13 +26,13 @@ import (
 	"github.com/golang/glog"
 	v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	federationcache "k8s.io/kubernetes/federation/client/cache"
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	cache "k8s.io/kubernetes/pkg/client/cache"
-	release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/controller"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
@@ -100,7 +100,7 @@ type serviceCache struct {
 
 type ServiceController struct {
 	dns              dnsprovider.Interface
-	federationClient federation_release_1_4.Interface
+	federationClient fedclientset.Interface
 	federationName   string
 	zoneName         string
 	// each federation should be configured with a single zone (e.g. "mycompany.com")
@@ -135,7 +135,7 @@ type ServiceController struct {
 // New returns a new service controller to keep DNS provider service resources
 // (like Kubernetes Services and DNS server records for service discovery) in sync with the registry.
 
-func New(federationClient federation_release_1_4.Interface, dns dnsprovider.Interface, federationName, zoneName string) *ServiceController {
+func New(federationClient fedclientset.Interface, dns dnsprovider.Interface, federationName, zoneName string) *ServiceController {
 	broadcaster := record.NewBroadcaster()
 	// federationClient event is not supported yet
 	// broadcaster.StartRecordingToSink(&unversioned_core.EventSinkImpl{Interface: kubeClient.Core().Events("")})
@@ -322,7 +322,7 @@ func wantsDNSRecords(service *v1.Service) bool {
 // processServiceForCluster creates or updates service to all registered running clusters,
 // update DNS records and update the service info with DNS entries to federation apiserver.
 // the function returns any error caught
-func (s *ServiceController) processServiceForCluster(cachedService *cachedService, clusterName string, service *v1.Service, client *release_1_4.Clientset) error {
+func (s *ServiceController) processServiceForCluster(cachedService *cachedService, clusterName string, service *v1.Service, client *kubeclientset.Clientset) error {
 	glog.V(4).Infof("Process service %s/%s for cluster %s", service.Namespace, service.Name, clusterName)
 	// Create or Update k8s Service
 	err := s.ensureClusterService(cachedService, clusterName, service, client)
@@ -382,7 +382,7 @@ func (s *ServiceController) deleteFederationService(cachedService *cachedService
 	return nil, !retryable
 }
 
-func (s *ServiceController) deleteClusterService(clusterName string, cachedService *cachedService, clientset *release_1_4.Clientset) error {
+func (s *ServiceController) deleteClusterService(clusterName string, cachedService *cachedService, clientset *kubeclientset.Clientset) error {
 	service := cachedService.lastState
 	glog.V(4).Infof("Deleting service %s/%s from cluster %s", service.Namespace, service.Name, clusterName)
 	var err error
@@ -399,7 +399,7 @@ func (s *ServiceController) deleteClusterService(clusterName string, cachedServi
 	return err
 }
 
-func (s *ServiceController) ensureClusterService(cachedService *cachedService, clusterName string, service *v1.Service, client *release_1_4.Clientset) error {
+func (s *ServiceController) ensureClusterService(cachedService *cachedService, clusterName string, service *v1.Service, client *kubeclientset.Clientset) error {
 	var err error
 	var needUpdate bool
 	for i := 0; i < clientRetryCount; i++ {

--- a/federation/pkg/federation-controller/util/cluster_util.go
+++ b/federation/pkg/federation-controller/util/cluster_util.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -133,10 +133,10 @@ var KubeconfigGetterForSecret = func(secretName string) clientcmd.KubeconfigGett
 }
 
 // Retruns Clientset for the given cluster.
-func GetClientsetForCluster(cluster *federation_v1beta1.Cluster) (*federation_release_1_4.Clientset, error) {
+func GetClientsetForCluster(cluster *federation_v1beta1.Cluster) (*fedclientset.Clientset, error) {
 	clusterConfig, err := BuildClusterConfig(cluster)
 	if err != nil && clusterConfig != nil {
-		clientset := federation_release_1_4.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, userAgentName))
+		clientset := fedclientset.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, userAgentName))
 		return clientset, nil
 	}
 	return nil, err

--- a/federation/pkg/federation-controller/util/eventsink/eventsink.go
+++ b/federation/pkg/federation-controller/util/eventsink/eventsink.go
@@ -17,7 +17,7 @@ limitations under the License.
 package eventsink
 
 import (
-	federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	api "k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/record"
@@ -25,13 +25,13 @@ import (
 
 // Implemnts k8s.io/kubernetes/pkg/client/record.EventSink.
 type FederatedEventSink struct {
-	clientset federation_release_1_4.Interface
+	clientset fedclientset.Interface
 }
 
 // To check if all required functions are implemented.
 var _ record.EventSink = &FederatedEventSink{}
 
-func NewFederatedEventSink(clientset federation_release_1_4.Interface) *FederatedEventSink {
+func NewFederatedEventSink(clientset fedclientset.Interface) *FederatedEventSink {
 	return &FederatedEventSink{
 		clientset: clientset,
 	}

--- a/federation/pkg/federation-controller/util/eventsink/eventsink_test.go
+++ b/federation/pkg/federation-controller/util/eventsink/eventsink_test.go
@@ -19,7 +19,7 @@ package eventsink
 import (
 	"testing"
 
-	fake_federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fake_fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	. "k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	api "k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventSink(t *testing.T) {
-	fakeFederationClient := &fake_federation_release_1_4.Clientset{}
+	fakeFederationClient := &fake_fedclientset.Clientset{}
 	createdChan := make(chan runtime.Object, 100)
 	fakeFederationClient.AddReactor("create", "events", func(action core.Action) (bool, runtime.Object, error) {
 		createAction := action.(core.CreateAction)

--- a/federation/pkg/federation-controller/util/federated_informer_test.go
+++ b/federation/pkg/federation-controller/util/federated_informer_test.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	federation_api "k8s.io/kubernetes/federation/apis/federation/v1beta1"
-	fake_federation_release_1_4 "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_4/fake"
+	fakefederationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	api "k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/cache"
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
-	fake_kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4/fake"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	fake_kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
@@ -37,7 +37,7 @@ import (
 // Basic test for Federated Informer. Checks whether the subinformer are added and deleted
 // when the corresponding cluster entries appear and disappear from etcd.
 func TestFederatedInformer(t *testing.T) {
-	fakeFederationClient := &fake_federation_release_1_4.Clientset{}
+	fakeFederationClient := &fakefederationclientset.Clientset{}
 
 	// Add a single cluster to federation and remove it when needed.
 	cluster := federation_api.Cluster{
@@ -63,7 +63,7 @@ func TestFederatedInformer(t *testing.T) {
 		return true, fakeWatch, nil
 	})
 
-	fakeKubeClient := &fake_kube_release_1_4.Clientset{}
+	fakeKubeClient := &fake_kubeclientset.Clientset{}
 	// There is a single service ns1/s1 in cluster mycluster.
 	service := api_v1.Service{
 		ObjectMeta: api_v1.ObjectMeta{
@@ -78,7 +78,7 @@ func TestFederatedInformer(t *testing.T) {
 		return true, watch.NewFake(), nil
 	})
 
-	targetInformerFactory := func(cluster *federation_api.Cluster, clientset kube_release_1_4.Interface) (cache.Store, cache.ControllerInterface) {
+	targetInformerFactory := func(cluster *federation_api.Cluster, clientset kubeclientset.Interface) (cache.Store, cache.ControllerInterface) {
 		return cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -107,7 +107,7 @@ func TestFederatedInformer(t *testing.T) {
 	}
 
 	informer := NewFederatedInformer(fakeFederationClient, targetInformerFactory, &lifecycle).(*federatedInformerImpl)
-	informer.clientFactory = func(cluster *federation_api.Cluster) (kube_release_1_4.Interface, error) {
+	informer.clientFactory = func(cluster *federation_api.Cluster) (kubeclientset.Interface, error) {
 		return fakeKubeClient, nil
 	}
 	assert.NotNil(t, informer)

--- a/federation/pkg/federation-controller/util/federated_updater.go
+++ b/federation/pkg/federation-controller/util/federated_updater.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	kube_release_1_4 "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -52,7 +52,7 @@ type FederatedUpdater interface {
 }
 
 // A function that executes some operation using the passed client and object.
-type FederatedOperationHandler func(kube_release_1_4.Interface, pkg_runtime.Object) error
+type FederatedOperationHandler func(kubeclientset.Interface, pkg_runtime.Object) error
 
 type federatedUpdaterImpl struct {
 	federation FederationView

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/fake/fake_pod_expansion.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/fake/fake_pod_expansion.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	"k8s.io/kubernetes/pkg/api/v1"
+	policy "k8s.io/kubernetes/pkg/apis/policy/v1alpha1"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 )
@@ -43,4 +44,15 @@ func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 
 	_, _ = c.Fake.Invokes(action, &v1.Pod{})
 	return &restclient.Request{}
+}
+
+func (c *FakePods) Evict(eviction *policy.Eviction) error {
+	action := core.CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = podsResource
+	action.Subresource = "eviction"
+	action.Object = eviction
+
+	_, err := c.Fake.Invokes(action, eviction)
+	return err
 }


### PR DESCRIPTION
This PR is based on #32243, we won't merge it until next week, to make cherry-picks easier.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32246)

<!-- Reviewable:end -->
