### PR TITLE
Remove explicit limits from manifest files

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -31,11 +31,8 @@
                     "-c",
                     "./cluster-autoscaler --kubernetes=http://127.0.0.1:8080?inClusterConfig=f --v=4 {{params}} 1>>/var/log/cluster-autoscaler.log 2>&1"
                 ],
+                # TODO: Make resource requirements depend on the size of the cluster
                 "resources": {
-                    "limits": {
-                        "cpu": "100m",
-                        "memory": "300Mi"
-                    },
                     "requests": {
                         "cpu": "20m",
                         "memory": "300Mi"

--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -33,11 +33,9 @@ spec:
       name: logfile
       readOnly: false
     resources:
-      # Request and limits are set to accomodate this pod alongside the other
+      # Request is set to accomodate this pod alongside the other
       # master components on a single core master.
-      limits:
-        cpu: 100m
-        memory: 100Mi
+      # TODO: Make resource requirements depend on the size of the cluster
       requests:
         cpu: 10m
         memory: 50Mi

--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -17,10 +17,8 @@ spec:
     - mountPath: /var/log/rescheduler.log
       name: logfile
       readOnly: false
+    # TODO: Make resource requirements depend on the size of the cluster
     resources:
-      limits:
-        cpu: 100m
-        memory: 300Mi
       requests:
         cpu: 10m
         memory: 100Mi


### PR DESCRIPTION
Current setting make those addons OOM in 2k Node clusters.

cc @piosz @mwielgus @bprashanth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32363)

<!-- Reviewable:end -->
