### PR TITLE
update pkg/cloudprovider OWNERS to spread the review load

### DIFF
--- a/pkg/cloudprovider/OWNERS
+++ b/pkg/cloudprovider/OWNERS
@@ -1,2 +1,4 @@
 assignees:
   - mikedanese
+owners:
+  - mikedanese

--- a/pkg/cloudprovider/providers/cloudstack/OWNERS
+++ b/pkg/cloudprovider/providers/cloudstack/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- runseb
+- ngtuna
+- svanharmelen

--- a/pkg/cloudprovider/providers/openstack/OWNERS
+++ b/pkg/cloudprovider/providers/openstack/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- anguslees
+- dagnello

--- a/pkg/cloudprovider/providers/vsphere/OWNERS
+++ b/pkg/cloudprovider/providers/vsphere/OWNERS
@@ -1,4 +1,7 @@
 maintainers:
-  - dagnello
-  - abithap
-
+- dagnello
+- abithap
+- imkin
+- abrarshivani
+- kerneltime
+- luomiao


### PR DESCRIPTION
This is going to make the mungebot start assigning reviews in your cloudprovider packages.

fyi @runseb @dagnello @imkin @anguslees @dagnello 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32307)

<!-- Reviewable:end -->
