### PR TITLE
add local subject access review API

### DIFF
--- a/api/swagger-spec/authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1beta1.json
@@ -9,6 +9,59 @@
   },
   "apis": [
    {
+    "path": "/apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews",
+    "description": "API at /apis/authorization.k8s.io/v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.LocalSubjectAccessReview",
+      "method": "POST",
+      "summary": "create a LocalSubjectAccessReview",
+      "nickname": "createNamespacedLocalSubjectAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.LocalSubjectAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.LocalSubjectAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews",
     "description": "API at /apis/authorization.k8s.io/v1beta1",
     "operations": [
@@ -123,9 +176,9 @@
    }
   ],
   "models": {
-   "v1beta1.SelfSubjectAccessReview": {
-    "id": "v1beta1.SelfSubjectAccessReview",
-    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+   "v1beta1.LocalSubjectAccessReview": {
+    "id": "v1beta1.LocalSubjectAccessReview",
+    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
     "required": [
      "spec"
     ],
@@ -142,8 +195,8 @@
       "$ref": "v1.ObjectMeta"
      },
      "spec": {
-      "$ref": "v1beta1.SelfSubjectAccessReviewSpec",
-      "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
+      "$ref": "v1beta1.SubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
      },
      "status": {
       "$ref": "v1beta1.SubjectAccessReviewStatus",
@@ -259,9 +312,9 @@
      }
     }
    },
-   "v1beta1.SelfSubjectAccessReviewSpec": {
-    "id": "v1beta1.SelfSubjectAccessReviewSpec",
-    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+   "v1beta1.SubjectAccessReviewSpec": {
+    "id": "v1beta1.SubjectAccessReviewSpec",
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
     "properties": {
      "resourceAttributes": {
       "$ref": "v1beta1.ResourceAttributes",
@@ -270,6 +323,21 @@
      "nonResourceAttributes": {
       "$ref": "v1beta1.NonResourceAttributes",
       "description": "NonResourceAttributes describes information for a non-resource access request"
+     },
+     "user": {
+      "type": "string",
+      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups"
+     },
+     "group": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Groups is the groups you're testing for."
+     },
+     "extra": {
+      "type": "object",
+      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here."
      }
     }
    },
@@ -342,6 +410,48 @@
      }
     }
    },
+   "v1beta1.SelfSubjectAccessReview": {
+    "id": "v1beta1.SelfSubjectAccessReview",
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.SelfSubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
+     },
+     "status": {
+      "$ref": "v1beta1.SubjectAccessReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+     }
+    }
+   },
+   "v1beta1.SelfSubjectAccessReviewSpec": {
+    "id": "v1beta1.SelfSubjectAccessReviewSpec",
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "resourceAttributes": {
+      "$ref": "v1beta1.ResourceAttributes",
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+     },
+     "nonResourceAttributes": {
+      "$ref": "v1beta1.NonResourceAttributes",
+      "description": "NonResourceAttributes describes information for a non-resource access request"
+     }
+    }
+   },
    "v1beta1.SubjectAccessReview": {
     "id": "v1beta1.SubjectAccessReview",
     "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
@@ -367,35 +477,6 @@
      "status": {
       "$ref": "v1beta1.SubjectAccessReviewStatus",
       "description": "Status is filled in by the server and indicates whether the request is allowed or not"
-     }
-    }
-   },
-   "v1beta1.SubjectAccessReviewSpec": {
-    "id": "v1beta1.SubjectAccessReviewSpec",
-    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-    "properties": {
-     "resourceAttributes": {
-      "$ref": "v1beta1.ResourceAttributes",
-      "description": "ResourceAuthorizationAttributes describes information for a resource access request"
-     },
-     "nonResourceAttributes": {
-      "$ref": "v1beta1.NonResourceAttributes",
-      "description": "NonResourceAttributes describes information for a non-resource access request"
-     },
-     "user": {
-      "type": "string",
-      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups"
-     },
-     "group": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "Groups is the groups you're testing for."
-     },
-     "extra": {
-      "type": "object",
-      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here."
      }
     }
    },

