### PR TITLE
PetSet replica count status test

### DIFF
--- a/pkg/controller/petset/pet_set_test.go
+++ b/pkg/controller/petset/pet_set_test.go
@@ -25,6 +25,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/client/cache"
+	fake_internal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/fake"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/util/errors"
 )
@@ -268,12 +271,61 @@ func TestPetSetBlockingPetIsCleared(t *testing.T) {
 	}
 }
 
-// TODO(mkwiek): test if the petset.Status.Replicas is actually correct
-func TestPetSetReplicaCount(t *testing.T) {
+func TestSyncPetSetBlockedPet(t *testing.T) {
 	psc, fc := newFakePetSetController()
 	ps := newPetSet(3)
 	i, _ := psc.syncPetSet(ps, fc.getPodList())
 	if i != len(fc.getPodList()) {
 		t.Errorf("syncPetSet should return actual amount of pods")
+	}
+}
+
+type fakeClient struct {
+	fake_internal.Clientset
+	petSetClient *fakePetSetClient
+}
+
+func (c *fakeClient) Apps() unversioned.AppsInterface {
+	return &fakeApps{c, &fake.FakeApps{}}
+}
+
+type fakeApps struct {
+	*fakeClient
+	*fake.FakeApps
+}
+
+func (c *fakeApps) PetSets(namespace string) unversioned.PetSetInterface {
+	c.petSetClient.Namespace = namespace
+	return c.petSetClient
+}
+
+type fakePetSetClient struct {
+	*fake.FakePetSets
+	Namespace string
+	replicas  int
+}
+
+func (f *fakePetSetClient) UpdateStatus(petSet *apps.PetSet) (*apps.PetSet, error) {
+	f.replicas = petSet.Status.Replicas
+	return petSet, nil
+}
+
+func TestPetSetReplicaCount(t *testing.T) {
+	fpsc := &fakePetSetClient{}
+	psc, _ := newFakePetSetController()
+	psc.kubeClient = &fakeClient{
+		petSetClient: fpsc,
+	}
+
+	ps := newPetSet(3)
+	psKey := fmt.Sprintf("%v/%v", ps.Namespace, ps.Name)
+	psc.psStore.Store.Add(ps)
+
+	if err := psc.Sync(psKey); err != nil {
+		t.Errorf("Error during sync of deleted petset %v", err)
+	}
+
+	if fpsc.replicas != 1 {
+		t.Errorf("Replicas count sent as status update for PetSet should be 1, is %d instead", fpsc.replicas)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: It adds a test for PetSet status replica count. It should fail now, but will pass when https://github.com/kubernetes/kubernetes/pull/32117 is merged.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #31965

**Special notes for your reviewer**: It will need to be rebased after #32117 is merged in, don't need detailed review before that.

**Release note**:

``` release-note
NONE
```

Added fakeKubeClient and other fake types needed to test what is sent to
API when replica count is updated. These fakes can be extended for
other tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32373)

<!-- Reviewable:end -->
