### PR TITLE
kubectl: add ability to copy configmaps around

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -333,7 +333,7 @@ runTests() {
   petset_replicas_field=".spec.replicas"
   job_parallelism_field=".spec.parallelism"
   deployment_replicas=".spec.replicas"
-  secret_data=".data"
+  configmap_data=".data"
   secret_type=".type"
   deployment_image_field="(index .spec.template.spec.containers 0).image"
   deployment_second_image_field="(index .spec.template.spec.containers 1).image"
@@ -570,6 +570,10 @@ runTests() {
   kubectl create configmap test-configmap --from-literal=key-2=value2 --namespace=test-kubectl-describe-pod
   # Post-condition: configmap exists and has expected values
   kube::test::get_object_assert 'configmap/test-configmap --namespace=test-kubectl-describe-pod' "{{$id_field}}" 'test-configmap'
+  # Command
+  kubectl create configmap test-copy --from-configmap=test-configmap --namespace=test-kubectl-describe-pod
+  # Post-condition: configmap exists and has expected values
+  [[ "$(kubectl get configmap/test-copy -o yaml --namespace=test-kubectl-describe-pod "${kube_flags[@]}" | grep key-2:value2)" ]]
 
   # Create a pod that consumes secret, configmap, and downward API keys as envs
   kube::test::get_object_assert 'pods --namespace=test-kubectl-describe-pod' "{{range.items}}{{$id_field}}:{{end}}" ''
@@ -582,7 +586,7 @@ runTests() {
   # Clean-up
   kubectl delete pod env-test-pod --namespace=test-kubectl-describe-pod
   kubectl delete secret test-secret --namespace=test-kubectl-describe-pod
-  kubectl delete configmap test-configmap --namespace=test-kubectl-describe-pod
+  kubectl delete cm/test-configmap cm/test-copy --namespace=test-kubectl-describe-pod
   kubectl delete namespace test-kubectl-describe-pod
 
   ### Create two PODs

--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -38,6 +38,8 @@ type ConfigMapGeneratorV1 struct {
 	FileSources []string
 	// LiteralSources to derive the configMap from (optional)
 	LiteralSources []string
+	// Data contains any data that need to be copied in the new config map
+	Data map[string]string
 }
 
 // Ensure it supports the generator pattern that uses parameter injection.
@@ -103,6 +105,10 @@ func (s ConfigMapGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 	configMap := &api.ConfigMap{}
 	configMap.Name = s.Name
 	configMap.Data = map[string]string{}
+	// Note that keys from file or literal sources can overwrite copied data.
+	for key, value := range s.Data {
+		configMap.Data[key] = value
+	}
 	if len(s.FileSources) > 0 {
 		if err := handleConfigMapFromFileSources(configMap, s.FileSources); err != nil {
 			return nil, err


### PR DESCRIPTION
@kubernetes/kubectl this adds the ability to copy config maps around.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32367)

<!-- Reviewable:end -->
