### PR TITLE
Remove panic handling from federated test helper

### DIFF
--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -169,12 +169,6 @@ func RegisterFakeCopyOnUpdate(resource string, client *core.Fake, watcher *Watch
 		obj := updateAction.GetObject()
 		go func() {
 			glog.V(4).Infof("Object updated. Writing to channel: %v", obj)
-			defer func() {
-				// Sometimes the channel is already closed.
-				if panicVal := recover(); panicVal != nil {
-					glog.Errorf("Recovering from panic: %v", panicVal)
-				}
-			}()
 			watcher.Modify(obj)
 			objChan <- obj
 		}()


### PR DESCRIPTION
This was added by accident when helping @quinton-hoole with https://github.com/kubernetes/kubernetes/pull/31600.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32282)

<!-- Reviewable:end -->
