### PR TITLE
Protect systemd on GCI machines

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -1,6 +1,20 @@
 #cloud-config
 
 write_files:
+  - path: /etc/systemd/system/kube-protect-systemd.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Protect Systemd From OOM kills
+
+      [Service]
+      RemainAfterExit=yes
+      ExecStart=/bin/sh -c "echo -999 > /proc/`pidof systemd`/oom_score_adj"
+
+      [Install]
+      WantedBy=kubernetes.target
+
   - path: /etc/systemd/system/kube-master-installation.service
     permissions: 0644
     owner: root

--- a/cluster/gce/gci/node.yaml
+++ b/cluster/gce/gci/node.yaml
@@ -1,6 +1,20 @@
 #cloud-config
 
 write_files:
+  - path: /etc/systemd/system/kube-protect-systemd.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Protect Systemd From OOM kills
+
+      [Service]
+      RemainAfterExit=yes
+      ExecStart=/bin/sh -c "echo -999 > /proc/`pidof systemd`/oom_score_adj"
+
+      [Install]
+      WantedBy=kubernetes.target
+
   - path: /etc/systemd/system/kube-node-installation.service
     permissions: 0644
     owner: root


### PR DESCRIPTION
Since systemd is not being run as init on GCI, it can get OOM killed
easily.
Adjusting its oom-score-adj setting to be `-999` to reduce the chances
of systemd being OOM killed.
When systemd is killed it will result in a node reboot which is
disruptive to users of GCI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32252)

<!-- Reviewable:end -->
