### PR TITLE
convert more kubectl to generated client

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -47,12 +47,12 @@ func RunApiVersions(f *cmdutil.Factory, w io.Writer) error {
 		printDeprecationWarning("api-versions", "apiversions")
 	}
 
-	client, err := f.Client()
+	clientset, err := f.ClientSet()
 	if err != nil {
 		return err
 	}
 
-	groupList, err := client.Discovery().ServerGroups()
+	groupList, err := clientset.Discovery().ServerGroups()
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)
 	}

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -102,7 +102,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 			Client:               fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) { return nil, nil }),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{}
+		tf.ClientConfig = defaultClientConfig()
 
 		cmd := &cobra.Command{}
 		options := test.p

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -178,7 +178,7 @@ func TestAttach(t *testing.T) {
 			}),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
+		tf.ClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs, GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
 		bufOut := bytes.NewBuffer([]byte{})
 		bufErr := bytes.NewBuffer([]byte{})
 		bufIn := bytes.NewBuffer([]byte{})
@@ -212,7 +212,7 @@ func TestAttach(t *testing.T) {
 			continue
 		}
 		if remoteAttach.url.Path != test.attachPath {
-			t.Errorf("%s: Did not get expected path for exec request", test.name)
+			t.Errorf("%s: Did not get expected path for exec request: %q %q", test.name, test.attachPath, remoteAttach.url.Path)
 			continue
 		}
 		if remoteAttach.method != "POST" {
@@ -257,7 +257,7 @@ func TestAttachWarnings(t *testing.T) {
 			}),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
+		tf.ClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs, GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
 		bufOut := bytes.NewBuffer([]byte{})
 		bufErr := bytes.NewBuffer([]byte{})
 		bufIn := bytes.NewBuffer([]byte{})

--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -86,17 +85,17 @@ func setupOutputWriter(cmd *cobra.Command, defaultWriter io.Writer, filename str
 }
 
 func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
