### PR TITLE
KillContainerInPod should check if pod is nil

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1433,7 +1433,7 @@ func (dm *DockerManager) killPodWithSyncResult(pod *api.Pod, runningPod kubecont
 // and will attempt to lookup the other information if missing.
 func (dm *DockerManager) KillContainerInPod(containerID kubecontainer.ContainerID, container *api.Container, pod *api.Pod, message string, gracePeriodOverride *int64) error {
 	switch {
-	case containerID.IsEmpty():
+	case containerID.IsEmpty() && pod != nil && container != nil:
 		// Locate the container.
 		pods, err := dm.GetPods(false)
 		if err != nil {


### PR DESCRIPTION
If the case condition do not check pod nil, the code line 1442 will panic
targetPod := kubecontainer.Pods(pods).FindPod(kubecontainer.GetPodFullName(pod), pod.UID)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32261)

<!-- Reviewable:end -->
