### PR TITLE
improve the output for config view

### DIFF
--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -71,7 +71,7 @@ func NewCmdConfigView(out io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra
 				cmd.Flags().Set("output", defaultOutputFormat)
 			}
 			if outputFormat == "" {
-				fmt.Printf("reset to default output format (%s) as --output is empty", defaultOutputFormat)
+				fmt.Printf("reset to default output format (%s) as --output is empty\n\n", defaultOutputFormat)
 				cmd.Flags().Set("output", defaultOutputFormat)
 			}
 


### PR DESCRIPTION
**before**

``` shell
$ kubectl config view --output
reset to default output format (yaml) as --output is emptyapiVersion: v1
clusters: []
contexts: []
current-context: ""
kind: Config
preferences: {}
users: []
```

**after**

``` shell
$ kubectl config view --output
reset to default output format (yaml) as --output is empty

apiVersion: v1
clusters: []
contexts: []
current-context: ""
kind: Config
preferences: {}
users: []
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32355)

<!-- Reviewable:end -->