-	var c *unversioned.Client
-	var err error
-	if c, err = f.Client(); err != nil {
+	clientset, err := f.ClientSet()
+	if err != nil {
 		return err
 	}
+
 	printer, _, err := kubectl.GetPrinter("json", "", false)
 	if err != nil {
 		return err
 	}
 
-	nodes, err := c.Nodes().List(api.ListOptions{})
+	nodes, err := clientset.Core().Nodes().List(api.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -107,7 +106,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 
 	var namespaces []string
 	if cmdutil.GetFlagBool(cmd, "all-namespaces") {
-		namespaceList, err := c.Namespaces().List(api.ListOptions{})
+		namespaceList, err := clientset.Core().Namespaces().List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -130,7 +129,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 	for _, namespace := range namespaces {
 		// TODO: this is repetitive in the extreme.  Use reflection or
 		// something to make this a for loop.
-		events, err := c.Events(namespace).List(api.ListOptions{})
+		events, err := clientset.Core().Events(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -138,7 +137,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		rcs, err := c.ReplicationControllers(namespace).List(api.ListOptions{})
+		rcs, err := clientset.Core().ReplicationControllers(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -146,7 +145,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		svcs, err := c.Services(namespace).List(api.ListOptions{})
+		svcs, err := clientset.Core().Services(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -154,7 +153,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		sets, err := c.DaemonSets(namespace).List(api.ListOptions{})
+		sets, err := clientset.Extensions().DaemonSets(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -162,7 +161,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		deps, err := c.Deployments(namespace).List(api.ListOptions{})
+		deps, err := clientset.Extensions().Deployments(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -170,7 +169,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		rps, err := c.ReplicaSets(namespace).List(api.ListOptions{})
+		rps, err := clientset.Extensions().ReplicaSets(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -178,7 +177,7 @@ func dumpClusterInfo(f *cmdutil.Factory, cmd *cobra.Command, args []string, out 
 			return err
 		}
 
-		pods, err := c.Pods(namespace).List(api.ListOptions{})
+		pods, err := clientset.Core().Pods(namespace).List(api.ListOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -33,9 +33,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	clientset "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -294,6 +296,13 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec, runtime.Neg
 			c.Client = fakeClient.Client
 			c.ExtensionsClient.Client = fakeClient.Client
 			return c, t.Err
+		},
+		ClientSet: func() (*internalclientset.Clientset, error) {
+			fakeClient := t.Client.(*fake.RESTClient)
+			c := client.NewOrDie(t.ClientConfig)
+			c.Client = fakeClient.Client
+			c.ExtensionsClient.Client = fakeClient.Client
+			return clientset.FromUnversionedClient(c), nil
 		},
 		ClientForMapping: func(*meta.RESTMapping) (resource.RESTClient, error) {
 			return t.Client, t.Err

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -552,7 +552,10 @@ type MyReq struct {
 func (m *MyReq) isFor(method string, path string) bool {
 	req := m.Request
 
-	return method == req.Method && (req.URL.Path == path || req.URL.Path == strings.Join([]string{"/api/v1", path}, "") || req.URL.Path == strings.Join([]string{"/apis/extensions/v1beta1", path}, ""))
+	return method == req.Method && (req.URL.Path == path ||
+		req.URL.Path == strings.Join([]string{"/api/v1", path}, "") ||
+		req.URL.Path == strings.Join([]string{"/apis/extensions/v1beta1", path}, "") ||
+		req.URL.Path == strings.Join([]string{"/apis/batch/v1", path}, ""))
 }
 
 func refJson(t *testing.T, o runtime.Object) string {

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -25,9 +25,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
+
 	"k8s.io/kubernetes/pkg/api"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	remotecommandserver "k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
@@ -130,9 +131,9 @@ type ExecOptions struct {
 
 	Command []string
 
-	Executor RemoteExecutor
-	Client   *client.Client
-	Config   *restclient.Config
+	Executor  RemoteExecutor
+	PodClient coreclient.PodsGetter
+	Config    *restclient.Config
 }
 
 // Complete verifies command line arguments and loads data from the command environment
@@ -167,11 +168,11 @@ func (p *ExecOptions) Complete(f *cmdutil.Factory, cmd *cobra.Command, argsIn []
 	}
 	p.Config = config
 
-	client, err := f.Client()
+	clientset, err := f.ClientSet()
 	if err != nil {
 		return err
 	}
-	p.Client = client
+	p.PodClient = clientset.Core()
 
 	return nil
 }
@@ -187,7 +188,7 @@ func (p *ExecOptions) Validate() error {
 	if p.Out == nil || p.Err == nil {
 		return fmt.Errorf("both output and error output must be provided")
 	}
-	if p.Executor == nil || p.Client == nil || p.Config == nil {
+	if p.Executor == nil || p.PodClient == nil || p.Config == nil {
 		return fmt.Errorf("client, client config, and executor must be provided")
 	}
 	return nil
@@ -247,7 +248,7 @@ func (o *StreamOptions) setupTTY() term.TTY {
 
 // Run executes a validated remote execution against a pod.
 func (p *ExecOptions) Run() error {
-	pod, err := p.Client.Pods(p.Namespace).Get(p.PodName)
+	pod, err := p.PodClient.Pods(p.Namespace).Get(p.PodName)
 	if err != nil {
 		return err
 	}
@@ -276,8 +277,13 @@ func (p *ExecOptions) Run() error {
 	}
 
 	fn := func() error {
+		restClient, err := restclient.RESTClientFor(p.Config)
+		if err != nil {
+			return err
+		}
+
 		// TODO: consider abstracting into a client invocation or client helper
-		req := p.Client.RESTClient.Post().
+		req := restClient.Post().
 			Resource("pods").
 			Name(pod.Name).
 			Namespace(pod.Namespace).

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -31,7 +31,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/util/term"
@@ -133,7 +132,7 @@ func TestPodAndContainer(t *testing.T) {
 			Client:               fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) { return nil, nil }),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{}
+		tf.ClientConfig = defaultClientConfig()
 
 		cmd := &cobra.Command{}
 		options := test.p
@@ -162,20 +161,18 @@ func TestPodAndContainer(t *testing.T) {
 func TestExec(t *testing.T) {
 	version := testapi.Default.GroupVersion().Version
 	tests := []struct {
-		name, version, podPath, execPath, container string
-		pod                                         *api.Pod
-		execErr                                     bool
+		name, podPath, execPath, container string
+		pod                                *api.Pod
+		execErr                            bool
 	}{
 		{
 			name:     "pod exec",
-			version:  version,
 			podPath:  "/api/" + version + "/namespaces/test/pods/foo",
 			execPath: "/api/" + version + "/namespaces/test/pods/foo/exec",
 			pod:      execPod(),
 		},
 		{
 			name:     "pod exec error",
-			version:  version,
 			podPath:  "/api/" + version + "/namespaces/test/pods/foo",
 			execPath: "/api/" + version + "/namespaces/test/pods/foo/exec",
 			pod:      execPod(),
@@ -199,7 +196,7 @@ func TestExec(t *testing.T) {
 			}),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
+		tf.ClientConfig = defaultClientConfig()
 		bufOut := bytes.NewBuffer([]byte{})
 		bufErr := bytes.NewBuffer([]byte{})
 		bufIn := bytes.NewBuffer([]byte{})

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
+
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -126,12 +127,12 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 // TODO: convert all direct flag accessors to a struct and pass that instead of cmd
 func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
 	if len(options.Raw) > 0 {
-		client, err := f.Client()
+		restClient, err := f.RESTClient()
 		if err != nil {
 			return err
 		}
 
-		stream, err := client.RESTClient.Get().RequestURI(options.Raw).Stream()
+		stream, err := restClient.Get().RequestURI(options.Raw).Stream()
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
+
 	"k8s.io/kubernetes/pkg/api"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/portforward"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -37,8 +38,9 @@ import (
 type PortForwardOptions struct {
 	Namespace     string
 	PodName       string
+	RESTClient    *restclient.RESTClient
 	Config        *restclient.Config
-	Client        *client.Client
+	PodClient     coreclient.PodsGetter
 	Ports         []string
 	PortForwarder portForwarder
 	StopChannel   chan struct{}
@@ -130,12 +132,17 @@ func (o *PortForwardOptions) Complete(f *cmdutil.Factory, cmd *cobra.Command, ar
 		return err
 	}
 
-	o.Client, err = f.Client()
+	clientset, err := f.ClientSet()
 	if err != nil {
 		return err
 	}
+	o.PodClient = clientset.Core()
 
 	o.Config, err = f.ClientConfig()
+	if err != nil {
+		return err
+	}
+	o.RESTClient, err = f.RESTClient()
 	if err != nil {
 		return err
 	}
@@ -155,15 +162,15 @@ func (o PortForwardOptions) Validate() error {
 		return fmt.Errorf("at least 1 PORT is required for port-forward")
 	}
 
-	if o.PortForwarder == nil || o.Client == nil || o.Config == nil {
-		return fmt.Errorf("client, client config, and portforwarder must be provided")
+	if o.PortForwarder == nil || o.PodClient == nil || o.RESTClient == nil || o.Config == nil {
+		return fmt.Errorf("client, client config, restClient, and portforwarder must be provided")
 	}
 	return nil
 }
 
 // RunPortForward implements all the necessary functionality for port-forward cmd.
 func (o PortForwardOptions) RunPortForward() error {
-	pod, err := o.Client.Pods(o.Namespace).Get(o.PodName)
+	pod, err := o.PodClient.Pods(o.Namespace).Get(o.PodName)
 	if err != nil {
 		return err
 	}
@@ -183,7 +190,7 @@ func (o PortForwardOptions) RunPortForward() error {
 		}
 	}()
 
-	req := o.Client.RESTClient.Post().
+	req := o.RESTClient.Post().
 		Resource("pods").
 		Namespace(o.Namespace).
 		Name(pod.Name).

--- a/pkg/kubectl/cmd/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward_test.go
@@ -27,8 +27,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 )
 
@@ -48,20 +46,19 @@ func TestPortForward(t *testing.T) {
 	version := testapi.Default.GroupVersion().Version
 
 	tests := []struct {
-		name, version, podPath, pfPath, container string
-		pod                                       *api.Pod
-		pfErr                                     bool
+		name                       string
+		podPath, pfPath, container string
+		pod                        *api.Pod
+		pfErr                      bool
 	}{
 		{
 			name:    "pod portforward",
-			version: version,
 			podPath: "/api/" + version + "/namespaces/test/pods/foo",
 			pfPath:  "/api/" + version + "/namespaces/test/pods/foo/portforward",
 			pod:     execPod(),
 		},
 		{
 			name:    "pod portforward error",
-			version: version,
 			podPath: "/api/" + version + "/namespaces/test/pods/foo",
 			pfPath:  "/api/" + version + "/namespaces/test/pods/foo/portforward",
 			pod:     execPod(),
@@ -86,7 +83,7 @@ func TestPortForward(t *testing.T) {
 			}),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
+		tf.ClientConfig = defaultClientConfig()
 		ff := &fakePortForwarder{}
 		if test.pfErr {
 			ff.pfErr = fmt.Errorf("pf error")
@@ -130,20 +127,18 @@ func TestPortForwardWithPFlag(t *testing.T) {
 	version := testapi.Default.GroupVersion().Version
 
 	tests := []struct {
-		name, version, podPath, pfPath, container string
-		pod                                       *api.Pod
-		pfErr                                     bool
+		name, podPath, pfPath, container string
+		pod                              *api.Pod
+		pfErr                            bool
 	}{
 		{
 			name:    "pod portforward",
-			version: version,
 			podPath: "/api/" + version + "/namespaces/test/pods/foo",
 			pfPath:  "/api/" + version + "/namespaces/test/pods/foo/portforward",
 			pod:     execPod(),
 		},
 		{
 			name:    "pod portforward error",
-			version: version,
 			podPath: "/api/" + version + "/namespaces/test/pods/foo",
 			pfPath:  "/api/" + version + "/namespaces/test/pods/foo/portforward",
 			pod:     execPod(),
@@ -168,7 +163,7 @@ func TestPortForwardWithPFlag(t *testing.T) {
 			}),
 		}
 		tf.Namespace = "test"
-		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &unversioned.GroupVersion{Version: test.version}}}
+		tf.ClientConfig = defaultClientConfig()
 		ff := &fakePortForwarder{}
 		if test.pfErr {
 			ff.pfErr = fmt.Errorf("pf error")

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -274,7 +274,12 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 		if err != nil {
 			return err
 		}
-		opts.Client = client
+
+		clientset, err := f.ClientSet()
+		if err != nil {
+			return err
+		}
+		opts.PodClient = clientset.Core()
 
 		attachablePod, err := f.AttachablePodForObject(obj)
 		if err != nil {
@@ -475,7 +480,13 @@ func handleAttachPod(f *cmdutil.Factory, c *client.Client, ns, name string, opts
 		_, err = io.Copy(opts.Out, readCloser)
 		return err
 	}
-	opts.Client = c
+
+	clientset, err := f.ClientSet()
+	if err != nil {
+		return nil
+	}
+	opts.PodClient = clientset.Core()
+
 	opts.PodName = name
 	opts.Namespace = ns
 	// TODO: opts.Run sets opts.Err to nil, we need to find a better way

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/storage"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
@@ -98,6 +99,8 @@ type Factory struct {
 	JSONEncoder func() runtime.Encoder
 	// Returns a client for accessing Kubernetes resources or an error.
 	Client func() (*client.Client, error)
+	// ClientSet gives you back an internal, generated clientset
+	ClientSet func() (*internalclientset.Clientset, error)
 	// Returns a client.Config for accessing the Kubernetes server.
 	ClientConfig func() (*restclient.Config, error)
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
@@ -405,6 +408,15 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 		},
 		Client: func() (*client.Client, error) {
 			return clients.ClientForVersion(nil)
+		},
+
+		ClientSet: func() (*internalclientset.Clientset, error) {
+			cfg, err := clients.ClientConfigForVersion(nil)
+			if err != nil {
+				return nil, err
+			}
+
+			return internalclientset.NewForConfig(cfg)
 		},
 		ClientConfig: func() (*restclient.Config, error) {
 			return clients.ClientConfigForVersion(nil)

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -101,6 +101,8 @@ type Factory struct {
 	Client func() (*client.Client, error)
 	// ClientSet gives you back an internal, generated clientset
 	ClientSet func() (*internalclientset.Clientset, error)
+	// Returns a RESTClient for accessing Kubernetes resources or an error.
+	RESTClient func() (*restclient.RESTClient, error)
 	// Returns a client.Config for accessing the Kubernetes server.
 	ClientConfig func() (*restclient.Config, error)
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
@@ -409,7 +411,13 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 		Client: func() (*client.Client, error) {
 			return clients.ClientForVersion(nil)
 		},
-
+		RESTClient: func() (*restclient.RESTClient, error) {
+			clientConfig, err := clients.ClientConfigForVersion(nil)
+			if err != nil {
+				return nil, err
+			}
+			return restclient.RESTClientFor(clientConfig)
+		},
 		ClientSet: func() (*internalclientset.Clientset, error) {
 			cfg, err := clients.ClientConfigForVersion(nil)
 			if err != nil {

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -45,11 +46,16 @@ func RunVersion(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		return nil
 	}
 
-	client, err := f.Client()
+	clientset, err := f.ClientSet()
 	if err != nil {
 		return err
 	}
 
-	kubectl.GetServerVersion(out, client)
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Server Version: %#v\n", *serverVersion)
 	return nil
 }

--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -19,21 +19,9 @@ package kubectl
 import (
 	"fmt"
 	"io"
-	"os"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/version"
 )
-
-func GetServerVersion(w io.Writer, kubeClient client.Interface) {
-	serverVersion, err := kubeClient.Discovery().ServerVersion()
-	if err != nil {
-		fmt.Printf("Couldn't read server version from server: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Fprintf(w, "Server Version: %#v\n", *serverVersion)
-}
 
 func GetClientVersion(w io.Writer) {
 	fmt.Fprintf(w, "Client Version: %#v\n", version.Get())


### PR DESCRIPTION
Continuing work for switching to generated clients.  See the second commit.

I got to a point where I hit the scaler APIs and the pull started to get really large.

@kargakis ptal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32293)

<!-- Reviewable:end -->
