### PR TITLE
Provide an e2e skip helper checking for available resource

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -433,6 +433,22 @@ func SkipUnlessFederated(c *client.Client) {
 	}
 }
 
+func SkipIfMissingResource(clientPool dynamic.ClientPool, gvr unversioned.GroupVersionResource, namespace string) {
+	dynamicClient, err := clientPool.ClientForGroupVersion(gvr.GroupVersion())
+	if err != nil {
+		Failf("Unexpected error getting dynamic client for %v: %v", gvr.GroupVersion(), err)
+	}
+	apiResource := unversioned.APIResource{Name: gvr.Resource, Namespaced: true}
+	_, err = dynamicClient.Resource(&apiResource, namespace).List(&v1.ListOptions{})
+	if err != nil {
+		// not all resources support list, so we ignore those
+		if apierrs.IsMethodNotSupported(err) || apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {
+			Skipf("Could not find %s resource, skipping test: %#v", gvr, err)
+		}
+		Failf("Unexpected error getting %v: %v", gvr, err)
+	}
+}
+
 // ProvidersWithSSH are those providers where each node is accessible with SSH
 var ProvidersWithSSH = []string{"gce", "gke", "aws"}
 

--- a/test/e2e/scheduledjob.go
+++ b/test/e2e/scheduledjob.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/kubernetes/pkg/api"
-	apierrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -47,11 +46,7 @@ var _ = framework.KubeDescribe("[Feature:ScheduledJob]", func() {
 	f := framework.NewFramework("scheduledjob", options, nil)
 
 	BeforeEach(func() {
-		if _, err := f.Client.Batch().ScheduledJobs(f.Namespace.Name).List(api.ListOptions{}); err != nil {
-			if apierrs.IsNotFound(err) {
-				framework.Skipf("Could not find ScheduledJobs resource, skipping test: %#v", err)
-			}
-		}
+		framework.SkipIfMissingResource(f.ClientPool, unversioned.GroupVersionResource{Group: batch.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}, f.Namespace.Name)
 	})
 
 	// multiple jobs running at once


### PR DESCRIPTION
@janetkuo @dims this is the promised util function, but unfortunately I just learned that dynamic client suffers from the problem I've fixed in the manually written one (https://github.com/kubernetes/kubernetes/pull/29187) I need to look into the dynamic client in that case :/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32374)

<!-- Reviewable:end -->
