### PR TITLE
Fix experimental examples (StorageClass) - Fixes #32225

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -51,7 +51,7 @@ The name of a StorageClass object is significant, and is how users can request a
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs
@@ -71,7 +71,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd
@@ -86,7 +86,7 @@ parameters:
 #### GLUSTERFS
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: slow
@@ -109,7 +109,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: gold
 provisioner: kubernetes.io/cinder

--- a/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
+++ b/examples/experimental/persistent-volume-provisioning/aws-ebs.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs

--- a/examples/experimental/persistent-volume-provisioning/gce-pd.yaml
+++ b/examples/experimental/persistent-volume-provisioning/gce-pd.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: slow


### PR DESCRIPTION
@deads2k moved the `StorageClass` in  https://github.com/kubernetes/kubernetes/commit/6320dc6e73b8d2405618af4bc3acf8d51b7d0f63 from `apiVersion: extensions/v1beta1` to `apiVersion: storage.k8s.io/v1beta1` this PR updates the files inside `examples/experimental/persistent-volume-provisioning` to work with the modification.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32388)

<!-- Reviewable:end -->
