### PR TITLE
Only set sysctls for infra containers

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -687,18 +687,20 @@ func (dm *DockerManager) runContainer(
 	}
 
 	// Set sysctls if requested
-	sysctls, unsafeSysctls, err := api.SysctlsFromPodAnnotations(pod.Annotations)
-	if err != nil {
-		dm.recorder.Eventf(ref, api.EventTypeWarning, events.FailedToCreateContainer, "Failed to create docker container %q of pod %q with error: %v", container.Name, format.Pod(pod), err)
-		return kubecontainer.ContainerID{}, err
-	}
-	if len(sysctls)+len(unsafeSysctls) > 0 {
-		hc.Sysctls = make(map[string]string, len(sysctls)+len(unsafeSysctls))
-		for _, c := range sysctls {
-			hc.Sysctls[c.Name] = c.Value
+	if container.Name == PodInfraContainerName {
+		sysctls, unsafeSysctls, err := api.SysctlsFromPodAnnotations(pod.Annotations)
+		if err != nil {
+			dm.recorder.Eventf(ref, api.EventTypeWarning, events.FailedToCreateContainer, "Failed to create docker container %q of pod %q with error: %v", container.Name, format.Pod(pod), err)
+			return kubecontainer.ContainerID{}, err
 		}
-		for _, c := range unsafeSysctls {
-			hc.Sysctls[c.Name] = c.Value
+		if len(sysctls)+len(unsafeSysctls) > 0 {
+			hc.Sysctls = make(map[string]string, len(sysctls)+len(unsafeSysctls))
+			for _, c := range sysctls {
+				hc.Sysctls[c.Name] = c.Value
+			}
+			for _, c := range unsafeSysctls {
+				hc.Sysctls[c.Name] = c.Value
+			}
 		}
 	}
 


### PR DESCRIPTION
We did set the sysctls for each container in a pod. This opens up a way to set un-whitelisted sysctls during upgrade from v1.3:
- set annotation in v1.3 with an un-whitelisted sysctl. Set restartPolicy=Always
- upgrade cluster to v1.4
- kill container process
- un-whitelisted sysctl is set on restart of the killed container.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32383)

<!-- Reviewable:end -->
