### PR TITLE
err can be nil here, fix it

### DIFF
--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -188,8 +188,8 @@ func (b *nfsMounter) SetUp(fsGroup *int64) error {
 
 func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
-	glog.V(4).Infof("NFS mount set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
+		glog.V(4).Infof("NFS mount set up: %s %v %v", dir, !notMnt, err)
 		return err
 	}
 	if !notMnt {


### PR DESCRIPTION
err can be nil here. remove glog.V(4).Infof() to if err != nil && !os.IsNotExist(err) {}

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32347)

<!-- Reviewable:end -->
