### PR TITLE
correct imagefs inodes value in kubelet summary stats

### DIFF
--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -134,7 +134,7 @@ func (sb *summaryBuilder) build() (*stats.Summary, error) {
 				CapacityBytes:  &sb.imageFsInfo.Capacity,
 				UsedBytes:      &sb.imageStats.TotalStorageBytes,
 				InodesFree:     sb.imageFsInfo.InodesFree,
-				Inodes:         sb.rootFsInfo.Inodes,
+				Inodes:         sb.imageFsInfo.Inodes,
 			},
 		},
 	}


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/31501
Correct get imagefs inodes value from imageFsInfo.Inodes in kubelet summary stats api. 

@derekwaynecarr

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32268)

<!-- Reviewable:end -->
