### PR TITLE
Verify that kubelet will switch to another api-server

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -1,15 +1,21 @@
 {% set kubeconfig = "--kubeconfig=/var/lib/kube-proxy/kubeconfig" -%}
 {% if grains.api_servers is defined -%}
-  {% set api_servers = "--master=https://" + grains.api_servers -%}
+  {% set api_servers = "--api-servers=https://" + grains.api_servers -%}
 {% else -%}
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
-  {% set api_servers = "--master=https://" + ips[0][0] -%}
+  {% set api_servers = "--api-servers=https://" + ips[0][0] -%}
 {% endif -%}
+
 {% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller', 'openstack', 'azure-legacy' ]  %}
   {% set api_servers_with_port = api_servers -%}
 {% else -%}
   {% set api_servers_with_port = api_servers + ":6443" -%}
 {% endif -%}
+
+{% if grains.test_api_servers is defined %}
+  {% set api_servers_with_port = api_servers_with_port + grains.test_api_servers %}
+{% -%}
+
 {% set test_args = "" -%}
 {% if pillar['kubeproxy_test_args'] is defined -%}
   {% set test_args=pillar['kubeproxy_test_args'] %}

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -22,6 +22,10 @@
   {% set api_servers_with_port = api_servers + ":6443" -%}
 {% endif -%}
 
+{% if grains.test_api_servers is defined %}
+  {% set api_servers_with_port = api_servers_with_port + grains.test_api_servers %}
+{% -%}
+
 {% set master_kubelet_args = "" %}
 
 {% set debugging_handlers = "--enable-debugging-handlers=true" -%}

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -113,6 +113,9 @@ OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}
 
+# Workaround until multiple api servers will be deployable
+TEST_API_SERVERS="${TEST_API_SERVERS:-https://${MASTER_IP}:6444}"
+
 # Default fallback NETWORK_IF_NAME, will be used in case when no 'VAGRANT-BEGIN' comments were defined in network-script
 export DEFAULT_NETWORK_IF_NAME="eth0"
 

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -104,6 +104,7 @@ grains:
   master_extra_sans: '$(echo "$MASTER_EXTRA_SANS" | sed -e "s/'/''/g")'
   keep_host_etcd: true
   kube_user: '$(echo "$KUBE_USER" | sed -e "s/'/''/g")'
+  test_api_servers: '$(echo "${TEST_API_SERVERS}" | sed -e "s/'/''/g")'
 EOF
 }
 

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -118,7 +118,7 @@ function ensure-temp-dir {
 # Create a set of provision scripts for the master and each of the nodes
 function create-provision-scripts {
   ensure-temp-dir
-
+  echo "------------------${KUBE_TEMP}"
   (
     echo "#! /bin/bash"
     echo-kube-env
@@ -189,6 +189,7 @@ function echo-kube-env() {
   echo "E2E_STORAGE_TEST_ENVIRONMENT='${E2E_STORAGE_TEST_ENVIRONMENT:-}'"
   echo "CUSTOM_FEDORA_REPOSITORY_URL='${CUSTOM_FEDORA_REPOSITORY_URL:-}'"
   echo "EVICTION_HARD='${EVICTION_HARD:-}'"
+  echo "TEST_API_SERVERS='${TEST_API_SERVERS:-}'"
 }
 
 function verify-cluster {

--- a/test/e2e/api_failover_test.go
+++ b/test/e2e/api_failover_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.KubeDescribe("Nodes api failover [Slow]", func() {
+	f := framework.NewDefaultFramework("nodes-failover")
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vagrant")
+	})
+
+	// this test relies on kubelet being configured with multiple api servers with 443 and 6444 port
+	It("should work if 443 is blocked, because client will try to connect on 6444 port", func() {
+		originalPort := 443
+		backupPort := 6444
+		markName := "111"
+		framework.MasterExec(fmt.Sprintf("sudo iptables -t nat -A PREROUTING -p tcp -m tcp --dport %v -j REDIRECT --to-ports %v", originalPort, backupPort))
+		framework.MasterExec(fmt.Sprintf("sudo iptables -t mangle -A PREROUTING -p tcp --dport %v -j MARK --set-mark %v", originalPort, markName))
+		framework.MasterExec(fmt.Sprintf("sudo iptables -A INPUT -m mark --mark %v -j DROP", markName))
+		Eventually(func() error {
+			nodes, err := f.Client.Nodes().List(api.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(nodes.Items) == 0 {
+				return fmt.Errorf("empty node list: %+v", nodes)
+			}
+			for _, node := range nodes.Items {
+				if !api.IsNodeReady(&node) {
+					return fmt.Errorf("Node %v is not in ready condition", node.Name)
+				}
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(BeNil())
+		framework.MasterExec(fmt.Sprintf("sudo iptables -t nat -D PREROUTING -p tcp -m tcp --dport %v -j REDIRECT --to-ports %v", originalPort, backupPort))
+		framework.MasterExec(fmt.Sprintf("sudo iptables -t mangle -D PREROUTING -p tcp --dport %v -j MARK --set-mark %v", originalPort, markName))
+		framework.MasterExec(fmt.Sprintf("sudo iptables -D INPUT -m mark --mark %v -j DROP", markName))
+	})
+})

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -873,6 +873,16 @@ func filterLabels(selectors map[string]string, cli *client.Client, ns string) (*
 	return pl, err
 }
 
+// MasterExec runs provided command on master
+func MasterExec(cmd string) {
+	result, err := SSH(cmd, strings.Split(GetMasterHost(), ":")[0]+":22", TestContext.Provider)
+	Expect(err).NotTo(HaveOccurred())
+	if result.Code != 0 {
+		LogSSHResult(result)
+		Failf("master exec command returned non-zero")
+	}
+}
+
 // filter filters pods which pass a filter.  It can be used to compose
 // the more useful abstractions like ForEach, WaitFor, and so on, which
 // can be used directly by tests.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4070,6 +4070,12 @@ func GetSigner(provider string) (ssh.Signer, error) {
 		}
 		// Otherwise revert to home dir
 		keyfile = "kube_aws_rsa"
+	case "vagrant":
+		keyfile := os.Getenv("VAGRANT_MASTER_SSH_KEY")
+		if len(keyfile) != 0 {
+			return sshutil.MakePrivateKeySignerFromFile(keyfile)
+		}
+		return nil, fmt.Errorf("VAGRANT_MASTER_SSH_KEY env variable should be provided")
 	default:
 		return nil, fmt.Errorf("GetSigner(...) not implemented for %s", provider)
 	}


### PR DESCRIPTION
We have single api-server which listens on ports 8080 and 443. Before my change each remote client (kubelet and kube-proxy in particular) was communicating over secure port with signle api-server.

I need to change it so that each client will have an illusion that it communicates with two different api-servers. For that I will add TEST_API_SERVERS with fake port (6444). It will be appended to kubelet and kube-proxy --api-servers flag.

In the test I will block traffic to 443 port and expect that client will switch and use 6444. But it turns out to be quite tricky. e2e tests also need to communicate with kube-apiserver and it could run on local or remote server. Thus we need to drop traffic only with specific source ip.

Solution for this is to add iptables rule for every node in PREROUTING chain. This rule will have to mark traffic which will come from specific nodes and later we will be able to drop it in INPUT chain.

But overall it is hacky as hell, so maybe it would be better to wait until we will have ha configuration ready for e2e tests.

related to: https://github.com/kubernetes/kubernetes/pull/30588/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32380)

<!-- Reviewable:end -->