--- a/pkg/apis/authorization/types.go
+++ b/pkg/apis/authorization/types.go
@@ -56,6 +56,9 @@ type SelfSubjectAccessReview struct {
 	Status SubjectAccessReviewStatus
 }
 
+// +genclient=true
+// +noMethods=true
+
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.

--- a/pkg/apis/authorization/v1beta1/types.go
+++ b/pkg/apis/authorization/v1beta1/types.go
@@ -57,6 +57,9 @@ type SelfSubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+// +genclient=true
+// +noMethods=true
+
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.

--- a/pkg/apis/authorization/validation/validation_test.go
+++ b/pkg/apis/authorization/validation/validation_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api"
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 )
@@ -126,6 +127,71 @@ func TestValidateSelfSAR(t *testing.T) {
 		}
 
 		errs = ValidateSelfSubjectAccessReview(&authorizationapi.SelfSubjectAccessReview{Spec: c.obj})
+		if len(errs) == 0 {
+			t.Errorf("%s: expected failure for %q", c.name, c.msg)
+		} else if !strings.Contains(errs[0].Error(), c.msg) {
+			t.Errorf("%s: unexpected error: %q, expected: %q", c.name, errs[0], c.msg)
+		}
+	}
+}
+
+func TestValidateLocalSAR(t *testing.T) {
+	successCases := []authorizationapi.LocalSubjectAccessReview{
+		{
+			Spec: authorizationapi.SubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationapi.ResourceAttributes{},
+				User:               "user",
+			},
+		},
+	}
+	for _, successCase := range successCases {
+		if errs := ValidateLocalSubjectAccessReview(&successCase); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+
+	errorCases := []struct {
+		name string
+		obj  *authorizationapi.LocalSubjectAccessReview
+		msg  string
+	}{
+		{
+			name: "name",
+			obj: &authorizationapi.LocalSubjectAccessReview{
+				ObjectMeta: api.ObjectMeta{Name: "a"},
+				Spec: authorizationapi.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationapi.ResourceAttributes{},
+					User:               "user",
+				},
+			},
+			msg: "must be empty except for namespace",
+		},
+		{
+			name: "namespace conflict",
+			obj: &authorizationapi.LocalSubjectAccessReview{
+				ObjectMeta: api.ObjectMeta{Namespace: "a"},
+				Spec: authorizationapi.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationapi.ResourceAttributes{},
+					User:               "user",
+				},
+			},
+			msg: "must match metadata.namespace",
+		},
+		{
+			name: "nonresource",
+			obj: &authorizationapi.LocalSubjectAccessReview{
+				ObjectMeta: api.ObjectMeta{Namespace: "a"},
+				Spec: authorizationapi.SubjectAccessReviewSpec{
+					NonResourceAttributes: &authorizationapi.NonResourceAttributes{},
+					User: "user",
+				},
+			},
+			msg: "disallowed on this kind of request",
+		},
+	}
+
+	for _, c := range errorCases {
+		errs := ValidateLocalSubjectAccessReview(c.obj)
 		if len(errs) == 0 {
 			t.Errorf("%s: expected failure for %q", c.name, c.msg)
 		} else if !strings.Contains(errs[0].Error(), c.msg) {

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
@@ -24,6 +24,7 @@ import (
 
 type AuthorizationInterface interface {
 	GetRESTClient() *restclient.RESTClient
+	LocalSubjectAccessReviewsGetter
 	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
 }
@@ -31,6 +32,10 @@ type AuthorizationInterface interface {
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
 	*restclient.RESTClient
+}
+
+func (c *AuthorizationClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
+	return newLocalSubjectAccessReviews(c, namespace)
 }
 
 func (c *AuthorizationClient) SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface {

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
@@ -26,6 +26,10 @@ type FakeAuthorization struct {
 	*core.Fake
 }
 
+func (c *FakeAuthorization) LocalSubjectAccessReviews(namespace string) unversioned.LocalSubjectAccessReviewInterface {
+	return &FakeLocalSubjectAccessReviews{c, namespace}
+}
+
 func (c *FakeAuthorization) SelfSubjectAccessReviews() unversioned.SelfSubjectAccessReviewInterface {
 	return &FakeSelfSubjectAccessReviews{c}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_localsubjectaccessreview.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+// FakeLocalSubjectAccessReviews implements LocalSubjectAccessReviewInterface
+type FakeLocalSubjectAccessReviews struct {
+	Fake *FakeAuthorization
+	ns   string
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+// LocalSubjectAccessReviewsGetter has a method to return a LocalSubjectAccessReviewInterface.
+// A group's client should implement this interface.
+type LocalSubjectAccessReviewsGetter interface {
+	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface
+}
+
+// LocalSubjectAccessReviewInterface has methods to work with LocalSubjectAccessReview resources.
+type LocalSubjectAccessReviewInterface interface {
+	LocalSubjectAccessReviewExpansion
+}
+
+// localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
+type localSubjectAccessReviews struct {
+	client *AuthorizationClient
+	ns     string
+}
+
+// newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
+func newLocalSubjectAccessReviews(c *AuthorizationClient, namespace string) *localSubjectAccessReviews {
+	return &localSubjectAccessReviews{
+		client: c,
+		ns:     namespace,
+	}
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview_expansion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
+)
+
+type LocalSubjectAccessReviewExpansion interface {
+	Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error)
+}
+
+func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error) {
+	result = &authorizationapi.LocalSubjectAccessReview{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("localsubjectaccessreviews").
+		Body(sar).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/authorization_client.go
@@ -25,6 +25,7 @@ import (
 
 type AuthorizationInterface interface {
 	GetRESTClient() *restclient.RESTClient
+	LocalSubjectAccessReviewsGetter
 	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
 }
@@ -32,6 +33,10 @@ type AuthorizationInterface interface {
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
 	*restclient.RESTClient
+}
+
+func (c *AuthorizationClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
+	return newLocalSubjectAccessReviews(c, namespace)
 }
 
 func (c *AuthorizationClient) SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface {

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_authorization_client.go
@@ -26,6 +26,10 @@ type FakeAuthorization struct {
 	*core.Fake
 }
 
+func (c *FakeAuthorization) LocalSubjectAccessReviews(namespace string) v1beta1.LocalSubjectAccessReviewInterface {
+	return &FakeLocalSubjectAccessReviews{c, namespace}
+}
+
 func (c *FakeAuthorization) SelfSubjectAccessReviews() v1beta1.SelfSubjectAccessReviewInterface {
 	return &FakeSelfSubjectAccessReviews{c}
 }

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_localsubjectaccessreview.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+// FakeLocalSubjectAccessReviews implements LocalSubjectAccessReviewInterface
+type FakeLocalSubjectAccessReviews struct {
+	Fake *FakeAuthorization
+	ns   string
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_localsubjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/fake/fake_localsubjectaccessreview_expansion.go
@@ -17,20 +17,10 @@ limitations under the License.
 package fake
 
 import (
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 
 	"k8s.io/kubernetes/pkg/client/testing/core"
 )
-
-func (c *FakeSubjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
-	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("subjectaccessreviews"), sar), &authorizationapi.SubjectAccessReview{})
-	return obj.(*authorizationapi.SubjectAccessReview), err
-}
-
-func (c *FakeSelfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
-	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("selfsubjectaccessreviews"), sar), &authorizationapi.SelfSubjectAccessReview{})
-	return obj.(*authorizationapi.SelfSubjectAccessReview), err
-}
 
 func (c *FakeLocalSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error) {
 	obj, err := c.Fake.Invokes(core.NewCreateAction(authorizationapi.SchemeGroupVersion.WithResource("localsubjectaccessreviews"), c.ns, sar), &authorizationapi.SubjectAccessReview{})

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// LocalSubjectAccessReviewsGetter has a method to return a LocalSubjectAccessReviewInterface.
+// A group's client should implement this interface.
+type LocalSubjectAccessReviewsGetter interface {
+	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface
+}
+
+// LocalSubjectAccessReviewInterface has methods to work with LocalSubjectAccessReview resources.
+type LocalSubjectAccessReviewInterface interface {
+	LocalSubjectAccessReviewExpansion
+}
+
+// localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
+type localSubjectAccessReviews struct {
+	client *AuthorizationClient
+	ns     string
+}
+
+// newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
+func newLocalSubjectAccessReviews(c *AuthorizationClient, namespace string) *localSubjectAccessReviews {
+	return &localSubjectAccessReviews{
+		client: c,
+		ns:     namespace,
+	}
+}

--- a/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
+++ b/pkg/client/clientset_generated/release_1_4/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
+)
+
+type LocalSubjectAccessReviewExpansion interface {
+	Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error)
+}
+
+func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error) {
+	result = &authorizationapi.LocalSubjectAccessReview{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("localsubjectaccessreviews").
+		Body(sar).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -525,13 +525,14 @@ func (gc *GarbageCollector) monitorFor(resource unversioned.GroupVersionResource
 }
 
 var ignoredResources = map[unversioned.GroupVersionResource]struct{}{
-	unversioned.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicationcontrollers"}:             {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "bindings"}:                                          {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuses"}:                                 {},
-	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}:                                            {},
-	unversioned.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1beta1", Resource: "tokenreviews"}:            {},
-	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "subjectaccessreviews"}:     {},
-	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "selfsubjectaccessreviews"}: {},
+	unversioned.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicationcontrollers"}:              {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "bindings"}:                                           {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuses"}:                                  {},
+	unversioned.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}:                                             {},
+	unversioned.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1beta1", Resource: "tokenreviews"}:             {},
+	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "subjectaccessreviews"}:      {},
+	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "selfsubjectaccessreviews"}:  {},
+	unversioned.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "localsubjectaccessreviews"}: {},
 }
 
 func NewGarbageCollector(metaOnlyClientPool dynamic.ClientPool, clientPool dynamic.ClientPool, resources []unversioned.GroupVersionResource) (*GarbageCollector, error) {

--- a/pkg/master/storage_authorization.go
+++ b/pkg/master/storage_authorization.go
@@ -22,6 +22,7 @@ import (
 	authorizationv1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry/authorization/localsubjectaccessreview"
 	"k8s.io/kubernetes/pkg/registry/authorization/selfsubjectaccessreview"
 	"k8s.io/kubernetes/pkg/registry/authorization/subjectaccessreview"
 )
@@ -56,6 +57,9 @@ func (p AuthorizationRESTStorageProvider) v1beta1Storage(apiResourceConfigSource
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
 		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("localsubjectaccessreviews")) {
+		storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
 	}
 
 	return storage

--- a/pkg/registry/authorization/util/helpers.go
+++ b/pkg/registry/authorization/util/helpers.go
@@ -42,3 +42,33 @@ func NonResourceAttributesFrom(user user.Info, in authorizationapi.NonResourceAt
 		Path:            in.Path,
 	}
 }
