### PR TITLE
Automated cherry pick of #32258

### DIFF
--- a/pkg/genericapiserver/storage_factory.go
+++ b/pkg/genericapiserver/storage_factory.go
@@ -289,6 +289,7 @@ var specialDefaultResourcePrefixes = map[unversioned.GroupResource]string{
 	unversioned.GroupResource{Group: "", Resource: "endpoints"}:              "services/endpoints",
 	unversioned.GroupResource{Group: "", Resource: "nodes"}:                  "minions",
 	unversioned.GroupResource{Group: "", Resource: "services"}:               "services/specs",
+	unversioned.GroupResource{Group: "extensions", Resource: "ingresses"}:    "ingress",
 }
 
 func (s *DefaultStorageFactory) ResourcePrefix(groupResource unversioned.GroupResource) string {


### PR DESCRIPTION
fixes #32255
Cherry pick of #32258 on release-1.4.

``` release-note
In v1.4.0-alpha.2, v1.4.0-alpha.3, and v1.4.0-beta.0, Ingress objects were stored in an incorrect location in etcd. Before upgrading from one of those versions, Ingress objects should be exported and deleted, then recreated after upgrading:

kubectl get ingress --all-namespaces -o yaml > ingresses.yaml
kubectl delete -f ingresses.yaml
... upgrade ...
kubectl create -f ingresses.yaml

No action is required when upgrading from versions prior to v1.4.0-alpha.2
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32294)

<!-- Reviewable:end -->
