### PR TITLE
Fix etcd2 cross-build in the Makefile

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[TAG=2.2.1] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[TAG=3.0.4] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 
 TAG?=3.0.4
 ARCH?=amd64
@@ -42,8 +42,9 @@ build:
 	# without copying the subdirectories.
 	find ./ -maxdepth 1 -type f | xargs cp -t $(TEMP_DIR)
 
-	make -C ../../../ WHAT=cluster/images/etcd/attachlease KUBE_STATIC_OVERRIDES="etcd";
-	cp "../../../_output/bin/attachlease" $(TEMP_DIR)
+	# Compile attachlease
+	docker run -it -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+		/bin/bash -c "CGO_ENABLED=0 go build -o /build/attachlease k8s.io/kubernetes/cluster/images/etcd/attachlease"
 
 ifeq ($(ARCH),amd64)
 
@@ -57,7 +58,7 @@ else
 		&& cd /go/src/github.com/coreos/etcd \
 		&& git checkout v$(TAG) \
 		&& GOARM=$(GOARM) GOARCH=$(ARCH) ./build \
-		&& cp bin/$(ARCH)/* /etcdbin"
+		&& cp -f bin/$(ARCH)/etcd* bin/etcd* /etcdbin; echo 'done'"
 
 	# Add this ENV variable in order to workaround an unsupported arch blocker
 	# The multiarch feature is in an limited and experimental state right now, and etcd should work fine on arm64


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/32328

Make it possible to compile both etcd2 and etcd3 in the Makefile and compile attachlease for multiple arches as well.

@lavalamp The etcd build-from-source semantics changed between etcd2 and etcd3.
I updated it to etcd3 in my last PR, and didn't think we were gonna build etcd2 more.
However, I've now fixed it to build for both versions.
Thanks!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32397)

<!-- Reviewable:end -->
