### PR TITLE
delete the member before delete the pool

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1054,6 +1054,12 @@ func (lb *LbaasV1) EnsureLoadBalancerDeleted(clusterName string, service *api.Se
 				return err
 			}
 		}
+		for _, memberId := range pool.MemberIDs {
+			err = members.Delete(lb.network, memberId).ExtractErr()
+			if err != nil && !isNotFound(err) {
+				return err
+			}
+		}
 		err = pools.Delete(lb.network, pool.ID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return err


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/32285. it is necessary to delete members before delete the pool.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32290)

<!-- Reviewable:end -->
