### PR TITLE
Automated cherry pick of #32072

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,7 @@ binary | sha256 hash
 ### Other notable changes
 
 * rkt: Improve support for privileged pod (pod whose all containers are privileged)  ([#31286](https://github.com/kubernetes/kubernetes/pull/31286), [@yifan-gu](https://github.com/yifan-gu))
-* The pod annotation `security.alpha.kubernetes.io/sysctls` now allows customization of namespaced and well isolated kernel parameters (sysctls), starting with `kernel.shm_rmid_forced`, `net.ipv4.ip_local_port_range`, `net.ipv4.tcp_max_syn_backlog` and `net.ipv4.tcp_syncookies` for Kubernetes 1.4. ([#27180](https://github.com/kubernetes/kubernetes/pull/27180), [@sttts](https://github.com/sttts))
+* The pod annotation `security.alpha.kubernetes.io/sysctls` now allows customization of namespaced and well isolated kernel parameters (sysctls), starting with `kernel.shm_rmid_forced`, `net.ipv4.ip_local_port_range` and `net.ipv4.tcp_syncookies` for Kubernetes 1.4. ([#27180](https://github.com/kubernetes/kubernetes/pull/27180), [@sttts](https://github.com/sttts))
     * The pod annotation  `security.alpha.kubernetes.io/unsafe-sysctls` allows customization of namespaced sysctls where isolation is unclear. Unsafe sysctls must be enabled at-your-own-risk on the kubelet with the `--experimental-allowed-unsafe-sysctls` flag. Future versions will improve on resource isolation and more sysctls will be considered safe.
 * Increase request timeout based on termination grace period ([#31275](https://github.com/kubernetes/kubernetes/pull/31275), [@dims](https://github.com/dims))
 * Fixed two issues of kubectl bash completion. ([#31135](https://github.com/kubernetes/kubernetes/pull/31135), [@xingzhou](https://github.com/xingzhou))

--- a/pkg/kubelet/sysctl/whitelist.go
+++ b/pkg/kubelet/sysctl/whitelist.go
@@ -40,7 +40,6 @@ func SafeSysctlWhitelist() []string {
 	return []string{
 		"kernel.shm_rmid_forced",
 		"net.ipv4.ip_local_port_range",
-		"net.ipv4.tcp_max_syn_backlog",
 		"net.ipv4.tcp_syncookies",
 	}
 }


### PR DESCRIPTION
Cherry pick of #32072 on release-1.4.

1.4 justification:

**Risk:** the whitelist is a published API. We shouldn't have sysctls on there which do not work.
**Rollback:** nothing should depend on this behavior.
**Cost:** the cost of this is relatively low, as no pod with this sysctl will launch.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32382)

<!-- Reviewable:end -->
