### PR TITLE
Summary API is using wrong fs for imagefs inodes

### DIFF
--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -134,7 +134,7 @@ func (sb *summaryBuilder) build() (*stats.Summary, error) {
 				CapacityBytes:  &sb.imageFsInfo.Capacity,
 				UsedBytes:      &sb.imageStats.TotalStorageBytes,
 				InodesFree:     sb.imageFsInfo.InodesFree,
-				Inodes:         sb.rootFsInfo.Inodes,
+				Inodes:         sb.imageFsInfo.Inodes,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/31501

Marking this p0, if it fails to make the release, node eviction on imagefs based on inodes will not work properly as the wrong value is returned.

/cc @vishh @ronnielai @dchen1107 @mdshuai

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32311)

<!-- Reviewable:end -->