+
+func convertToUserInfoExtra(extra map[string]authorizationapi.ExtraValue) map[string][]string {
+	if extra == nil {
+		return nil
+	}
+	ret := map[string][]string{}
+	for k, v := range extra {
+		ret[k] = []string(v)
+	}
+
+	return ret
+}
+
+// AuthorizationAttributesFrom takes a spec and returns the proper authz attributes to check it.
+func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) authorizer.AttributesRecord {
+	userToCheck := &user.DefaultInfo{
+		Name:   spec.User,
+		Groups: spec.Groups,
+		Extra:  convertToUserInfoExtra(spec.Extra),
+	}
+
+	var authorizationAttributes authorizer.AttributesRecord
+	if spec.ResourceAttributes != nil {
+		authorizationAttributes = ResourceAttributesFrom(userToCheck, *spec.ResourceAttributes)
+	} else {
+		authorizationAttributes = NonResourceAttributesFrom(userToCheck, *spec.NonResourceAttributes)
+	}
+
+	return authorizationAttributes
+}


### PR DESCRIPTION
Adds a local subject access review endpoint to allow a project-admin (someone with full rights within a namespace) the power to inspect whether a person can perform an action in his namespace.  This is a separate resource be factoring like this ensures that it is impossible for him to look outside his namespace and makes it possible to create authorization rules that can restrict this power to a project-admin in his own namespace.  Other factorings require introspection of objects.

@kubernetes/sig-auth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32407)

<!-- Reviewable:end -->
