### PR TITLE
Run hack/update-munge-docs.sh

### DIFF
--- a/docs/proposals/external-lb-source-ip-preservation.md
+++ b/docs/proposals/external-lb-source-ip-preservation.md
@@ -18,6 +18,11 @@
 If you are using a released version of Kubernetes, you should
 refer to the docs that go with that version.
 
+<!-- TAG RELEASE_LINK, added by the munger automatically -->
+<strong>
+The latest release of this document can be found
+[here](http://releases.k8s.io/release-1.4/docs/proposals/external-lb-source-ip-preservation.md).
+
 Documentation for other releases can be found at
 [releases.k8s.io](http://releases.k8s.io).
 </strong>


### PR DESCRIPTION
Seems like hack/verify-munge-docs.sh  fails right now on the release branch.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32394)

<!-- Reviewable:end -->
