### PR TITLE
Add Rancher as a cloud provider

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1345,6 +1345,10 @@
 			"Rev": "8096f47503459bcc74d1f4c487b7e6e42e5746b5"
 		},
 		{
+			"ImportPath": "github.com/gorilla/websocket",
+			"Rev": "6eb6ad425a89d9da7a5549bc6da8f79ba5c17844"
+		},
+		{
 			"ImportPath": "github.com/grpc-ecosystem/grpc-gateway/runtime",
 			"Comment": "v1.0.0-8-gf52d055",
 			"Rev": "f52d055dc48aec25854ed7d31862f78913cf17d1"
@@ -2020,6 +2024,11 @@
 			"ImportPath": "github.com/rackspace/gophercloud/testhelper/client",
 			"Comment": "v1.0.0-920-g934dbf8",
 			"Rev": "934dbf81977c67c521c75492dc1f55ca74dc5b04"
+		},
+		{
+			"ImportPath": "github.com/rancher/go-rancher/client",
+			"Comment": "v0.1.0-196-g09693a8",
+			"Rev": "09693a8743ba5ee58c58c1b1e8a4abd17af00d45"
 		},
 		{
 			"ImportPath": "github.com/renstrom/dedent",

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -21,6 +21,7 @@ import (
 	// Credential providers
 	_ "k8s.io/kubernetes/pkg/credentialprovider/aws"
 	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+	_ "k8s.io/kubernetes/pkg/credentialprovider/rancher"
 	// Network plugins
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/cni"

--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -26,5 +26,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rancher"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 )

--- a/pkg/cloudprovider/providers/rancher/rancher.go
+++ b/pkg/cloudprovider/providers/rancher/rancher.go
@@ -1,0 +1,925 @@
+package rancher
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rancher/go-rancher/client"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type Host struct {
+	RancherHost *client.Host
+	IPAddresses []client.IpAddress
+}
+
+type PublicEndpoint struct {
+	IPAddress string
+	Port      int
+}
+
+const (
+	providerName                = "rancher"
+	lbNameFormat         string = "lb-%s"
+	kubernetesEnvName    string = "kubernetes-loadbalancers"
+	kubernetesExternalId string = "kubernetes-loadbalancers://"
+)
+
+var allowedChars = regexp.MustCompile("[^a-zA-Z0-9-]")
+var dupeHyphen = regexp.MustCompile("-+")
+
+// CloudProvider implents Instances, Zones, and LoadBalancer
+type CloudProvider struct {
+	client    *client.RancherClient
+	conf      *rConfig
+	hostCache cache.Store
+}
+
+// ProviderName returns the cloud provider ID.
+func (r *CloudProvider) ProviderName() string {
+	return providerName
+}
+
+// ScrubDNS filters DNS settings for pods.
+func (r *CloudProvider) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
+// LoadBalancer returns an implementation of LoadBalancer for Rancher
+func (r *CloudProvider) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return r, true
+}
+
+// Zones returns an implementation of Zones for Rancher
+func (r *CloudProvider) Zones() (cloudprovider.Zones, bool) {
+	return r, true
+}
+
+// Instances returns an implementation of Instances for Rancher
+func (r *CloudProvider) Instances() (cloudprovider.Instances, bool) {
+	return r, true
+}
+
+// Clusters not supported
+func (r *CloudProvider) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// Routes not supported
+func (r *CloudProvider) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+// --- LoadBalancer Functions ---
+
+type instanceCollection struct {
+	Data []instanceAndHost `json:"data,omitempty"`
+}
+
+type instanceAndHost struct {
+	client.Instance
+	Hosts []client.Host `json:"hosts,omitempty"`
+}
+
+type hostCollection struct {
+	Data []hostAndIPAddresses
+}
+
+type hostAndIPAddresses struct {
+	client.Host
+	IPAddresses []client.IpAddress `json:"ipAddresses,omitempty"`
+}
+
+// GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
+func (r *CloudProvider) GetLoadBalancer(clusterName string, service *api.Service) (status *api.LoadBalancerStatus, exists bool, retErr error) {
+	name := formatLBName(cloudprovider.GetLoadBalancerName(service))
+	glog.Infof("GetLoadBalancer [%s]", name)
+
+	lb, err := r.getLBByName(name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if lb == nil {
+		glog.Infof("Can't find lb by name [%s]", name)
+		return &api.LoadBalancerStatus{}, false, nil
+	}
+
+	return r.toLBStatus(lb)
+}
+
+// EnsureLoadBalancer is an implementation of LoadBalancer.EnsureLoadBalancer.
+func (r *CloudProvider) EnsureLoadBalancer(clusterName string, service *api.Service, hosts []string) (*api.LoadBalancerStatus, error) {
+	name := formatLBName(cloudprovider.GetLoadBalancerName(service))
+	loadBalancerIP := service.Spec.LoadBalancerIP
+	ports := service.Spec.Ports
+	affinity := service.Spec.SessionAffinity
+	glog.Infof("EnsureLoadBalancer [%s] [%#v] [%#v] [%s] [%s]", name, loadBalancerIP, ports, hosts, affinity)
+
+	if loadBalancerIP != "" {
+		// Rancher doesn't support specifying loadBalancer IP
+		return nil, fmt.Errorf("loadBalancerIP cannot be specified for Rancher LoadBalancer")
+	}
+
+	if affinity != api.ServiceAffinityNone {
+		// Rancher supports sticky sessions, but only when configured for HTTP/HTTPS
+		return nil, fmt.Errorf("Unsupported load balancer affinity: %v", affinity)
+	}
+
+	lb, err := r.getLBByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	lbPorts := []string{}
+	for _, port := range ports {
+		if port.NodePort == 0 {
+			glog.Warningf("Ignoring port without NodePort: %s", port)
+		}
+		lbPorts = append(lbPorts, fmt.Sprintf("%v:%v/tcp", port.Port, port.NodePort))
+	}
+
+	if lb != nil && portsChanged(lbPorts, lb.LaunchConfig.Ports) {
+		glog.Infof("Deleting the lb because the ports changed %s", lb.Name)
+		// Cannot update ports on an LB, so if the ports have changed, need to recreate
+		err = r.deleteLoadBalancer(lb)
+		if err != nil {
+			return nil, err
+		}
+		lb = nil
+	}
+
+	if lb == nil {
+		env, err := r.getOrCreateEnvironment()
+		if err != nil {
+			return nil, err
+		}
+
+		lb = &client.LoadBalancerService{
+			Name:          name,
+			EnvironmentId: env.Id,
+			LaunchConfig: &client.LaunchConfig{
+				Ports: lbPorts,
+			},
+			ExternalId: string(service.UID),
+		}
+
+		lb, err = r.client.LoadBalancerService.Create(lb)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to create load balancer for service %s. Error: %#v", name, err)
+		}
+	}
+
+	err = r.setLBHosts(lb, hosts)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.EqualFold(lb.State, "active") {
+		actionChannel := r.waitForLBAction("activate", lb)
+		lbInterface, ok := <-actionChannel
+		if !ok {
+			return nil, fmt.Errorf("Couldn't call activate on LB %s", lb.Name)
+		}
+		lb = convertLB(lbInterface)
+		_, err = r.client.LoadBalancerService.ActionActivate(lb)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating LB %s. Couldn't activate LB. Error: %#v", name, err)
+		}
+	}
+
+	lb, err = r.reloadLBService(lb)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating LB %s. Couldn't reload LB to get status. Error: %#v", name, err)
+	}
+
+	// wait till service is active
+	actionChannel := r.waitForLBAction("deactivate", lb)
+	lbInterface, ok := <-actionChannel
+	if !ok {
+		return nil, fmt.Errorf("Timeout for service to become active %s", lb.Name)
+	}
+	lb = convertLB(lbInterface)
+
+	epChannel := r.waitForLBPublicEndpoints(1, lb)
+	_, ok = <-epChannel
+	if !ok {
+		return nil, fmt.Errorf("Couldn't get publicEndpoints for LB %s", name)
+	}
+
+	lb, err = r.reloadLBService(lb)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating LB %s. Couldn't reload LB to get status. Error: %#v", name, err)
+	}
+
+	status, _, err := r.toLBStatus(lb)
+	if err != nil {
+		return nil, err
+	}
+
+	return status, nil
+}
+
+func (r *CloudProvider) waitForLBPublicEndpoints(count int, lb *client.LoadBalancerService) <-chan interface{} {
+	cb := func(result chan<- interface{}) (bool, error) {
+		lb, err := r.reloadLBService(lb)
+		if err != nil {
+			return false, err
+		}
+		if len(lb.PublicEndpoints) >= count {
+			result <- lb
+			return true, nil
+		}
+		return false, nil
+	}
+	return r.waitForAction("publicEndpoints", cb)
+}
+
+func (r *CloudProvider) reloadLBService(lb *client.LoadBalancerService) (*client.LoadBalancerService, error) {
+	lb, err := r.client.LoadBalancerService.ById(lb.Id)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't reload LB [%s]. Error: %#v", lb.Name, err)
+	}
+	return lb, nil
+}
+
+func convertLB(intf interface{}) *client.LoadBalancerService {
+	lb, ok := intf.(*client.LoadBalancerService)
+	if !ok {
+		panic(fmt.Sprintf("Couldn't cast to LoadBalancerService type! Interface: %#v", intf))
+	}
+	return lb
+}
+
+// UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
+func (r *CloudProvider) UpdateLoadBalancer(clusterName string, service *api.Service, hosts []string) error {
+	name := formatLBName(cloudprovider.GetLoadBalancerName(service))
+	glog.Infof("UpdateLoadBalancer [%s] [%s]", name, hosts)
+	lb, err := r.getLBByName(name)
+	if err != nil {
+		return err
+	}
+
+	if lb == nil {
+		return fmt.Errorf("Couldn't find LB with name %s", name)
+	}
+
+	err = r.deleteLBConsumedServices(lb)
+	if err != nil {
+		return err
+	}
+
+	err = r.setLBHosts(lb, hosts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// EnsureLoadBalancerDeleted is an implementation of LoadBalancer.EnsureLoadBalancerDeleted.
+func (r *CloudProvider) EnsureLoadBalancerDeleted(clusterName string, service *api.Service) error {
+	name := formatLBName(cloudprovider.GetLoadBalancerName(service))
+	glog.Infof("EnsureLoadBalancerDeleted [%s]", name)
+	lb, err := r.getLBByName(name)
+	if err != nil {
+		return err
+	}
+
+	if lb == nil {
+		glog.Infof("Couldn't find LB %s to delete. Nothing to do.")
+		return nil
+	}
+
+	return r.deleteLoadBalancer(lb)
+}
+
+func (r *CloudProvider) getOrCreateEnvironment() (*client.Environment, error) {
+	opts := client.NewListOpts()
+	opts.Filters["name"] = kubernetesEnvName
+	opts.Filters["removed_null"] = "1"
+	opts.Filters["external_id"] = kubernetesExternalId
+
+	envs, err := r.client.Environment.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get host by name [%s]. Error: %#v", kubernetesEnvName, err)
+	}
+
+	if len(envs.Data) >= 1 {
+		return &envs.Data[0], nil
+	}
+
+	env := &client.Environment{
+		Name:       kubernetesEnvName,
+		ExternalId: kubernetesExternalId,
+	}
+
+	env, err = r.client.Environment.Create(env)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't create environment for kubernetes LBs. Error: %#v", err)
+	}
+	return env, nil
+}
+
+func (r *CloudProvider) setLBHosts(lb *client.LoadBalancerService, hosts []string) error {
+	serviceLinks := &client.SetLoadBalancerServiceLinksInput{}
+	for _, hostname := range hosts {
+		extSvcName := buildExternalServiceName(hostname)
+		opts := client.NewListOpts()
+		opts.Filters["name"] = extSvcName
+		opts.Filters["environmentId"] = lb.EnvironmentId
+		opts.Filters["removed_null"] = "1"
+
+		exSvces, err := r.client.ExternalService.List(opts)
+		if err != nil {
+			return fmt.Errorf("Couldn't get external service %s for LB %s. Error: %#v.", extSvcName, lb.Name, err)
+		}
+
+		var exSvc *client.ExternalService
+		if len(exSvces.Data) > 0 {
+			exSvc = &exSvces.Data[0]
+		} else {
+			host, err := r.hostGetOrFetchFromCache(hostname)
+			if err != nil {
+				return fmt.Errorf("Couldn't create extrnal service %s for LB %s. Error: %#v", hostname, lb.Name, err)
+			}
+
+			if len(host.IPAddresses) < 1 {
+				continue
+			}
+
+			exSvc = &client.ExternalService{
+				Name:                extSvcName,
+				ExternalIpAddresses: []string{host.IPAddresses[0].Address},
+				EnvironmentId:       lb.EnvironmentId,
+			}
+			exSvc, err = r.client.ExternalService.Create(exSvc)
+			if err != nil {
+				return fmt.Errorf("Error setting hosts for LB %s. Couldn't create external service for host %s. Error: %#v",
+					lb.Name, extSvcName, err)
+			}
+		}
+
+		if exSvc.State != "active" {
+			actionChannel := r.waitForSvcAction("activate", exSvc)
+			svcInterface, ok := <-actionChannel
+			if !ok {
+				return fmt.Errorf("Couldn't call activate on external service %s for LB %s", exSvc.Id, lb.Name)
+			}
+			exSvc, ok = svcInterface.(*client.ExternalService)
+			if !ok {
+				panic(fmt.Sprintf("Couldn't cast to ExternalService type! Interface: %#v", svcInterface))
+			}
+
+			_, err = r.client.ExternalService.ActionActivate(exSvc)
+			if err != nil {
+				return fmt.Errorf("Couldn't activate service for LB %s. Error: %#v", lb.Name, err)
+			}
+		}
+		serviceLinks.ServiceLinks = append(serviceLinks.ServiceLinks, &client.LoadBalancerServiceLink{ServiceId: exSvc.Id})
+
+	}
+
+	actionChannel := r.waitForLBAction("setservicelinks", lb)
+	lbInterface, ok := <-actionChannel
+	if !ok {
+		return fmt.Errorf("Couldn't call setservicelinks on LB %s", lb.Name)
+	}
+	lb = convertLB(lbInterface)
+
+	_, err := r.client.LoadBalancerService.ActionSetservicelinks(lb, serviceLinks)
+	if err != nil {
+		return fmt.Errorf("Error setting hosts for LB%s. Couldn't set LB service links. Error: %#v.", lb.Name, err)
+	}
+
+	return nil
+}
+
+func buildExternalServiceName(hostname string) string {
+	cleaned := allowedChars.ReplaceAllString(hostname, "-")
+	cleaned = strings.Trim(cleaned, "-")
+	cleaned = dupeHyphen.ReplaceAllString(cleaned, "-")
+	if len(cleaned) > 63 {
+		cleaned = cleaned[:63]
+	}
+	return cleaned
+}
+
+type waitCallback func(result chan<- interface{}) (bool, error)
+
+func (r *CloudProvider) waitForLBAction(action string, lb *client.LoadBalancerService) <-chan interface{} {
+	cb := func(result chan<- interface{}) (bool, error) {
+		l, err := r.client.LoadBalancerService.ById(lb.Id)
+		if err != nil {
+			return false, fmt.Errorf("Error waiting for action %s for LB %s. Couldn't get LB by id. Error: %#v.", action, lb.Name, err)
+		}
+		if _, ok := l.Actions[action]; ok {
+			result <- l
+			return true, nil
+		}
+		return false, nil
+	}
+	return r.waitForAction(action, cb)
+}
+
+func (r *CloudProvider) waitForSvcAction(action string, svc *client.ExternalService) <-chan interface{} {
+	cb := func(result chan<- interface{}) (bool, error) {
+		s, err := r.client.ExternalService.ById(svc.Id)
+		if err != nil {
+			return false, fmt.Errorf("Error waiting for action %s for service %s. Couldn't get service by id. Error %#v.", action, svc.Name, err)
+		}
+		if _, ok := s.Actions[action]; ok {
+			result <- s
+			return true, nil
+		}
+		return false, nil
+	}
+	return r.waitForAction(action, cb)
+}
+
+func (r *CloudProvider) waitForAction(action string, callback waitCallback) <-chan interface{} {
+	ready := make(chan interface{}, 0)
+	go func() {
+		sleep := 2
+		defer close(ready)
+		for i := 0; i < 30; i++ {
+			foundAction, err := callback(ready)
+			if err != nil {
+				glog.Errorf("Error: %#v", err)
+				return
+			}
+
+			if foundAction {
+				return
+			}
+			time.Sleep(time.Second * time.Duration(sleep))
+		}
+		glog.Errorf("Timed out waiting for action %s.", action)
+	}()
+	return ready
+}
+
+func (r *CloudProvider) getLBByName(name string) (*client.LoadBalancerService, error) {
+	opts := client.NewListOpts()
+	opts.Filters["name"] = name
+	opts.Filters["removed_null"] = "1"
+	lbs, err := r.client.LoadBalancerService.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get LB by name [%s]. Error: %#v", name, err)
+	}
+
+	if len(lbs.Data) == 0 {
+		return nil, nil
+	}
+
+	if len(lbs.Data) > 1 {
+		return nil, fmt.Errorf("Multiple LBs found for name: %s", name)
+	}
+
+	return &lbs.Data[0], nil
+}
+
+func convertObject(obj1 interface{}, obj2 interface{}) error {
+	b, err := json.Marshal(obj1)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(b, obj2); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CloudProvider) toLBStatus(lb *client.LoadBalancerService) (*api.LoadBalancerStatus, bool, error) {
+	eps := lb.PublicEndpoints
+
+	ingress := []api.LoadBalancerIngress{}
+
+	for _, epObj := range eps {
+		ep := PublicEndpoint{}
+
+		err := convertObject(epObj, &ep)
+		if err != nil {
+			return nil, false, err
+		}
+		ingress = append(ingress, api.LoadBalancerIngress{IP: ep.IPAddress})
+	}
+
+	return &api.LoadBalancerStatus{ingress}, true, nil
+}
+
+func (r *CloudProvider) deleteLoadBalancer(lb *client.LoadBalancerService) error {
+	err := r.deleteLBConsumedServices(lb)
+	if err != nil {
+		return err
+	}
+
+	err = r.client.LoadBalancerService.Delete(lb)
+	if err != nil {
+		return fmt.Errorf("Unable to delete load balancer for service %s. Error: %#v", lb.Name, err)
+	}
+	return nil
+}
+
+func (r *CloudProvider) deleteLBConsumedServices(lb *client.LoadBalancerService) error {
+	coll := &client.ServiceCollection{}
+	err := r.client.GetLink(lb.Resource, "consumedservices", coll)
+	if err != nil {
+		return fmt.Errorf("Can't delete consumed services for LB %s. Error getting consumed services. Error: %#v", lb.Name, err)
+	}
+
+	for _, service := range coll.Data {
+		consumedBy := &client.ServiceCollection{}
+		err = r.client.GetLink(service.Resource, "consumedbyservices", consumedBy)
+		if err != nil {
+			glog.Errorf("Error getting consumedby services for service %s. This service won't be deleted. Error: %#v",
+				service.Id, err)
+			continue
+		}
+
+		if len(consumedBy.Data) > 1 {
+			glog.Infof("Service %s has more than consumer. Will not delete it.", service.Id)
+			continue
+		}
+
+		err = r.client.Service.Delete(&service)
+		if err != nil {
+			glog.Warningf("Error deleting service %s. Moving on. Error: %#v", service.Id, err)
+		}
+	}
+
+	return nil
+}
+
+// --- Instances Functions ---
+
+// NodeAddresses returns the addresses of the specified instance.
+// This implementation only returns the address of the calling instance. This is ok
+// because the gce implementation makes that assumption and the comment for the interface
+// states it as a todo to clarify that it is only for the current host
+func (r *CloudProvider) NodeAddresses(name string) ([]api.NodeAddress, error) {
+	host, err := r.hostGetOrFetchFromCache(name)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := []api.NodeAddress{}
+	for _, ip := range host.IPAddresses {
+		addresses = append(addresses, api.NodeAddress{Type: api.NodeExternalIP, Address: ip.Address})
+		addresses = append(addresses, api.NodeAddress{Type: api.NodeLegacyHostIP, Address: ip.Address})
+	}
+	addresses = append(addresses, api.NodeAddress{Type: api.NodeHostName, Address: host.RancherHost.Hostname})
+
+	return addresses, nil
+}
+
+// ExternalID returns the cloud provider ID of the specified instance (deprecated).
+func (r *CloudProvider) ExternalID(name string) (string, error) {
+	glog.Infof("ExternalID [%s]", name)
+	return r.InstanceID(name)
+}
+
+// InstanceID returns the cloud provider ID of the specified instance.
+func (r *CloudProvider) InstanceID(name string) (string, error) {
+	glog.Infof("InstanceID [%s]", name)
+	host, err := r.hostGetOrFetchFromCache(name)
+	if err != nil {
+		return "", err
+	}
+
+	return host.RancherHost.Uuid, nil
+}
+
+// InstanceType returns the type of the specified instance.
+// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
+func (r *CloudProvider) InstanceType(name string) (string, error) {
+	_, err := r.InstanceID(name)
+	if err != nil {
+		return "", err
+	}
+
+	// Maybe do something smarter here
+	return "rancher", nil
+}
+
+// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
+func (r *CloudProvider) List(filter string) ([]string, error) {
+	glog.Infof("List %s", filter)
+
+	opts := client.NewListOpts()
+	opts.Filters["removed_null"] = "1"
+	hosts, err := r.client.Host.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get hosts by filter [%s]. Error: %#v", filter, err)
+	}
+
+	if len(hosts.Data) == 0 {
+		return nil, fmt.Errorf("No hosts found")
+	}
+
+	if strings.HasPrefix(filter, "'") && strings.HasSuffix(filter, "'") {
+		filter = filter[1 : len(filter)-1]
+	}
+
+	re, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	retHosts := []string{}
+	for _, host := range hosts.Data {
+		if re.MatchString(host.Hostname) {
+			retHosts = append(retHosts, host.Hostname)
+		}
+	}
+
+	return retHosts, err
+}
+
+// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
+// expected format for the key is standard ssh-keygen format: <protocol> <blob>
+func (r *CloudProvider) AddSSHKeyToAllInstances(user string, keyData []byte) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// CurrentNodeName returns the name of the node we are currently running on
+func (r *CloudProvider) CurrentNodeName(hostname string) (string, error) {
+	return hostname, nil
+}
+
+func (r *CloudProvider) addHostToCache(host *Host) {
+	if host != nil {
+		r.hostCache.Add(host)
+	}
+}
+
+func (r *CloudProvider) removeFromCache(name string) {
+	host := r.getHostFromCache(name)
+	if host != nil {
+		r.hostCache.Delete(host)
+	}
+}
+
+func (r *CloudProvider) getHostFromCache(name string) *Host {
+	var host *Host
+
+	// entry gets expired once retrieved
+	defer r.addHostToCache(host)
+
+	hostObj, exists, err := r.hostCache.GetByKey(name)
+	if err == nil && exists {
+		h, ok := hostObj.(*Host)
+		if ok {
+			host = h
+		}
+	}
+	return host
+}
+
+func (r *CloudProvider) hostGetOrFetchFromCache(name string) (*Host, error) {
+	host, err := r.getHostByName(name)
+	if err != nil {
+		if err == cloudprovider.InstanceNotFound {
+			// evict from cache
+			r.removeFromCache(name)
+			return nil, err
+		} else {
+			host := r.getHostFromCache(name)
+			if host != nil {
+				return host, nil
+			}
+		}
+	}
+	r.addHostToCache(host)
+	return host, nil
+}
+
+func (r *CloudProvider) getHostByName(name string) (*Host, error) {
+	opts := client.NewListOpts()
+	opts.Filters["removed_null"] = "1"
+	hosts, err := r.client.Host.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get host by name [%s]. Error: %#v", name, err)
+	}
+
+	hostsToReturn := make([]client.Host, 0)
+	for _, host := range hosts.Data {
+		if strings.EqualFold(host.Hostname, name) {
+			hostsToReturn = append(hostsToReturn, host)
+		}
+	}
+
+	if len(hostsToReturn) == 0 {
+		return nil, cloudprovider.InstanceNotFound
+	}
+
+	if len(hostsToReturn) > 1 {
+		return nil, fmt.Errorf("multiple instances found for name: %s", name)
+	}
+
+	rancherHost := &hostsToReturn[0]
+
+	coll := &client.IpAddressCollection{}
+	err = r.client.GetLink(rancherHost.Resource, "ipAddresses", coll)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting ip addresses for node [%s]. Error: %#v", name, err)
+	}
+
+	if len(coll.Data) == 0 {
+		return nil, cloudprovider.InstanceNotFound
+	}
+
+	host := &Host{
+		RancherHost: rancherHost,
+		IPAddresses: coll.Data,
+	}
+
+	return host, nil
+}
+
+// --- Zones Functions ---
+
+// GetZone is an implementation of Zones.GetZone
+func (r *CloudProvider) GetZone() (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{
+		FailureDomain: "FailureDomain1",
+		Region:        "Region1",
+	}, nil
+}
+
+// --- Utility functions ---
+
+func init() {
+	cloudprovider.RegisterCloudProvider(providerName, func(config io.Reader) (cloudprovider.Interface, error) {
+		return newRancherCloud(config)
+	})
+}
+
+type configGlobal struct {
+	CattleURL       string `gcfg:"cattle-url"`
+	CattleAccessKey string `gcfg:"cattle-access-key"`
+	CattleSecretKey string `gcfg:"cattle-secret-key"`
+}
+
+type rConfig struct {
+	Global configGlobal
+}
+
+func newRancherCloud(config io.Reader) (cloudprovider.Interface, error) {
+	url := os.Getenv("CATTLE_URL")
+	accessKey := os.Getenv("CATTLE_ACCESS_KEY")
+	secretKey := os.Getenv("CATTLE_SECRET_KEY")
+	conf := rConfig{
+		Global: configGlobal{
+			CattleURL:       url,
+			CattleAccessKey: accessKey,
+			CattleSecretKey: secretKey,
+		},
+	}
+	client, err := getRancherClient(conf)
+	if err != nil {
+		return nil, fmt.Errorf("Could not create rancher client: %#v", err)
+	}
+
+	cache := cache.NewTTLStore(hostStoreKeyFunc, time.Duration(24)*time.Hour)
+
+	return &CloudProvider{
+		client:    client,
+		conf:      &conf,
+		hostCache: cache,
+	}, nil
+}
+
+func hostStoreKeyFunc(obj interface{}) (string, error) {
+	return obj.(*Host).RancherHost.Hostname, nil
+}
+
+func getRancherClient(conf rConfig) (*client.RancherClient, error) {
+	return client.NewRancherClient(&client.ClientOpts{
+		Url:       conf.Global.CattleURL,
+		AccessKey: conf.Global.CattleAccessKey,
+		SecretKey: conf.Global.CattleSecretKey,
+	})
+}
+
+func (r *CloudProvider) get(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get %s: Error creating request: %v", url, err)
+	}
+	req.Header.Add("Authorization", basicAuth(r.conf.Global.CattleAccessKey, r.conf.Global.CattleSecretKey))
+	resp, err := http.DefaultClient.Do(req)
+
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get %s: %v", url, err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error ready body of response to [%s]. Error %v", url, err)
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Received unexpected response code for [%s]: [%v]. Response body: [%s]", url, resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func metadata(path string) (string, error) {
+	resp, err := http.Get("http://rancher-metadata/latest" + path)
+	if err != nil {
+		return "", fmt.Errorf("Couldn't get %s: %v", path, err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	ret := string(body)
+	if err != nil {
+		return "", fmt.Errorf("Couldn't get %s: %v", path, err)
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("Received unexpected response code: [%v], Response body: [%s]", resp.StatusCode, ret)
+	}
+
+	return ret, nil
+}
+
+func (r *CloudProvider) getJSON(url string, params map[string][]string, respObject interface{}) error {
+	url, err := addParameters(url, params)
+	if err != nil {
+		return err
+	}
+
+	instanceRaw, err := r.get(url)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(instanceRaw, respObject)
+	if err != nil {
+		return fmt.Errorf("Couldn't unmarshal response json for [%s]. Error: %#v", url, err)
+	}
+
+	return nil
+}
+
+func addParameters(baseURL string, params map[string][]string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("Couldn't parse url [%s]. Error: %#v", baseURL, err)
+	}
+	q := u.Query()
+	for key, vals := range params {
+		for _, val := range vals {
+			q.Add(key, val)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func portsChanged(newPorts []string, oldPorts []string) bool {
+	if len(newPorts) != len(oldPorts) {
+		return true
+	}
+
+	if len(newPorts) == 0 {
+		return false
+	}
+
+	sort.Strings(newPorts)
+	sort.Strings(oldPorts)
+	for idx, p := range newPorts {
+		if p != oldPorts[idx] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func formatLBName(name string) string {
+	return fmt.Sprintf(lbNameFormat, name)
+}

--- a/pkg/cloudprovider/providers/rancher/rancher_test.go
+++ b/pkg/cloudprovider/providers/rancher/rancher_test.go
@@ -1,0 +1,854 @@
+package rancher
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rancher/go-rancher/client"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+)
+
+var (
+	testClient    *client.RancherClient
+	cloudProvider *CloudProvider
+
+	hostTestSerializer *sync.Mutex
+	lbTestSerializer   *sync.Mutex
+
+	hostList                *client.HostCollection
+	loadBalancerServiceList *client.LoadBalancerServiceCollection
+	serviceList             *client.ServiceCollection
+	externalServiceList     *client.ExternalServiceCollection
+
+	ipAddressLinks            map[string]*client.IpAddressCollection
+	lbConsumedServicesLinks   map[string]*client.ServiceCollection
+	lbConsumedByServicesLinks map[string]*client.ServiceCollection
+	lbServiceLinks            map[string]*client.SetLoadBalancerServiceLinksInput
+)
+
+type fakeRancherBaseClient struct {
+	client.RancherBaseClientImpl
+}
+
+func (f *fakeRancherBaseClient) GetLink(resource client.Resource, link string, respObject interface{}) error {
+	switch link {
+	case "ipAddresses":
+		if tmp, ok := ipAddressLinks[resource.Id]; ok {
+			respObject.(*client.IpAddressCollection).Data = tmp.Data
+		}
+	case "consumedservices":
+		if tmp, ok := lbConsumedServicesLinks[resource.Id]; ok {
+			respObject.(*client.ServiceCollection).Data = tmp.Data
+		}
+	case "consumedbyservices":
+		if tmp, ok := lbConsumedByServicesLinks[resource.Id]; ok {
+			respObject.(*client.ServiceCollection).Data = tmp.Data
+		}
+	}
+	return nil
+}
+
+type fakeHostClient struct{}
+
+func (f *fakeHostClient) List(opts *client.ListOpts) (*client.HostCollection, error) {
+	return hostList, nil
+}
+
+func (f *fakeHostClient) Create(opts *client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) Update(existing *client.Host, updates interface{}) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ById(id string) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) Delete(container *client.Host) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionActivate(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionCreate(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionDeactivate(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionDockersocket(*client.Host) (*client.HostAccess, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionPurge(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionRemove(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionRestore(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeHostClient) ActionUpdate(*client.Host) (*client.Host, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type fakeLoadBalancerServiceClient struct{}
+
+func (f *fakeLoadBalancerServiceClient) List(opts *client.ListOpts) (*client.LoadBalancerServiceCollection, error) {
+	return loadBalancerServiceList, nil
+}
+
+func (f *fakeLoadBalancerServiceClient) Create(opts *client.LoadBalancerService) (*client.LoadBalancerService, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) Update(existing *client.LoadBalancerService, updates interface{}) (*client.LoadBalancerService, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ById(id string) (*client.LoadBalancerService, error) {
+	for _, lbserv := range loadBalancerServiceList.Data {
+		if lbserv.Id == id {
+			return &lbserv, nil
+		}
+	}
+	return nil, fmt.Errorf("Could not find lb service")
+}
+
+func (f *fakeLoadBalancerServiceClient) Delete(lb *client.LoadBalancerService) error {
+	for pos, lbserv := range loadBalancerServiceList.Data {
+		if lbserv.Id == lb.Id {
+			//remove the element
+			loadBalancerServiceList.Data = append(loadBalancerServiceList.Data[:pos], loadBalancerServiceList.Data[pos+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("Could not find lb service")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionActivate(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionAddservicelink(*client.LoadBalancerService, *client.AddRemoveLoadBalancerServiceLinkInput) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionCancelrollback(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionCancelupgrade(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionCreate(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionDeactivate(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionFinishupgrade(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionRemove(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionRemoveservicelink(*client.LoadBalancerService, *client.AddRemoveLoadBalancerServiceLinkInput) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionRestart(*client.LoadBalancerService, *client.ServiceRestart) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionRollback(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionSetservicelinks(lb *client.LoadBalancerService, links *client.SetLoadBalancerServiceLinksInput) (*client.Service, error) {
+	lbServiceLinks[lb.Id] = links
+	return nil, nil
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionUpdate(*client.LoadBalancerService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeLoadBalancerServiceClient) ActionUpgrade(*client.LoadBalancerService, *client.ServiceUpgrade) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type fakeServiceClient struct{}
+
+func (f *fakeServiceClient) List(opts *client.ListOpts) (*client.ServiceCollection, error) {
+	return serviceList, nil
+}
+
+func (f *fakeServiceClient) Create(opts *client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) Update(existing *client.Service, updates interface{}) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ById(id string) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) Delete(s *client.Service) error {
+	for pos, serv := range serviceList.Data {
+		if serv.Id == s.Id {
+			//remove the element
+			serviceList.Data = append(serviceList.Data[:pos], serviceList.Data[pos+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("Could not find service")
+}
+
+func (f *fakeServiceClient) ActionActivate(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionAddservicelink(*client.Service, *client.AddRemoveServiceLinkInput) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionCancelrollback(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionCancelupgrade(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionCreate(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionDeactivate(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionFinishupgrade(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionRemove(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionRemoveservicelink(*client.Service, *client.AddRemoveServiceLinkInput) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionRestart(*client.Service, *client.ServiceRestart) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionRollback(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionSetservicelinks(*client.Service, *client.SetServiceLinksInput) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionUpdate(*client.Service) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeServiceClient) ActionUpgrade(*client.Service, *client.ServiceUpgrade) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type fakeExternalServiceClient struct{}
+
+func (f *fakeExternalServiceClient) List(opts *client.ListOpts) (*client.ExternalServiceCollection, error) {
+	return externalServiceList, nil
+}
+
+func (f *fakeExternalServiceClient) Create(opts *client.ExternalService) (*client.ExternalService, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) Update(existing *client.ExternalService, updates interface{}) (*client.ExternalService, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ById(id string) (*client.ExternalService, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) Delete(s *client.ExternalService) error {
+	for pos, serv := range externalServiceList.Data {
+		if serv.Id == s.Id {
+			//remove the element
+			externalServiceList.Data = append(externalServiceList.Data[:pos], externalServiceList.Data[pos+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("Could not find service")
+}
+
+func (f *fakeExternalServiceClient) ActionActivate(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionCancelrollback(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionCancelupgrade(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionCreate(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionDeactivate(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionFinishupgrade(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionRemove(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionRestart(*client.ExternalService, *client.ServiceRestart) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionRollback(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionUpdate(*client.ExternalService) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeExternalServiceClient) ActionUpgrade(*client.ExternalService, *client.ServiceUpgrade) (*client.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestMain(m *testing.M) {
+	hostTestSerializer = &sync.Mutex{}
+	lbTestSerializer = &sync.Mutex{}
+
+	testClient = &client.RancherClient{
+		RancherBaseClient: &fakeRancherBaseClient{
+			RancherBaseClientImpl: client.RancherBaseClientImpl{
+				Types: map[string]client.Schema{},
+			},
+		},
+	}
+
+	hostClient := &fakeHostClient{}
+	testClient.Host = hostClient
+
+	loadBalancerServiceClient := &fakeLoadBalancerServiceClient{}
+	testClient.LoadBalancerService = loadBalancerServiceClient
+
+	serviceClient := &fakeServiceClient{}
+	testClient.Service = serviceClient
+
+	externalServiceClient := &fakeExternalServiceClient{}
+	testClient.ExternalService = externalServiceClient
+
+	ipAddressLinks = make(map[string]*client.IpAddressCollection)
+	lbConsumedServicesLinks = make(map[string]*client.ServiceCollection)
+	lbConsumedByServicesLinks = make(map[string]*client.ServiceCollection)
+	lbServiceLinks = make(map[string]*client.SetLoadBalancerServiceLinksInput)
+
+	cloudProvider = &CloudProvider{
+		client:    testClient,
+		conf:      &rConfig{},
+		hostCache: cache.NewTTLStore(hostStoreKeyFunc, time.Duration(24)*time.Hour),
+	}
+	os.Exit(m.Run())
+}
+
+func TestList(t *testing.T) {
+	hostTestSerializer.Lock()
+	defer hostTestSerializer.Unlock()
+	hostList = &client.HostCollection{
+		Data: []client.Host{
+			client.Host{
+				Hostname: "test1",
+			},
+			client.Host{
+				Hostname: "test2",
+			},
+			client.Host{
+				Hostname: "notATest",
+			},
+		},
+	}
+
+	foundHosts, err := cloudProvider.List("^test.*")
+	found1 := false
+	found2 := false
+	for _, host := range foundHosts {
+		if host == "test1" {
+			found1 = true
+		}
+		if host == "test2" {
+			found2 = true
+		}
+	}
+
+	if !(found1 && found2) {
+		t.Errorf("expected [test1, test2] found [%v], err: [%v]", foundHosts, err)
+	}
+}
+
+func TestInstanceID(t *testing.T) {
+	hostTestSerializer.Lock()
+	defer hostTestSerializer.Unlock()
+	hostList = &client.HostCollection{
+		Data: []client.Host{
+			client.Host{
+				Resource: client.Resource{
+					Id: "1h1",
+				},
+				Hostname: "test1",
+				Uuid:     "abcd",
+			},
+		},
+	}
+	coll := new(client.IpAddressCollection)
+	coll.Data = make([]client.IpAddress, 1)
+	coll.Data = append(coll.Data, client.IpAddress{Address: "127.0.0.1"})
+	ipAddressLinks["1h1"] = coll
+
+	instanceId, err := cloudProvider.InstanceID("test1")
+	if instanceId != "abcd" {
+		t.Errorf("expected instanceID abcd, found [%v], err: [%v]", instanceId, err)
+	}
+}
+
+func TestNodeAddresses(t *testing.T) {
+	hostTestSerializer.Lock()
+	defer hostTestSerializer.Unlock()
+	hostList = &client.HostCollection{
+		Data: []client.Host{
+			client.Host{
+				Resource: client.Resource{
+					Id: "1h2",
+				},
+				Hostname: "test2",
+				Uuid:     "abcd",
+			},
+		},
+	}
+	coll := new(client.IpAddressCollection)
+	coll.Data = make([]client.IpAddress, 1)
+	coll.Data = append(coll.Data, client.IpAddress{Address: "192.168.1.1"})
+	ipAddressLinks["1h2"] = coll
+
+	addresses, err := cloudProvider.NodeAddresses("test2")
+
+	if len(addresses) != 5 {
+		t.Errorf("expected 5 addresses, found, [%+v], err: [%v]", addresses, err)
+	}
+
+	if addresses[2].Type != api.NodeExternalIP || addresses[2].Address != "192.168.1.1" {
+		t.Errorf("expected address 0 to be 192.168.1.1, found %s", addresses[2].Address)
+	}
+
+	if addresses[3].Type != api.NodeLegacyHostIP || addresses[3].Address != "192.168.1.1" {
+		t.Errorf("expected address 1 to be 192.168.1.1, found %s", addresses[3].Address)
+	}
+
+	if addresses[4].Type != api.NodeHostName || addresses[4].Address != "test2" {
+		t.Errorf("expected address 2 to be test2, found %s", addresses[4].Address)
+	}
+}
+
+func TestGetLoadBalancer(t *testing.T) {
+	lbTestSerializer.Lock()
+	defer lbTestSerializer.Unlock()
+	loadBalancerServiceList = &client.LoadBalancerServiceCollection{
+		Data: []client.LoadBalancerService{
+			client.LoadBalancerService{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+				PublicEndpoints: []interface{}{
+					PublicEndpoint{
+						IPAddress: "172.178.1.1",
+						Port:      8080,
+					},
+				},
+				Name: "atestlb1",
+			},
+		},
+	}
+
+	service := api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test-lb-1",
+			UID:  "test-lb-1",
+		},
+	}
+	status, exists, err := cloudProvider.GetLoadBalancer("", &service)
+
+	if !exists {
+		t.Errorf("Did not find a load balancer, err: [%v]", err)
+	}
+
+	if len(status.Ingress) != 1 {
+		t.Errorf("Expected to find 1 ingress, found [%d]", len(status.Ingress))
+	}
+
+	if status.Ingress[0].IP != "172.178.1.1" {
+		t.Errorf("Expected to find IP 172.178.1.1, found %s", status.Ingress[0].IP)
+	}
+}
+
+func TestEnsureLoadBalancerDeleted(t *testing.T) {
+	lbTestSerializer.Lock()
+	defer lbTestSerializer.Unlock()
+	loadBalancerServiceList = &client.LoadBalancerServiceCollection{
+		Data: []client.LoadBalancerService{
+			client.LoadBalancerService{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+				PublicEndpoints: []interface{}{
+					PublicEndpoint{
+						IPAddress: "172.178.1.1",
+						Port:      8080,
+					},
+				},
+				Name: "atestlb1",
+			},
+		},
+	}
+
+	service := api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test-lb-1",
+			UID:  "test-lb-1",
+		},
+	}
+	serviceList = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+			},
+		},
+	}
+
+	lbConsumedServicesLinks["1lb1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+			},
+		},
+	}
+
+	lbConsumedByServicesLinks["1s1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+			},
+		},
+	}
+
+	lbConsumedByServicesLinks["1s2"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+			},
+			client.Service{
+				Resource: client.Resource{
+					Id: "1lb2",
+				},
+			},
+		},
+	}
+	err := cloudProvider.EnsureLoadBalancerDeleted("", &service)
+
+	if err != nil {
+		t.Errorf("Error deleting load balancer, err: [%v]", err)
+	}
+
+	if len(loadBalancerServiceList.Data) != 0 {
+		t.Errorf("expected load balancer to be deleted, but it persists")
+	}
+
+	if len(serviceList.Data) != 1 {
+		t.Errorf("consumed services have not been deleted as expected, remaining services %+v", serviceList.Data)
+	}
+
+}
+
+func TestUpdateLoadBalancer(t *testing.T) {
+	lbTestSerializer.Lock()
+	defer lbTestSerializer.Unlock()
+	externalServiceList = &client.ExternalServiceCollection{
+		Data: []client.ExternalService{
+			client.ExternalService{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+				EnvironmentId: "1e1",
+				Name:          "externalserv1",
+				State:         "active",
+			},
+		},
+	}
+
+	loadBalancerServiceList = &client.LoadBalancerServiceCollection{
+		Data: []client.LoadBalancerService{
+			client.LoadBalancerService{
+				Resource: client.Resource{
+					Id: "1lb1",
+					Actions: map[string]string{
+						"setservicelinks": "setservicelinks",
+					},
+				},
+				PublicEndpoints: []interface{}{
+					PublicEndpoint{
+						IPAddress: "172.178.1.1",
+						Port:      8080,
+					},
+				},
+				Name:          "atestlb1",
+				EnvironmentId: "1e1",
+			},
+		},
+	}
+
+	service := api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test-lb-1",
+			UID:  "test-lb-1",
+		},
+	}
+	serviceList = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+			},
+		},
+	}
+
+	lbConsumedServicesLinks["1lb1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+		},
+	}
+
+	lbConsumedByServicesLinks["1s1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+			},
+		},
+	}
+
+	err := cloudProvider.UpdateLoadBalancer("", &service, []string{"host1"})
+
+	if err != nil {
+		t.Errorf("Error deleting load balancer, err: [%v]", err)
+	}
+
+	if len(serviceList.Data) != 1 {
+		t.Errorf("consumed services have not been deleted as expected, remaining services %+v", serviceList.Data)
+	}
+
+	lbServiceLink, ok := lbServiceLinks["1lb1"]
+	if !ok {
+		t.Errorf("lb service links not updated as expected")
+	}
+
+	if len(lbServiceLink.ServiceLinks) != 1 {
+		t.Errorf("lb service links not updated as expected")
+	}
+
+	if lbServiceLink.ServiceLinks[0].(*client.LoadBalancerServiceLink).ServiceId != "1s2" {
+		t.Errorf("lb service links not updated as expected")
+	}
+}
+
+func TestEnsureLoadBalancer(t *testing.T) {
+	lbTestSerializer.Lock()
+	defer lbTestSerializer.Unlock()
+	externalServiceList = &client.ExternalServiceCollection{
+		Data: []client.ExternalService{
+			client.ExternalService{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+				EnvironmentId: "1e1",
+				Name:          "externalserv1",
+				State:         "active",
+			},
+		},
+	}
+
+	loadBalancerServiceList = &client.LoadBalancerServiceCollection{
+		Data: []client.LoadBalancerService{
+			client.LoadBalancerService{
+				Resource: client.Resource{
+					Id: "1lb1",
+					Actions: map[string]string{
+						"setservicelinks": "setservicelinks",
+						"deactivate":      "deactivate",
+					},
+				},
+				PublicEndpoints: []interface{}{
+					PublicEndpoint{
+						IPAddress: "192.168.1.2",
+						Port:      8080,
+					},
+				},
+				Name:          "atestlb1",
+				EnvironmentId: "1e1",
+				LaunchConfig: &client.LaunchConfig{
+					Ports: []string{
+						"80:8000/tcp",
+					},
+				},
+				State: "active",
+			},
+		},
+	}
+
+	service := api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test-lb-1",
+			UID:  "test-lb-1",
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{
+				api.ServicePort{
+					Name:     "testPort",
+					Protocol: "TCP",
+					Port:     80,
+					NodePort: 8000,
+				},
+			},
+			SessionAffinity: api.ServiceAffinityNone,
+		},
+	}
+	serviceList = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s2",
+				},
+			},
+		},
+	}
+
+	lbConsumedServicesLinks["1lb1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1s1",
+				},
+			},
+		},
+	}
+
+	lbConsumedByServicesLinks["1s1"] = &client.ServiceCollection{
+		Data: []client.Service{
+			client.Service{
+				Resource: client.Resource{
+					Id: "1lb1",
+				},
+			},
+		},
+	}
+
+	status, err := cloudProvider.EnsureLoadBalancer("", &service, []string{"host1"})
+
+	if err != nil {
+		t.Errorf("Error ensuring load balancer, err: [%v]", err)
+	}
+
+	lbServiceLink, ok := lbServiceLinks["1lb1"]
+	if !ok {
+		t.Errorf("lb service links not updated as expected")
+	}
+
+	if len(lbServiceLink.ServiceLinks) != 1 {
+		t.Errorf("lb service links not updated as expected")
+	}
+
+	if lbServiceLink.ServiceLinks[0].(*client.LoadBalancerServiceLink).ServiceId != "1s2" {
+		t.Errorf("lb service links not updated as expected")
+	}
+
+	if len(status.Ingress) != 1 {
+		t.Errorf("Expected to find 1 ingress, found [%d]", len(status.Ingress))
+	}
+
+	if status.Ingress[0].IP != "192.168.1.2" {
+		t.Errorf("Expected to find IP 192.168.1.2, found %s", status.Ingress[0].IP)
+	}
+}

--- a/pkg/credentialprovider/rancher/doc.go
+++ b/pkg/credentialprovider/rancher/doc.go
@@ -1,0 +1,1 @@
+package rancher_credentials

--- a/pkg/credentialprovider/rancher/rancher_registry_credentials.go
+++ b/pkg/credentialprovider/rancher/rancher_registry_credentials.go
@@ -1,0 +1,128 @@
+package rancher_credentials
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rancher/go-rancher/client"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+// rancher provider
+type rancherProvider struct {
+	credGetter credentialsGetter
+}
+
+// credentials getter from Rancher private registry
+type rancherCredentialsGetter struct {
+	client *client.RancherClient
+}
+
+type rConfig struct {
+	Global configGlobal
+}
+
+// An interface for testing purposes.
+type credentialsGetter interface {
+	getCredentials() []registryCredential
+}
+
+type configGlobal struct {
+	CattleURL       string `gcfg:"cattle-url"`
+	CattleAccessKey string `gcfg:"cattle-access-key"`
+	CattleSecretKey string `gcfg:"cattle-secret-key"`
+}
+
+type registryCredential struct {
+	credential *client.RegistryCredential
+	serverIP   string
+}
+
+func init() {
+	client, err := getRancherClient()
+	if err != nil {
+		glog.Errorf("Failed to get rancher client: %v", err)
+	}
+
+	rancherGetter := &rancherCredentialsGetter{
+		client: client,
+	}
+
+	credentialprovider.RegisterCredentialProvider("rancher-registry-creds",
+		&credentialprovider.CachingDockerConfigProvider{
+			Provider: &rancherProvider{rancherGetter},
+			Lifetime: 30 * time.Minute,
+		})
+}
+
+// Assuming it's always enabled
+func (p *rancherProvider) Enabled() bool {
+	return p.credGetter != nil
+}
+
+// LazyProvide implements DockerConfigProvider. Should never be called.
+func (p *rancherProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
+}
+
+// Provide implements DockerConfigProvider.Provide, refreshing Rancher tokens on demand
+func (p *rancherProvider) Provide() credentialprovider.DockerConfig {
+	cfg := credentialprovider.DockerConfig{}
+	for _, cred := range p.credGetter.getCredentials() {
+		entry := credentialprovider.DockerConfigEntry{
+			Username: cred.credential.PublicValue,
+			Password: cred.credential.SecretValue,
+			Email:    cred.credential.Email,
+		}
+		cfg[cred.serverIP] = entry
+	}
+
+	return cfg
+}
+
+func (g *rancherCredentialsGetter) getCredentials() []registryCredential {
+	var registryCreds []registryCredential
+	credColl, err := g.client.RegistryCredential.List(client.NewListOpts())
+	if err != nil {
+		glog.Errorf("Failed to pull registry credentials from rancher %v", err)
+		return registryCreds
+	}
+	for _, cred := range credColl.Data {
+		registry := &client.Registry{}
+		if err = g.client.GetLink(cred.Resource, "registry", registry); err != nil {
+			glog.Errorf("Failed to pull registry from rancher %v", err)
+			return registryCreds
+		}
+		registryCred := registryCredential{
+			credential: &cred,
+			serverIP:   registry.ServerAddress,
+		}
+		registryCreds = append(registryCreds, registryCred)
+	}
+	return registryCreds
+}
+
+func getRancherClient() (*client.RancherClient, error) {
+	url := os.Getenv("CATTLE_URL")
+	accessKey := os.Getenv("CATTLE_ACCESS_KEY")
+	secretKey := os.Getenv("CATTLE_SECRET_KEY")
+
+	if url == "" || accessKey == "" || secretKey == "" {
+		return nil, nil
+	}
+
+	conf := rConfig{
+		Global: configGlobal{
+			CattleURL:       url,
+			CattleAccessKey: accessKey,
+			CattleSecretKey: secretKey,
+		},
+	}
+
+	return client.NewRancherClient(&client.ClientOpts{
+		Url:       conf.Global.CattleURL,
+		AccessKey: conf.Global.CattleAccessKey,
+		SecretKey: conf.Global.CattleSecretKey,
+	})
+}

--- a/pkg/credentialprovider/rancher/rancher_registry_credentials_test.go
+++ b/pkg/credentialprovider/rancher/rancher_registry_credentials_test.go
@@ -1,0 +1,104 @@
+package rancher_credentials
+
+import (
+	"path"
+	"testing"
+
+	"github.com/rancher/go-rancher/client"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+const username = "foo"
+const password = "qwerty"
+const email = "foo@bar.baz"
+
+var serverAddresses = []string{"quay.io", "192.168.5.0"}
+
+type testCredentialsGetter struct {
+	client *client.RancherClient
+}
+
+func (p *testCredentialsGetter) getCredentials() []registryCredential {
+	var registryCreds []registryCredential
+
+	for _, serverAddress := range serverAddresses {
+		cred := &client.RegistryCredential{
+			PublicValue: username,
+			SecretValue: password,
+			Email:       email,
+		}
+		registryCred := registryCredential{
+			credential: cred,
+			serverIP:   serverAddress,
+		}
+		registryCreds = append(registryCreds, registryCred)
+	}
+
+	return registryCreds
+}
+
+func TestRancherCredentialsProvide(t *testing.T) {
+	image := "foo/bar"
+
+	url := "http://localhost:8080"
+	accessKey := "B481F55E0C48C546E094"
+	secretKey := "dND2fBcytWWvCRJ8LvqnYcjyNfEkaikvfVxk2C5r"
+	conf := rConfig{
+		Global: configGlobal{
+			CattleURL:       url,
+			CattleAccessKey: accessKey,
+			CattleSecretKey: secretKey,
+		},
+	}
+
+	rancherClient, _ := client.NewRancherClient(&client.ClientOpts{
+		Url:       conf.Global.CattleURL,
+		AccessKey: conf.Global.CattleAccessKey,
+		SecretKey: conf.Global.CattleSecretKey,
+	})
+
+	testGetter := &testCredentialsGetter{
+		client: rancherClient,
+	}
+
+	provider := &rancherProvider{
+		credGetter: testGetter,
+	}
+
+	keyring := &credentialprovider.BasicDockerKeyring{}
+	keyring.Add(provider.Provide())
+
+	for _, registry := range serverAddresses {
+		fullImagePath := path.Join(registry, image)
+		creds, ok := keyring.Lookup(fullImagePath)
+		if !ok {
+			t.Errorf("Didn't find expected image: %s", fullImagePath)
+			return
+		}
+
+		if len(creds) > 1 {
+			t.Errorf("Expected 1 result, received %v", len(creds))
+		}
+
+		val := creds[0]
+
+		if username != val.Username {
+			t.Errorf("Unexpected username value, want: %s, got: %s", username, val.Username)
+		}
+		if password != val.Password {
+			t.Errorf("Unexpected password value, want: %s, got: %s", password, val.Password)
+		}
+		if email != val.Email {
+			t.Errorf("Unexpected email value, want: %s, got: %s", email, val.Email)
+		}
+	}
+
+	// try to fetch non-existing registry
+	fullImagePath := path.Join("1.1.1.1", image)
+	_, ok := keyring.Lookup(fullImagePath)
+	if ok {
+		t.Errorf("Found non-existing image: %s", fullImagePath)
+	}
+
+	return
+}

--- a/vendor/github.com/gorilla/websocket/.gitignore
+++ b/vendor/github.com/gorilla/websocket/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/gorilla/websocket/.travis.yml
+++ b/vendor/github.com/gorilla/websocket/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.1
+  - 1.2
+  - tip

--- a/vendor/github.com/gorilla/websocket/AUTHORS
+++ b/vendor/github.com/gorilla/websocket/AUTHORS
@@ -1,0 +1,8 @@
+# This is the official list of Gorilla WebSocket authors for copyright
+# purposes.
+#
+# Please keep the list sorted.
+
+Gary Burd <gary@beagledreams.com>
+Joachim Bauch <mail@joachim-bauch.de>
+

--- a/vendor/github.com/gorilla/websocket/LICENSE
+++ b/vendor/github.com/gorilla/websocket/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gorilla/websocket/README.md
+++ b/vendor/github.com/gorilla/websocket/README.md
@@ -1,0 +1,59 @@
+# Gorilla WebSocket
+
+Gorilla WebSocket is a [Go](http://golang.org/) implementation of the
+[WebSocket](http://www.rfc-editor.org/rfc/rfc6455.txt) protocol.
+
+### Documentation
+
+* [API Reference](http://godoc.org/github.com/gorilla/websocket)
+* [Chat example](https://github.com/gorilla/websocket/tree/master/examples/chat)
+* [File watch example](https://github.com/gorilla/websocket/tree/master/examples/filewatch)
+
+### Status
+
+The Gorilla WebSocket package provides a complete and tested implementation of
+the [WebSocket](http://www.rfc-editor.org/rfc/rfc6455.txt) protocol. The
+package API is stable.
+
+### Installation
+
+    go get github.com/gorilla/websocket
+
+### Protocol Compliance
+
+The Gorilla WebSocket package passes the server tests in the [Autobahn Test
+Suite](http://autobahn.ws/testsuite) using the application in the [examples/autobahn
+subdirectory](https://github.com/gorilla/websocket/tree/master/examples/autobahn).
+
+### Gorilla WebSocket compared with other packages
+
+<table>
+<tr>
+<th></th>
+<th><a href="http://godoc.org/github.com/gorilla/websocket">github.com/gorilla</a></th>
+<th><a href="http://godoc.org/golang.org/x/net/websocket">golang.org/x/net</a></th>
+</tr>
+<tr>
+<tr><td colspan="3"><a href="http://tools.ietf.org/html/rfc6455">RFC 6455</a> Features</td></tr>
+<tr><td>Passes <a href="http://autobahn.ws/testsuite/">Autobahn Test Suite</a></td><td><a href="https://github.com/gorilla/websocket/tree/master/examples/autobahn">Yes</a></td><td>No</td></tr>
+<tr><td>Receive <a href="https://tools.ietf.org/html/rfc6455#section-5.4">fragmented</a> message<td>Yes</td><td><a href="https://code.google.com/p/go/issues/detail?id=7632">No</a>, see note 1</td></tr>
+<tr><td>Send <a href="https://tools.ietf.org/html/rfc6455#section-5.5.1">close</a> message</td><td><a href="http://godoc.org/github.com/gorilla/websocket#hdr-Control_Messages">Yes</a></td><td><a href="https://code.google.com/p/go/issues/detail?id=4588">No</a></td></tr>
+<tr><td>Send <a href="https://tools.ietf.org/html/rfc6455#section-5.5.2">pings</a> and receive <a href="https://tools.ietf.org/html/rfc6455#section-5.5.3">pongs</a></td><td><a href="http://godoc.org/github.com/gorilla/websocket#hdr-Control_Messages">Yes</a></td><td>No</td></tr>
+<tr><td>Get the <a href="https://tools.ietf.org/html/rfc6455#section-5.6">type</a> of a received data message</td><td>Yes</td><td>Yes, see note 2</td></tr>
+<tr><td colspan="3">Other Features</tr></td>
+<tr><td>Limit size of received message</td><td><a href="http://godoc.org/github.com/gorilla/websocket#Conn.SetReadLimit">Yes</a></td><td><a href="https://code.google.com/p/go/issues/detail?id=5082">No</a></td></tr>
+<tr><td>Read message using io.Reader</td><td><a href="http://godoc.org/github.com/gorilla/websocket#Conn.NextReader">Yes</a></td><td>No, see note 3</td></tr>
+<tr><td>Write message using io.WriteCloser</td><td><a href="http://godoc.org/github.com/gorilla/websocket#Conn.NextWriter">Yes</a></td><td>No, see note 3</td></tr>
+</table>
+
+Notes: 
+
+1. Large messages are fragmented in [Chrome's new WebSocket implementation](http://www.ietf.org/mail-archive/web/hybi/current/msg10503.html).
+2. The application can get the type of a received data message by implementing
+   a [Codec marshal](http://godoc.org/golang.org/x/net/websocket#Codec.Marshal)
+   function.
+3. The go.net io.Reader and io.Writer operate across WebSocket frame boundaries.
+  Read returns when the input buffer is full or a frame boundary is
+  encountered. Each call to Write sends a single frame message. The Gorilla
+  io.Reader and io.WriteCloser operate on a single WebSocket message.
+

--- a/vendor/github.com/gorilla/websocket/client.go
+++ b/vendor/github.com/gorilla/websocket/client.go
@@ -1,0 +1,269 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrBadHandshake is returned when the server response to opening handshake is
+// invalid.
+var ErrBadHandshake = errors.New("websocket: bad handshake")
+
+// NewClient creates a new client connection using the given net connection.
+// The URL u specifies the host and request URI. Use requestHeader to specify
+// the origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies
+// (Cookie). Use the response.Header to get the selected subprotocol
+// (Sec-WebSocket-Protocol) and cookies (Set-Cookie).
+//
+// If the WebSocket handshake fails, ErrBadHandshake is returned along with a
+// non-nil *http.Response so that callers can handle redirects, authentication,
+// etc.
+func NewClient(netConn net.Conn, u *url.URL, requestHeader http.Header, readBufSize, writeBufSize int) (c *Conn, response *http.Response, err error) {
+	challengeKey, err := generateChallengeKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	acceptKey := computeAcceptKey(challengeKey)
+
+	c = newConn(netConn, false, readBufSize, writeBufSize)
+	p := c.writeBuf[:0]
+	p = append(p, "GET "...)
+	p = append(p, u.RequestURI()...)
+	p = append(p, " HTTP/1.1\r\nHost: "...)
+	p = append(p, u.Host...)
+	// "Upgrade" is capitalized for servers that do not use case insensitive
+	// comparisons on header tokens.
+	p = append(p, "\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: "...)
+	p = append(p, challengeKey...)
+	p = append(p, "\r\n"...)
+	for k, vs := range requestHeader {
+		for _, v := range vs {
+			p = append(p, k...)
+			p = append(p, ": "...)
+			p = append(p, v...)
+			p = append(p, "\r\n"...)
+		}
+	}
+	p = append(p, "\r\n"...)
+
+	if _, err := netConn.Write(p); err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := http.ReadResponse(c.br, &http.Request{Method: "GET", URL: u})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != 101 ||
+		!strings.EqualFold(resp.Header.Get("Upgrade"), "websocket") ||
+		!strings.EqualFold(resp.Header.Get("Connection"), "upgrade") ||
+		resp.Header.Get("Sec-Websocket-Accept") != acceptKey {
+		return nil, resp, ErrBadHandshake
+	}
+	c.subprotocol = resp.Header.Get("Sec-Websocket-Protocol")
+	return c, resp, nil
+}
+
+// A Dialer contains options for connecting to WebSocket server.
+type Dialer struct {
+	// NetDial specifies the dial function for creating TCP connections. If
+	// NetDial is nil, net.Dial is used.
+	NetDial func(network, addr string) (net.Conn, error)
+
+	// TLSClientConfig specifies the TLS configuration to use with tls.Client.
+	// If nil, the default configuration is used.
+	TLSClientConfig *tls.Config
+
+	// HandshakeTimeout specifies the duration for the handshake to complete.
+	HandshakeTimeout time.Duration
+
+	// Input and output buffer sizes. If the buffer size is zero, then a
+	// default value of 4096 is used.
+	ReadBufferSize, WriteBufferSize int
+
+	// Subprotocols specifies the client's requested subprotocols.
+	Subprotocols []string
+}
+
+var errMalformedURL = errors.New("malformed ws or wss URL")
+
+// parseURL parses the URL. The url.Parse function is not used here because
+// url.Parse mangles the path.
+func parseURL(s string) (*url.URL, error) {
+	// From the RFC:
+	//
+	// ws-URI = "ws:" "//" host [ ":" port ] path [ "?" query ]
+	// wss-URI = "wss:" "//" host [ ":" port ] path [ "?" query ]
+	//
+	// We don't use the net/url parser here because the dialer interface does
+	// not provide a way for applications to work around percent deocding in
+	// the net/url parser.
+
+	var u url.URL
+	switch {
+	case strings.HasPrefix(s, "ws://"):
+		u.Scheme = "ws"
+		s = s[len("ws://"):]
+	case strings.HasPrefix(s, "wss://"):
+		u.Scheme = "wss"
+		s = s[len("wss://"):]
+	default:
+		return nil, errMalformedURL
+	}
+
+	u.Host = s
+	u.Opaque = "/"
+	if i := strings.Index(s, "/"); i >= 0 {
+		u.Host = s[:i]
+		u.Opaque = s[i:]
+	}
+
+	if strings.Contains(u.Host, "@") {
+		// WebSocket URIs do not contain user information.
+		return nil, errMalformedURL
+	}
+
+	return &u, nil
+}
+
+func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
+	hostPort = u.Host
+	hostNoPort = u.Host
+	if i := strings.LastIndex(u.Host, ":"); i > strings.LastIndex(u.Host, "]") {
+		hostNoPort = hostNoPort[:i]
+	} else {
+		if u.Scheme == "wss" {
+			hostPort += ":443"
+		} else {
+			hostPort += ":80"
+		}
+	}
+	return hostPort, hostNoPort
+}
+
+// DefaultDialer is a dialer with all fields set to the default zero values.
+var DefaultDialer *Dialer
+
+// Dial creates a new client connection. Use requestHeader to specify the
+// origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies (Cookie).
+// Use the response.Header to get the selected subprotocol
+// (Sec-WebSocket-Protocol) and cookies (Set-Cookie).
+//
+// If the WebSocket handshake fails, ErrBadHandshake is returned along with a
+// non-nil *http.Response so that callers can handle redirects, authentication,
+// etcetera. The response body may not contain the entire response and does not
+// need to be closed by the application.
+func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
+	u, err := parseURL(urlStr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostPort, hostNoPort := hostPortNoPort(u)
+
+	if d == nil {
+		d = &Dialer{}
+	}
+
+	var deadline time.Time
+	if d.HandshakeTimeout != 0 {
+		deadline = time.Now().Add(d.HandshakeTimeout)
+	}
+
+	netDial := d.NetDial
+	if netDial == nil {
+		netDialer := &net.Dialer{Deadline: deadline}
+		netDial = netDialer.Dial
+	}
+
+	netConn, err := netDial("tcp", hostPort)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer func() {
+		if netConn != nil {
+			netConn.Close()
+		}
+	}()
+
+	if err := netConn.SetDeadline(deadline); err != nil {
+		return nil, nil, err
+	}
+
+	if u.Scheme == "wss" {
+		cfg := d.TLSClientConfig
+		if cfg == nil {
+			cfg = &tls.Config{ServerName: hostNoPort}
+		} else if cfg.ServerName == "" {
+			shallowCopy := *cfg
+			cfg = &shallowCopy
+			cfg.ServerName = hostNoPort
+		}
+		tlsConn := tls.Client(netConn, cfg)
+		netConn = tlsConn
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, nil, err
+		}
+		if !cfg.InsecureSkipVerify {
+			if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	if len(d.Subprotocols) > 0 {
+		h := http.Header{}
+		for k, v := range requestHeader {
+			h[k] = v
+		}
+		h.Set("Sec-Websocket-Protocol", strings.Join(d.Subprotocols, ", "))
+		requestHeader = h
+	}
+
+	if len(requestHeader["Host"]) > 0 {
+		// This can be used to supply a Host: header which is different from
+		// the dial address.
+		u.Host = requestHeader.Get("Host")
+
+		// Drop "Host" header
+		h := http.Header{}
+		for k, v := range requestHeader {
+			if k == "Host" {
+				continue
+			}
+			h[k] = v
+		}
+		requestHeader = h
+	}
+
+	conn, resp, err := NewClient(netConn, u, requestHeader, d.ReadBufferSize, d.WriteBufferSize)
+
+	if err != nil {
+		if err == ErrBadHandshake {
+			// Before closing the network connection on return from this
+			// function, slurp up some of the response to aid application
+			// debugging.
+			buf := make([]byte, 1024)
+			n, _ := io.ReadFull(resp.Body, buf)
+			resp.Body = ioutil.NopCloser(bytes.NewReader(buf[:n]))
+		}
+		return nil, resp, err
+	}
+
+	netConn.SetDeadline(time.Time{})
+	netConn = nil // to avoid close in defer.
+	return conn, resp, nil
+}

--- a/vendor/github.com/gorilla/websocket/conn.go
+++ b/vendor/github.com/gorilla/websocket/conn.go
@@ -1,0 +1,825 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"strconv"
+	"time"
+)
+
+const (
+	maxFrameHeaderSize         = 2 + 8 + 4 // Fixed header + length + mask
+	maxControlFramePayloadSize = 125
+	finalBit                   = 1 << 7
+	maskBit                    = 1 << 7
+	writeWait                  = time.Second
+
+	defaultReadBufferSize  = 4096
+	defaultWriteBufferSize = 4096
+
+	continuationFrame = 0
+	noFrame           = -1
+)
+
+// Close codes defined in RFC 6455, section 11.7.
+const (
+	CloseNormalClosure           = 1000
+	CloseGoingAway               = 1001
+	CloseProtocolError           = 1002
+	CloseUnsupportedData         = 1003
+	CloseNoStatusReceived        = 1005
+	CloseAbnormalClosure         = 1006
+	CloseInvalidFramePayloadData = 1007
+	ClosePolicyViolation         = 1008
+	CloseMessageTooBig           = 1009
+	CloseMandatoryExtension      = 1010
+	CloseInternalServerErr       = 1011
+	CloseTLSHandshake            = 1015
+)
+
+// The message types are defined in RFC 6455, section 11.8.
+const (
+	// TextMessage denotes a text data message. The text message payload is
+	// interpreted as UTF-8 encoded text data.
+	TextMessage = 1
+
+	// BinaryMessage denotes a binary data message.
+	BinaryMessage = 2
+
+	// CloseMessage denotes a close control message. The optional message
+	// payload contains a numeric code and text. Use the FormatCloseMessage
+	// function to format a close message payload.
+	CloseMessage = 8
+
+	// PingMessage denotes a ping control message. The optional message payload
+	// is UTF-8 encoded text.
+	PingMessage = 9
+
+	// PongMessage denotes a ping control message. The optional message payload
+	// is UTF-8 encoded text.
+	PongMessage = 10
+)
+
+// ErrCloseSent is returned when the application writes a message to the
+// connection after sending a close message.
+var ErrCloseSent = errors.New("websocket: close sent")
+
+// ErrReadLimit is returned when reading a message that is larger than the
+// read limit set for the connection.
+var ErrReadLimit = errors.New("websocket: read limit exceeded")
+
+// netError satisfies the net Error interface.
+type netError struct {
+	msg       string
+	temporary bool
+	timeout   bool
+}
+
+func (e *netError) Error() string   { return e.msg }
+func (e *netError) Temporary() bool { return e.temporary }
+func (e *netError) Timeout() bool   { return e.timeout }
+
+// closeError represents close frame.
+type closeError struct {
+	code int
+	text string
+}
+
+func (e *closeError) Error() string {
+	return "websocket: close " + strconv.Itoa(e.code) + " " + e.text
+}
+
+var (
+	errWriteTimeout        = &netError{msg: "websocket: write timeout", timeout: true}
+	errUnexpectedEOF       = &closeError{code: CloseAbnormalClosure, text: io.ErrUnexpectedEOF.Error()}
+	errBadWriteOpCode      = errors.New("websocket: bad write message type")
+	errWriteClosed         = errors.New("websocket: write closed")
+	errInvalidControlFrame = errors.New("websocket: invalid control frame")
+)
+
+func hideTempErr(err error) error {
+	if e, ok := err.(net.Error); ok && e.Temporary() {
+		err = &netError{msg: e.Error(), timeout: e.Timeout()}
+	}
+	return err
+}
+
+func isControl(frameType int) bool {
+	return frameType == CloseMessage || frameType == PingMessage || frameType == PongMessage
+}
+
+func isData(frameType int) bool {
+	return frameType == TextMessage || frameType == BinaryMessage
+}
+
+func maskBytes(key [4]byte, pos int, b []byte) int {
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+	return pos & 3
+}
+
+func newMaskKey() [4]byte {
+	n := rand.Uint32()
+	return [4]byte{byte(n), byte(n >> 8), byte(n >> 16), byte(n >> 24)}
+}
+
+// Conn represents a WebSocket connection.
+type Conn struct {
+	conn        net.Conn
+	isServer    bool
+	subprotocol string
+
+	// Write fields
+	mu        chan bool // used as mutex to protect write to conn and closeSent
+	closeSent bool      // true if close message was sent
+
+	// Message writer fields.
+	writeErr       error
+	writeBuf       []byte // frame is constructed in this buffer.
+	writePos       int    // end of data in writeBuf.
+	writeFrameType int    // type of the current frame.
+	writeSeq       int    // incremented to invalidate message writers.
+	writeDeadline  time.Time
+
+	// Read fields
+	readErr       error
+	br            *bufio.Reader
+	readRemaining int64 // bytes remaining in current frame.
+	readFinal     bool  // true the current message has more frames.
+	readSeq       int   // incremented to invalidate message readers.
+	readLength    int64 // Message size.
+	readLimit     int64 // Maximum message size.
+	readMaskPos   int
+	readMaskKey   [4]byte
+	handlePong    func(string) error
+	handlePing    func(string) error
+}
+
+func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int) *Conn {
+	mu := make(chan bool, 1)
+	mu <- true
+
+	if readBufferSize == 0 {
+		readBufferSize = defaultReadBufferSize
+	}
+	if writeBufferSize == 0 {
+		writeBufferSize = defaultWriteBufferSize
+	}
+
+	c := &Conn{
+		isServer:       isServer,
+		br:             bufio.NewReaderSize(conn, readBufferSize),
+		conn:           conn,
+		mu:             mu,
+		readFinal:      true,
+		writeBuf:       make([]byte, writeBufferSize+maxFrameHeaderSize),
+		writeFrameType: noFrame,
+		writePos:       maxFrameHeaderSize,
+	}
+	c.SetPingHandler(nil)
+	c.SetPongHandler(nil)
+	return c
+}
+
+// Subprotocol returns the negotiated protocol for the connection.
+func (c *Conn) Subprotocol() string {
+	return c.subprotocol
+}
+
+// Close closes the underlying network connection without sending or waiting for a close frame.
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
+// LocalAddr returns the local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// Write methods
+
+func (c *Conn) write(frameType int, deadline time.Time, bufs ...[]byte) error {
+	<-c.mu
+	defer func() { c.mu <- true }()
+
+	if c.closeSent {
+		return ErrCloseSent
+	} else if frameType == CloseMessage {
+		c.closeSent = true
+	}
+
+	c.conn.SetWriteDeadline(deadline)
+	for _, buf := range bufs {
+		if len(buf) > 0 {
+			n, err := c.conn.Write(buf)
+			if n != len(buf) {
+				// Close on partial write.
+				c.conn.Close()
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// WriteControl writes a control message with the given deadline. The allowed
+// message types are CloseMessage, PingMessage and PongMessage.
+func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	if !isControl(messageType) {
+		return errBadWriteOpCode
+	}
+	if len(data) > maxControlFramePayloadSize {
+		return errInvalidControlFrame
+	}
+
+	b0 := byte(messageType) | finalBit
+	b1 := byte(len(data))
+	if !c.isServer {
+		b1 |= maskBit
+	}
+
+	buf := make([]byte, 0, maxFrameHeaderSize+maxControlFramePayloadSize)
+	buf = append(buf, b0, b1)
+
+	if c.isServer {
+		buf = append(buf, data...)
+	} else {
+		key := newMaskKey()
+		buf = append(buf, key[:]...)
+		buf = append(buf, data...)
+		maskBytes(key, 0, buf[6:])
+	}
+
+	d := time.Hour * 1000
+	if !deadline.IsZero() {
+		d = deadline.Sub(time.Now())
+		if d < 0 {
+			return errWriteTimeout
+		}
+	}
+
+	timer := time.NewTimer(d)
+	select {
+	case <-c.mu:
+		timer.Stop()
+	case <-timer.C:
+		return errWriteTimeout
+	}
+	defer func() { c.mu <- true }()
+
+	if c.closeSent {
+		return ErrCloseSent
+	} else if messageType == CloseMessage {
+		c.closeSent = true
+	}
+
+	c.conn.SetWriteDeadline(deadline)
+	n, err := c.conn.Write(buf)
+	if n != 0 && n != len(buf) {
+		c.conn.Close()
+	}
+	return err
+}
+
+// NextWriter returns a writer for the next message to send.  The writer's
+// Close method flushes the complete message to the network.
+//
+// There can be at most one open writer on a connection. NextWriter closes the
+// previous writer if the application has not already done so.
+//
+// The NextWriter method and the writers returned from the method cannot be
+// accessed by more than one goroutine at a time.
+func (c *Conn) NextWriter(messageType int) (io.WriteCloser, error) {
+	if c.writeErr != nil {
+		return nil, c.writeErr
+	}
+
+	if c.writeFrameType != noFrame {
+		if err := c.flushFrame(true, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	if !isControl(messageType) && !isData(messageType) {
+		return nil, errBadWriteOpCode
+	}
+
+	c.writeFrameType = messageType
+	return messageWriter{c, c.writeSeq}, nil
+}
+
+func (c *Conn) flushFrame(final bool, extra []byte) error {
+	length := c.writePos - maxFrameHeaderSize + len(extra)
+
+	// Check for invalid control frames.
+	if isControl(c.writeFrameType) &&
+		(!final || length > maxControlFramePayloadSize) {
+		c.writeSeq++
+		c.writeFrameType = noFrame
+		c.writePos = maxFrameHeaderSize
+		return errInvalidControlFrame
+	}
+
+	b0 := byte(c.writeFrameType)
+	if final {
+		b0 |= finalBit
+	}
+	b1 := byte(0)
+	if !c.isServer {
+		b1 |= maskBit
+	}
+
+	// Assume that the frame starts at beginning of c.writeBuf.
+	framePos := 0
+	if c.isServer {
+		// Adjust up if mask not included in the header.
+		framePos = 4
+	}
+
+	switch {
+	case length >= 65536:
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | 127
+		binary.BigEndian.PutUint64(c.writeBuf[framePos+2:], uint64(length))
+	case length > 125:
+		framePos += 6
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | 126
+		binary.BigEndian.PutUint16(c.writeBuf[framePos+2:], uint16(length))
+	default:
+		framePos += 8
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | byte(length)
+	}
+
+	if !c.isServer {
+		key := newMaskKey()
+		copy(c.writeBuf[maxFrameHeaderSize-4:], key[:])
+		maskBytes(key, 0, c.writeBuf[maxFrameHeaderSize:c.writePos])
+		if len(extra) > 0 {
+			c.writeErr = errors.New("websocket: internal error, extra used in client mode")
+			return c.writeErr
+		}
+	}
+
+	// Write the buffers to the connection.
+	c.writeErr = c.write(c.writeFrameType, c.writeDeadline, c.writeBuf[framePos:c.writePos], extra)
+
+	// Setup for next frame.
+	c.writePos = maxFrameHeaderSize
+	c.writeFrameType = continuationFrame
+	if final {
+		c.writeSeq++
+		c.writeFrameType = noFrame
+	}
+	return c.writeErr
+}
+
+type messageWriter struct {
+	c   *Conn
+	seq int
+}
+
+func (w messageWriter) err() error {
+	c := w.c
+	if c.writeSeq != w.seq {
+		return errWriteClosed
+	}
+	if c.writeErr != nil {
+		return c.writeErr
+	}
+	return nil
+}
+
+func (w messageWriter) ncopy(max int) (int, error) {
+	n := len(w.c.writeBuf) - w.c.writePos
+	if n <= 0 {
+		if err := w.c.flushFrame(false, nil); err != nil {
+			return 0, err
+		}
+		n = len(w.c.writeBuf) - w.c.writePos
+	}
+	if n > max {
+		n = max
+	}
+	return n, nil
+}
+
+func (w messageWriter) write(final bool, p []byte) (int, error) {
+	if err := w.err(); err != nil {
+		return 0, err
+	}
+
+	if len(p) > 2*len(w.c.writeBuf) && w.c.isServer {
+		// Don't buffer large messages.
+		err := w.c.flushFrame(final, p)
+		if err != nil {
+			return 0, err
+		}
+		return len(p), nil
+	}
+
+	nn := len(p)
+	for len(p) > 0 {
+		n, err := w.ncopy(len(p))
+		if err != nil {
+			return 0, err
+		}
+		copy(w.c.writeBuf[w.c.writePos:], p[:n])
+		w.c.writePos += n
+		p = p[n:]
+	}
+	return nn, nil
+}
+
+func (w messageWriter) Write(p []byte) (int, error) {
+	return w.write(false, p)
+}
+
+func (w messageWriter) WriteString(p string) (int, error) {
+	if err := w.err(); err != nil {
+		return 0, err
+	}
+
+	nn := len(p)
+	for len(p) > 0 {
+		n, err := w.ncopy(len(p))
+		if err != nil {
+			return 0, err
+		}
+		copy(w.c.writeBuf[w.c.writePos:], p[:n])
+		w.c.writePos += n
+		p = p[n:]
+	}
+	return nn, nil
+}
+
+func (w messageWriter) ReadFrom(r io.Reader) (nn int64, err error) {
+	if err := w.err(); err != nil {
+		return 0, err
+	}
+	for {
+		if w.c.writePos == len(w.c.writeBuf) {
+			err = w.c.flushFrame(false, nil)
+			if err != nil {
+				break
+			}
+		}
+		var n int
+		n, err = r.Read(w.c.writeBuf[w.c.writePos:])
+		w.c.writePos += n
+		nn += int64(n)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			break
+		}
+	}
+	return nn, err
+}
+
+func (w messageWriter) Close() error {
+	if err := w.err(); err != nil {
+		return err
+	}
+	return w.c.flushFrame(true, nil)
+}
+
+// WriteMessage is a helper method for getting a writer using NextWriter,
+// writing the message and closing the writer.
+func (c *Conn) WriteMessage(messageType int, data []byte) error {
+	wr, err := c.NextWriter(messageType)
+	if err != nil {
+		return err
+	}
+	w := wr.(messageWriter)
+	if _, err := w.write(true, data); err != nil {
+		return err
+	}
+	if c.writeSeq == w.seq {
+		if err := c.flushFrame(true, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetWriteDeadline sets the write deadline on the underlying network
+// connection. After a write has timed out, the websocket state is corrupt and
+// all future writes will return an error. A zero value for t means writes will
+// not time out.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline = t
+	return nil
+}
+
+// Read methods
+
+// readFull is like io.ReadFull except that io.EOF is never returned.
+func (c *Conn) readFull(p []byte) (err error) {
+	var n int
+	for n < len(p) && err == nil {
+		var nn int
+		nn, err = c.br.Read(p[n:])
+		n += nn
+	}
+	if n == len(p) {
+		err = nil
+	} else if err == io.EOF {
+		err = errUnexpectedEOF
+	}
+	return
+}
+
+func (c *Conn) advanceFrame() (int, error) {
+
+	// 1. Skip remainder of previous frame.
+
+	if c.readRemaining > 0 {
+		if _, err := io.CopyN(ioutil.Discard, c.br, c.readRemaining); err != nil {
+			return noFrame, err
+		}
+	}
+
+	// 2. Read and parse first two bytes of frame header.
+
+	var b [8]byte
+	if err := c.readFull(b[:2]); err != nil {
+		return noFrame, err
+	}
+
+	final := b[0]&finalBit != 0
+	frameType := int(b[0] & 0xf)
+	reserved := int((b[0] >> 4) & 0x7)
+	mask := b[1]&maskBit != 0
+	c.readRemaining = int64(b[1] & 0x7f)
+
+	if reserved != 0 {
+		return noFrame, c.handleProtocolError("unexpected reserved bits " + strconv.Itoa(reserved))
+	}
+
+	switch frameType {
+	case CloseMessage, PingMessage, PongMessage:
+		if c.readRemaining > maxControlFramePayloadSize {
+			return noFrame, c.handleProtocolError("control frame length > 125")
+		}
+		if !final {
+			return noFrame, c.handleProtocolError("control frame not final")
+		}
+	case TextMessage, BinaryMessage:
+		if !c.readFinal {
+			return noFrame, c.handleProtocolError("message start before final message frame")
+		}
+		c.readFinal = final
+	case continuationFrame:
+		if c.readFinal {
+			return noFrame, c.handleProtocolError("continuation after final message frame")
+		}
+		c.readFinal = final
+	default:
+		return noFrame, c.handleProtocolError("unknown opcode " + strconv.Itoa(frameType))
+	}
+
+	// 3. Read and parse frame length.
+
+	switch c.readRemaining {
+	case 126:
+		if err := c.readFull(b[:2]); err != nil {
+			return noFrame, err
+		}
+		c.readRemaining = int64(binary.BigEndian.Uint16(b[:2]))
+	case 127:
+		if err := c.readFull(b[:8]); err != nil {
+			return noFrame, err
+		}
+		c.readRemaining = int64(binary.BigEndian.Uint64(b[:8]))
+	}
+
+	// 4. Handle frame masking.
+
+	if mask != c.isServer {
+		return noFrame, c.handleProtocolError("incorrect mask flag")
+	}
+
+	if mask {
+		c.readMaskPos = 0
+		if err := c.readFull(c.readMaskKey[:]); err != nil {
+			return noFrame, err
+		}
+	}
+
+	// 5. For text and binary messages, enforce read limit and return.
+
+	if frameType == continuationFrame || frameType == TextMessage || frameType == BinaryMessage {
+
+		c.readLength += c.readRemaining
+		if c.readLimit > 0 && c.readLength > c.readLimit {
+			c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(writeWait))
+			return noFrame, ErrReadLimit
+		}
+
+		return frameType, nil
+	}
+
+	// 6. Read control frame payload.
+
+	var payload []byte
+	if c.readRemaining > 0 {
+		payload = make([]byte, c.readRemaining)
+		c.readRemaining = 0
+		if err := c.readFull(payload); err != nil {
+			return noFrame, err
+		}
+		if c.isServer {
+			maskBytes(c.readMaskKey, 0, payload)
+		}
+	}
+
+	// 7. Process control frame payload.
+
+	switch frameType {
+	case PongMessage:
+		if err := c.handlePong(string(payload)); err != nil {
+			return noFrame, err
+		}
+	case PingMessage:
+		if err := c.handlePing(string(payload)); err != nil {
+			return noFrame, err
+		}
+	case CloseMessage:
+		c.WriteControl(CloseMessage, []byte{}, time.Now().Add(writeWait))
+		closeCode := CloseNoStatusReceived
+		closeText := ""
+		if len(payload) >= 2 {
+			closeCode = int(binary.BigEndian.Uint16(payload))
+			closeText = string(payload[2:])
+		}
+		switch closeCode {
+		case CloseNormalClosure, CloseGoingAway:
+			return noFrame, io.EOF
+		default:
+			return noFrame, &closeError{code: closeCode, text: closeText}
+		}
+	}
+
+	return frameType, nil
+}
+
+func (c *Conn) handleProtocolError(message string) error {
+	c.WriteControl(CloseMessage, FormatCloseMessage(CloseProtocolError, message), time.Now().Add(writeWait))
+	return errors.New("websocket: " + message)
+}
+
+// NextReader returns the next data message received from the peer. The
+// returned messageType is either TextMessage or BinaryMessage.
+//
+// There can be at most one open reader on a connection. NextReader discards
+// the previous message if the application has not already consumed it.
+//
+// The NextReader method and the readers returned from the method cannot be
+// accessed by more than one goroutine at a time.
+func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
+
+	c.readSeq++
+	c.readLength = 0
+
+	for c.readErr == nil {
+		frameType, err := c.advanceFrame()
+		if err != nil {
+			c.readErr = hideTempErr(err)
+			break
+		}
+		if frameType == TextMessage || frameType == BinaryMessage {
+			return frameType, messageReader{c, c.readSeq}, nil
+		}
+	}
+	return noFrame, nil, c.readErr
+}
+
+type messageReader struct {
+	c   *Conn
+	seq int
+}
+
+func (r messageReader) Read(b []byte) (int, error) {
+
+	if r.seq != r.c.readSeq {
+		return 0, io.EOF
+	}
+
+	for r.c.readErr == nil {
+
+		if r.c.readRemaining > 0 {
+			if int64(len(b)) > r.c.readRemaining {
+				b = b[:r.c.readRemaining]
+			}
+			n, err := r.c.br.Read(b)
+			r.c.readErr = hideTempErr(err)
+			if r.c.isServer {
+				r.c.readMaskPos = maskBytes(r.c.readMaskKey, r.c.readMaskPos, b[:n])
+			}
+			r.c.readRemaining -= int64(n)
+			return n, r.c.readErr
+		}
+
+		if r.c.readFinal {
+			r.c.readSeq++
+			return 0, io.EOF
+		}
+
+		frameType, err := r.c.advanceFrame()
+		switch {
+		case err != nil:
+			r.c.readErr = hideTempErr(err)
+		case frameType == TextMessage || frameType == BinaryMessage:
+			r.c.readErr = errors.New("websocket: internal error, unexpected text or binary in Reader")
+		}
+	}
+
+	err := r.c.readErr
+	if err == io.EOF && r.seq == r.c.readSeq {
+		err = errUnexpectedEOF
+	}
+	return 0, err
+}
+
+// ReadMessage is a helper method for getting a reader using NextReader and
+// reading from that reader to a buffer.
+func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
+	var r io.Reader
+	messageType, r, err = c.NextReader()
+	if err != nil {
+		return messageType, nil, err
+	}
+	p, err = ioutil.ReadAll(r)
+	return messageType, p, err
+}
+
+// SetReadDeadline sets the read deadline on the underlying network connection.
+// After a read has timed out, the websocket connection state is corrupt and
+// all future reads will return an error. A zero value for t means reads will
+// not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetReadLimit sets the maximum size for a message read from the peer. If a
+// message exceeds the limit, the connection sends a close frame to the peer
+// and returns ErrReadLimit to the application.
+func (c *Conn) SetReadLimit(limit int64) {
+	c.readLimit = limit
+}
+
+// SetPingHandler sets the handler for ping messages received from the peer.
+// The default ping handler sends a pong to the peer.
+func (c *Conn) SetPingHandler(h func(string) error) {
+	if h == nil {
+		h = func(message string) error {
+			c.WriteControl(PongMessage, []byte(message), time.Now().Add(writeWait))
+			return nil
+		}
+	}
+	c.handlePing = h
+}
+
+// SetPongHandler sets the handler for pong messages received from the peer.
+// The default pong handler does nothing.
+func (c *Conn) SetPongHandler(h func(string) error) {
+	if h == nil {
+		h = func(string) error { return nil }
+	}
+	c.handlePong = h
+}
+
+// UnderlyingConn returns the internal net.Conn. This can be used to further
+// modifications to connection specific flags.
+func (c *Conn) UnderlyingConn() net.Conn {
+	return c.conn
+}
+
+// FormatCloseMessage formats closeCode and text as a WebSocket close message.
+func FormatCloseMessage(closeCode int, text string) []byte {
+	buf := make([]byte, 2+len(text))
+	binary.BigEndian.PutUint16(buf, uint16(closeCode))
+	copy(buf[2:], text)
+	return buf
+}

--- a/vendor/github.com/gorilla/websocket/doc.go
+++ b/vendor/github.com/gorilla/websocket/doc.go
@@ -1,0 +1,148 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package websocket implements the WebSocket protocol defined in RFC 6455.
+//
+// Overview
+//
+// The Conn type represents a WebSocket connection. A server application uses
+// the Upgrade function from an Upgrader object with a HTTP request handler
+// to get a pointer to a Conn:
+//
+//  var upgrader = websocket.Upgrader{
+//      ReadBufferSize:  1024,
+//      WriteBufferSize: 1024,
+//  }
+//
+//  func handler(w http.ResponseWriter, r *http.Request) {
+//      conn, err := upgrader.Upgrade(w, r, nil)
+//      if err != nil {
+//          log.Println(err)
+//          return
+//      }
+//      ... Use conn to send and receive messages.
+//  }
+//
+// Call the connection's WriteMessage and ReadMessage methods to send and
+// receive messages as a slice of bytes. This snippet of code shows how to echo
+// messages using these methods:
+//
+//  for {
+//      messageType, p, err := conn.ReadMessage()
+//      if err != nil {
+//          return
+//      }
+//      if err = conn.WriteMessage(messageType, p); err != nil {
+//          return err
+//      }
+//  }
+//
+// In above snippet of code, p is a []byte and messageType is an int with value
+// websocket.BinaryMessage or websocket.TextMessage.
+//
+// An application can also send and receive messages using the io.WriteCloser
+// and io.Reader interfaces. To send a message, call the connection NextWriter
+// method to get an io.WriteCloser, write the message to the writer and close
+// the writer when done. To receive a message, call the connection NextReader
+// method to get an io.Reader and read until io.EOF is returned. This snippet
+// snippet shows how to echo messages using the NextWriter and NextReader
+// methods:
+//
+//  for {
+//      messageType, r, err := conn.NextReader()
+//      if err != nil {
+//          return
+//      }
+//      w, err := conn.NextWriter(messageType)
+//      if err != nil {
+//          return err
+//      }
+//      if _, err := io.Copy(w, r); err != nil {
+//          return err
+//      }
+//      if err := w.Close(); err != nil {
+//          return err
+//      }
+//  }
+//
+// Data Messages
+//
+// The WebSocket protocol distinguishes between text and binary data messages.
+// Text messages are interpreted as UTF-8 encoded text. The interpretation of
+// binary messages is left to the application.
+//
+// This package uses the TextMessage and BinaryMessage integer constants to
+// identify the two data message types. The ReadMessage and NextReader methods
+// return the type of the received message. The messageType argument to the
+// WriteMessage and NextWriter methods specifies the type of a sent message.
+//
+// It is the application's responsibility to ensure that text messages are
+// valid UTF-8 encoded text.
+//
+// Control Messages
+//
+// The WebSocket protocol defines three types of control messages: close, ping
+// and pong. Call the connection WriteControl, WriteMessage or NextWriter
+// methods to send a control message to the peer.
+//
+// Connections handle received ping and pong messages by invoking a callback
+// function set with SetPingHandler and SetPongHandler methods. These callback
+// functions can be invoked from the ReadMessage method, the NextReader method
+// or from a call to the data message reader returned from NextReader.
+//
+// Connections handle received close messages by returning an error from the
+// ReadMessage method, the NextReader method or from a call to the data message
+// reader returned from NextReader.
+//
+// Concurrency
+//
+// Connections do not support concurrent calls to the write methods
+// (NextWriter, SetWriteDeadline, WriteMessage) or concurrent calls to the read
+// methods methods (NextReader, SetReadDeadline, ReadMessage).  Connections do
+// support a concurrent reader and writer.
+//
+// The Close and WriteControl methods can be called concurrently with all other
+// methods.
+//
+// Read is Required
+//
+// The application must read the connection to process ping and close messages
+// sent from the peer. If the application is not otherwise interested in
+// messages from the peer, then the application should start a goroutine to read
+// and discard messages from the peer. A simple example is:
+//
+//  func readLoop(c *websocket.Conn) {
+//      for {
+//          if _, _, err := c.NextReader(); err != nil {
+//              c.Close()
+//              break
+//          }
+//      }
+//  }
+//
+// Origin Considerations
+//
+// Web browsers allow Javascript applications to open a WebSocket connection to
+// any host. It's up to the server to enforce an origin policy using the Origin
+// request header sent by the browser.
+//
+// The Upgrader calls the function specified in the CheckOrigin field to check
+// the origin. If the CheckOrigin function returns false, then the Upgrade
+// method fails the WebSocket handshake with HTTP status 403.
+//
+// If the CheckOrigin field is nil, then the Upgrader uses a safe default: fail
+// the handshake if the Origin request header is present and not equal to the
+// Host request header.
+//
+// An application can allow connections from any origin by specifying a
+// function that always returns true:
+//
+//    var upgrader = websocket.Upgrader{
+//      CheckOrigin: func(r *http.Request) bool { return true },
+//   }
+//
+// The deprecated Upgrade function does not enforce an origin policy. It's the
+// application's responsibility to check the Origin header before calling
+// Upgrade.
+package websocket

--- a/vendor/github.com/gorilla/websocket/json.go
+++ b/vendor/github.com/gorilla/websocket/json.go
@@ -1,0 +1,57 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// WriteJSON is deprecated, use c.WriteJSON instead.
+func WriteJSON(c *Conn, v interface{}) error {
+	return c.WriteJSON(v)
+}
+
+// WriteJSON writes the JSON encoding of v to the connection.
+//
+// See the documentation for encoding/json Marshal for details about the
+// conversion of Go values to JSON.
+func (c *Conn) WriteJSON(v interface{}) error {
+	w, err := c.NextWriter(TextMessage)
+	if err != nil {
+		return err
+	}
+	err1 := json.NewEncoder(w).Encode(v)
+	err2 := w.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// ReadJSON is deprecated, use c.ReadJSON instead.
+func ReadJSON(c *Conn, v interface{}) error {
+	return c.ReadJSON(v)
+}
+
+// ReadJSON reads the next JSON-encoded message from the connection and stores
+// it in the value pointed to by v.
+//
+// See the documentation for the encoding/json Unmarshal function for details
+// about the conversion of JSON to a Go value.
+func (c *Conn) ReadJSON(v interface{}) error {
+	_, r, err := c.NextReader()
+	if err != nil {
+		return err
+	}
+	err = json.NewDecoder(r).Decode(v)
+	if err == io.EOF {
+		// Decode returns io.EOF when the message is empty or all whitespace.
+		// Convert to io.ErrUnexpectedEOF so that application can distinguish
+		// between an error reading the JSON value and the connection closing.
+		err = io.ErrUnexpectedEOF
+	}
+	return err
+}

--- a/vendor/github.com/gorilla/websocket/server.go
+++ b/vendor/github.com/gorilla/websocket/server.go
@@ -1,0 +1,247 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// HandshakeError describes an error with the handshake from the peer.
+type HandshakeError struct {
+	message string
+}
+
+func (e HandshakeError) Error() string { return e.message }
+
+// Upgrader specifies parameters for upgrading an HTTP connection to a
+// WebSocket connection.
+type Upgrader struct {
+	// HandshakeTimeout specifies the duration for the handshake to complete.
+	HandshakeTimeout time.Duration
+
+	// ReadBufferSize and WriteBufferSize specify I/O buffer sizes. If a buffer
+	// size is zero, then a default value of 4096 is used. The I/O buffer sizes
+	// do not limit the size of the messages that can be sent or received.
+	ReadBufferSize, WriteBufferSize int
+
+	// Subprotocols specifies the server's supported protocols in order of
+	// preference. If this field is set, then the Upgrade method negotiates a
+	// subprotocol by selecting the first match in this list with a protocol
+	// requested by the client.
+	Subprotocols []string
+
+	// Error specifies the function for generating HTTP error responses. If Error
+	// is nil, then http.Error is used to generate the HTTP response.
+	Error func(w http.ResponseWriter, r *http.Request, status int, reason error)
+
+	// CheckOrigin returns true if the request Origin header is acceptable. If
+	// CheckOrigin is nil, the host in the Origin header must not be set or
+	// must match the host of the request.
+	CheckOrigin func(r *http.Request) bool
+}
+
+func (u *Upgrader) returnError(w http.ResponseWriter, r *http.Request, status int, reason string) (*Conn, error) {
+	err := HandshakeError{reason}
+	if u.Error != nil {
+		u.Error(w, r, status, err)
+	} else {
+		http.Error(w, http.StatusText(status), status)
+	}
+	return nil, err
+}
+
+// checkSameOrigin returns true if the origin is not set or is equal to the request host.
+func checkSameOrigin(r *http.Request) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	u, err := url.Parse(origin[0])
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host
+}
+
+func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {
+	if u.Subprotocols != nil {
+		clientProtocols := Subprotocols(r)
+		for _, serverProtocol := range u.Subprotocols {
+			for _, clientProtocol := range clientProtocols {
+				if clientProtocol == serverProtocol {
+					return clientProtocol
+				}
+			}
+		}
+	} else if responseHeader != nil {
+		return responseHeader.Get("Sec-Websocket-Protocol")
+	}
+	return ""
+}
+
+// Upgrade upgrades the HTTP server connection to the WebSocket protocol.
+//
+// The responseHeader is included in the response to the client's upgrade
+// request. Use the responseHeader to specify cookies (Set-Cookie) and the
+// application negotiated subprotocol (Sec-Websocket-Protocol).
+func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*Conn, error) {
+	if values := r.Header["Sec-Websocket-Version"]; len(values) == 0 || values[0] != "13" {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: version != 13")
+	}
+
+	if !tokenListContainsValue(r.Header, "Connection", "upgrade") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: could not find connection header with token 'upgrade'")
+	}
+
+	if !tokenListContainsValue(r.Header, "Upgrade", "websocket") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: could not find upgrade header with token 'websocket'")
+	}
+
+	checkOrigin := u.CheckOrigin
+	if checkOrigin == nil {
+		checkOrigin = checkSameOrigin
+	}
+	if !checkOrigin(r) {
+		return u.returnError(w, r, http.StatusForbidden, "websocket: origin not allowed")
+	}
+
+	challengeKey := r.Header.Get("Sec-Websocket-Key")
+	if challengeKey == "" {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: key missing or blank")
+	}
+
+	subprotocol := u.selectSubprotocol(r, responseHeader)
+
+	var (
+		netConn net.Conn
+		br      *bufio.Reader
+		err     error
+	)
+
+	h, ok := w.(http.Hijacker)
+	if !ok {
+		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
+	}
+	var rw *bufio.ReadWriter
+	netConn, rw, err = h.Hijack()
+	if err != nil {
+		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
+	}
+	br = rw.Reader
+
+	if br.Buffered() > 0 {
+		netConn.Close()
+		return nil, errors.New("websocket: client sent data before handshake is complete")
+	}
+
+	c := newConn(netConn, true, u.ReadBufferSize, u.WriteBufferSize)
+	c.subprotocol = subprotocol
+
+	p := c.writeBuf[:0]
+	p = append(p, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: "...)
+	p = append(p, computeAcceptKey(challengeKey)...)
+	p = append(p, "\r\n"...)
+	if c.subprotocol != "" {
+		p = append(p, "Sec-Websocket-Protocol: "...)
+		p = append(p, c.subprotocol...)
+		p = append(p, "\r\n"...)
+	}
+	for k, vs := range responseHeader {
+		if k == "Sec-Websocket-Protocol" {
+			continue
+		}
+		for _, v := range vs {
+			p = append(p, k...)
+			p = append(p, ": "...)
+			for i := 0; i < len(v); i++ {
+				b := v[i]
+				if b <= 31 {
+					// prevent response splitting.
+					b = ' '
+				}
+				p = append(p, b)
+			}
+			p = append(p, "\r\n"...)
+		}
+	}
+	p = append(p, "\r\n"...)
+
+	// Clear deadlines set by HTTP server.
+	netConn.SetDeadline(time.Time{})
+
+	if u.HandshakeTimeout > 0 {
+		netConn.SetWriteDeadline(time.Now().Add(u.HandshakeTimeout))
+	}
+	if _, err = netConn.Write(p); err != nil {
+		netConn.Close()
+		return nil, err
+	}
+	if u.HandshakeTimeout > 0 {
+		netConn.SetWriteDeadline(time.Time{})
+	}
+
+	return c, nil
+}
+
+// Upgrade upgrades the HTTP server connection to the WebSocket protocol.
+//
+// This function is deprecated, use websocket.Upgrader instead.
+//
+// The application is responsible for checking the request origin before
+// calling Upgrade. An example implementation of the same origin policy is:
+//
+//	if req.Header.Get("Origin") != "http://"+req.Host {
+//		http.Error(w, "Origin not allowed", 403)
+//		return
+//	}
+//
+// If the endpoint supports subprotocols, then the application is responsible
+// for negotiating the protocol used on the connection. Use the Subprotocols()
+// function to get the subprotocols requested by the client. Use the
+// Sec-Websocket-Protocol response header to specify the subprotocol selected
+// by the application.
+//
+// The responseHeader is included in the response to the client's upgrade
+// request. Use the responseHeader to specify cookies (Set-Cookie) and the
+// negotiated subprotocol (Sec-Websocket-Protocol).
+//
+// The connection buffers IO to the underlying network connection. The
+// readBufSize and writeBufSize parameters specify the size of the buffers to
+// use. Messages can be larger than the buffers.
+//
+// If the request is not a valid WebSocket handshake, then Upgrade returns an
+// error of type HandshakeError. Applications should handle this error by
+// replying to the client with an HTTP error response.
+func Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header, readBufSize, writeBufSize int) (*Conn, error) {
+	u := Upgrader{ReadBufferSize: readBufSize, WriteBufferSize: writeBufSize}
+	u.Error = func(w http.ResponseWriter, r *http.Request, status int, reason error) {
+		// don't return errors to maintain backwards compatibility
+	}
+	u.CheckOrigin = func(r *http.Request) bool {
+		// allow all connections by default
+		return true
+	}
+	return u.Upgrade(w, r, responseHeader)
+}
+
+// Subprotocols returns the subprotocols requested by the client in the
+// Sec-Websocket-Protocol header.
+func Subprotocols(r *http.Request) []string {
+	h := strings.TrimSpace(r.Header.Get("Sec-Websocket-Protocol"))
+	if h == "" {
+		return nil
+	}
+	protocols := strings.Split(h, ",")
+	for i := range protocols {
+		protocols[i] = strings.TrimSpace(protocols[i])
+	}
+	return protocols
+}

--- a/vendor/github.com/gorilla/websocket/util.go
+++ b/vendor/github.com/gorilla/websocket/util.go
@@ -1,0 +1,44 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// tokenListContainsValue returns true if the 1#token header with the given
+// name contains token.
+func tokenListContainsValue(header http.Header, name string, value string) bool {
+	for _, v := range header[name] {
+		for _, s := range strings.Split(v, ",") {
+			if strings.EqualFold(value, strings.TrimSpace(s)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var keyGUID = []byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+
+func computeAcceptKey(challengeKey string) string {
+	h := sha1.New()
+	h.Write([]byte(challengeKey))
+	h.Write(keyGUID)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func generateChallengeKey() (string, error) {
+	p := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, p); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(p), nil
+}

--- a/vendor/github.com/rancher/go-rancher/LICENSE
+++ b/vendor/github.com/rancher/go-rancher/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/rancher/go-rancher/client/client.go
+++ b/vendor/github.com/rancher/go-rancher/client/client.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+type RancherBaseClientImpl struct {
+	Opts    *ClientOpts
+	Schemas *Schemas
+	Types   map[string]Schema
+}
+
+type RancherBaseClient interface {
+	Websocket(string, map[string][]string) (*websocket.Conn, *http.Response, error)
+	List(string, *ListOpts, interface{}) error
+	Post(string, interface{}, interface{}) error
+	GetLink(Resource, string, interface{}) error
+	Create(string, interface{}, interface{}) error
+	Update(string, *Resource, interface{}, interface{}) error
+	ById(string, string, interface{}) error
+	Delete(*Resource) error
+	Reload(*Resource, interface{}) error
+	Action(string, string, *Resource, interface{}, interface{}) error
+
+	doGet(string, *ListOpts, interface{}) error
+	doList(string, *ListOpts, interface{}) error
+	doModify(string, string, interface{}, interface{}) error
+	doCreate(string, interface{}, interface{}) error
+	doUpdate(string, *Resource, interface{}, interface{}) error
+	doById(string, string, interface{}) error
+	doResourceDelete(string, *Resource) error
+	doAction(string, string, *Resource, interface{}, interface{}) error
+}

--- a/vendor/github.com/rancher/go-rancher/client/common.go
+++ b/vendor/github.com/rancher/go-rancher/client/common.go
@@ -1,0 +1,571 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+)
+
+const (
+	SELF       = "self"
+	COLLECTION = "collection"
+)
+
+var (
+	debug  = false
+	dialer = &websocket.Dialer{}
+)
+
+type ClientOpts struct {
+	Url       string
+	AccessKey string
+	SecretKey string
+	Timeout   time.Duration
+}
+
+type ApiError struct {
+	StatusCode int
+	Url        string
+	Msg        string
+	Status     string
+	Body       string
+}
+
+func (e *ApiError) Error() string {
+	return e.Msg
+}
+
+func IsNotFound(err error) bool {
+	apiError, ok := err.(*ApiError)
+	if !ok {
+		return false
+	}
+
+	return apiError.StatusCode == http.StatusNotFound
+}
+
+func newApiError(resp *http.Response, url string) *ApiError {
+	contents, err := ioutil.ReadAll(resp.Body)
+	var body string
+	if err != nil {
+		body = "Unreadable body."
+	} else {
+		body = string(contents)
+	}
+
+	data := map[string]interface{}{}
+	if json.Unmarshal(contents, &data) == nil {
+		delete(data, "id")
+		delete(data, "links")
+		delete(data, "actions")
+		delete(data, "type")
+		delete(data, "status")
+		buf := &bytes.Buffer{}
+		for k, v := range data {
+			if v == nil {
+				continue
+			}
+			if buf.Len() > 0 {
+				buf.WriteString(", ")
+			}
+			fmt.Fprintf(buf, "%s=%v", k, v)
+		}
+		body = buf.String()
+	}
+	formattedMsg := fmt.Sprintf("Bad response statusCode [%d]. Status [%s]. Body: [%s] from [%s]",
+		resp.StatusCode, resp.Status, body, url)
+	return &ApiError{
+		Url:        url,
+		Msg:        formattedMsg,
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       body,
+	}
+}
+
+func contains(array []string, item string) bool {
+	for _, check := range array {
+		if check == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+func appendFilters(urlString string, filters map[string]interface{}) (string, error) {
+	if len(filters) == 0 {
+		return urlString, nil
+	}
+
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	for k, v := range filters {
+		if l, ok := v.([]string); ok {
+			for _, v := range l {
+				q.Add(k, v)
+			}
+		} else {
+			q.Add(k, fmt.Sprintf("%v", v))
+		}
+	}
+
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func setupRancherBaseClient(rancherClient *RancherBaseClientImpl, opts *ClientOpts) error {
+	if opts.Timeout == 0 {
+		opts.Timeout = time.Second * 10
+	}
+	client := &http.Client{Timeout: opts.Timeout}
+	req, err := http.NewRequest("GET", opts.Url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(opts.AccessKey, opts.SecretKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return newApiError(resp, opts.Url)
+	}
+
+	schemasUrls := resp.Header.Get("X-API-Schemas")
+	if len(schemasUrls) == 0 {
+		return errors.New("Failed to find schema at [" + opts.Url + "]")
+	}
+
+	if schemasUrls != opts.Url {
+		req, err = http.NewRequest("GET", schemasUrls, nil)
+		req.SetBasicAuth(opts.AccessKey, opts.SecretKey)
+		if err != nil {
+			return err
+		}
+
+		resp, err = client.Do(req)
+		if err != nil {
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			return newApiError(resp, opts.Url)
+		}
+	}
+
+	var schemas Schemas
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bytes, &schemas)
+	if err != nil {
+		return err
+	}
+
+	rancherClient.Opts = opts
+	rancherClient.Schemas = &schemas
+
+	for _, schema := range schemas.Data {
+		rancherClient.Types[schema.Id] = schema
+	}
+
+	return nil
+}
+
+func NewListOpts() *ListOpts {
+	return &ListOpts{
+		Filters: map[string]interface{}{},
+	}
+}
+
+func (rancherClient *RancherBaseClientImpl) setupRequest(req *http.Request) {
+	req.SetBasicAuth(rancherClient.Opts.AccessKey, rancherClient.Opts.SecretKey)
+}
+
+func (rancherClient *RancherBaseClientImpl) newHttpClient() *http.Client {
+	if rancherClient.Opts.Timeout == 0 {
+		rancherClient.Opts.Timeout = time.Second * 10
+	}
+	return &http.Client{Timeout: rancherClient.Opts.Timeout}
+}
+
+func (rancherClient *RancherBaseClientImpl) doDelete(url string) error {
+	client := rancherClient.newHttpClient()
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	rancherClient.setupRequest(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	io.Copy(ioutil.Discard, resp.Body)
+
+	if resp.StatusCode >= 300 {
+		return newApiError(resp, url)
+	}
+
+	return nil
+}
+
+func (rancherClient *RancherBaseClientImpl) Websocket(url string, headers map[string][]string) (*websocket.Conn, *http.Response, error) {
+	return dialer.Dial(url, http.Header(headers))
+}
+
+func (rancherClient *RancherBaseClientImpl) doGet(url string, opts *ListOpts, respObject interface{}) error {
+	if opts == nil {
+		opts = NewListOpts()
+	}
+	url, err := appendFilters(url, opts.Filters)
+	if err != nil {
+		return err
+	}
+
+	if debug {
+		fmt.Println("GET " + url)
+	}
+
+	client := rancherClient.newHttpClient()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	rancherClient.setupRequest(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return newApiError(resp, url)
+	}
+
+	byteContent, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if debug {
+		fmt.Println("Response <= " + string(byteContent))
+	}
+
+	if err := json.Unmarshal(byteContent, respObject); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to parse: %s", byteContent))
+	}
+
+	return nil
+}
+
+func (rancherClient *RancherBaseClientImpl) List(schemaType string, opts *ListOpts, respObject interface{}) error {
+	return rancherClient.doList(schemaType, opts, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doList(schemaType string, opts *ListOpts, respObject interface{}) error {
+	schema, ok := rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	if !contains(schema.CollectionMethods, "GET") {
+		return errors.New("Resource type [" + schemaType + "] is not listable")
+	}
+
+	collectionUrl, ok := schema.Links[COLLECTION]
+	if !ok {
+		return errors.New("Failed to find collection URL for [" + schemaType + "]")
+	}
+
+	return rancherClient.doGet(collectionUrl, opts, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) Post(url string, createObj interface{}, respObject interface{}) error {
+	return rancherClient.doModify("POST", url, createObj, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) GetLink(resource Resource, link string, respObject interface{}) error {
+	url := resource.Links[link]
+	if url == "" {
+		return fmt.Errorf("Failed to find link: %s", link)
+	}
+
+	return rancherClient.doGet(url, &ListOpts{}, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doModify(method string, url string, createObj interface{}, respObject interface{}) error {
+	bodyContent, err := json.Marshal(createObj)
+	if err != nil {
+		return err
+	}
+
+	if debug {
+		fmt.Println(method + " " + url)
+		fmt.Println("Request => " + string(bodyContent))
+	}
+
+	client := rancherClient.newHttpClient()
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(bodyContent))
+	if err != nil {
+		return err
+	}
+
+	rancherClient.setupRequest(req)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", string(len(bodyContent)))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return newApiError(resp, url)
+	}
+
+	byteContent, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if len(byteContent) > 0 {
+		if debug {
+			fmt.Println("Response <= " + string(byteContent))
+		}
+		return json.Unmarshal(byteContent, respObject)
+	}
+
+	return nil
+}
+
+func (rancherClient *RancherBaseClientImpl) Create(schemaType string, createObj interface{}, respObject interface{}) error {
+	return rancherClient.doCreate(schemaType, createObj, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doCreate(schemaType string, createObj interface{}, respObject interface{}) error {
+	if createObj == nil {
+		createObj = map[string]string{}
+	}
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
+	}
+	schema, ok := rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	if !contains(schema.CollectionMethods, "POST") {
+		return errors.New("Resource type [" + schemaType + "] is not creatable")
+	}
+
+	var collectionUrl string
+	collectionUrl, ok = schema.Links[COLLECTION]
+	if !ok {
+		// return errors.New("Failed to find collection URL for [" + schemaType + "]")
+		// This is a hack to address https://github.com/rancher/cattle/issues/254
+		re := regexp.MustCompile("schemas.*")
+		collectionUrl = re.ReplaceAllString(schema.Links[SELF], schema.PluralName)
+	}
+
+	return rancherClient.doModify("POST", collectionUrl, createObj, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) Update(schemaType string, existing *Resource, updates interface{}, respObject interface{}) error {
+	return rancherClient.doUpdate(schemaType, existing, updates, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doUpdate(schemaType string, existing *Resource, updates interface{}, respObject interface{}) error {
+	if existing == nil {
+		return errors.New("Existing object is nil")
+	}
+
+	selfUrl, ok := existing.Links[SELF]
+	if !ok {
+		return errors.New(fmt.Sprintf("Failed to find self URL of [%v]", existing))
+	}
+
+	if updates == nil {
+		updates = map[string]string{}
+	}
+
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
+	}
+
+	schema, ok := rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	if !contains(schema.ResourceMethods, "PUT") {
+		return errors.New("Resource type [" + schemaType + "] is not updatable")
+	}
+
+	return rancherClient.doModify("PUT", selfUrl, updates, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) ById(schemaType string, id string, respObject interface{}) error {
+	return rancherClient.doById(schemaType, id, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doById(schemaType string, id string, respObject interface{}) error {
+	schema, ok := rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	if !contains(schema.ResourceMethods, "GET") {
+		return errors.New("Resource type [" + schemaType + "] can not be looked up by ID")
+	}
+
+	collectionUrl, ok := schema.Links[COLLECTION]
+	if !ok {
+		return errors.New("Failed to find collection URL for [" + schemaType + "]")
+	}
+
+	err := rancherClient.doGet(collectionUrl+"/"+id, nil, respObject)
+	//TODO check for 404 and return nil, nil
+	return err
+}
+
+func (rancherClient *RancherBaseClientImpl) Delete(existing *Resource) error {
+	if existing == nil {
+		return nil
+	}
+	return rancherClient.doResourceDelete(existing.Type, existing)
+}
+
+func (rancherClient *RancherBaseClientImpl) doResourceDelete(schemaType string, existing *Resource) error {
+	schema, ok := rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	if !contains(schema.ResourceMethods, "DELETE") {
+		return errors.New("Resource type [" + schemaType + "] can not be deleted")
+	}
+
+	selfUrl, ok := existing.Links[SELF]
+	if !ok {
+		return errors.New(fmt.Sprintf("Failed to find self URL of [%v]", existing))
+	}
+
+	return rancherClient.doDelete(selfUrl)
+}
+
+func (rancherClient *RancherBaseClientImpl) Reload(existing *Resource, output interface{}) error {
+	selfUrl, ok := existing.Links[SELF]
+	if !ok {
+		return errors.New(fmt.Sprintf("Failed to find self URL of [%v]", existing))
+	}
+
+	return rancherClient.doGet(selfUrl, NewListOpts(), output)
+}
+
+func (rancherClient *RancherBaseClientImpl) Action(schemaType string, action string,
+	existing *Resource, inputObject, respObject interface{}) error {
+	return rancherClient.doAction(schemaType, action, existing, inputObject, respObject)
+}
+
+func (rancherClient *RancherBaseClientImpl) doAction(schemaType string, action string,
+	existing *Resource, inputObject, respObject interface{}) error {
+
+	if existing == nil {
+		return errors.New("Existing object is nil")
+	}
+
+	actionUrl, ok := existing.Actions[action]
+	if !ok {
+		return errors.New(fmt.Sprintf("Action [%v] not available on [%v]", action, existing))
+	}
+
+	_, ok = rancherClient.Types[schemaType]
+	if !ok {
+		return errors.New("Unknown schema type [" + schemaType + "]")
+	}
+
+	var input io.Reader
+
+	if inputObject != nil {
+		bodyContent, err := json.Marshal(inputObject)
+		if err != nil {
+			return err
+		}
+		if debug {
+			fmt.Println("Request => " + string(bodyContent))
+		}
+		input = bytes.NewBuffer(bodyContent)
+	}
+
+	client := rancherClient.newHttpClient()
+	req, err := http.NewRequest("POST", actionUrl, input)
+	if err != nil {
+		return err
+	}
+
+	rancherClient.setupRequest(req)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", "0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return newApiError(resp, actionUrl)
+	}
+
+	byteContent, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if debug {
+		fmt.Println("Response <= " + string(byteContent))
+	}
+
+	return json.Unmarshal(byteContent, respObject)
+}
+
+func init() {
+	debug = os.Getenv("RANCHER_CLIENT_DEBUG") == "true"
+	if debug {
+		fmt.Println("Rancher client debug on")
+	}
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_account.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_account.go
@@ -1,0 +1,172 @@
+package client
+
+const (
+	ACCOUNT_TYPE = "account"
+)
+
+type Account struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExternalIdType string `json:"externalIdType,omitempty" yaml:"external_id_type,omitempty"`
+
+	Identity string `json:"identity,omitempty" yaml:"identity,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type AccountCollection struct {
+	Collection
+	Data []Account `json:"data,omitempty"`
+}
+
+type AccountClient struct {
+	rancherClient *RancherClient
+}
+
+type AccountOperations interface {
+	List(opts *ListOpts) (*AccountCollection, error)
+	Create(opts *Account) (*Account, error)
+	Update(existing *Account, updates interface{}) (*Account, error)
+	ById(id string) (*Account, error)
+	Delete(container *Account) error
+
+	ActionActivate(*Account) (*Account, error)
+
+	ActionCreate(*Account) (*Account, error)
+
+	ActionDeactivate(*Account) (*Account, error)
+
+	ActionPurge(*Account) (*Account, error)
+
+	ActionRemove(*Account) (*Account, error)
+
+	ActionRestore(*Account) (*Account, error)
+
+	ActionUpdate(*Account) (*Account, error)
+}
+
+func newAccountClient(rancherClient *RancherClient) *AccountClient {
+	return &AccountClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AccountClient) Create(container *Account) (*Account, error) {
+	resp := &Account{}
+	err := c.rancherClient.doCreate(ACCOUNT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AccountClient) Update(existing *Account, updates interface{}) (*Account, error) {
+	resp := &Account{}
+	err := c.rancherClient.doUpdate(ACCOUNT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AccountClient) List(opts *ListOpts) (*AccountCollection, error) {
+	resp := &AccountCollection{}
+	err := c.rancherClient.doList(ACCOUNT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AccountClient) ById(id string) (*Account, error) {
+	resp := &Account{}
+	err := c.rancherClient.doById(ACCOUNT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AccountClient) Delete(container *Account) error {
+	return c.rancherClient.doResourceDelete(ACCOUNT_TYPE, &container.Resource)
+}
+
+func (c *AccountClient) ActionActivate(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionCreate(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionDeactivate(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionPurge(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionRemove(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionRestore(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AccountClient) ActionUpdate(resource *Account) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(ACCOUNT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_active_setting.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_active_setting.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	ACTIVE_SETTING_TYPE = "activeSetting"
+)
+
+type ActiveSetting struct {
+	Resource
+
+	ActiveValue interface{} `json:"activeValue,omitempty" yaml:"active_value,omitempty"`
+
+	InDb bool `json:"inDb,omitempty" yaml:"in_db,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+type ActiveSettingCollection struct {
+	Collection
+	Data []ActiveSetting `json:"data,omitempty"`
+}
+
+type ActiveSettingClient struct {
+	rancherClient *RancherClient
+}
+
+type ActiveSettingOperations interface {
+	List(opts *ListOpts) (*ActiveSettingCollection, error)
+	Create(opts *ActiveSetting) (*ActiveSetting, error)
+	Update(existing *ActiveSetting, updates interface{}) (*ActiveSetting, error)
+	ById(id string) (*ActiveSetting, error)
+	Delete(container *ActiveSetting) error
+}
+
+func newActiveSettingClient(rancherClient *RancherClient) *ActiveSettingClient {
+	return &ActiveSettingClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ActiveSettingClient) Create(container *ActiveSetting) (*ActiveSetting, error) {
+	resp := &ActiveSetting{}
+	err := c.rancherClient.doCreate(ACTIVE_SETTING_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ActiveSettingClient) Update(existing *ActiveSetting, updates interface{}) (*ActiveSetting, error) {
+	resp := &ActiveSetting{}
+	err := c.rancherClient.doUpdate(ACTIVE_SETTING_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ActiveSettingClient) List(opts *ListOpts) (*ActiveSettingCollection, error) {
+	resp := &ActiveSettingCollection{}
+	err := c.rancherClient.doList(ACTIVE_SETTING_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ActiveSettingClient) ById(id string) (*ActiveSetting, error) {
+	resp := &ActiveSetting{}
+	err := c.rancherClient.doById(ACTIVE_SETTING_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ActiveSettingClient) Delete(container *ActiveSetting) error {
+	return c.rancherClient.doResourceDelete(ACTIVE_SETTING_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_add_outputs_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_add_outputs_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	ADD_OUTPUTS_INPUT_TYPE = "addOutputsInput"
+)
+
+type AddOutputsInput struct {
+	Resource
+
+	Outputs map[string]interface{} `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+}
+
+type AddOutputsInputCollection struct {
+	Collection
+	Data []AddOutputsInput `json:"data,omitempty"`
+}
+
+type AddOutputsInputClient struct {
+	rancherClient *RancherClient
+}
+
+type AddOutputsInputOperations interface {
+	List(opts *ListOpts) (*AddOutputsInputCollection, error)
+	Create(opts *AddOutputsInput) (*AddOutputsInput, error)
+	Update(existing *AddOutputsInput, updates interface{}) (*AddOutputsInput, error)
+	ById(id string) (*AddOutputsInput, error)
+	Delete(container *AddOutputsInput) error
+}
+
+func newAddOutputsInputClient(rancherClient *RancherClient) *AddOutputsInputClient {
+	return &AddOutputsInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AddOutputsInputClient) Create(container *AddOutputsInput) (*AddOutputsInput, error) {
+	resp := &AddOutputsInput{}
+	err := c.rancherClient.doCreate(ADD_OUTPUTS_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AddOutputsInputClient) Update(existing *AddOutputsInput, updates interface{}) (*AddOutputsInput, error) {
+	resp := &AddOutputsInput{}
+	err := c.rancherClient.doUpdate(ADD_OUTPUTS_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AddOutputsInputClient) List(opts *ListOpts) (*AddOutputsInputCollection, error) {
+	resp := &AddOutputsInputCollection{}
+	err := c.rancherClient.doList(ADD_OUTPUTS_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AddOutputsInputClient) ById(id string) (*AddOutputsInput, error) {
+	resp := &AddOutputsInput{}
+	err := c.rancherClient.doById(ADD_OUTPUTS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AddOutputsInputClient) Delete(container *AddOutputsInput) error {
+	return c.rancherClient.doResourceDelete(ADD_OUTPUTS_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_service_link_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_service_link_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE = "addRemoveLoadBalancerServiceLinkInput"
+)
+
+type AddRemoveLoadBalancerServiceLinkInput struct {
+	Resource
+
+	ServiceLink LoadBalancerServiceLink `json:"serviceLink,omitempty" yaml:"service_link,omitempty"`
+}
+
+type AddRemoveLoadBalancerServiceLinkInputCollection struct {
+	Collection
+	Data []AddRemoveLoadBalancerServiceLinkInput `json:"data,omitempty"`
+}
+
+type AddRemoveLoadBalancerServiceLinkInputClient struct {
+	rancherClient *RancherClient
+}
+
+type AddRemoveLoadBalancerServiceLinkInputOperations interface {
+	List(opts *ListOpts) (*AddRemoveLoadBalancerServiceLinkInputCollection, error)
+	Create(opts *AddRemoveLoadBalancerServiceLinkInput) (*AddRemoveLoadBalancerServiceLinkInput, error)
+	Update(existing *AddRemoveLoadBalancerServiceLinkInput, updates interface{}) (*AddRemoveLoadBalancerServiceLinkInput, error)
+	ById(id string) (*AddRemoveLoadBalancerServiceLinkInput, error)
+	Delete(container *AddRemoveLoadBalancerServiceLinkInput) error
+}
+
+func newAddRemoveLoadBalancerServiceLinkInputClient(rancherClient *RancherClient) *AddRemoveLoadBalancerServiceLinkInputClient {
+	return &AddRemoveLoadBalancerServiceLinkInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AddRemoveLoadBalancerServiceLinkInputClient) Create(container *AddRemoveLoadBalancerServiceLinkInput) (*AddRemoveLoadBalancerServiceLinkInput, error) {
+	resp := &AddRemoveLoadBalancerServiceLinkInput{}
+	err := c.rancherClient.doCreate(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AddRemoveLoadBalancerServiceLinkInputClient) Update(existing *AddRemoveLoadBalancerServiceLinkInput, updates interface{}) (*AddRemoveLoadBalancerServiceLinkInput, error) {
+	resp := &AddRemoveLoadBalancerServiceLinkInput{}
+	err := c.rancherClient.doUpdate(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AddRemoveLoadBalancerServiceLinkInputClient) List(opts *ListOpts) (*AddRemoveLoadBalancerServiceLinkInputCollection, error) {
+	resp := &AddRemoveLoadBalancerServiceLinkInputCollection{}
+	err := c.rancherClient.doList(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AddRemoveLoadBalancerServiceLinkInputClient) ById(id string) (*AddRemoveLoadBalancerServiceLinkInput, error) {
+	resp := &AddRemoveLoadBalancerServiceLinkInput{}
+	err := c.rancherClient.doById(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AddRemoveLoadBalancerServiceLinkInputClient) Delete(container *AddRemoveLoadBalancerServiceLinkInput) error {
+	return c.rancherClient.doResourceDelete(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_add_remove_service_link_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_add_remove_service_link_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	ADD_REMOVE_SERVICE_LINK_INPUT_TYPE = "addRemoveServiceLinkInput"
+)
+
+type AddRemoveServiceLinkInput struct {
+	Resource
+
+	ServiceLink ServiceLink `json:"serviceLink,omitempty" yaml:"service_link,omitempty"`
+}
+
+type AddRemoveServiceLinkInputCollection struct {
+	Collection
+	Data []AddRemoveServiceLinkInput `json:"data,omitempty"`
+}
+
+type AddRemoveServiceLinkInputClient struct {
+	rancherClient *RancherClient
+}
+
+type AddRemoveServiceLinkInputOperations interface {
+	List(opts *ListOpts) (*AddRemoveServiceLinkInputCollection, error)
+	Create(opts *AddRemoveServiceLinkInput) (*AddRemoveServiceLinkInput, error)
+	Update(existing *AddRemoveServiceLinkInput, updates interface{}) (*AddRemoveServiceLinkInput, error)
+	ById(id string) (*AddRemoveServiceLinkInput, error)
+	Delete(container *AddRemoveServiceLinkInput) error
+}
+
+func newAddRemoveServiceLinkInputClient(rancherClient *RancherClient) *AddRemoveServiceLinkInputClient {
+	return &AddRemoveServiceLinkInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AddRemoveServiceLinkInputClient) Create(container *AddRemoveServiceLinkInput) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doCreate(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) Update(existing *AddRemoveServiceLinkInput, updates interface{}) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doUpdate(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) List(opts *ListOpts) (*AddRemoveServiceLinkInputCollection, error) {
+	resp := &AddRemoveServiceLinkInputCollection{}
+	err := c.rancherClient.doList(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) ById(id string) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doById(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) Delete(container *AddRemoveServiceLinkInput) error {
+	return c.rancherClient.doResourceDelete(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_agent.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_agent.go
@@ -1,0 +1,194 @@
+package client
+
+const (
+	AGENT_TYPE = "agent"
+)
+
+type Agent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ManagedConfig bool `json:"managedConfig,omitempty" yaml:"managed_config,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type AgentCollection struct {
+	Collection
+	Data []Agent `json:"data,omitempty"`
+}
+
+type AgentClient struct {
+	rancherClient *RancherClient
+}
+
+type AgentOperations interface {
+	List(opts *ListOpts) (*AgentCollection, error)
+	Create(opts *Agent) (*Agent, error)
+	Update(existing *Agent, updates interface{}) (*Agent, error)
+	ById(id string) (*Agent, error)
+	Delete(container *Agent) error
+
+	ActionActivate(*Agent) (*Agent, error)
+
+	ActionCreate(*Agent) (*Agent, error)
+
+	ActionDeactivate(*Agent) (*Agent, error)
+
+	ActionDisconnect(*Agent) (*Agent, error)
+
+	ActionPurge(*Agent) (*Agent, error)
+
+	ActionReconnect(*Agent) (*Agent, error)
+
+	ActionRemove(*Agent) (*Agent, error)
+
+	ActionRestore(*Agent) (*Agent, error)
+
+	ActionUpdate(*Agent) (*Agent, error)
+}
+
+func newAgentClient(rancherClient *RancherClient) *AgentClient {
+	return &AgentClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AgentClient) Create(container *Agent) (*Agent, error) {
+	resp := &Agent{}
+	err := c.rancherClient.doCreate(AGENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AgentClient) Update(existing *Agent, updates interface{}) (*Agent, error) {
+	resp := &Agent{}
+	err := c.rancherClient.doUpdate(AGENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AgentClient) List(opts *ListOpts) (*AgentCollection, error) {
+	resp := &AgentCollection{}
+	err := c.rancherClient.doList(AGENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AgentClient) ById(id string) (*Agent, error) {
+	resp := &Agent{}
+	err := c.rancherClient.doById(AGENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AgentClient) Delete(container *Agent) error {
+	return c.rancherClient.doResourceDelete(AGENT_TYPE, &container.Resource)
+}
+
+func (c *AgentClient) ActionActivate(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionCreate(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionDeactivate(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionDisconnect(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "disconnect", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionPurge(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionReconnect(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "reconnect", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionRemove(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionRestore(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *AgentClient) ActionUpdate(resource *Agent) (*Agent, error) {
+
+	resp := &Agent{}
+
+	err := c.rancherClient.doAction(AGENT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_amazonec2config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_amazonec2config.go
@@ -1,0 +1,121 @@
+package client
+
+const (
+	AMAZONEC2CONFIG_TYPE = "amazonec2Config"
+)
+
+type Amazonec2Config struct {
+	Resource
+
+	AccessKey string `json:"accessKey,omitempty" yaml:"access_key,omitempty"`
+
+	Ami string `json:"ami,omitempty" yaml:"ami,omitempty"`
+
+	DeviceName string `json:"deviceName,omitempty" yaml:"device_name,omitempty"`
+
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+
+	IamInstanceProfile string `json:"iamInstanceProfile,omitempty" yaml:"iam_instance_profile,omitempty"`
+
+	InsecureTransport bool `json:"insecureTransport,omitempty" yaml:"insecure_transport,omitempty"`
+
+	InstanceType string `json:"instanceType,omitempty" yaml:"instance_type,omitempty"`
+
+	KeypairName string `json:"keypairName,omitempty" yaml:"keypair_name,omitempty"`
+
+	Monitoring bool `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
+
+	OpenPort []string `json:"openPort,omitempty" yaml:"open_port,omitempty"`
+
+	PrivateAddressOnly bool `json:"privateAddressOnly,omitempty" yaml:"private_address_only,omitempty"`
+
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+
+	RequestSpotInstance bool `json:"requestSpotInstance,omitempty" yaml:"request_spot_instance,omitempty"`
+
+	Retries string `json:"retries,omitempty" yaml:"retries,omitempty"`
+
+	RootSize string `json:"rootSize,omitempty" yaml:"root_size,omitempty"`
+
+	SecretKey string `json:"secretKey,omitempty" yaml:"secret_key,omitempty"`
+
+	SecurityGroup []string `json:"securityGroup,omitempty" yaml:"security_group,omitempty"`
+
+	SessionToken string `json:"sessionToken,omitempty" yaml:"session_token,omitempty"`
+
+	SpotPrice string `json:"spotPrice,omitempty" yaml:"spot_price,omitempty"`
+
+	SshKeypath string `json:"sshKeypath,omitempty" yaml:"ssh_keypath,omitempty"`
+
+	SshUser string `json:"sshUser,omitempty" yaml:"ssh_user,omitempty"`
+
+	SubnetId string `json:"subnetId,omitempty" yaml:"subnet_id,omitempty"`
+
+	Tags string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	UseEbsOptimizedInstance bool `json:"useEbsOptimizedInstance,omitempty" yaml:"use_ebs_optimized_instance,omitempty"`
+
+	UsePrivateAddress bool `json:"usePrivateAddress,omitempty" yaml:"use_private_address,omitempty"`
+
+	VolumeType string `json:"volumeType,omitempty" yaml:"volume_type,omitempty"`
+
+	VpcId string `json:"vpcId,omitempty" yaml:"vpc_id,omitempty"`
+
+	Zone string `json:"zone,omitempty" yaml:"zone,omitempty"`
+}
+
+type Amazonec2ConfigCollection struct {
+	Collection
+	Data []Amazonec2Config `json:"data,omitempty"`
+}
+
+type Amazonec2ConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type Amazonec2ConfigOperations interface {
+	List(opts *ListOpts) (*Amazonec2ConfigCollection, error)
+	Create(opts *Amazonec2Config) (*Amazonec2Config, error)
+	Update(existing *Amazonec2Config, updates interface{}) (*Amazonec2Config, error)
+	ById(id string) (*Amazonec2Config, error)
+	Delete(container *Amazonec2Config) error
+}
+
+func newAmazonec2ConfigClient(rancherClient *RancherClient) *Amazonec2ConfigClient {
+	return &Amazonec2ConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *Amazonec2ConfigClient) Create(container *Amazonec2Config) (*Amazonec2Config, error) {
+	resp := &Amazonec2Config{}
+	err := c.rancherClient.doCreate(AMAZONEC2CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *Amazonec2ConfigClient) Update(existing *Amazonec2Config, updates interface{}) (*Amazonec2Config, error) {
+	resp := &Amazonec2Config{}
+	err := c.rancherClient.doUpdate(AMAZONEC2CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *Amazonec2ConfigClient) List(opts *ListOpts) (*Amazonec2ConfigCollection, error) {
+	resp := &Amazonec2ConfigCollection{}
+	err := c.rancherClient.doList(AMAZONEC2CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *Amazonec2ConfigClient) ById(id string) (*Amazonec2Config, error) {
+	resp := &Amazonec2Config{}
+	err := c.rancherClient.doById(AMAZONEC2CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *Amazonec2ConfigClient) Delete(container *Amazonec2Config) error {
+	return c.rancherClient.doResourceDelete(AMAZONEC2CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_api_key.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_api_key.go
@@ -1,0 +1,161 @@
+package client
+
+const (
+	API_KEY_TYPE = "apiKey"
+)
+
+type ApiKey struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicValue string `json:"publicValue,omitempty" yaml:"public_value,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SecretValue string `json:"secretValue,omitempty" yaml:"secret_value,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ApiKeyCollection struct {
+	Collection
+	Data []ApiKey `json:"data,omitempty"`
+}
+
+type ApiKeyClient struct {
+	rancherClient *RancherClient
+}
+
+type ApiKeyOperations interface {
+	List(opts *ListOpts) (*ApiKeyCollection, error)
+	Create(opts *ApiKey) (*ApiKey, error)
+	Update(existing *ApiKey, updates interface{}) (*ApiKey, error)
+	ById(id string) (*ApiKey, error)
+	Delete(container *ApiKey) error
+
+	ActionActivate(*ApiKey) (*Credential, error)
+
+	ActionCreate(*ApiKey) (*Credential, error)
+
+	ActionDeactivate(*ApiKey) (*Credential, error)
+
+	ActionPurge(*ApiKey) (*Credential, error)
+
+	ActionRemove(*ApiKey) (*Credential, error)
+
+	ActionUpdate(*ApiKey) (*Credential, error)
+}
+
+func newApiKeyClient(rancherClient *RancherClient) *ApiKeyClient {
+	return &ApiKeyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ApiKeyClient) Create(container *ApiKey) (*ApiKey, error) {
+	resp := &ApiKey{}
+	err := c.rancherClient.doCreate(API_KEY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ApiKeyClient) Update(existing *ApiKey, updates interface{}) (*ApiKey, error) {
+	resp := &ApiKey{}
+	err := c.rancherClient.doUpdate(API_KEY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ApiKeyClient) List(opts *ListOpts) (*ApiKeyCollection, error) {
+	resp := &ApiKeyCollection{}
+	err := c.rancherClient.doList(API_KEY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ApiKeyClient) ById(id string) (*ApiKey, error) {
+	resp := &ApiKey{}
+	err := c.rancherClient.doById(API_KEY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ApiKeyClient) Delete(container *ApiKey) error {
+	return c.rancherClient.doResourceDelete(API_KEY_TYPE, &container.Resource)
+}
+
+func (c *ApiKeyClient) ActionActivate(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ApiKeyClient) ActionCreate(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ApiKeyClient) ActionDeactivate(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ApiKeyClient) ActionPurge(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ApiKeyClient) ActionRemove(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ApiKeyClient) ActionUpdate(resource *ApiKey) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(API_KEY_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_audit_log.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_audit_log.go
@@ -1,0 +1,93 @@
+package client
+
+const (
+	AUDIT_LOG_TYPE = "auditLog"
+)
+
+type AuditLog struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AuthType string `json:"authType,omitempty" yaml:"auth_type,omitempty"`
+
+	AuthenticatedAsAccountId string `json:"authenticatedAsAccountId,omitempty" yaml:"authenticated_as_account_id,omitempty"`
+
+	AuthenticatedAsIdentityId string `json:"authenticatedAsIdentityId,omitempty" yaml:"authenticated_as_identity_id,omitempty"`
+
+	ClientIp string `json:"clientIp,omitempty" yaml:"client_ip,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	RequestObject string `json:"requestObject,omitempty" yaml:"request_object,omitempty"`
+
+	ResourceId int64 `json:"resourceId,omitempty" yaml:"resource_id,omitempty"`
+
+	ResourceType string `json:"resourceType,omitempty" yaml:"resource_type,omitempty"`
+
+	ResponseCode string `json:"responseCode,omitempty" yaml:"response_code,omitempty"`
+
+	ResponseObject string `json:"responseObject,omitempty" yaml:"response_object,omitempty"`
+}
+
+type AuditLogCollection struct {
+	Collection
+	Data []AuditLog `json:"data,omitempty"`
+}
+
+type AuditLogClient struct {
+	rancherClient *RancherClient
+}
+
+type AuditLogOperations interface {
+	List(opts *ListOpts) (*AuditLogCollection, error)
+	Create(opts *AuditLog) (*AuditLog, error)
+	Update(existing *AuditLog, updates interface{}) (*AuditLog, error)
+	ById(id string) (*AuditLog, error)
+	Delete(container *AuditLog) error
+}
+
+func newAuditLogClient(rancherClient *RancherClient) *AuditLogClient {
+	return &AuditLogClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AuditLogClient) Create(container *AuditLog) (*AuditLog, error) {
+	resp := &AuditLog{}
+	err := c.rancherClient.doCreate(AUDIT_LOG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AuditLogClient) Update(existing *AuditLog, updates interface{}) (*AuditLog, error) {
+	resp := &AuditLog{}
+	err := c.rancherClient.doUpdate(AUDIT_LOG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AuditLogClient) List(opts *ListOpts) (*AuditLogCollection, error) {
+	resp := &AuditLogCollection{}
+	err := c.rancherClient.doList(AUDIT_LOG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AuditLogClient) ById(id string) (*AuditLog, error) {
+	resp := &AuditLog{}
+	err := c.rancherClient.doById(AUDIT_LOG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AuditLogClient) Delete(container *AuditLog) error {
+	return c.rancherClient.doResourceDelete(AUDIT_LOG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_azure_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_azure_config.go
@@ -1,0 +1,107 @@
+package client
+
+const (
+	AZURE_CONFIG_TYPE = "azureConfig"
+)
+
+type AzureConfig struct {
+	Resource
+
+	AvailabilitySet string `json:"availabilitySet,omitempty" yaml:"availability_set,omitempty"`
+
+	ClientId string `json:"clientId,omitempty" yaml:"client_id,omitempty"`
+
+	ClientSecret string `json:"clientSecret,omitempty" yaml:"client_secret,omitempty"`
+
+	CustomData string `json:"customData,omitempty" yaml:"custom_data,omitempty"`
+
+	DockerPort string `json:"dockerPort,omitempty" yaml:"docker_port,omitempty"`
+
+	Environment string `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
+
+	NoPublicIp bool `json:"noPublicIp,omitempty" yaml:"no_public_ip,omitempty"`
+
+	OpenPort []string `json:"openPort,omitempty" yaml:"open_port,omitempty"`
+
+	PrivateIpAddress string `json:"privateIpAddress,omitempty" yaml:"private_ip_address,omitempty"`
+
+	ResourceGroup string `json:"resourceGroup,omitempty" yaml:"resource_group,omitempty"`
+
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
+
+	SshUser string `json:"sshUser,omitempty" yaml:"ssh_user,omitempty"`
+
+	StaticPublicIp bool `json:"staticPublicIp,omitempty" yaml:"static_public_ip,omitempty"`
+
+	StorageType string `json:"storageType,omitempty" yaml:"storage_type,omitempty"`
+
+	Subnet string `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+
+	SubnetPrefix string `json:"subnetPrefix,omitempty" yaml:"subnet_prefix,omitempty"`
+
+	SubscriptionId string `json:"subscriptionId,omitempty" yaml:"subscription_id,omitempty"`
+
+	UsePrivateIp bool `json:"usePrivateIp,omitempty" yaml:"use_private_ip,omitempty"`
+
+	Vnet string `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+}
+
+type AzureConfigCollection struct {
+	Collection
+	Data []AzureConfig `json:"data,omitempty"`
+}
+
+type AzureConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type AzureConfigOperations interface {
+	List(opts *ListOpts) (*AzureConfigCollection, error)
+	Create(opts *AzureConfig) (*AzureConfig, error)
+	Update(existing *AzureConfig, updates interface{}) (*AzureConfig, error)
+	ById(id string) (*AzureConfig, error)
+	Delete(container *AzureConfig) error
+}
+
+func newAzureConfigClient(rancherClient *RancherClient) *AzureConfigClient {
+	return &AzureConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AzureConfigClient) Create(container *AzureConfig) (*AzureConfig, error) {
+	resp := &AzureConfig{}
+	err := c.rancherClient.doCreate(AZURE_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AzureConfigClient) Update(existing *AzureConfig, updates interface{}) (*AzureConfig, error) {
+	resp := &AzureConfig{}
+	err := c.rancherClient.doUpdate(AZURE_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AzureConfigClient) List(opts *ListOpts) (*AzureConfigCollection, error) {
+	resp := &AzureConfigCollection{}
+	err := c.rancherClient.doList(AZURE_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AzureConfigClient) ById(id string) (*AzureConfig, error) {
+	resp := &AzureConfig{}
+	err := c.rancherClient.doById(AZURE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AzureConfigClient) Delete(container *AzureConfig) error {
+	return c.rancherClient.doResourceDelete(AZURE_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_azureadconfig.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_azureadconfig.go
@@ -1,0 +1,81 @@
+package client
+
+const (
+	AZUREADCONFIG_TYPE = "azureadconfig"
+)
+
+type Azureadconfig struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	AdminAccountPassword string `json:"adminAccountPassword,omitempty" yaml:"admin_account_password,omitempty"`
+
+	AdminAccountUsername string `json:"adminAccountUsername,omitempty" yaml:"admin_account_username,omitempty"`
+
+	ClientId string `json:"clientId,omitempty" yaml:"client_id,omitempty"`
+
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	TenantId string `json:"tenantId,omitempty" yaml:"tenant_id,omitempty"`
+}
+
+type AzureadconfigCollection struct {
+	Collection
+	Data []Azureadconfig `json:"data,omitempty"`
+}
+
+type AzureadconfigClient struct {
+	rancherClient *RancherClient
+}
+
+type AzureadconfigOperations interface {
+	List(opts *ListOpts) (*AzureadconfigCollection, error)
+	Create(opts *Azureadconfig) (*Azureadconfig, error)
+	Update(existing *Azureadconfig, updates interface{}) (*Azureadconfig, error)
+	ById(id string) (*Azureadconfig, error)
+	Delete(container *Azureadconfig) error
+}
+
+func newAzureadconfigClient(rancherClient *RancherClient) *AzureadconfigClient {
+	return &AzureadconfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AzureadconfigClient) Create(container *Azureadconfig) (*Azureadconfig, error) {
+	resp := &Azureadconfig{}
+	err := c.rancherClient.doCreate(AZUREADCONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AzureadconfigClient) Update(existing *Azureadconfig, updates interface{}) (*Azureadconfig, error) {
+	resp := &Azureadconfig{}
+	err := c.rancherClient.doUpdate(AZUREADCONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AzureadconfigClient) List(opts *ListOpts) (*AzureadconfigCollection, error) {
+	resp := &AzureadconfigCollection{}
+	err := c.rancherClient.doList(AZUREADCONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AzureadconfigClient) ById(id string) (*Azureadconfig, error) {
+	resp := &Azureadconfig{}
+	err := c.rancherClient.doById(AZUREADCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *AzureadconfigClient) Delete(container *Azureadconfig) error {
+	return c.rancherClient.doResourceDelete(AZUREADCONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_backup.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_backup.go
@@ -1,0 +1,121 @@
+package client
+
+const (
+	BACKUP_TYPE = "backup"
+)
+
+type Backup struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	BackupTargetId string `json:"backupTargetId,omitempty" yaml:"backup_target_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SnapshotId string `json:"snapshotId,omitempty" yaml:"snapshot_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VolumeId string `json:"volumeId,omitempty" yaml:"volume_id,omitempty"`
+}
+
+type BackupCollection struct {
+	Collection
+	Data []Backup `json:"data,omitempty"`
+}
+
+type BackupClient struct {
+	rancherClient *RancherClient
+}
+
+type BackupOperations interface {
+	List(opts *ListOpts) (*BackupCollection, error)
+	Create(opts *Backup) (*Backup, error)
+	Update(existing *Backup, updates interface{}) (*Backup, error)
+	ById(id string) (*Backup, error)
+	Delete(container *Backup) error
+
+	ActionCreate(*Backup) (*Backup, error)
+
+	ActionRemove(*Backup) (*Backup, error)
+}
+
+func newBackupClient(rancherClient *RancherClient) *BackupClient {
+	return &BackupClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *BackupClient) Create(container *Backup) (*Backup, error) {
+	resp := &Backup{}
+	err := c.rancherClient.doCreate(BACKUP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *BackupClient) Update(existing *Backup, updates interface{}) (*Backup, error) {
+	resp := &Backup{}
+	err := c.rancherClient.doUpdate(BACKUP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *BackupClient) List(opts *ListOpts) (*BackupCollection, error) {
+	resp := &BackupCollection{}
+	err := c.rancherClient.doList(BACKUP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *BackupClient) ById(id string) (*Backup, error) {
+	resp := &Backup{}
+	err := c.rancherClient.doById(BACKUP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *BackupClient) Delete(container *Backup) error {
+	return c.rancherClient.doResourceDelete(BACKUP_TYPE, &container.Resource)
+}
+
+func (c *BackupClient) ActionCreate(resource *Backup) (*Backup, error) {
+
+	resp := &Backup{}
+
+	err := c.rancherClient.doAction(BACKUP_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *BackupClient) ActionRemove(resource *Backup) (*Backup, error) {
+
+	resp := &Backup{}
+
+	err := c.rancherClient.doAction(BACKUP_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_backup_target.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_backup_target.go
@@ -1,0 +1,115 @@
+package client
+
+const (
+	BACKUP_TARGET_TYPE = "backupTarget"
+)
+
+type BackupTarget struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NfsConfig *NfsConfig `json:"nfsConfig,omitempty" yaml:"nfs_config,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type BackupTargetCollection struct {
+	Collection
+	Data []BackupTarget `json:"data,omitempty"`
+}
+
+type BackupTargetClient struct {
+	rancherClient *RancherClient
+}
+
+type BackupTargetOperations interface {
+	List(opts *ListOpts) (*BackupTargetCollection, error)
+	Create(opts *BackupTarget) (*BackupTarget, error)
+	Update(existing *BackupTarget, updates interface{}) (*BackupTarget, error)
+	ById(id string) (*BackupTarget, error)
+	Delete(container *BackupTarget) error
+
+	ActionCreate(*BackupTarget) (*BackupTarget, error)
+
+	ActionRemove(*BackupTarget) (*BackupTarget, error)
+}
+
+func newBackupTargetClient(rancherClient *RancherClient) *BackupTargetClient {
+	return &BackupTargetClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *BackupTargetClient) Create(container *BackupTarget) (*BackupTarget, error) {
+	resp := &BackupTarget{}
+	err := c.rancherClient.doCreate(BACKUP_TARGET_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *BackupTargetClient) Update(existing *BackupTarget, updates interface{}) (*BackupTarget, error) {
+	resp := &BackupTarget{}
+	err := c.rancherClient.doUpdate(BACKUP_TARGET_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *BackupTargetClient) List(opts *ListOpts) (*BackupTargetCollection, error) {
+	resp := &BackupTargetCollection{}
+	err := c.rancherClient.doList(BACKUP_TARGET_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *BackupTargetClient) ById(id string) (*BackupTarget, error) {
+	resp := &BackupTarget{}
+	err := c.rancherClient.doById(BACKUP_TARGET_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *BackupTargetClient) Delete(container *BackupTarget) error {
+	return c.rancherClient.doResourceDelete(BACKUP_TARGET_TYPE, &container.Resource)
+}
+
+func (c *BackupTargetClient) ActionCreate(resource *BackupTarget) (*BackupTarget, error) {
+
+	resp := &BackupTarget{}
+
+	err := c.rancherClient.doAction(BACKUP_TARGET_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *BackupTargetClient) ActionRemove(resource *BackupTarget) (*BackupTarget, error) {
+
+	resp := &BackupTarget{}
+
+	err := c.rancherClient.doAction(BACKUP_TARGET_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_base_machine_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_base_machine_config.go
@@ -1,0 +1,65 @@
+package client
+
+const (
+	BASE_MACHINE_CONFIG_TYPE = "baseMachineConfig"
+)
+
+type BaseMachineConfig struct {
+	Resource
+}
+
+type BaseMachineConfigCollection struct {
+	Collection
+	Data []BaseMachineConfig `json:"data,omitempty"`
+}
+
+type BaseMachineConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type BaseMachineConfigOperations interface {
+	List(opts *ListOpts) (*BaseMachineConfigCollection, error)
+	Create(opts *BaseMachineConfig) (*BaseMachineConfig, error)
+	Update(existing *BaseMachineConfig, updates interface{}) (*BaseMachineConfig, error)
+	ById(id string) (*BaseMachineConfig, error)
+	Delete(container *BaseMachineConfig) error
+}
+
+func newBaseMachineConfigClient(rancherClient *RancherClient) *BaseMachineConfigClient {
+	return &BaseMachineConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *BaseMachineConfigClient) Create(container *BaseMachineConfig) (*BaseMachineConfig, error) {
+	resp := &BaseMachineConfig{}
+	err := c.rancherClient.doCreate(BASE_MACHINE_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *BaseMachineConfigClient) Update(existing *BaseMachineConfig, updates interface{}) (*BaseMachineConfig, error) {
+	resp := &BaseMachineConfig{}
+	err := c.rancherClient.doUpdate(BASE_MACHINE_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *BaseMachineConfigClient) List(opts *ListOpts) (*BaseMachineConfigCollection, error) {
+	resp := &BaseMachineConfigCollection{}
+	err := c.rancherClient.doList(BASE_MACHINE_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *BaseMachineConfigClient) ById(id string) (*BaseMachineConfig, error) {
+	resp := &BaseMachineConfig{}
+	err := c.rancherClient.doById(BASE_MACHINE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *BaseMachineConfigClient) Delete(container *BaseMachineConfig) error {
+	return c.rancherClient.doResourceDelete(BASE_MACHINE_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_blkio_device_option.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_blkio_device_option.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	BLKIO_DEVICE_OPTION_TYPE = "blkioDeviceOption"
+)
+
+type BlkioDeviceOption struct {
+	Resource
+
+	ReadBps int64 `json:"readBps,omitempty" yaml:"read_bps,omitempty"`
+
+	ReadIops int64 `json:"readIops,omitempty" yaml:"read_iops,omitempty"`
+
+	Weight int64 `json:"weight,omitempty" yaml:"weight,omitempty"`
+
+	WriteBps int64 `json:"writeBps,omitempty" yaml:"write_bps,omitempty"`
+
+	WriteIops int64 `json:"writeIops,omitempty" yaml:"write_iops,omitempty"`
+}
+
+type BlkioDeviceOptionCollection struct {
+	Collection
+	Data []BlkioDeviceOption `json:"data,omitempty"`
+}
+
+type BlkioDeviceOptionClient struct {
+	rancherClient *RancherClient
+}
+
+type BlkioDeviceOptionOperations interface {
+	List(opts *ListOpts) (*BlkioDeviceOptionCollection, error)
+	Create(opts *BlkioDeviceOption) (*BlkioDeviceOption, error)
+	Update(existing *BlkioDeviceOption, updates interface{}) (*BlkioDeviceOption, error)
+	ById(id string) (*BlkioDeviceOption, error)
+	Delete(container *BlkioDeviceOption) error
+}
+
+func newBlkioDeviceOptionClient(rancherClient *RancherClient) *BlkioDeviceOptionClient {
+	return &BlkioDeviceOptionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *BlkioDeviceOptionClient) Create(container *BlkioDeviceOption) (*BlkioDeviceOption, error) {
+	resp := &BlkioDeviceOption{}
+	err := c.rancherClient.doCreate(BLKIO_DEVICE_OPTION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *BlkioDeviceOptionClient) Update(existing *BlkioDeviceOption, updates interface{}) (*BlkioDeviceOption, error) {
+	resp := &BlkioDeviceOption{}
+	err := c.rancherClient.doUpdate(BLKIO_DEVICE_OPTION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *BlkioDeviceOptionClient) List(opts *ListOpts) (*BlkioDeviceOptionCollection, error) {
+	resp := &BlkioDeviceOptionCollection{}
+	err := c.rancherClient.doList(BLKIO_DEVICE_OPTION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *BlkioDeviceOptionClient) ById(id string) (*BlkioDeviceOption, error) {
+	resp := &BlkioDeviceOption{}
+	err := c.rancherClient.doById(BLKIO_DEVICE_OPTION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *BlkioDeviceOptionClient) Delete(container *BlkioDeviceOption) error {
+	return c.rancherClient.doResourceDelete(BLKIO_DEVICE_OPTION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_certificate.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_certificate.go
@@ -1,0 +1,150 @@
+package client
+
+const (
+	CERTIFICATE_TYPE = "certificate"
+)
+
+type Certificate struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Algorithm string `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+
+	CN string `json:"cN,omitempty" yaml:"cn,omitempty"`
+
+	Cert string `json:"cert,omitempty" yaml:"cert,omitempty"`
+
+	CertChain string `json:"certChain,omitempty" yaml:"cert_chain,omitempty"`
+
+	CertFingerprint string `json:"certFingerprint,omitempty" yaml:"cert_fingerprint,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExpiresAt string `json:"expiresAt,omitempty" yaml:"expires_at,omitempty"`
+
+	IssuedAt string `json:"issuedAt,omitempty" yaml:"issued_at,omitempty"`
+
+	Issuer string `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+
+	KeySize int64 `json:"keySize,omitempty" yaml:"key_size,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SerialNumber string `json:"serialNumber,omitempty" yaml:"serial_number,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	SubjectAlternativeNames []string `json:"subjectAlternativeNames,omitempty" yaml:"subject_alternative_names,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+type CertificateCollection struct {
+	Collection
+	Data []Certificate `json:"data,omitempty"`
+}
+
+type CertificateClient struct {
+	rancherClient *RancherClient
+}
+
+type CertificateOperations interface {
+	List(opts *ListOpts) (*CertificateCollection, error)
+	Create(opts *Certificate) (*Certificate, error)
+	Update(existing *Certificate, updates interface{}) (*Certificate, error)
+	ById(id string) (*Certificate, error)
+	Delete(container *Certificate) error
+
+	ActionCreate(*Certificate) (*Certificate, error)
+
+	ActionRemove(*Certificate) (*Certificate, error)
+
+	ActionUpdate(*Certificate) (*Certificate, error)
+}
+
+func newCertificateClient(rancherClient *RancherClient) *CertificateClient {
+	return &CertificateClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *CertificateClient) Create(container *Certificate) (*Certificate, error) {
+	resp := &Certificate{}
+	err := c.rancherClient.doCreate(CERTIFICATE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *CertificateClient) Update(existing *Certificate, updates interface{}) (*Certificate, error) {
+	resp := &Certificate{}
+	err := c.rancherClient.doUpdate(CERTIFICATE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *CertificateClient) List(opts *ListOpts) (*CertificateCollection, error) {
+	resp := &CertificateCollection{}
+	err := c.rancherClient.doList(CERTIFICATE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *CertificateClient) ById(id string) (*Certificate, error) {
+	resp := &Certificate{}
+	err := c.rancherClient.doById(CERTIFICATE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *CertificateClient) Delete(container *Certificate) error {
+	return c.rancherClient.doResourceDelete(CERTIFICATE_TYPE, &container.Resource)
+}
+
+func (c *CertificateClient) ActionCreate(resource *Certificate) (*Certificate, error) {
+
+	resp := &Certificate{}
+
+	err := c.rancherClient.doAction(CERTIFICATE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CertificateClient) ActionRemove(resource *Certificate) (*Certificate, error) {
+
+	resp := &Certificate{}
+
+	err := c.rancherClient.doAction(CERTIFICATE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CertificateClient) ActionUpdate(resource *Certificate) (*Certificate, error) {
+
+	resp := &Certificate{}
+
+	err := c.rancherClient.doAction(CERTIFICATE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_change_secret_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_change_secret_input.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	CHANGE_SECRET_INPUT_TYPE = "changeSecretInput"
+)
+
+type ChangeSecretInput struct {
+	Resource
+
+	NewSecret string `json:"newSecret,omitempty" yaml:"new_secret,omitempty"`
+
+	OldSecret string `json:"oldSecret,omitempty" yaml:"old_secret,omitempty"`
+}
+
+type ChangeSecretInputCollection struct {
+	Collection
+	Data []ChangeSecretInput `json:"data,omitempty"`
+}
+
+type ChangeSecretInputClient struct {
+	rancherClient *RancherClient
+}
+
+type ChangeSecretInputOperations interface {
+	List(opts *ListOpts) (*ChangeSecretInputCollection, error)
+	Create(opts *ChangeSecretInput) (*ChangeSecretInput, error)
+	Update(existing *ChangeSecretInput, updates interface{}) (*ChangeSecretInput, error)
+	ById(id string) (*ChangeSecretInput, error)
+	Delete(container *ChangeSecretInput) error
+}
+
+func newChangeSecretInputClient(rancherClient *RancherClient) *ChangeSecretInputClient {
+	return &ChangeSecretInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ChangeSecretInputClient) Create(container *ChangeSecretInput) (*ChangeSecretInput, error) {
+	resp := &ChangeSecretInput{}
+	err := c.rancherClient.doCreate(CHANGE_SECRET_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ChangeSecretInputClient) Update(existing *ChangeSecretInput, updates interface{}) (*ChangeSecretInput, error) {
+	resp := &ChangeSecretInput{}
+	err := c.rancherClient.doUpdate(CHANGE_SECRET_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ChangeSecretInputClient) List(opts *ListOpts) (*ChangeSecretInputCollection, error) {
+	resp := &ChangeSecretInputCollection{}
+	err := c.rancherClient.doList(CHANGE_SECRET_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ChangeSecretInputClient) ById(id string) (*ChangeSecretInput, error) {
+	resp := &ChangeSecretInput{}
+	err := c.rancherClient.doById(CHANGE_SECRET_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ChangeSecretInputClient) Delete(container *ChangeSecretInput) error {
+	return c.rancherClient.doResourceDelete(CHANGE_SECRET_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_client.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_client.go
@@ -1,0 +1,313 @@
+package client
+
+type RancherClient struct {
+	RancherBaseClient
+
+	Account                                  AccountOperations
+	ActiveSetting                            ActiveSettingOperations
+	AddOutputsInput                          AddOutputsInputOperations
+	AddRemoveLoadBalancerServiceLinkInput    AddRemoveLoadBalancerServiceLinkInputOperations
+	AddRemoveServiceLinkInput                AddRemoveServiceLinkInputOperations
+	Agent                                    AgentOperations
+	Amazonec2Config                          Amazonec2ConfigOperations
+	ApiKey                                   ApiKeyOperations
+	AuditLog                                 AuditLogOperations
+	AzureConfig                              AzureConfigOperations
+	Azureadconfig                            AzureadconfigOperations
+	Backup                                   BackupOperations
+	BackupTarget                             BackupTargetOperations
+	BaseMachineConfig                        BaseMachineConfigOperations
+	BlkioDeviceOption                        BlkioDeviceOptionOperations
+	Certificate                              CertificateOperations
+	ChangeSecretInput                        ChangeSecretInputOperations
+	ComposeConfig                            ComposeConfigOperations
+	ComposeConfigInput                       ComposeConfigInputOperations
+	ComposeProject                           ComposeProjectOperations
+	ComposeService                           ComposeServiceOperations
+	ConfigItem                               ConfigItemOperations
+	ConfigItemStatus                         ConfigItemStatusOperations
+	Container                                ContainerOperations
+	ContainerEvent                           ContainerEventOperations
+	ContainerExec                            ContainerExecOperations
+	ContainerLogs                            ContainerLogsOperations
+	ContainerProxy                           ContainerProxyOperations
+	Credential                               CredentialOperations
+	Databasechangelog                        DatabasechangelogOperations
+	Databasechangeloglock                    DatabasechangeloglockOperations
+	DigitaloceanConfig                       DigitaloceanConfigOperations
+	DnsService                               DnsServiceOperations
+	DockerBuild                              DockerBuildOperations
+	DynamicSchema                            DynamicSchemaOperations
+	Environment                              EnvironmentOperations
+	EnvironmentUpgrade                       EnvironmentUpgradeOperations
+	ExtensionImplementation                  ExtensionImplementationOperations
+	ExtensionPoint                           ExtensionPointOperations
+	ExternalDnsEvent                         ExternalDnsEventOperations
+	ExternalEvent                            ExternalEventOperations
+	ExternalHandler                          ExternalHandlerOperations
+	ExternalHandlerExternalHandlerProcessMap ExternalHandlerExternalHandlerProcessMapOperations
+	ExternalHandlerProcess                   ExternalHandlerProcessOperations
+	ExternalHandlerProcessConfig             ExternalHandlerProcessConfigOperations
+	ExternalHostEvent                        ExternalHostEventOperations
+	ExternalService                          ExternalServiceOperations
+	ExternalServiceEvent                     ExternalServiceEventOperations
+	ExternalStoragePoolEvent                 ExternalStoragePoolEventOperations
+	ExternalVolumeEvent                      ExternalVolumeEventOperations
+	FieldDocumentation                       FieldDocumentationOperations
+	Githubconfig                             GithubconfigOperations
+	HaConfig                                 HaConfigOperations
+	HaConfigInput                            HaConfigInputOperations
+	HaproxyConfig                            HaproxyConfigOperations
+	HealthcheckInstanceHostMap               HealthcheckInstanceHostMapOperations
+	Host                                     HostOperations
+	HostAccess                               HostAccessOperations
+	HostApiProxyToken                        HostApiProxyTokenOperations
+	Identity                                 IdentityOperations
+	Image                                    ImageOperations
+	InServiceUpgradeStrategy                 InServiceUpgradeStrategyOperations
+	Instance                                 InstanceOperations
+	InstanceConsole                          InstanceConsoleOperations
+	InstanceConsoleInput                     InstanceConsoleInputOperations
+	InstanceHealthCheck                      InstanceHealthCheckOperations
+	InstanceLink                             InstanceLinkOperations
+	InstanceStop                             InstanceStopOperations
+	IpAddress                                IpAddressOperations
+	IpAddressAssociateInput                  IpAddressAssociateInputOperations
+	KubernetesService                        KubernetesServiceOperations
+	KubernetesStack                          KubernetesStackOperations
+	KubernetesStackUpgrade                   KubernetesStackUpgradeOperations
+	Label                                    LabelOperations
+	LaunchConfig                             LaunchConfigOperations
+	Ldapconfig                               LdapconfigOperations
+	LoadBalancerAppCookieStickinessPolicy    LoadBalancerAppCookieStickinessPolicyOperations
+	LoadBalancerConfig                       LoadBalancerConfigOperations
+	LoadBalancerCookieStickinessPolicy       LoadBalancerCookieStickinessPolicyOperations
+	LoadBalancerService                      LoadBalancerServiceOperations
+	LoadBalancerServiceLink                  LoadBalancerServiceLinkOperations
+	LocalAuthConfig                          LocalAuthConfigOperations
+	LogConfig                                LogConfigOperations
+	Machine                                  MachineOperations
+	MachineDriver                            MachineDriverOperations
+	Mount                                    MountOperations
+	Network                                  NetworkOperations
+	NfsConfig                                NfsConfigOperations
+	Openldapconfig                           OpenldapconfigOperations
+	PacketConfig                             PacketConfigOperations
+	Password                                 PasswordOperations
+	PhysicalHost                             PhysicalHostOperations
+	Port                                     PortOperations
+	ProcessDefinition                        ProcessDefinitionOperations
+	ProcessExecution                         ProcessExecutionOperations
+	ProcessInstance                          ProcessInstanceOperations
+	Project                                  ProjectOperations
+	ProjectMember                            ProjectMemberOperations
+	PublicEndpoint                           PublicEndpointOperations
+	Publish                                  PublishOperations
+	PullTask                                 PullTaskOperations
+	RecreateOnQuorumStrategyConfig           RecreateOnQuorumStrategyConfigOperations
+	Register                                 RegisterOperations
+	RegistrationToken                        RegistrationTokenOperations
+	Registry                                 RegistryOperations
+	RegistryCredential                       RegistryCredentialOperations
+	ResourceDefinition                       ResourceDefinitionOperations
+	RestartPolicy                            RestartPolicyOperations
+	RestoreFromBackupInput                   RestoreFromBackupInputOperations
+	RevertToSnapshotInput                    RevertToSnapshotInputOperations
+	RollingRestartStrategy                   RollingRestartStrategyOperations
+	ScalePolicy                              ScalePolicyOperations
+	SecondaryLaunchConfig                    SecondaryLaunchConfigOperations
+	Service                                  ServiceOperations
+	ServiceConsumeMap                        ServiceConsumeMapOperations
+	ServiceEvent                             ServiceEventOperations
+	ServiceExposeMap                         ServiceExposeMapOperations
+	ServiceLink                              ServiceLinkOperations
+	ServiceProxy                             ServiceProxyOperations
+	ServiceRestart                           ServiceRestartOperations
+	ServiceUpgrade                           ServiceUpgradeOperations
+	ServiceUpgradeStrategy                   ServiceUpgradeStrategyOperations
+	ServicesPortRange                        ServicesPortRangeOperations
+	SetLabelsInput                           SetLabelsInputOperations
+	SetLoadBalancerServiceLinksInput         SetLoadBalancerServiceLinksInputOperations
+	SetProjectMembersInput                   SetProjectMembersInputOperations
+	SetServiceLinksInput                     SetServiceLinksInputOperations
+	Setting                                  SettingOperations
+	Snapshot                                 SnapshotOperations
+	SnapshotBackupInput                      SnapshotBackupInputOperations
+	StateTransition                          StateTransitionOperations
+	StatsAccess                              StatsAccessOperations
+	StoragePool                              StoragePoolOperations
+	Subscribe                                SubscribeOperations
+	Task                                     TaskOperations
+	TaskInstance                             TaskInstanceOperations
+	ToServiceUpgradeStrategy                 ToServiceUpgradeStrategyOperations
+	TypeDocumentation                        TypeDocumentationOperations
+	VirtualMachine                           VirtualMachineOperations
+	VirtualMachineDisk                       VirtualMachineDiskOperations
+	Volume                                   VolumeOperations
+	VolumeSnapshotInput                      VolumeSnapshotInputOperations
+}
+
+func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
+	client := &RancherClient{
+		RancherBaseClient: rancherBaseClient,
+	}
+
+	client.Account = newAccountClient(client)
+	client.ActiveSetting = newActiveSettingClient(client)
+	client.AddOutputsInput = newAddOutputsInputClient(client)
+	client.AddRemoveLoadBalancerServiceLinkInput = newAddRemoveLoadBalancerServiceLinkInputClient(client)
+	client.AddRemoveServiceLinkInput = newAddRemoveServiceLinkInputClient(client)
+	client.Agent = newAgentClient(client)
+	client.Amazonec2Config = newAmazonec2ConfigClient(client)
+	client.ApiKey = newApiKeyClient(client)
+	client.AuditLog = newAuditLogClient(client)
+	client.AzureConfig = newAzureConfigClient(client)
+	client.Azureadconfig = newAzureadconfigClient(client)
+	client.Backup = newBackupClient(client)
+	client.BackupTarget = newBackupTargetClient(client)
+	client.BaseMachineConfig = newBaseMachineConfigClient(client)
+	client.BlkioDeviceOption = newBlkioDeviceOptionClient(client)
+	client.Certificate = newCertificateClient(client)
+	client.ChangeSecretInput = newChangeSecretInputClient(client)
+	client.ComposeConfig = newComposeConfigClient(client)
+	client.ComposeConfigInput = newComposeConfigInputClient(client)
+	client.ComposeProject = newComposeProjectClient(client)
+	client.ComposeService = newComposeServiceClient(client)
+	client.ConfigItem = newConfigItemClient(client)
+	client.ConfigItemStatus = newConfigItemStatusClient(client)
+	client.Container = newContainerClient(client)
+	client.ContainerEvent = newContainerEventClient(client)
+	client.ContainerExec = newContainerExecClient(client)
+	client.ContainerLogs = newContainerLogsClient(client)
+	client.ContainerProxy = newContainerProxyClient(client)
+	client.Credential = newCredentialClient(client)
+	client.Databasechangelog = newDatabasechangelogClient(client)
+	client.Databasechangeloglock = newDatabasechangeloglockClient(client)
+	client.DigitaloceanConfig = newDigitaloceanConfigClient(client)
+	client.DnsService = newDnsServiceClient(client)
+	client.DockerBuild = newDockerBuildClient(client)
+	client.DynamicSchema = newDynamicSchemaClient(client)
+	client.Environment = newEnvironmentClient(client)
+	client.EnvironmentUpgrade = newEnvironmentUpgradeClient(client)
+	client.ExtensionImplementation = newExtensionImplementationClient(client)
+	client.ExtensionPoint = newExtensionPointClient(client)
+	client.ExternalDnsEvent = newExternalDnsEventClient(client)
+	client.ExternalEvent = newExternalEventClient(client)
+	client.ExternalHandler = newExternalHandlerClient(client)
+	client.ExternalHandlerExternalHandlerProcessMap = newExternalHandlerExternalHandlerProcessMapClient(client)
+	client.ExternalHandlerProcess = newExternalHandlerProcessClient(client)
+	client.ExternalHandlerProcessConfig = newExternalHandlerProcessConfigClient(client)
+	client.ExternalHostEvent = newExternalHostEventClient(client)
+	client.ExternalService = newExternalServiceClient(client)
+	client.ExternalServiceEvent = newExternalServiceEventClient(client)
+	client.ExternalStoragePoolEvent = newExternalStoragePoolEventClient(client)
+	client.ExternalVolumeEvent = newExternalVolumeEventClient(client)
+	client.FieldDocumentation = newFieldDocumentationClient(client)
+	client.Githubconfig = newGithubconfigClient(client)
+	client.HaConfig = newHaConfigClient(client)
+	client.HaConfigInput = newHaConfigInputClient(client)
+	client.HaproxyConfig = newHaproxyConfigClient(client)
+	client.HealthcheckInstanceHostMap = newHealthcheckInstanceHostMapClient(client)
+	client.Host = newHostClient(client)
+	client.HostAccess = newHostAccessClient(client)
+	client.HostApiProxyToken = newHostApiProxyTokenClient(client)
+	client.Identity = newIdentityClient(client)
+	client.Image = newImageClient(client)
+	client.InServiceUpgradeStrategy = newInServiceUpgradeStrategyClient(client)
+	client.Instance = newInstanceClient(client)
+	client.InstanceConsole = newInstanceConsoleClient(client)
+	client.InstanceConsoleInput = newInstanceConsoleInputClient(client)
+	client.InstanceHealthCheck = newInstanceHealthCheckClient(client)
+	client.InstanceLink = newInstanceLinkClient(client)
+	client.InstanceStop = newInstanceStopClient(client)
+	client.IpAddress = newIpAddressClient(client)
+	client.IpAddressAssociateInput = newIpAddressAssociateInputClient(client)
+	client.KubernetesService = newKubernetesServiceClient(client)
+	client.KubernetesStack = newKubernetesStackClient(client)
+	client.KubernetesStackUpgrade = newKubernetesStackUpgradeClient(client)
+	client.Label = newLabelClient(client)
+	client.LaunchConfig = newLaunchConfigClient(client)
+	client.Ldapconfig = newLdapconfigClient(client)
+	client.LoadBalancerAppCookieStickinessPolicy = newLoadBalancerAppCookieStickinessPolicyClient(client)
+	client.LoadBalancerConfig = newLoadBalancerConfigClient(client)
+	client.LoadBalancerCookieStickinessPolicy = newLoadBalancerCookieStickinessPolicyClient(client)
+	client.LoadBalancerService = newLoadBalancerServiceClient(client)
+	client.LoadBalancerServiceLink = newLoadBalancerServiceLinkClient(client)
+	client.LocalAuthConfig = newLocalAuthConfigClient(client)
+	client.LogConfig = newLogConfigClient(client)
+	client.Machine = newMachineClient(client)
+	client.MachineDriver = newMachineDriverClient(client)
+	client.Mount = newMountClient(client)
+	client.Network = newNetworkClient(client)
+	client.NfsConfig = newNfsConfigClient(client)
+	client.Openldapconfig = newOpenldapconfigClient(client)
+	client.PacketConfig = newPacketConfigClient(client)
+	client.Password = newPasswordClient(client)
+	client.PhysicalHost = newPhysicalHostClient(client)
+	client.Port = newPortClient(client)
+	client.ProcessDefinition = newProcessDefinitionClient(client)
+	client.ProcessExecution = newProcessExecutionClient(client)
+	client.ProcessInstance = newProcessInstanceClient(client)
+	client.Project = newProjectClient(client)
+	client.ProjectMember = newProjectMemberClient(client)
+	client.PublicEndpoint = newPublicEndpointClient(client)
+	client.Publish = newPublishClient(client)
+	client.PullTask = newPullTaskClient(client)
+	client.RecreateOnQuorumStrategyConfig = newRecreateOnQuorumStrategyConfigClient(client)
+	client.Register = newRegisterClient(client)
+	client.RegistrationToken = newRegistrationTokenClient(client)
+	client.Registry = newRegistryClient(client)
+	client.RegistryCredential = newRegistryCredentialClient(client)
+	client.ResourceDefinition = newResourceDefinitionClient(client)
+	client.RestartPolicy = newRestartPolicyClient(client)
+	client.RestoreFromBackupInput = newRestoreFromBackupInputClient(client)
+	client.RevertToSnapshotInput = newRevertToSnapshotInputClient(client)
+	client.RollingRestartStrategy = newRollingRestartStrategyClient(client)
+	client.ScalePolicy = newScalePolicyClient(client)
+	client.SecondaryLaunchConfig = newSecondaryLaunchConfigClient(client)
+	client.Service = newServiceClient(client)
+	client.ServiceConsumeMap = newServiceConsumeMapClient(client)
+	client.ServiceEvent = newServiceEventClient(client)
+	client.ServiceExposeMap = newServiceExposeMapClient(client)
+	client.ServiceLink = newServiceLinkClient(client)
+	client.ServiceProxy = newServiceProxyClient(client)
+	client.ServiceRestart = newServiceRestartClient(client)
+	client.ServiceUpgrade = newServiceUpgradeClient(client)
+	client.ServiceUpgradeStrategy = newServiceUpgradeStrategyClient(client)
+	client.ServicesPortRange = newServicesPortRangeClient(client)
+	client.SetLabelsInput = newSetLabelsInputClient(client)
+	client.SetLoadBalancerServiceLinksInput = newSetLoadBalancerServiceLinksInputClient(client)
+	client.SetProjectMembersInput = newSetProjectMembersInputClient(client)
+	client.SetServiceLinksInput = newSetServiceLinksInputClient(client)
+	client.Setting = newSettingClient(client)
+	client.Snapshot = newSnapshotClient(client)
+	client.SnapshotBackupInput = newSnapshotBackupInputClient(client)
+	client.StateTransition = newStateTransitionClient(client)
+	client.StatsAccess = newStatsAccessClient(client)
+	client.StoragePool = newStoragePoolClient(client)
+	client.Subscribe = newSubscribeClient(client)
+	client.Task = newTaskClient(client)
+	client.TaskInstance = newTaskInstanceClient(client)
+	client.ToServiceUpgradeStrategy = newToServiceUpgradeStrategyClient(client)
+	client.TypeDocumentation = newTypeDocumentationClient(client)
+	client.VirtualMachine = newVirtualMachineClient(client)
+	client.VirtualMachineDisk = newVirtualMachineDiskClient(client)
+	client.Volume = newVolumeClient(client)
+	client.VolumeSnapshotInput = newVolumeSnapshotInputClient(client)
+
+	return client
+}
+
+func NewRancherClient(opts *ClientOpts) (*RancherClient, error) {
+	rancherBaseClient := &RancherBaseClientImpl{
+		Types: map[string]Schema{},
+	}
+	client := constructClient(rancherBaseClient)
+
+	err := setupRancherBaseClient(rancherBaseClient, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_compose_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_compose_config.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	COMPOSE_CONFIG_TYPE = "composeConfig"
+)
+
+type ComposeConfig struct {
+	Resource
+
+	DockerComposeConfig string `json:"dockerComposeConfig,omitempty" yaml:"docker_compose_config,omitempty"`
+
+	RancherComposeConfig string `json:"rancherComposeConfig,omitempty" yaml:"rancher_compose_config,omitempty"`
+}
+
+type ComposeConfigCollection struct {
+	Collection
+	Data []ComposeConfig `json:"data,omitempty"`
+}
+
+type ComposeConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeConfigOperations interface {
+	List(opts *ListOpts) (*ComposeConfigCollection, error)
+	Create(opts *ComposeConfig) (*ComposeConfig, error)
+	Update(existing *ComposeConfig, updates interface{}) (*ComposeConfig, error)
+	ById(id string) (*ComposeConfig, error)
+	Delete(container *ComposeConfig) error
+}
+
+func newComposeConfigClient(rancherClient *RancherClient) *ComposeConfigClient {
+	return &ComposeConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeConfigClient) Create(container *ComposeConfig) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doCreate(COMPOSE_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) Update(existing *ComposeConfig, updates interface{}) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doUpdate(COMPOSE_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) List(opts *ListOpts) (*ComposeConfigCollection, error) {
+	resp := &ComposeConfigCollection{}
+	err := c.rancherClient.doList(COMPOSE_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) ById(id string) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doById(COMPOSE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ComposeConfigClient) Delete(container *ComposeConfig) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_compose_config_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_compose_config_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	COMPOSE_CONFIG_INPUT_TYPE = "composeConfigInput"
+)
+
+type ComposeConfigInput struct {
+	Resource
+
+	ServiceIds []string `json:"serviceIds,omitempty" yaml:"service_ids,omitempty"`
+}
+
+type ComposeConfigInputCollection struct {
+	Collection
+	Data []ComposeConfigInput `json:"data,omitempty"`
+}
+
+type ComposeConfigInputClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeConfigInputOperations interface {
+	List(opts *ListOpts) (*ComposeConfigInputCollection, error)
+	Create(opts *ComposeConfigInput) (*ComposeConfigInput, error)
+	Update(existing *ComposeConfigInput, updates interface{}) (*ComposeConfigInput, error)
+	ById(id string) (*ComposeConfigInput, error)
+	Delete(container *ComposeConfigInput) error
+}
+
+func newComposeConfigInputClient(rancherClient *RancherClient) *ComposeConfigInputClient {
+	return &ComposeConfigInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeConfigInputClient) Create(container *ComposeConfigInput) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doCreate(COMPOSE_CONFIG_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) Update(existing *ComposeConfigInput, updates interface{}) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doUpdate(COMPOSE_CONFIG_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) List(opts *ListOpts) (*ComposeConfigInputCollection, error) {
+	resp := &ComposeConfigInputCollection{}
+	err := c.rancherClient.doList(COMPOSE_CONFIG_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) ById(id string) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doById(COMPOSE_CONFIG_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) Delete(container *ComposeConfigInput) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_CONFIG_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_compose_project.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_compose_project.go
@@ -1,0 +1,180 @@
+package client
+
+const (
+	COMPOSE_PROJECT_TYPE = "composeProject"
+)
+
+type ComposeProject struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PreviousEnvironment map[string]interface{} `json:"previousEnvironment,omitempty" yaml:"previous_environment,omitempty"`
+
+	PreviousExternalId string `json:"previousExternalId,omitempty" yaml:"previous_external_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Templates map[string]interface{} `json:"templates,omitempty" yaml:"templates,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ComposeProjectCollection struct {
+	Collection
+	Data []ComposeProject `json:"data,omitempty"`
+}
+
+type ComposeProjectClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeProjectOperations interface {
+	List(opts *ListOpts) (*ComposeProjectCollection, error)
+	Create(opts *ComposeProject) (*ComposeProject, error)
+	Update(existing *ComposeProject, updates interface{}) (*ComposeProject, error)
+	ById(id string) (*ComposeProject, error)
+	Delete(container *ComposeProject) error
+
+	ActionCancelrollback(*ComposeProject) (*Environment, error)
+
+	ActionCancelupgrade(*ComposeProject) (*Environment, error)
+
+	ActionCreate(*ComposeProject) (*Environment, error)
+
+	ActionError(*ComposeProject) (*Environment, error)
+
+	ActionFinishupgrade(*ComposeProject) (*Environment, error)
+
+	ActionRemove(*ComposeProject) (*Environment, error)
+
+	ActionRollback(*ComposeProject) (*Environment, error)
+}
+
+func newComposeProjectClient(rancherClient *RancherClient) *ComposeProjectClient {
+	return &ComposeProjectClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeProjectClient) Create(container *ComposeProject) (*ComposeProject, error) {
+	resp := &ComposeProject{}
+	err := c.rancherClient.doCreate(COMPOSE_PROJECT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeProjectClient) Update(existing *ComposeProject, updates interface{}) (*ComposeProject, error) {
+	resp := &ComposeProject{}
+	err := c.rancherClient.doUpdate(COMPOSE_PROJECT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeProjectClient) List(opts *ListOpts) (*ComposeProjectCollection, error) {
+	resp := &ComposeProjectCollection{}
+	err := c.rancherClient.doList(COMPOSE_PROJECT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ById(id string) (*ComposeProject, error) {
+	resp := &ComposeProject{}
+	err := c.rancherClient.doById(COMPOSE_PROJECT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ComposeProjectClient) Delete(container *ComposeProject) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_PROJECT_TYPE, &container.Resource)
+}
+
+func (c *ComposeProjectClient) ActionCancelrollback(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionCancelupgrade(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionCreate(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionError(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionFinishupgrade(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionRemove(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeProjectClient) ActionRollback(resource *ComposeProject) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(COMPOSE_PROJECT_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_compose_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_compose_service.go
@@ -1,0 +1,194 @@
+package client
+
+const (
+	COMPOSE_SERVICE_TYPE = "composeService"
+)
+
+type ComposeService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	CurrentScale int64 `json:"currentScale,omitempty" yaml:"current_scale,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	Scale int64 `json:"scale,omitempty" yaml:"scale,omitempty"`
+
+	ScalePolicy *ScalePolicy `json:"scalePolicy,omitempty" yaml:"scale_policy,omitempty"`
+
+	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
+
+	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vip string `json:"vip,omitempty" yaml:"vip,omitempty"`
+}
+
+type ComposeServiceCollection struct {
+	Collection
+	Data []ComposeService `json:"data,omitempty"`
+}
+
+type ComposeServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeServiceOperations interface {
+	List(opts *ListOpts) (*ComposeServiceCollection, error)
+	Create(opts *ComposeService) (*ComposeService, error)
+	Update(existing *ComposeService, updates interface{}) (*ComposeService, error)
+	ById(id string) (*ComposeService, error)
+	Delete(container *ComposeService) error
+
+	ActionActivate(*ComposeService) (*Service, error)
+
+	ActionCancelrollback(*ComposeService) (*Service, error)
+
+	ActionCancelupgrade(*ComposeService) (*Service, error)
+
+	ActionCreate(*ComposeService) (*Service, error)
+
+	ActionFinishupgrade(*ComposeService) (*Service, error)
+
+	ActionRemove(*ComposeService) (*Service, error)
+
+	ActionRollback(*ComposeService) (*Service, error)
+}
+
+func newComposeServiceClient(rancherClient *RancherClient) *ComposeServiceClient {
+	return &ComposeServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeServiceClient) Create(container *ComposeService) (*ComposeService, error) {
+	resp := &ComposeService{}
+	err := c.rancherClient.doCreate(COMPOSE_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeServiceClient) Update(existing *ComposeService, updates interface{}) (*ComposeService, error) {
+	resp := &ComposeService{}
+	err := c.rancherClient.doUpdate(COMPOSE_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeServiceClient) List(opts *ListOpts) (*ComposeServiceCollection, error) {
+	resp := &ComposeServiceCollection{}
+	err := c.rancherClient.doList(COMPOSE_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ById(id string) (*ComposeService, error) {
+	resp := &ComposeService{}
+	err := c.rancherClient.doById(COMPOSE_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ComposeServiceClient) Delete(container *ComposeService) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *ComposeServiceClient) ActionActivate(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionCancelrollback(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionCancelupgrade(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionCreate(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionFinishupgrade(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionRemove(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ComposeServiceClient) ActionRollback(resource *ComposeService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(COMPOSE_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_config_item.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_config_item.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	CONFIG_ITEM_TYPE = "configItem"
+)
+
+type ConfigItem struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	SourceVersion string `json:"sourceVersion,omitempty" yaml:"source_version,omitempty"`
+}
+
+type ConfigItemCollection struct {
+	Collection
+	Data []ConfigItem `json:"data,omitempty"`
+}
+
+type ConfigItemClient struct {
+	rancherClient *RancherClient
+}
+
+type ConfigItemOperations interface {
+	List(opts *ListOpts) (*ConfigItemCollection, error)
+	Create(opts *ConfigItem) (*ConfigItem, error)
+	Update(existing *ConfigItem, updates interface{}) (*ConfigItem, error)
+	ById(id string) (*ConfigItem, error)
+	Delete(container *ConfigItem) error
+}
+
+func newConfigItemClient(rancherClient *RancherClient) *ConfigItemClient {
+	return &ConfigItemClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ConfigItemClient) Create(container *ConfigItem) (*ConfigItem, error) {
+	resp := &ConfigItem{}
+	err := c.rancherClient.doCreate(CONFIG_ITEM_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ConfigItemClient) Update(existing *ConfigItem, updates interface{}) (*ConfigItem, error) {
+	resp := &ConfigItem{}
+	err := c.rancherClient.doUpdate(CONFIG_ITEM_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ConfigItemClient) List(opts *ListOpts) (*ConfigItemCollection, error) {
+	resp := &ConfigItemCollection{}
+	err := c.rancherClient.doList(CONFIG_ITEM_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ConfigItemClient) ById(id string) (*ConfigItem, error) {
+	resp := &ConfigItem{}
+	err := c.rancherClient.doById(CONFIG_ITEM_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ConfigItemClient) Delete(container *ConfigItem) error {
+	return c.rancherClient.doResourceDelete(CONFIG_ITEM_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_config_item_status.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_config_item_status.go
@@ -1,0 +1,81 @@
+package client
+
+const (
+	CONFIG_ITEM_STATUS_TYPE = "configItemStatus"
+)
+
+type ConfigItemStatus struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AppliedUpdated string `json:"appliedUpdated,omitempty" yaml:"applied_updated,omitempty"`
+
+	AppliedVersion int64 `json:"appliedVersion,omitempty" yaml:"applied_version,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RequestedUpdated string `json:"requestedUpdated,omitempty" yaml:"requested_updated,omitempty"`
+
+	RequestedVersion int64 `json:"requestedVersion,omitempty" yaml:"requested_version,omitempty"`
+
+	SourceVersion string `json:"sourceVersion,omitempty" yaml:"source_version,omitempty"`
+}
+
+type ConfigItemStatusCollection struct {
+	Collection
+	Data []ConfigItemStatus `json:"data,omitempty"`
+}
+
+type ConfigItemStatusClient struct {
+	rancherClient *RancherClient
+}
+
+type ConfigItemStatusOperations interface {
+	List(opts *ListOpts) (*ConfigItemStatusCollection, error)
+	Create(opts *ConfigItemStatus) (*ConfigItemStatus, error)
+	Update(existing *ConfigItemStatus, updates interface{}) (*ConfigItemStatus, error)
+	ById(id string) (*ConfigItemStatus, error)
+	Delete(container *ConfigItemStatus) error
+}
+
+func newConfigItemStatusClient(rancherClient *RancherClient) *ConfigItemStatusClient {
+	return &ConfigItemStatusClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ConfigItemStatusClient) Create(container *ConfigItemStatus) (*ConfigItemStatus, error) {
+	resp := &ConfigItemStatus{}
+	err := c.rancherClient.doCreate(CONFIG_ITEM_STATUS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ConfigItemStatusClient) Update(existing *ConfigItemStatus, updates interface{}) (*ConfigItemStatus, error) {
+	resp := &ConfigItemStatus{}
+	err := c.rancherClient.doUpdate(CONFIG_ITEM_STATUS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ConfigItemStatusClient) List(opts *ListOpts) (*ConfigItemStatusCollection, error) {
+	resp := &ConfigItemStatusCollection{}
+	err := c.rancherClient.doList(CONFIG_ITEM_STATUS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ConfigItemStatusClient) ById(id string) (*ConfigItemStatus, error) {
+	resp := &ConfigItemStatus{}
+	err := c.rancherClient.doById(CONFIG_ITEM_STATUS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ConfigItemStatusClient) Delete(container *ConfigItemStatus) error {
+	return c.rancherClient.doResourceDelete(CONFIG_ITEM_STATUS_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_container.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_container.go
@@ -1,0 +1,431 @@
+package client
+
+const (
+	CONTAINER_TYPE = "container"
+)
+
+type Container struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AllocationState string `json:"allocationState,omitempty" yaml:"allocation_state,omitempty"`
+
+	BlkioDeviceOptions map[string]interface{} `json:"blkioDeviceOptions,omitempty" yaml:"blkio_device_options,omitempty"`
+
+	Build *DockerBuild `json:"build,omitempty" yaml:"build,omitempty"`
+
+	CapAdd []string `json:"capAdd,omitempty" yaml:"cap_add,omitempty"`
+
+	CapDrop []string `json:"capDrop,omitempty" yaml:"cap_drop,omitempty"`
+
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Count int64 `json:"count,omitempty" yaml:"count,omitempty"`
+
+	CpuSet string `json:"cpuSet,omitempty" yaml:"cpu_set,omitempty"`
+
+	CpuShares int64 `json:"cpuShares,omitempty" yaml:"cpu_shares,omitempty"`
+
+	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
+	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
+
+	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`
+
+	DeploymentUnitUuid string `json:"deploymentUnitUuid,omitempty" yaml:"deployment_unit_uuid,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Devices []string `json:"devices,omitempty" yaml:"devices,omitempty"`
+
+	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
+
+	DnsSearch []string `json:"dnsSearch,omitempty" yaml:"dns_search,omitempty"`
+
+	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
+
+	EntryPoint []string `json:"entryPoint,omitempty" yaml:"entry_point,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	Expose []string `json:"expose,omitempty" yaml:"expose,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExtraHosts []string `json:"extraHosts,omitempty" yaml:"extra_hosts,omitempty"`
+
+	FirstRunning string `json:"firstRunning,omitempty" yaml:"first_running,omitempty"`
+
+	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	ImageUuid string `json:"imageUuid,omitempty" yaml:"image_uuid,omitempty"`
+
+	InstanceLinks map[string]interface{} `json:"instanceLinks,omitempty" yaml:"instance_links,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	LogConfig *LogConfig `json:"logConfig,omitempty" yaml:"log_config,omitempty"`
+
+	LxcConf map[string]interface{} `json:"lxcConf,omitempty" yaml:"lxc_conf,omitempty"`
+
+	Memory int64 `json:"memory,omitempty" yaml:"memory,omitempty"`
+
+	MemorySwap int64 `json:"memorySwap,omitempty" yaml:"memory_swap,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NativeContainer bool `json:"nativeContainer,omitempty" yaml:"native_container,omitempty"`
+
+	NetworkContainerId string `json:"networkContainerId,omitempty" yaml:"network_container_id,omitempty"`
+
+	NetworkIds []string `json:"networkIds,omitempty" yaml:"network_ids,omitempty"`
+
+	NetworkMode string `json:"networkMode,omitempty" yaml:"network_mode,omitempty"`
+
+	PidMode string `json:"pidMode,omitempty" yaml:"pid_mode,omitempty"`
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	PrimaryIpAddress string `json:"primaryIpAddress,omitempty" yaml:"primary_ip_address,omitempty"`
+
+	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+
+	PublishAllPorts bool `json:"publishAllPorts,omitempty" yaml:"publish_all_ports,omitempty"`
+
+	ReadOnly bool `json:"readOnly,omitempty" yaml:"read_only,omitempty"`
+
+	RegistryCredentialId string `json:"registryCredentialId,omitempty" yaml:"registry_credential_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
+
+	RestartPolicy *RestartPolicy `json:"restartPolicy,omitempty" yaml:"restart_policy,omitempty"`
+
+	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	StdinOpen bool `json:"stdinOpen,omitempty" yaml:"stdin_open,omitempty"`
+
+	SystemContainer string `json:"systemContainer,omitempty" yaml:"system_container,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Tty bool `json:"tty,omitempty" yaml:"tty,omitempty"`
+
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	VolumeDriver string `json:"volumeDriver,omitempty" yaml:"volume_driver,omitempty"`
+
+	WorkingDir string `json:"workingDir,omitempty" yaml:"working_dir,omitempty"`
+}
+
+type ContainerCollection struct {
+	Collection
+	Data []Container `json:"data,omitempty"`
+}
+
+type ContainerClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerOperations interface {
+	List(opts *ListOpts) (*ContainerCollection, error)
+	Create(opts *Container) (*Container, error)
+	Update(existing *Container, updates interface{}) (*Container, error)
+	ById(id string) (*Container, error)
+	Delete(container *Container) error
+
+	ActionAllocate(*Container) (*Instance, error)
+
+	ActionConsole(*Container, *InstanceConsoleInput) (*InstanceConsole, error)
+
+	ActionCreate(*Container) (*Instance, error)
+
+	ActionDeallocate(*Container) (*Instance, error)
+
+	ActionError(*Container) (*Instance, error)
+
+	ActionExecute(*Container, *ContainerExec) (*HostAccess, error)
+
+	ActionLogs(*Container, *ContainerLogs) (*HostAccess, error)
+
+	ActionMigrate(*Container) (*Instance, error)
+
+	ActionProxy(*Container, *ContainerProxy) (*HostAccess, error)
+
+	ActionPurge(*Container) (*Instance, error)
+
+	ActionRemove(*Container) (*Instance, error)
+
+	ActionRestart(*Container) (*Instance, error)
+
+	ActionRestore(*Container) (*Instance, error)
+
+	ActionSetlabels(*Container, *SetLabelsInput) (*Container, error)
+
+	ActionStart(*Container) (*Instance, error)
+
+	ActionStop(*Container, *InstanceStop) (*Instance, error)
+
+	ActionUpdate(*Container) (*Instance, error)
+
+	ActionUpdatehealthy(*Container) (*Instance, error)
+
+	ActionUpdatereinitializing(*Container) (*Instance, error)
+
+	ActionUpdateunhealthy(*Container) (*Instance, error)
+}
+
+func newContainerClient(rancherClient *RancherClient) *ContainerClient {
+	return &ContainerClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerClient) Create(container *Container) (*Container, error) {
+	resp := &Container{}
+	err := c.rancherClient.doCreate(CONTAINER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerClient) Update(existing *Container, updates interface{}) (*Container, error) {
+	resp := &Container{}
+	err := c.rancherClient.doUpdate(CONTAINER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerClient) List(opts *ListOpts) (*ContainerCollection, error) {
+	resp := &ContainerCollection{}
+	err := c.rancherClient.doList(CONTAINER_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerClient) ById(id string) (*Container, error) {
+	resp := &Container{}
+	err := c.rancherClient.doById(CONTAINER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerClient) Delete(container *Container) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_TYPE, &container.Resource)
+}
+
+func (c *ContainerClient) ActionAllocate(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionConsole(resource *Container, input *InstanceConsoleInput) (*InstanceConsole, error) {
+
+	resp := &InstanceConsole{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "console", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionCreate(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionDeallocate(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionError(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionExecute(resource *Container, input *ContainerExec) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "execute", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionLogs(resource *Container, input *ContainerLogs) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "logs", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionMigrate(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionProxy(resource *Container, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "proxy", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionPurge(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionRemove(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionRestart(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "restart", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionRestore(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionSetlabels(resource *Container, input *SetLabelsInput) (*Container, error) {
+
+	resp := &Container{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "setlabels", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionStart(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "start", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionStop(resource *Container, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionUpdate(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionUpdatehealthy(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "updatehealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionUpdatereinitializing(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "updatereinitializing", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionUpdateunhealthy(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "updateunhealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_container_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_container_event.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	CONTAINER_EVENT_TYPE = "containerEvent"
+)
+
+type ContainerEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DockerInspect interface{} `json:"dockerInspect,omitempty" yaml:"docker_inspect,omitempty"`
+
+	ExternalFrom string `json:"externalFrom,omitempty" yaml:"external_from,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExternalStatus string `json:"externalStatus,omitempty" yaml:"external_status,omitempty"`
+
+	ExternalTimestamp int64 `json:"externalTimestamp,omitempty" yaml:"external_timestamp,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedHostUuid string `json:"reportedHostUuid,omitempty" yaml:"reported_host_uuid,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+}
+
+type ContainerEventCollection struct {
+	Collection
+	Data []ContainerEvent `json:"data,omitempty"`
+}
+
+type ContainerEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerEventOperations interface {
+	List(opts *ListOpts) (*ContainerEventCollection, error)
+	Create(opts *ContainerEvent) (*ContainerEvent, error)
+	Update(existing *ContainerEvent, updates interface{}) (*ContainerEvent, error)
+	ById(id string) (*ContainerEvent, error)
+	Delete(container *ContainerEvent) error
+
+	ActionCreate(*ContainerEvent) (*ContainerEvent, error)
+
+	ActionRemove(*ContainerEvent) (*ContainerEvent, error)
+}
+
+func newContainerEventClient(rancherClient *RancherClient) *ContainerEventClient {
+	return &ContainerEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerEventClient) Create(container *ContainerEvent) (*ContainerEvent, error) {
+	resp := &ContainerEvent{}
+	err := c.rancherClient.doCreate(CONTAINER_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerEventClient) Update(existing *ContainerEvent, updates interface{}) (*ContainerEvent, error) {
+	resp := &ContainerEvent{}
+	err := c.rancherClient.doUpdate(CONTAINER_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerEventClient) List(opts *ListOpts) (*ContainerEventCollection, error) {
+	resp := &ContainerEventCollection{}
+	err := c.rancherClient.doList(CONTAINER_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerEventClient) ById(id string) (*ContainerEvent, error) {
+	resp := &ContainerEvent{}
+	err := c.rancherClient.doById(CONTAINER_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerEventClient) Delete(container *ContainerEvent) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ContainerEventClient) ActionCreate(resource *ContainerEvent) (*ContainerEvent, error) {
+
+	resp := &ContainerEvent{}
+
+	err := c.rancherClient.doAction(CONTAINER_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerEventClient) ActionRemove(resource *ContainerEvent) (*ContainerEvent, error) {
+
+	resp := &ContainerEvent{}
+
+	err := c.rancherClient.doAction(CONTAINER_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_container_exec.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_container_exec.go
@@ -1,0 +1,73 @@
+package client
+
+const (
+	CONTAINER_EXEC_TYPE = "containerExec"
+)
+
+type ContainerExec struct {
+	Resource
+
+	AttachStdin bool `json:"attachStdin,omitempty" yaml:"attach_stdin,omitempty"`
+
+	AttachStdout bool `json:"attachStdout,omitempty" yaml:"attach_stdout,omitempty"`
+
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Tty bool `json:"tty,omitempty" yaml:"tty,omitempty"`
+}
+
+type ContainerExecCollection struct {
+	Collection
+	Data []ContainerExec `json:"data,omitempty"`
+}
+
+type ContainerExecClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerExecOperations interface {
+	List(opts *ListOpts) (*ContainerExecCollection, error)
+	Create(opts *ContainerExec) (*ContainerExec, error)
+	Update(existing *ContainerExec, updates interface{}) (*ContainerExec, error)
+	ById(id string) (*ContainerExec, error)
+	Delete(container *ContainerExec) error
+}
+
+func newContainerExecClient(rancherClient *RancherClient) *ContainerExecClient {
+	return &ContainerExecClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerExecClient) Create(container *ContainerExec) (*ContainerExec, error) {
+	resp := &ContainerExec{}
+	err := c.rancherClient.doCreate(CONTAINER_EXEC_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerExecClient) Update(existing *ContainerExec, updates interface{}) (*ContainerExec, error) {
+	resp := &ContainerExec{}
+	err := c.rancherClient.doUpdate(CONTAINER_EXEC_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerExecClient) List(opts *ListOpts) (*ContainerExecCollection, error) {
+	resp := &ContainerExecCollection{}
+	err := c.rancherClient.doList(CONTAINER_EXEC_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerExecClient) ById(id string) (*ContainerExec, error) {
+	resp := &ContainerExec{}
+	err := c.rancherClient.doById(CONTAINER_EXEC_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerExecClient) Delete(container *ContainerExec) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_EXEC_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_container_logs.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_container_logs.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	CONTAINER_LOGS_TYPE = "containerLogs"
+)
+
+type ContainerLogs struct {
+	Resource
+
+	Follow bool `json:"follow,omitempty" yaml:"follow,omitempty"`
+
+	Lines int64 `json:"lines,omitempty" yaml:"lines,omitempty"`
+}
+
+type ContainerLogsCollection struct {
+	Collection
+	Data []ContainerLogs `json:"data,omitempty"`
+}
+
+type ContainerLogsClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerLogsOperations interface {
+	List(opts *ListOpts) (*ContainerLogsCollection, error)
+	Create(opts *ContainerLogs) (*ContainerLogs, error)
+	Update(existing *ContainerLogs, updates interface{}) (*ContainerLogs, error)
+	ById(id string) (*ContainerLogs, error)
+	Delete(container *ContainerLogs) error
+}
+
+func newContainerLogsClient(rancherClient *RancherClient) *ContainerLogsClient {
+	return &ContainerLogsClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerLogsClient) Create(container *ContainerLogs) (*ContainerLogs, error) {
+	resp := &ContainerLogs{}
+	err := c.rancherClient.doCreate(CONTAINER_LOGS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerLogsClient) Update(existing *ContainerLogs, updates interface{}) (*ContainerLogs, error) {
+	resp := &ContainerLogs{}
+	err := c.rancherClient.doUpdate(CONTAINER_LOGS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerLogsClient) List(opts *ListOpts) (*ContainerLogsCollection, error) {
+	resp := &ContainerLogsCollection{}
+	err := c.rancherClient.doList(CONTAINER_LOGS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerLogsClient) ById(id string) (*ContainerLogs, error) {
+	resp := &ContainerLogs{}
+	err := c.rancherClient.doById(CONTAINER_LOGS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerLogsClient) Delete(container *ContainerLogs) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_LOGS_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_container_proxy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_container_proxy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	CONTAINER_PROXY_TYPE = "containerProxy"
+)
+
+type ContainerProxy struct {
+	Resource
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type ContainerProxyCollection struct {
+	Collection
+	Data []ContainerProxy `json:"data,omitempty"`
+}
+
+type ContainerProxyClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerProxyOperations interface {
+	List(opts *ListOpts) (*ContainerProxyCollection, error)
+	Create(opts *ContainerProxy) (*ContainerProxy, error)
+	Update(existing *ContainerProxy, updates interface{}) (*ContainerProxy, error)
+	ById(id string) (*ContainerProxy, error)
+	Delete(container *ContainerProxy) error
+}
+
+func newContainerProxyClient(rancherClient *RancherClient) *ContainerProxyClient {
+	return &ContainerProxyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerProxyClient) Create(container *ContainerProxy) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doCreate(CONTAINER_PROXY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) Update(existing *ContainerProxy, updates interface{}) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doUpdate(CONTAINER_PROXY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) List(opts *ListOpts) (*ContainerProxyCollection, error) {
+	resp := &ContainerProxyCollection{}
+	err := c.rancherClient.doList(CONTAINER_PROXY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) ById(id string) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doById(CONTAINER_PROXY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerProxyClient) Delete(container *ContainerProxy) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_PROXY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_credential.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_credential.go
@@ -1,0 +1,161 @@
+package client
+
+const (
+	CREDENTIAL_TYPE = "credential"
+)
+
+type Credential struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicValue string `json:"publicValue,omitempty" yaml:"public_value,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SecretValue string `json:"secretValue,omitempty" yaml:"secret_value,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type CredentialCollection struct {
+	Collection
+	Data []Credential `json:"data,omitempty"`
+}
+
+type CredentialClient struct {
+	rancherClient *RancherClient
+}
+
+type CredentialOperations interface {
+	List(opts *ListOpts) (*CredentialCollection, error)
+	Create(opts *Credential) (*Credential, error)
+	Update(existing *Credential, updates interface{}) (*Credential, error)
+	ById(id string) (*Credential, error)
+	Delete(container *Credential) error
+
+	ActionActivate(*Credential) (*Credential, error)
+
+	ActionCreate(*Credential) (*Credential, error)
+
+	ActionDeactivate(*Credential) (*Credential, error)
+
+	ActionPurge(*Credential) (*Credential, error)
+
+	ActionRemove(*Credential) (*Credential, error)
+
+	ActionUpdate(*Credential) (*Credential, error)
+}
+
+func newCredentialClient(rancherClient *RancherClient) *CredentialClient {
+	return &CredentialClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *CredentialClient) Create(container *Credential) (*Credential, error) {
+	resp := &Credential{}
+	err := c.rancherClient.doCreate(CREDENTIAL_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *CredentialClient) Update(existing *Credential, updates interface{}) (*Credential, error) {
+	resp := &Credential{}
+	err := c.rancherClient.doUpdate(CREDENTIAL_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *CredentialClient) List(opts *ListOpts) (*CredentialCollection, error) {
+	resp := &CredentialCollection{}
+	err := c.rancherClient.doList(CREDENTIAL_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *CredentialClient) ById(id string) (*Credential, error) {
+	resp := &Credential{}
+	err := c.rancherClient.doById(CREDENTIAL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *CredentialClient) Delete(container *Credential) error {
+	return c.rancherClient.doResourceDelete(CREDENTIAL_TYPE, &container.Resource)
+}
+
+func (c *CredentialClient) ActionActivate(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CredentialClient) ActionCreate(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CredentialClient) ActionDeactivate(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CredentialClient) ActionPurge(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CredentialClient) ActionRemove(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *CredentialClient) ActionUpdate(resource *Credential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(CREDENTIAL_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_databasechangelog.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_databasechangelog.go
@@ -1,0 +1,85 @@
+package client
+
+const (
+	DATABASECHANGELOG_TYPE = "databasechangelog"
+)
+
+type Databasechangelog struct {
+	Resource
+
+	Author string `json:"author,omitempty" yaml:"author,omitempty"`
+
+	Comments string `json:"comments,omitempty" yaml:"comments,omitempty"`
+
+	Dateexecuted string `json:"dateexecuted,omitempty" yaml:"dateexecuted,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Exectype string `json:"exectype,omitempty" yaml:"exectype,omitempty"`
+
+	Filename string `json:"filename,omitempty" yaml:"filename,omitempty"`
+
+	Liquibase string `json:"liquibase,omitempty" yaml:"liquibase,omitempty"`
+
+	Md5sum string `json:"md5sum,omitempty" yaml:"md5sum,omitempty"`
+
+	Orderexecuted int64 `json:"orderexecuted,omitempty" yaml:"orderexecuted,omitempty"`
+
+	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+}
+
+type DatabasechangelogCollection struct {
+	Collection
+	Data []Databasechangelog `json:"data,omitempty"`
+}
+
+type DatabasechangelogClient struct {
+	rancherClient *RancherClient
+}
+
+type DatabasechangelogOperations interface {
+	List(opts *ListOpts) (*DatabasechangelogCollection, error)
+	Create(opts *Databasechangelog) (*Databasechangelog, error)
+	Update(existing *Databasechangelog, updates interface{}) (*Databasechangelog, error)
+	ById(id string) (*Databasechangelog, error)
+	Delete(container *Databasechangelog) error
+}
+
+func newDatabasechangelogClient(rancherClient *RancherClient) *DatabasechangelogClient {
+	return &DatabasechangelogClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DatabasechangelogClient) Create(container *Databasechangelog) (*Databasechangelog, error) {
+	resp := &Databasechangelog{}
+	err := c.rancherClient.doCreate(DATABASECHANGELOG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DatabasechangelogClient) Update(existing *Databasechangelog, updates interface{}) (*Databasechangelog, error) {
+	resp := &Databasechangelog{}
+	err := c.rancherClient.doUpdate(DATABASECHANGELOG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DatabasechangelogClient) List(opts *ListOpts) (*DatabasechangelogCollection, error) {
+	resp := &DatabasechangelogCollection{}
+	err := c.rancherClient.doList(DATABASECHANGELOG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DatabasechangelogClient) ById(id string) (*Databasechangelog, error) {
+	resp := &Databasechangelog{}
+	err := c.rancherClient.doById(DATABASECHANGELOG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DatabasechangelogClient) Delete(container *Databasechangelog) error {
+	return c.rancherClient.doResourceDelete(DATABASECHANGELOG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_databasechangeloglock.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_databasechangeloglock.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	DATABASECHANGELOGLOCK_TYPE = "databasechangeloglock"
+)
+
+type Databasechangeloglock struct {
+	Resource
+
+	Locked bool `json:"locked,omitempty" yaml:"locked,omitempty"`
+
+	Lockedby string `json:"lockedby,omitempty" yaml:"lockedby,omitempty"`
+
+	Lockgranted string `json:"lockgranted,omitempty" yaml:"lockgranted,omitempty"`
+}
+
+type DatabasechangeloglockCollection struct {
+	Collection
+	Data []Databasechangeloglock `json:"data,omitempty"`
+}
+
+type DatabasechangeloglockClient struct {
+	rancherClient *RancherClient
+}
+
+type DatabasechangeloglockOperations interface {
+	List(opts *ListOpts) (*DatabasechangeloglockCollection, error)
+	Create(opts *Databasechangeloglock) (*Databasechangeloglock, error)
+	Update(existing *Databasechangeloglock, updates interface{}) (*Databasechangeloglock, error)
+	ById(id string) (*Databasechangeloglock, error)
+	Delete(container *Databasechangeloglock) error
+}
+
+func newDatabasechangeloglockClient(rancherClient *RancherClient) *DatabasechangeloglockClient {
+	return &DatabasechangeloglockClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DatabasechangeloglockClient) Create(container *Databasechangeloglock) (*Databasechangeloglock, error) {
+	resp := &Databasechangeloglock{}
+	err := c.rancherClient.doCreate(DATABASECHANGELOGLOCK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DatabasechangeloglockClient) Update(existing *Databasechangeloglock, updates interface{}) (*Databasechangeloglock, error) {
+	resp := &Databasechangeloglock{}
+	err := c.rancherClient.doUpdate(DATABASECHANGELOGLOCK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DatabasechangeloglockClient) List(opts *ListOpts) (*DatabasechangeloglockCollection, error) {
+	resp := &DatabasechangeloglockCollection{}
+	err := c.rancherClient.doList(DATABASECHANGELOGLOCK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DatabasechangeloglockClient) ById(id string) (*Databasechangeloglock, error) {
+	resp := &Databasechangeloglock{}
+	err := c.rancherClient.doById(DATABASECHANGELOGLOCK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DatabasechangeloglockClient) Delete(container *Databasechangeloglock) error {
+	return c.rancherClient.doResourceDelete(DATABASECHANGELOGLOCK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_digitalocean_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_digitalocean_config.go
@@ -1,0 +1,87 @@
+package client
+
+const (
+	DIGITALOCEAN_CONFIG_TYPE = "digitaloceanConfig"
+)
+
+type DigitaloceanConfig struct {
+	Resource
+
+	AccessToken string `json:"accessToken,omitempty" yaml:"access_token,omitempty"`
+
+	Backups bool `json:"backups,omitempty" yaml:"backups,omitempty"`
+
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	Ipv6 bool `json:"ipv6,omitempty" yaml:"ipv6,omitempty"`
+
+	PrivateNetworking bool `json:"privateNetworking,omitempty" yaml:"private_networking,omitempty"`
+
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
+
+	SshKeyFingerprint string `json:"sshKeyFingerprint,omitempty" yaml:"ssh_key_fingerprint,omitempty"`
+
+	SshPort string `json:"sshPort,omitempty" yaml:"ssh_port,omitempty"`
+
+	SshUser string `json:"sshUser,omitempty" yaml:"ssh_user,omitempty"`
+
+	Userdata string `json:"userdata,omitempty" yaml:"userdata,omitempty"`
+}
+
+type DigitaloceanConfigCollection struct {
+	Collection
+	Data []DigitaloceanConfig `json:"data,omitempty"`
+}
+
+type DigitaloceanConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type DigitaloceanConfigOperations interface {
+	List(opts *ListOpts) (*DigitaloceanConfigCollection, error)
+	Create(opts *DigitaloceanConfig) (*DigitaloceanConfig, error)
+	Update(existing *DigitaloceanConfig, updates interface{}) (*DigitaloceanConfig, error)
+	ById(id string) (*DigitaloceanConfig, error)
+	Delete(container *DigitaloceanConfig) error
+}
+
+func newDigitaloceanConfigClient(rancherClient *RancherClient) *DigitaloceanConfigClient {
+	return &DigitaloceanConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DigitaloceanConfigClient) Create(container *DigitaloceanConfig) (*DigitaloceanConfig, error) {
+	resp := &DigitaloceanConfig{}
+	err := c.rancherClient.doCreate(DIGITALOCEAN_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DigitaloceanConfigClient) Update(existing *DigitaloceanConfig, updates interface{}) (*DigitaloceanConfig, error) {
+	resp := &DigitaloceanConfig{}
+	err := c.rancherClient.doUpdate(DIGITALOCEAN_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DigitaloceanConfigClient) List(opts *ListOpts) (*DigitaloceanConfigCollection, error) {
+	resp := &DigitaloceanConfigCollection{}
+	err := c.rancherClient.doList(DIGITALOCEAN_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DigitaloceanConfigClient) ById(id string) (*DigitaloceanConfig, error) {
+	resp := &DigitaloceanConfig{}
+	err := c.rancherClient.doById(DIGITALOCEAN_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DigitaloceanConfigClient) Delete(container *DigitaloceanConfig) error {
+	return c.rancherClient.doResourceDelete(DIGITALOCEAN_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_dns_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_dns_service.go
@@ -1,0 +1,267 @@
+package client
+
+const (
+	DNS_SERVICE_TYPE = "dnsService"
+)
+
+type DnsService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RetainIp bool `json:"retainIp,omitempty" yaml:"retain_ip,omitempty"`
+
+	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type DnsServiceCollection struct {
+	Collection
+	Data []DnsService `json:"data,omitempty"`
+}
+
+type DnsServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type DnsServiceOperations interface {
+	List(opts *ListOpts) (*DnsServiceCollection, error)
+	Create(opts *DnsService) (*DnsService, error)
+	Update(existing *DnsService, updates interface{}) (*DnsService, error)
+	ById(id string) (*DnsService, error)
+	Delete(container *DnsService) error
+
+	ActionActivate(*DnsService) (*Service, error)
+
+	ActionAddservicelink(*DnsService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionCancelrollback(*DnsService) (*Service, error)
+
+	ActionCancelupgrade(*DnsService) (*Service, error)
+
+	ActionCreate(*DnsService) (*Service, error)
+
+	ActionDeactivate(*DnsService) (*Service, error)
+
+	ActionFinishupgrade(*DnsService) (*Service, error)
+
+	ActionRemove(*DnsService) (*Service, error)
+
+	ActionRemoveservicelink(*DnsService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRestart(*DnsService, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*DnsService) (*Service, error)
+
+	ActionSetservicelinks(*DnsService, *SetServiceLinksInput) (*Service, error)
+
+	ActionUpdate(*DnsService) (*Service, error)
+
+	ActionUpgrade(*DnsService, *ServiceUpgrade) (*Service, error)
+}
+
+func newDnsServiceClient(rancherClient *RancherClient) *DnsServiceClient {
+	return &DnsServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DnsServiceClient) Create(container *DnsService) (*DnsService, error) {
+	resp := &DnsService{}
+	err := c.rancherClient.doCreate(DNS_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DnsServiceClient) Update(existing *DnsService, updates interface{}) (*DnsService, error) {
+	resp := &DnsService{}
+	err := c.rancherClient.doUpdate(DNS_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DnsServiceClient) List(opts *ListOpts) (*DnsServiceCollection, error) {
+	resp := &DnsServiceCollection{}
+	err := c.rancherClient.doList(DNS_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DnsServiceClient) ById(id string) (*DnsService, error) {
+	resp := &DnsService{}
+	err := c.rancherClient.doById(DNS_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DnsServiceClient) Delete(container *DnsService) error {
+	return c.rancherClient.doResourceDelete(DNS_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *DnsServiceClient) ActionActivate(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionAddservicelink(resource *DnsService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionCancelrollback(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionCancelupgrade(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionCreate(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionDeactivate(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionFinishupgrade(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionRemove(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionRemoveservicelink(resource *DnsService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionRestart(resource *DnsService, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionRollback(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionSetservicelinks(resource *DnsService, input *SetServiceLinksInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "setservicelinks", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionUpdate(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionUpgrade(resource *DnsService, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_docker_build.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_docker_build.go
@@ -1,0 +1,77 @@
+package client
+
+const (
+	DOCKER_BUILD_TYPE = "dockerBuild"
+)
+
+type DockerBuild struct {
+	Resource
+
+	Context string `json:"context,omitempty" yaml:"context,omitempty"`
+
+	Dockerfile string `json:"dockerfile,omitempty" yaml:"dockerfile,omitempty"`
+
+	Forcerm bool `json:"forcerm,omitempty" yaml:"forcerm,omitempty"`
+
+	Nocache bool `json:"nocache,omitempty" yaml:"nocache,omitempty"`
+
+	Remote string `json:"remote,omitempty" yaml:"remote,omitempty"`
+
+	Rm bool `json:"rm,omitempty" yaml:"rm,omitempty"`
+}
+
+type DockerBuildCollection struct {
+	Collection
+	Data []DockerBuild `json:"data,omitempty"`
+}
+
+type DockerBuildClient struct {
+	rancherClient *RancherClient
+}
+
+type DockerBuildOperations interface {
+	List(opts *ListOpts) (*DockerBuildCollection, error)
+	Create(opts *DockerBuild) (*DockerBuild, error)
+	Update(existing *DockerBuild, updates interface{}) (*DockerBuild, error)
+	ById(id string) (*DockerBuild, error)
+	Delete(container *DockerBuild) error
+}
+
+func newDockerBuildClient(rancherClient *RancherClient) *DockerBuildClient {
+	return &DockerBuildClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DockerBuildClient) Create(container *DockerBuild) (*DockerBuild, error) {
+	resp := &DockerBuild{}
+	err := c.rancherClient.doCreate(DOCKER_BUILD_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DockerBuildClient) Update(existing *DockerBuild, updates interface{}) (*DockerBuild, error) {
+	resp := &DockerBuild{}
+	err := c.rancherClient.doUpdate(DOCKER_BUILD_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DockerBuildClient) List(opts *ListOpts) (*DockerBuildCollection, error) {
+	resp := &DockerBuildCollection{}
+	err := c.rancherClient.doList(DOCKER_BUILD_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DockerBuildClient) ById(id string) (*DockerBuild, error) {
+	resp := &DockerBuild{}
+	err := c.rancherClient.doById(DOCKER_BUILD_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DockerBuildClient) Delete(container *DockerBuild) error {
+	return c.rancherClient.doResourceDelete(DOCKER_BUILD_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_dynamic_schema.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_dynamic_schema.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	DYNAMIC_SCHEMA_TYPE = "dynamicSchema"
+)
+
+type DynamicSchema struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Definition string `json:"definition,omitempty" yaml:"definition,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Parent string `json:"parent,omitempty" yaml:"parent,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	Roles []string `json:"roles,omitempty" yaml:"roles,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type DynamicSchemaCollection struct {
+	Collection
+	Data []DynamicSchema `json:"data,omitempty"`
+}
+
+type DynamicSchemaClient struct {
+	rancherClient *RancherClient
+}
+
+type DynamicSchemaOperations interface {
+	List(opts *ListOpts) (*DynamicSchemaCollection, error)
+	Create(opts *DynamicSchema) (*DynamicSchema, error)
+	Update(existing *DynamicSchema, updates interface{}) (*DynamicSchema, error)
+	ById(id string) (*DynamicSchema, error)
+	Delete(container *DynamicSchema) error
+
+	ActionCreate(*DynamicSchema) (*DynamicSchema, error)
+
+	ActionRemove(*DynamicSchema) (*DynamicSchema, error)
+}
+
+func newDynamicSchemaClient(rancherClient *RancherClient) *DynamicSchemaClient {
+	return &DynamicSchemaClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DynamicSchemaClient) Create(container *DynamicSchema) (*DynamicSchema, error) {
+	resp := &DynamicSchema{}
+	err := c.rancherClient.doCreate(DYNAMIC_SCHEMA_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DynamicSchemaClient) Update(existing *DynamicSchema, updates interface{}) (*DynamicSchema, error) {
+	resp := &DynamicSchema{}
+	err := c.rancherClient.doUpdate(DYNAMIC_SCHEMA_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DynamicSchemaClient) List(opts *ListOpts) (*DynamicSchemaCollection, error) {
+	resp := &DynamicSchemaCollection{}
+	err := c.rancherClient.doList(DYNAMIC_SCHEMA_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *DynamicSchemaClient) ById(id string) (*DynamicSchema, error) {
+	resp := &DynamicSchema{}
+	err := c.rancherClient.doById(DYNAMIC_SCHEMA_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DynamicSchemaClient) Delete(container *DynamicSchema) error {
+	return c.rancherClient.doResourceDelete(DYNAMIC_SCHEMA_TYPE, &container.Resource)
+}
+
+func (c *DynamicSchemaClient) ActionCreate(resource *DynamicSchema) (*DynamicSchema, error) {
+
+	resp := &DynamicSchema{}
+
+	err := c.rancherClient.doAction(DYNAMIC_SCHEMA_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *DynamicSchemaClient) ActionRemove(resource *DynamicSchema) (*DynamicSchema, error) {
+
+	resp := &DynamicSchema{}
+
+	err := c.rancherClient.doAction(DYNAMIC_SCHEMA_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_environment.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_environment.go
@@ -1,0 +1,252 @@
+package client
+
+const (
+	ENVIRONMENT_TYPE = "environment"
+)
+
+type Environment struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	DockerCompose string `json:"dockerCompose,omitempty" yaml:"docker_compose,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Outputs map[string]interface{} `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+
+	PreviousEnvironment map[string]interface{} `json:"previousEnvironment,omitempty" yaml:"previous_environment,omitempty"`
+
+	PreviousExternalId string `json:"previousExternalId,omitempty" yaml:"previous_external_id,omitempty"`
+
+	RancherCompose string `json:"rancherCompose,omitempty" yaml:"rancher_compose,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type EnvironmentCollection struct {
+	Collection
+	Data []Environment `json:"data,omitempty"`
+}
+
+type EnvironmentClient struct {
+	rancherClient *RancherClient
+}
+
+type EnvironmentOperations interface {
+	List(opts *ListOpts) (*EnvironmentCollection, error)
+	Create(opts *Environment) (*Environment, error)
+	Update(existing *Environment, updates interface{}) (*Environment, error)
+	ById(id string) (*Environment, error)
+	Delete(container *Environment) error
+
+	ActionActivateservices(*Environment) (*Environment, error)
+
+	ActionAddoutputs(*Environment, *AddOutputsInput) (*Environment, error)
+
+	ActionCancelrollback(*Environment) (*Environment, error)
+
+	ActionCancelupgrade(*Environment) (*Environment, error)
+
+	ActionCreate(*Environment) (*Environment, error)
+
+	ActionDeactivateservices(*Environment) (*Environment, error)
+
+	ActionError(*Environment) (*Environment, error)
+
+	ActionExportconfig(*Environment, *ComposeConfigInput) (*ComposeConfig, error)
+
+	ActionFinishupgrade(*Environment) (*Environment, error)
+
+	ActionRemove(*Environment) (*Environment, error)
+
+	ActionRollback(*Environment) (*Environment, error)
+
+	ActionUpdate(*Environment) (*Environment, error)
+
+	ActionUpgrade(*Environment, *EnvironmentUpgrade) (*Environment, error)
+}
+
+func newEnvironmentClient(rancherClient *RancherClient) *EnvironmentClient {
+	return &EnvironmentClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *EnvironmentClient) Create(container *Environment) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doCreate(ENVIRONMENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) Update(existing *Environment, updates interface{}) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doUpdate(ENVIRONMENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) List(opts *ListOpts) (*EnvironmentCollection, error) {
+	resp := &EnvironmentCollection{}
+	err := c.rancherClient.doList(ENVIRONMENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) ById(id string) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doById(ENVIRONMENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *EnvironmentClient) Delete(container *Environment) error {
+	return c.rancherClient.doResourceDelete(ENVIRONMENT_TYPE, &container.Resource)
+}
+
+func (c *EnvironmentClient) ActionActivateservices(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "activateservices", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionAddoutputs(resource *Environment, input *AddOutputsInput) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "addoutputs", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionCancelrollback(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionCancelupgrade(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionCreate(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionDeactivateservices(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "deactivateservices", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionError(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionExportconfig(resource *Environment, input *ComposeConfigInput) (*ComposeConfig, error) {
+
+	resp := &ComposeConfig{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "exportconfig", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionFinishupgrade(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionRemove(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionRollback(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionUpdate(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionUpgrade(resource *Environment, input *EnvironmentUpgrade) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_environment_upgrade.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_environment_upgrade.go
@@ -1,0 +1,73 @@
+package client
+
+const (
+	ENVIRONMENT_UPGRADE_TYPE = "environmentUpgrade"
+)
+
+type EnvironmentUpgrade struct {
+	Resource
+
+	DockerCompose string `json:"dockerCompose,omitempty" yaml:"docker_compose,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	RancherCompose string `json:"rancherCompose,omitempty" yaml:"rancher_compose,omitempty"`
+}
+
+type EnvironmentUpgradeCollection struct {
+	Collection
+	Data []EnvironmentUpgrade `json:"data,omitempty"`
+}
+
+type EnvironmentUpgradeClient struct {
+	rancherClient *RancherClient
+}
+
+type EnvironmentUpgradeOperations interface {
+	List(opts *ListOpts) (*EnvironmentUpgradeCollection, error)
+	Create(opts *EnvironmentUpgrade) (*EnvironmentUpgrade, error)
+	Update(existing *EnvironmentUpgrade, updates interface{}) (*EnvironmentUpgrade, error)
+	ById(id string) (*EnvironmentUpgrade, error)
+	Delete(container *EnvironmentUpgrade) error
+}
+
+func newEnvironmentUpgradeClient(rancherClient *RancherClient) *EnvironmentUpgradeClient {
+	return &EnvironmentUpgradeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *EnvironmentUpgradeClient) Create(container *EnvironmentUpgrade) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doCreate(ENVIRONMENT_UPGRADE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) Update(existing *EnvironmentUpgrade, updates interface{}) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doUpdate(ENVIRONMENT_UPGRADE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) List(opts *ListOpts) (*EnvironmentUpgradeCollection, error) {
+	resp := &EnvironmentUpgradeCollection{}
+	err := c.rancherClient.doList(ENVIRONMENT_UPGRADE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) ById(id string) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doById(ENVIRONMENT_UPGRADE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) Delete(container *EnvironmentUpgrade) error {
+	return c.rancherClient.doResourceDelete(ENVIRONMENT_UPGRADE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_extension_implementation.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_extension_implementation.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	EXTENSION_IMPLEMENTATION_TYPE = "extensionImplementation"
+)
+
+type ExtensionImplementation struct {
+	Resource
+
+	ClassName string `json:"className,omitempty" yaml:"class_name,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Properties map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
+}
+
+type ExtensionImplementationCollection struct {
+	Collection
+	Data []ExtensionImplementation `json:"data,omitempty"`
+}
+
+type ExtensionImplementationClient struct {
+	rancherClient *RancherClient
+}
+
+type ExtensionImplementationOperations interface {
+	List(opts *ListOpts) (*ExtensionImplementationCollection, error)
+	Create(opts *ExtensionImplementation) (*ExtensionImplementation, error)
+	Update(existing *ExtensionImplementation, updates interface{}) (*ExtensionImplementation, error)
+	ById(id string) (*ExtensionImplementation, error)
+	Delete(container *ExtensionImplementation) error
+}
+
+func newExtensionImplementationClient(rancherClient *RancherClient) *ExtensionImplementationClient {
+	return &ExtensionImplementationClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExtensionImplementationClient) Create(container *ExtensionImplementation) (*ExtensionImplementation, error) {
+	resp := &ExtensionImplementation{}
+	err := c.rancherClient.doCreate(EXTENSION_IMPLEMENTATION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExtensionImplementationClient) Update(existing *ExtensionImplementation, updates interface{}) (*ExtensionImplementation, error) {
+	resp := &ExtensionImplementation{}
+	err := c.rancherClient.doUpdate(EXTENSION_IMPLEMENTATION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExtensionImplementationClient) List(opts *ListOpts) (*ExtensionImplementationCollection, error) {
+	resp := &ExtensionImplementationCollection{}
+	err := c.rancherClient.doList(EXTENSION_IMPLEMENTATION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExtensionImplementationClient) ById(id string) (*ExtensionImplementation, error) {
+	resp := &ExtensionImplementation{}
+	err := c.rancherClient.doById(EXTENSION_IMPLEMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExtensionImplementationClient) Delete(container *ExtensionImplementation) error {
+	return c.rancherClient.doResourceDelete(EXTENSION_IMPLEMENTATION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_extension_point.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_extension_point.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	EXTENSION_POINT_TYPE = "extensionPoint"
+)
+
+type ExtensionPoint struct {
+	Resource
+
+	ExcludeSetting string `json:"excludeSetting,omitempty" yaml:"exclude_setting,omitempty"`
+
+	Implementations []interface{} `json:"implementations,omitempty" yaml:"implementations,omitempty"`
+
+	IncludeSetting string `json:"includeSetting,omitempty" yaml:"include_setting,omitempty"`
+
+	ListSetting string `json:"listSetting,omitempty" yaml:"list_setting,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type ExtensionPointCollection struct {
+	Collection
+	Data []ExtensionPoint `json:"data,omitempty"`
+}
+
+type ExtensionPointClient struct {
+	rancherClient *RancherClient
+}
+
+type ExtensionPointOperations interface {
+	List(opts *ListOpts) (*ExtensionPointCollection, error)
+	Create(opts *ExtensionPoint) (*ExtensionPoint, error)
+	Update(existing *ExtensionPoint, updates interface{}) (*ExtensionPoint, error)
+	ById(id string) (*ExtensionPoint, error)
+	Delete(container *ExtensionPoint) error
+}
+
+func newExtensionPointClient(rancherClient *RancherClient) *ExtensionPointClient {
+	return &ExtensionPointClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExtensionPointClient) Create(container *ExtensionPoint) (*ExtensionPoint, error) {
+	resp := &ExtensionPoint{}
+	err := c.rancherClient.doCreate(EXTENSION_POINT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExtensionPointClient) Update(existing *ExtensionPoint, updates interface{}) (*ExtensionPoint, error) {
+	resp := &ExtensionPoint{}
+	err := c.rancherClient.doUpdate(EXTENSION_POINT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExtensionPointClient) List(opts *ListOpts) (*ExtensionPointCollection, error) {
+	resp := &ExtensionPointCollection{}
+	err := c.rancherClient.doList(EXTENSION_POINT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExtensionPointClient) ById(id string) (*ExtensionPoint, error) {
+	resp := &ExtensionPoint{}
+	err := c.rancherClient.doById(EXTENSION_POINT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExtensionPointClient) Delete(container *ExtensionPoint) error {
+	return c.rancherClient.doResourceDelete(EXTENSION_POINT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_dns_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_dns_event.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	EXTERNAL_DNS_EVENT_TYPE = "externalDnsEvent"
+)
+
+type ExternalDnsEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	ServiceName string `json:"serviceName,omitempty" yaml:"service_name,omitempty"`
+
+	StackName string `json:"stackName,omitempty" yaml:"stack_name,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalDnsEventCollection struct {
+	Collection
+	Data []ExternalDnsEvent `json:"data,omitempty"`
+}
+
+type ExternalDnsEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalDnsEventOperations interface {
+	List(opts *ListOpts) (*ExternalDnsEventCollection, error)
+	Create(opts *ExternalDnsEvent) (*ExternalDnsEvent, error)
+	Update(existing *ExternalDnsEvent, updates interface{}) (*ExternalDnsEvent, error)
+	ById(id string) (*ExternalDnsEvent, error)
+	Delete(container *ExternalDnsEvent) error
+
+	ActionCreate(*ExternalDnsEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalDnsEvent) (*ExternalEvent, error)
+}
+
+func newExternalDnsEventClient(rancherClient *RancherClient) *ExternalDnsEventClient {
+	return &ExternalDnsEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalDnsEventClient) Create(container *ExternalDnsEvent) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_DNS_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) Update(existing *ExternalDnsEvent, updates interface{}) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_DNS_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) List(opts *ListOpts) (*ExternalDnsEventCollection, error) {
+	resp := &ExternalDnsEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_DNS_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) ById(id string) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doById(EXTERNAL_DNS_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) Delete(container *ExternalDnsEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_DNS_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalDnsEventClient) ActionCreate(resource *ExternalDnsEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_DNS_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) ActionRemove(resource *ExternalDnsEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_DNS_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_event.go
@@ -1,0 +1,111 @@
+package client
+
+const (
+	EXTERNAL_EVENT_TYPE = "externalEvent"
+)
+
+type ExternalEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalEventCollection struct {
+	Collection
+	Data []ExternalEvent `json:"data,omitempty"`
+}
+
+type ExternalEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalEventOperations interface {
+	List(opts *ListOpts) (*ExternalEventCollection, error)
+	Create(opts *ExternalEvent) (*ExternalEvent, error)
+	Update(existing *ExternalEvent, updates interface{}) (*ExternalEvent, error)
+	ById(id string) (*ExternalEvent, error)
+	Delete(container *ExternalEvent) error
+
+	ActionCreate(*ExternalEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalEvent) (*ExternalEvent, error)
+}
+
+func newExternalEventClient(rancherClient *RancherClient) *ExternalEventClient {
+	return &ExternalEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalEventClient) Create(container *ExternalEvent) (*ExternalEvent, error) {
+	resp := &ExternalEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalEventClient) Update(existing *ExternalEvent, updates interface{}) (*ExternalEvent, error) {
+	resp := &ExternalEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalEventClient) List(opts *ListOpts) (*ExternalEventCollection, error) {
+	resp := &ExternalEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalEventClient) ById(id string) (*ExternalEvent, error) {
+	resp := &ExternalEvent{}
+	err := c.rancherClient.doById(EXTERNAL_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalEventClient) Delete(container *ExternalEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalEventClient) ActionCreate(resource *ExternalEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalEventClient) ActionRemove(resource *ExternalEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_handler.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_handler.go
@@ -1,0 +1,174 @@
+package client
+
+const (
+	EXTERNAL_HANDLER_TYPE = "externalHandler"
+)
+
+type ExternalHandler struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Priority int64 `json:"priority,omitempty" yaml:"priority,omitempty"`
+
+	ProcessConfigs []interface{} `json:"processConfigs,omitempty" yaml:"process_configs,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	Retries int64 `json:"retries,omitempty" yaml:"retries,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	TimeoutMillis int64 `json:"timeoutMillis,omitempty" yaml:"timeout_millis,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalHandlerCollection struct {
+	Collection
+	Data []ExternalHandler `json:"data,omitempty"`
+}
+
+type ExternalHandlerClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHandlerOperations interface {
+	List(opts *ListOpts) (*ExternalHandlerCollection, error)
+	Create(opts *ExternalHandler) (*ExternalHandler, error)
+	Update(existing *ExternalHandler, updates interface{}) (*ExternalHandler, error)
+	ById(id string) (*ExternalHandler, error)
+	Delete(container *ExternalHandler) error
+
+	ActionActivate(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionCreate(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionDeactivate(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionPurge(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionRemove(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionRestore(*ExternalHandler) (*ExternalHandler, error)
+
+	ActionUpdate(*ExternalHandler) (*ExternalHandler, error)
+}
+
+func newExternalHandlerClient(rancherClient *RancherClient) *ExternalHandlerClient {
+	return &ExternalHandlerClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHandlerClient) Create(container *ExternalHandler) (*ExternalHandler, error) {
+	resp := &ExternalHandler{}
+	err := c.rancherClient.doCreate(EXTERNAL_HANDLER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) Update(existing *ExternalHandler, updates interface{}) (*ExternalHandler, error) {
+	resp := &ExternalHandler{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HANDLER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) List(opts *ListOpts) (*ExternalHandlerCollection, error) {
+	resp := &ExternalHandlerCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HANDLER_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ById(id string) (*ExternalHandler, error) {
+	resp := &ExternalHandler{}
+	err := c.rancherClient.doById(EXTERNAL_HANDLER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) Delete(container *ExternalHandler) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HANDLER_TYPE, &container.Resource)
+}
+
+func (c *ExternalHandlerClient) ActionActivate(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionCreate(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionDeactivate(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionPurge(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionRemove(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionRestore(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerClient) ActionUpdate(resource *ExternalHandler) (*ExternalHandler, error) {
+
+	resp := &ExternalHandler{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_handler_external_handler_process_map.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_handler_external_handler_process_map.go
@@ -1,0 +1,172 @@
+package client
+
+const (
+	EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE = "externalHandlerExternalHandlerProcessMap"
+)
+
+type ExternalHandlerExternalHandlerProcessMap struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalHandlerId string `json:"externalHandlerId,omitempty" yaml:"external_handler_id,omitempty"`
+
+	ExternalHandlerProcessId string `json:"externalHandlerProcessId,omitempty" yaml:"external_handler_process_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	OnError string `json:"onError,omitempty" yaml:"on_error,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalHandlerExternalHandlerProcessMapCollection struct {
+	Collection
+	Data []ExternalHandlerExternalHandlerProcessMap `json:"data,omitempty"`
+}
+
+type ExternalHandlerExternalHandlerProcessMapClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHandlerExternalHandlerProcessMapOperations interface {
+	List(opts *ListOpts) (*ExternalHandlerExternalHandlerProcessMapCollection, error)
+	Create(opts *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+	Update(existing *ExternalHandlerExternalHandlerProcessMap, updates interface{}) (*ExternalHandlerExternalHandlerProcessMap, error)
+	ById(id string) (*ExternalHandlerExternalHandlerProcessMap, error)
+	Delete(container *ExternalHandlerExternalHandlerProcessMap) error
+
+	ActionActivate(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionCreate(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionDeactivate(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionPurge(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionRemove(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionRestore(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+
+	ActionUpdate(*ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error)
+}
+
+func newExternalHandlerExternalHandlerProcessMapClient(rancherClient *RancherClient) *ExternalHandlerExternalHandlerProcessMapClient {
+	return &ExternalHandlerExternalHandlerProcessMapClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) Create(container *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+	err := c.rancherClient.doCreate(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) Update(existing *ExternalHandlerExternalHandlerProcessMap, updates interface{}) (*ExternalHandlerExternalHandlerProcessMap, error) {
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) List(opts *ListOpts) (*ExternalHandlerExternalHandlerProcessMapCollection, error) {
+	resp := &ExternalHandlerExternalHandlerProcessMapCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ById(id string) (*ExternalHandlerExternalHandlerProcessMap, error) {
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+	err := c.rancherClient.doById(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) Delete(container *ExternalHandlerExternalHandlerProcessMap) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, &container.Resource)
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionActivate(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionCreate(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionDeactivate(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionPurge(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionRemove(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionRestore(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerExternalHandlerProcessMapClient) ActionUpdate(resource *ExternalHandlerExternalHandlerProcessMap) (*ExternalHandlerExternalHandlerProcessMap, error) {
+
+	resp := &ExternalHandlerExternalHandlerProcessMap{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_handler_process.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_handler_process.go
@@ -1,0 +1,166 @@
+package client
+
+const (
+	EXTERNAL_HANDLER_PROCESS_TYPE = "externalHandlerProcess"
+)
+
+type ExternalHandlerProcess struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalHandlerProcessCollection struct {
+	Collection
+	Data []ExternalHandlerProcess `json:"data,omitempty"`
+}
+
+type ExternalHandlerProcessClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHandlerProcessOperations interface {
+	List(opts *ListOpts) (*ExternalHandlerProcessCollection, error)
+	Create(opts *ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+	Update(existing *ExternalHandlerProcess, updates interface{}) (*ExternalHandlerProcess, error)
+	ById(id string) (*ExternalHandlerProcess, error)
+	Delete(container *ExternalHandlerProcess) error
+
+	ActionActivate(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionCreate(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionDeactivate(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionPurge(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionRemove(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionRestore(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+
+	ActionUpdate(*ExternalHandlerProcess) (*ExternalHandlerProcess, error)
+}
+
+func newExternalHandlerProcessClient(rancherClient *RancherClient) *ExternalHandlerProcessClient {
+	return &ExternalHandlerProcessClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHandlerProcessClient) Create(container *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+	resp := &ExternalHandlerProcess{}
+	err := c.rancherClient.doCreate(EXTERNAL_HANDLER_PROCESS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) Update(existing *ExternalHandlerProcess, updates interface{}) (*ExternalHandlerProcess, error) {
+	resp := &ExternalHandlerProcess{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HANDLER_PROCESS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) List(opts *ListOpts) (*ExternalHandlerProcessCollection, error) {
+	resp := &ExternalHandlerProcessCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HANDLER_PROCESS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ById(id string) (*ExternalHandlerProcess, error) {
+	resp := &ExternalHandlerProcess{}
+	err := c.rancherClient.doById(EXTERNAL_HANDLER_PROCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) Delete(container *ExternalHandlerProcess) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HANDLER_PROCESS_TYPE, &container.Resource)
+}
+
+func (c *ExternalHandlerProcessClient) ActionActivate(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionCreate(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionDeactivate(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionPurge(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionRemove(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionRestore(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessClient) ActionUpdate(resource *ExternalHandlerProcess) (*ExternalHandlerProcess, error) {
+
+	resp := &ExternalHandlerProcess{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HANDLER_PROCESS_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_handler_process_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_handler_process_config.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE = "externalHandlerProcessConfig"
+)
+
+type ExternalHandlerProcessConfig struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	OnError string `json:"onError,omitempty" yaml:"on_error,omitempty"`
+}
+
+type ExternalHandlerProcessConfigCollection struct {
+	Collection
+	Data []ExternalHandlerProcessConfig `json:"data,omitempty"`
+}
+
+type ExternalHandlerProcessConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHandlerProcessConfigOperations interface {
+	List(opts *ListOpts) (*ExternalHandlerProcessConfigCollection, error)
+	Create(opts *ExternalHandlerProcessConfig) (*ExternalHandlerProcessConfig, error)
+	Update(existing *ExternalHandlerProcessConfig, updates interface{}) (*ExternalHandlerProcessConfig, error)
+	ById(id string) (*ExternalHandlerProcessConfig, error)
+	Delete(container *ExternalHandlerProcessConfig) error
+}
+
+func newExternalHandlerProcessConfigClient(rancherClient *RancherClient) *ExternalHandlerProcessConfigClient {
+	return &ExternalHandlerProcessConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHandlerProcessConfigClient) Create(container *ExternalHandlerProcessConfig) (*ExternalHandlerProcessConfig, error) {
+	resp := &ExternalHandlerProcessConfig{}
+	err := c.rancherClient.doCreate(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessConfigClient) Update(existing *ExternalHandlerProcessConfig, updates interface{}) (*ExternalHandlerProcessConfig, error) {
+	resp := &ExternalHandlerProcessConfig{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessConfigClient) List(opts *ListOpts) (*ExternalHandlerProcessConfigCollection, error) {
+	resp := &ExternalHandlerProcessConfigCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessConfigClient) ById(id string) (*ExternalHandlerProcessConfig, error) {
+	resp := &ExternalHandlerProcessConfig{}
+	err := c.rancherClient.doById(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHandlerProcessConfigClient) Delete(container *ExternalHandlerProcessConfig) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_host_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_host_event.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	EXTERNAL_HOST_EVENT_TYPE = "externalHostEvent"
+)
+
+type ExternalHostEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DeleteHost bool `json:"deleteHost,omitempty" yaml:"delete_host,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	HostLabel string `json:"hostLabel,omitempty" yaml:"host_label,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalHostEventCollection struct {
+	Collection
+	Data []ExternalHostEvent `json:"data,omitempty"`
+}
+
+type ExternalHostEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHostEventOperations interface {
+	List(opts *ListOpts) (*ExternalHostEventCollection, error)
+	Create(opts *ExternalHostEvent) (*ExternalHostEvent, error)
+	Update(existing *ExternalHostEvent, updates interface{}) (*ExternalHostEvent, error)
+	ById(id string) (*ExternalHostEvent, error)
+	Delete(container *ExternalHostEvent) error
+
+	ActionCreate(*ExternalHostEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalHostEvent) (*ExternalEvent, error)
+}
+
+func newExternalHostEventClient(rancherClient *RancherClient) *ExternalHostEventClient {
+	return &ExternalHostEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHostEventClient) Create(container *ExternalHostEvent) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_HOST_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) Update(existing *ExternalHostEvent, updates interface{}) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HOST_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) List(opts *ListOpts) (*ExternalHostEventCollection, error) {
+	resp := &ExternalHostEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HOST_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) ById(id string) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doById(EXTERNAL_HOST_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) Delete(container *ExternalHostEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HOST_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalHostEventClient) ActionCreate(resource *ExternalHostEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HOST_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) ActionRemove(resource *ExternalHostEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HOST_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_service.go
@@ -1,0 +1,234 @@
+package client
+
+const (
+	EXTERNAL_SERVICE_TYPE = "externalService"
+)
+
+type ExternalService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExternalIpAddresses []string `json:"externalIpAddresses,omitempty" yaml:"external_ip_addresses,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalServiceCollection struct {
+	Collection
+	Data []ExternalService `json:"data,omitempty"`
+}
+
+type ExternalServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalServiceOperations interface {
+	List(opts *ListOpts) (*ExternalServiceCollection, error)
+	Create(opts *ExternalService) (*ExternalService, error)
+	Update(existing *ExternalService, updates interface{}) (*ExternalService, error)
+	ById(id string) (*ExternalService, error)
+	Delete(container *ExternalService) error
+
+	ActionActivate(*ExternalService) (*Service, error)
+
+	ActionCancelrollback(*ExternalService) (*Service, error)
+
+	ActionCancelupgrade(*ExternalService) (*Service, error)
+
+	ActionCreate(*ExternalService) (*Service, error)
+
+	ActionDeactivate(*ExternalService) (*Service, error)
+
+	ActionFinishupgrade(*ExternalService) (*Service, error)
+
+	ActionRemove(*ExternalService) (*Service, error)
+
+	ActionRestart(*ExternalService, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*ExternalService) (*Service, error)
+
+	ActionUpdate(*ExternalService) (*Service, error)
+
+	ActionUpgrade(*ExternalService, *ServiceUpgrade) (*Service, error)
+}
+
+func newExternalServiceClient(rancherClient *RancherClient) *ExternalServiceClient {
+	return &ExternalServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalServiceClient) Create(container *ExternalService) (*ExternalService, error) {
+	resp := &ExternalService{}
+	err := c.rancherClient.doCreate(EXTERNAL_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceClient) Update(existing *ExternalService, updates interface{}) (*ExternalService, error) {
+	resp := &ExternalService{}
+	err := c.rancherClient.doUpdate(EXTERNAL_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceClient) List(opts *ListOpts) (*ExternalServiceCollection, error) {
+	resp := &ExternalServiceCollection{}
+	err := c.rancherClient.doList(EXTERNAL_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ById(id string) (*ExternalService, error) {
+	resp := &ExternalService{}
+	err := c.rancherClient.doById(EXTERNAL_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalServiceClient) Delete(container *ExternalService) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *ExternalServiceClient) ActionActivate(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionCancelrollback(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionCancelupgrade(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionCreate(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionDeactivate(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionFinishupgrade(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionRemove(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionRestart(resource *ExternalService, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionRollback(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionUpdate(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionUpgrade(resource *ExternalService, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_service_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_service_event.go
@@ -1,0 +1,115 @@
+package client
+
+const (
+	EXTERNAL_SERVICE_EVENT_TYPE = "externalServiceEvent"
+)
+
+type ExternalServiceEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Environment interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	Service interface{} `json:"service,omitempty" yaml:"service,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalServiceEventCollection struct {
+	Collection
+	Data []ExternalServiceEvent `json:"data,omitempty"`
+}
+
+type ExternalServiceEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalServiceEventOperations interface {
+	List(opts *ListOpts) (*ExternalServiceEventCollection, error)
+	Create(opts *ExternalServiceEvent) (*ExternalServiceEvent, error)
+	Update(existing *ExternalServiceEvent, updates interface{}) (*ExternalServiceEvent, error)
+	ById(id string) (*ExternalServiceEvent, error)
+	Delete(container *ExternalServiceEvent) error
+
+	ActionCreate(*ExternalServiceEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalServiceEvent) (*ExternalEvent, error)
+}
+
+func newExternalServiceEventClient(rancherClient *RancherClient) *ExternalServiceEventClient {
+	return &ExternalServiceEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalServiceEventClient) Create(container *ExternalServiceEvent) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_SERVICE_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) Update(existing *ExternalServiceEvent, updates interface{}) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_SERVICE_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) List(opts *ListOpts) (*ExternalServiceEventCollection, error) {
+	resp := &ExternalServiceEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_SERVICE_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) ById(id string) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doById(EXTERNAL_SERVICE_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) Delete(container *ExternalServiceEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_SERVICE_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalServiceEventClient) ActionCreate(resource *ExternalServiceEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) ActionRemove(resource *ExternalServiceEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_storage_pool_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_storage_pool_event.go
@@ -1,0 +1,115 @@
+package client
+
+const (
+	EXTERNAL_STORAGE_POOL_EVENT_TYPE = "externalStoragePoolEvent"
+)
+
+type ExternalStoragePoolEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HostUuids []string `json:"hostUuids,omitempty" yaml:"host_uuids,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	StoragePool StoragePool `json:"storagePool,omitempty" yaml:"storage_pool,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalStoragePoolEventCollection struct {
+	Collection
+	Data []ExternalStoragePoolEvent `json:"data,omitempty"`
+}
+
+type ExternalStoragePoolEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalStoragePoolEventOperations interface {
+	List(opts *ListOpts) (*ExternalStoragePoolEventCollection, error)
+	Create(opts *ExternalStoragePoolEvent) (*ExternalStoragePoolEvent, error)
+	Update(existing *ExternalStoragePoolEvent, updates interface{}) (*ExternalStoragePoolEvent, error)
+	ById(id string) (*ExternalStoragePoolEvent, error)
+	Delete(container *ExternalStoragePoolEvent) error
+
+	ActionCreate(*ExternalStoragePoolEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalStoragePoolEvent) (*ExternalEvent, error)
+}
+
+func newExternalStoragePoolEventClient(rancherClient *RancherClient) *ExternalStoragePoolEventClient {
+	return &ExternalStoragePoolEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalStoragePoolEventClient) Create(container *ExternalStoragePoolEvent) (*ExternalStoragePoolEvent, error) {
+	resp := &ExternalStoragePoolEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_STORAGE_POOL_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalStoragePoolEventClient) Update(existing *ExternalStoragePoolEvent, updates interface{}) (*ExternalStoragePoolEvent, error) {
+	resp := &ExternalStoragePoolEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_STORAGE_POOL_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalStoragePoolEventClient) List(opts *ListOpts) (*ExternalStoragePoolEventCollection, error) {
+	resp := &ExternalStoragePoolEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_STORAGE_POOL_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalStoragePoolEventClient) ById(id string) (*ExternalStoragePoolEvent, error) {
+	resp := &ExternalStoragePoolEvent{}
+	err := c.rancherClient.doById(EXTERNAL_STORAGE_POOL_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalStoragePoolEventClient) Delete(container *ExternalStoragePoolEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_STORAGE_POOL_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalStoragePoolEventClient) ActionCreate(resource *ExternalStoragePoolEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_STORAGE_POOL_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalStoragePoolEventClient) ActionRemove(resource *ExternalStoragePoolEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_STORAGE_POOL_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_external_volume_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_external_volume_event.go
@@ -1,0 +1,113 @@
+package client
+
+const (
+	EXTERNAL_VOLUME_EVENT_TYPE = "externalVolumeEvent"
+)
+
+type ExternalVolumeEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Volume Volume `json:"volume,omitempty" yaml:"volume,omitempty"`
+}
+
+type ExternalVolumeEventCollection struct {
+	Collection
+	Data []ExternalVolumeEvent `json:"data,omitempty"`
+}
+
+type ExternalVolumeEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalVolumeEventOperations interface {
+	List(opts *ListOpts) (*ExternalVolumeEventCollection, error)
+	Create(opts *ExternalVolumeEvent) (*ExternalVolumeEvent, error)
+	Update(existing *ExternalVolumeEvent, updates interface{}) (*ExternalVolumeEvent, error)
+	ById(id string) (*ExternalVolumeEvent, error)
+	Delete(container *ExternalVolumeEvent) error
+
+	ActionCreate(*ExternalVolumeEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalVolumeEvent) (*ExternalEvent, error)
+}
+
+func newExternalVolumeEventClient(rancherClient *RancherClient) *ExternalVolumeEventClient {
+	return &ExternalVolumeEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalVolumeEventClient) Create(container *ExternalVolumeEvent) (*ExternalVolumeEvent, error) {
+	resp := &ExternalVolumeEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_VOLUME_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalVolumeEventClient) Update(existing *ExternalVolumeEvent, updates interface{}) (*ExternalVolumeEvent, error) {
+	resp := &ExternalVolumeEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_VOLUME_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalVolumeEventClient) List(opts *ListOpts) (*ExternalVolumeEventCollection, error) {
+	resp := &ExternalVolumeEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_VOLUME_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalVolumeEventClient) ById(id string) (*ExternalVolumeEvent, error) {
+	resp := &ExternalVolumeEvent{}
+	err := c.rancherClient.doById(EXTERNAL_VOLUME_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalVolumeEventClient) Delete(container *ExternalVolumeEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_VOLUME_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalVolumeEventClient) ActionCreate(resource *ExternalVolumeEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_VOLUME_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalVolumeEventClient) ActionRemove(resource *ExternalVolumeEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_VOLUME_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_field_documentation.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_field_documentation.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	FIELD_DOCUMENTATION_TYPE = "fieldDocumentation"
+)
+
+type FieldDocumentation struct {
+	Resource
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type FieldDocumentationCollection struct {
+	Collection
+	Data []FieldDocumentation `json:"data,omitempty"`
+}
+
+type FieldDocumentationClient struct {
+	rancherClient *RancherClient
+}
+
+type FieldDocumentationOperations interface {
+	List(opts *ListOpts) (*FieldDocumentationCollection, error)
+	Create(opts *FieldDocumentation) (*FieldDocumentation, error)
+	Update(existing *FieldDocumentation, updates interface{}) (*FieldDocumentation, error)
+	ById(id string) (*FieldDocumentation, error)
+	Delete(container *FieldDocumentation) error
+}
+
+func newFieldDocumentationClient(rancherClient *RancherClient) *FieldDocumentationClient {
+	return &FieldDocumentationClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *FieldDocumentationClient) Create(container *FieldDocumentation) (*FieldDocumentation, error) {
+	resp := &FieldDocumentation{}
+	err := c.rancherClient.doCreate(FIELD_DOCUMENTATION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *FieldDocumentationClient) Update(existing *FieldDocumentation, updates interface{}) (*FieldDocumentation, error) {
+	resp := &FieldDocumentation{}
+	err := c.rancherClient.doUpdate(FIELD_DOCUMENTATION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *FieldDocumentationClient) List(opts *ListOpts) (*FieldDocumentationCollection, error) {
+	resp := &FieldDocumentationCollection{}
+	err := c.rancherClient.doList(FIELD_DOCUMENTATION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *FieldDocumentationClient) ById(id string) (*FieldDocumentation, error) {
+	resp := &FieldDocumentation{}
+	err := c.rancherClient.doById(FIELD_DOCUMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *FieldDocumentationClient) Delete(container *FieldDocumentation) error {
+	return c.rancherClient.doResourceDelete(FIELD_DOCUMENTATION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_githubconfig.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_githubconfig.go
@@ -1,0 +1,81 @@
+package client
+
+const (
+	GITHUBCONFIG_TYPE = "githubconfig"
+)
+
+type Githubconfig struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	AllowedIdentities []interface{} `json:"allowedIdentities,omitempty" yaml:"allowed_identities,omitempty"`
+
+	ClientId string `json:"clientId,omitempty" yaml:"client_id,omitempty"`
+
+	ClientSecret string `json:"clientSecret,omitempty" yaml:"client_secret,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type GithubconfigCollection struct {
+	Collection
+	Data []Githubconfig `json:"data,omitempty"`
+}
+
+type GithubconfigClient struct {
+	rancherClient *RancherClient
+}
+
+type GithubconfigOperations interface {
+	List(opts *ListOpts) (*GithubconfigCollection, error)
+	Create(opts *Githubconfig) (*Githubconfig, error)
+	Update(existing *Githubconfig, updates interface{}) (*Githubconfig, error)
+	ById(id string) (*Githubconfig, error)
+	Delete(container *Githubconfig) error
+}
+
+func newGithubconfigClient(rancherClient *RancherClient) *GithubconfigClient {
+	return &GithubconfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *GithubconfigClient) Create(container *Githubconfig) (*Githubconfig, error) {
+	resp := &Githubconfig{}
+	err := c.rancherClient.doCreate(GITHUBCONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *GithubconfigClient) Update(existing *Githubconfig, updates interface{}) (*Githubconfig, error) {
+	resp := &Githubconfig{}
+	err := c.rancherClient.doUpdate(GITHUBCONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *GithubconfigClient) List(opts *ListOpts) (*GithubconfigCollection, error) {
+	resp := &GithubconfigCollection{}
+	err := c.rancherClient.doList(GITHUBCONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *GithubconfigClient) ById(id string) (*Githubconfig, error) {
+	resp := &Githubconfig{}
+	err := c.rancherClient.doById(GITHUBCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *GithubconfigClient) Delete(container *Githubconfig) error {
+	return c.rancherClient.doResourceDelete(GITHUBCONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_ha_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_ha_config.go
@@ -1,0 +1,73 @@
+package client
+
+const (
+	HA_CONFIG_TYPE = "haConfig"
+)
+
+type HaConfig struct {
+	Resource
+
+	ClusterSize int64 `json:"clusterSize,omitempty" yaml:"cluster_size,omitempty"`
+
+	DbHost string `json:"dbHost,omitempty" yaml:"db_host,omitempty"`
+
+	DbSize int64 `json:"dbSize,omitempty" yaml:"db_size,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+type HaConfigCollection struct {
+	Collection
+	Data []HaConfig `json:"data,omitempty"`
+}
+
+type HaConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type HaConfigOperations interface {
+	List(opts *ListOpts) (*HaConfigCollection, error)
+	Create(opts *HaConfig) (*HaConfig, error)
+	Update(existing *HaConfig, updates interface{}) (*HaConfig, error)
+	ById(id string) (*HaConfig, error)
+	Delete(container *HaConfig) error
+}
+
+func newHaConfigClient(rancherClient *RancherClient) *HaConfigClient {
+	return &HaConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HaConfigClient) Create(container *HaConfig) (*HaConfig, error) {
+	resp := &HaConfig{}
+	err := c.rancherClient.doCreate(HA_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HaConfigClient) Update(existing *HaConfig, updates interface{}) (*HaConfig, error) {
+	resp := &HaConfig{}
+	err := c.rancherClient.doUpdate(HA_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HaConfigClient) List(opts *ListOpts) (*HaConfigCollection, error) {
+	resp := &HaConfigCollection{}
+	err := c.rancherClient.doList(HA_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HaConfigClient) ById(id string) (*HaConfig, error) {
+	resp := &HaConfig{}
+	err := c.rancherClient.doById(HA_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HaConfigClient) Delete(container *HaConfig) error {
+	return c.rancherClient.doResourceDelete(HA_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_ha_config_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_ha_config_input.go
@@ -1,0 +1,97 @@
+package client
+
+const (
+	HA_CONFIG_INPUT_TYPE = "haConfigInput"
+)
+
+type HaConfigInput struct {
+	Resource
+
+	Cert string `json:"cert,omitempty" yaml:"cert,omitempty"`
+
+	CertChain string `json:"certChain,omitempty" yaml:"cert_chain,omitempty"`
+
+	ClusterSize int64 `json:"clusterSize,omitempty" yaml:"cluster_size,omitempty"`
+
+	HostRegistrationUrl string `json:"hostRegistrationUrl,omitempty" yaml:"host_registration_url,omitempty"`
+
+	HttpEnabled bool `json:"httpEnabled,omitempty" yaml:"http_enabled,omitempty"`
+
+	HttpPort int64 `json:"httpPort,omitempty" yaml:"http_port,omitempty"`
+
+	HttpsPort int64 `json:"httpsPort,omitempty" yaml:"https_port,omitempty"`
+
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+
+	PpHttpPort int64 `json:"ppHttpPort,omitempty" yaml:"pp_http_port,omitempty"`
+
+	PpHttpsPort int64 `json:"ppHttpsPort,omitempty" yaml:"pp_https_port,omitempty"`
+
+	RedisPort int64 `json:"redisPort,omitempty" yaml:"redis_port,omitempty"`
+
+	SwarmEnabled bool `json:"swarmEnabled,omitempty" yaml:"swarm_enabled,omitempty"`
+
+	SwarmPort int64 `json:"swarmPort,omitempty" yaml:"swarm_port,omitempty"`
+
+	ZookeeperClientPort int64 `json:"zookeeperClientPort,omitempty" yaml:"zookeeper_client_port,omitempty"`
+
+	ZookeeperLeaderPort int64 `json:"zookeeperLeaderPort,omitempty" yaml:"zookeeper_leader_port,omitempty"`
+
+	ZookeeperQuorumPort int64 `json:"zookeeperQuorumPort,omitempty" yaml:"zookeeper_quorum_port,omitempty"`
+}
+
+type HaConfigInputCollection struct {
+	Collection
+	Data []HaConfigInput `json:"data,omitempty"`
+}
+
+type HaConfigInputClient struct {
+	rancherClient *RancherClient
+}
+
+type HaConfigInputOperations interface {
+	List(opts *ListOpts) (*HaConfigInputCollection, error)
+	Create(opts *HaConfigInput) (*HaConfigInput, error)
+	Update(existing *HaConfigInput, updates interface{}) (*HaConfigInput, error)
+	ById(id string) (*HaConfigInput, error)
+	Delete(container *HaConfigInput) error
+}
+
+func newHaConfigInputClient(rancherClient *RancherClient) *HaConfigInputClient {
+	return &HaConfigInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HaConfigInputClient) Create(container *HaConfigInput) (*HaConfigInput, error) {
+	resp := &HaConfigInput{}
+	err := c.rancherClient.doCreate(HA_CONFIG_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HaConfigInputClient) Update(existing *HaConfigInput, updates interface{}) (*HaConfigInput, error) {
+	resp := &HaConfigInput{}
+	err := c.rancherClient.doUpdate(HA_CONFIG_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HaConfigInputClient) List(opts *ListOpts) (*HaConfigInputCollection, error) {
+	resp := &HaConfigInputCollection{}
+	err := c.rancherClient.doList(HA_CONFIG_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HaConfigInputClient) ById(id string) (*HaConfigInput, error) {
+	resp := &HaConfigInput{}
+	err := c.rancherClient.doById(HA_CONFIG_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HaConfigInputClient) Delete(container *HaConfigInput) error {
+	return c.rancherClient.doResourceDelete(HA_CONFIG_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_haproxy_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_haproxy_config.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	HAPROXY_CONFIG_TYPE = "haproxyConfig"
+)
+
+type HaproxyConfig struct {
+	Resource
+
+	Defaults string `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+
+	Global string `json:"global,omitempty" yaml:"global,omitempty"`
+}
+
+type HaproxyConfigCollection struct {
+	Collection
+	Data []HaproxyConfig `json:"data,omitempty"`
+}
+
+type HaproxyConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type HaproxyConfigOperations interface {
+	List(opts *ListOpts) (*HaproxyConfigCollection, error)
+	Create(opts *HaproxyConfig) (*HaproxyConfig, error)
+	Update(existing *HaproxyConfig, updates interface{}) (*HaproxyConfig, error)
+	ById(id string) (*HaproxyConfig, error)
+	Delete(container *HaproxyConfig) error
+}
+
+func newHaproxyConfigClient(rancherClient *RancherClient) *HaproxyConfigClient {
+	return &HaproxyConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HaproxyConfigClient) Create(container *HaproxyConfig) (*HaproxyConfig, error) {
+	resp := &HaproxyConfig{}
+	err := c.rancherClient.doCreate(HAPROXY_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HaproxyConfigClient) Update(existing *HaproxyConfig, updates interface{}) (*HaproxyConfig, error) {
+	resp := &HaproxyConfig{}
+	err := c.rancherClient.doUpdate(HAPROXY_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HaproxyConfigClient) List(opts *ListOpts) (*HaproxyConfigCollection, error) {
+	resp := &HaproxyConfigCollection{}
+	err := c.rancherClient.doList(HAPROXY_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HaproxyConfigClient) ById(id string) (*HaproxyConfig, error) {
+	resp := &HaproxyConfig{}
+	err := c.rancherClient.doById(HAPROXY_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HaproxyConfigClient) Delete(container *HaproxyConfig) error {
+	return c.rancherClient.doResourceDelete(HAPROXY_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_healthcheck_instance_host_map.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_healthcheck_instance_host_map.go
@@ -1,0 +1,119 @@
+package client
+
+const (
+	HEALTHCHECK_INSTANCE_HOST_MAP_TYPE = "healthcheckInstanceHostMap"
+)
+
+type HealthcheckInstanceHostMap struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type HealthcheckInstanceHostMapCollection struct {
+	Collection
+	Data []HealthcheckInstanceHostMap `json:"data,omitempty"`
+}
+
+type HealthcheckInstanceHostMapClient struct {
+	rancherClient *RancherClient
+}
+
+type HealthcheckInstanceHostMapOperations interface {
+	List(opts *ListOpts) (*HealthcheckInstanceHostMapCollection, error)
+	Create(opts *HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error)
+	Update(existing *HealthcheckInstanceHostMap, updates interface{}) (*HealthcheckInstanceHostMap, error)
+	ById(id string) (*HealthcheckInstanceHostMap, error)
+	Delete(container *HealthcheckInstanceHostMap) error
+
+	ActionCreate(*HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error)
+
+	ActionRemove(*HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error)
+}
+
+func newHealthcheckInstanceHostMapClient(rancherClient *RancherClient) *HealthcheckInstanceHostMapClient {
+	return &HealthcheckInstanceHostMapClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HealthcheckInstanceHostMapClient) Create(container *HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error) {
+	resp := &HealthcheckInstanceHostMap{}
+	err := c.rancherClient.doCreate(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HealthcheckInstanceHostMapClient) Update(existing *HealthcheckInstanceHostMap, updates interface{}) (*HealthcheckInstanceHostMap, error) {
+	resp := &HealthcheckInstanceHostMap{}
+	err := c.rancherClient.doUpdate(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HealthcheckInstanceHostMapClient) List(opts *ListOpts) (*HealthcheckInstanceHostMapCollection, error) {
+	resp := &HealthcheckInstanceHostMapCollection{}
+	err := c.rancherClient.doList(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HealthcheckInstanceHostMapClient) ById(id string) (*HealthcheckInstanceHostMap, error) {
+	resp := &HealthcheckInstanceHostMap{}
+	err := c.rancherClient.doById(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HealthcheckInstanceHostMapClient) Delete(container *HealthcheckInstanceHostMap) error {
+	return c.rancherClient.doResourceDelete(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, &container.Resource)
+}
+
+func (c *HealthcheckInstanceHostMapClient) ActionCreate(resource *HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error) {
+
+	resp := &HealthcheckInstanceHostMap{}
+
+	err := c.rancherClient.doAction(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HealthcheckInstanceHostMapClient) ActionRemove(resource *HealthcheckInstanceHostMap) (*HealthcheckInstanceHostMap, error) {
+
+	resp := &HealthcheckInstanceHostMap{}
+
+	err := c.rancherClient.doAction(HEALTHCHECK_INSTANCE_HOST_MAP_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_host.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_host.go
@@ -1,0 +1,197 @@
+package client
+
+const (
+	HOST_TYPE = "host"
+)
+
+type Host struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AgentState string `json:"agentState,omitempty" yaml:"agent_state,omitempty"`
+
+	ApiProxy string `json:"apiProxy,omitempty" yaml:"api_proxy,omitempty"`
+
+	ComputeTotal int64 `json:"computeTotal,omitempty" yaml:"compute_total,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	Info interface{} `json:"info,omitempty" yaml:"info,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PhysicalHostId string `json:"physicalHostId,omitempty" yaml:"physical_host_id,omitempty"`
+
+	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type HostCollection struct {
+	Collection
+	Data []Host `json:"data,omitempty"`
+}
+
+type HostClient struct {
+	rancherClient *RancherClient
+}
+
+type HostOperations interface {
+	List(opts *ListOpts) (*HostCollection, error)
+	Create(opts *Host) (*Host, error)
+	Update(existing *Host, updates interface{}) (*Host, error)
+	ById(id string) (*Host, error)
+	Delete(container *Host) error
+
+	ActionActivate(*Host) (*Host, error)
+
+	ActionCreate(*Host) (*Host, error)
+
+	ActionDeactivate(*Host) (*Host, error)
+
+	ActionDockersocket(*Host) (*HostAccess, error)
+
+	ActionPurge(*Host) (*Host, error)
+
+	ActionRemove(*Host) (*Host, error)
+
+	ActionRestore(*Host) (*Host, error)
+
+	ActionUpdate(*Host) (*Host, error)
+}
+
+func newHostClient(rancherClient *RancherClient) *HostClient {
+	return &HostClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HostClient) Create(container *Host) (*Host, error) {
+	resp := &Host{}
+	err := c.rancherClient.doCreate(HOST_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HostClient) Update(existing *Host, updates interface{}) (*Host, error) {
+	resp := &Host{}
+	err := c.rancherClient.doUpdate(HOST_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HostClient) List(opts *ListOpts) (*HostCollection, error) {
+	resp := &HostCollection{}
+	err := c.rancherClient.doList(HOST_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HostClient) ById(id string) (*Host, error) {
+	resp := &Host{}
+	err := c.rancherClient.doById(HOST_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HostClient) Delete(container *Host) error {
+	return c.rancherClient.doResourceDelete(HOST_TYPE, &container.Resource)
+}
+
+func (c *HostClient) ActionActivate(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionCreate(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionDeactivate(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionDockersocket(resource *Host) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "dockersocket", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionPurge(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionRemove(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionRestore(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionUpdate(resource *Host) (*Host, error) {
+
+	resp := &Host{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_host_access.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_host_access.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	HOST_ACCESS_TYPE = "hostAccess"
+)
+
+type HostAccess struct {
+	Resource
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type HostAccessCollection struct {
+	Collection
+	Data []HostAccess `json:"data,omitempty"`
+}
+
+type HostAccessClient struct {
+	rancherClient *RancherClient
+}
+
+type HostAccessOperations interface {
+	List(opts *ListOpts) (*HostAccessCollection, error)
+	Create(opts *HostAccess) (*HostAccess, error)
+	Update(existing *HostAccess, updates interface{}) (*HostAccess, error)
+	ById(id string) (*HostAccess, error)
+	Delete(container *HostAccess) error
+}
+
+func newHostAccessClient(rancherClient *RancherClient) *HostAccessClient {
+	return &HostAccessClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HostAccessClient) Create(container *HostAccess) (*HostAccess, error) {
+	resp := &HostAccess{}
+	err := c.rancherClient.doCreate(HOST_ACCESS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HostAccessClient) Update(existing *HostAccess, updates interface{}) (*HostAccess, error) {
+	resp := &HostAccess{}
+	err := c.rancherClient.doUpdate(HOST_ACCESS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HostAccessClient) List(opts *ListOpts) (*HostAccessCollection, error) {
+	resp := &HostAccessCollection{}
+	err := c.rancherClient.doList(HOST_ACCESS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HostAccessClient) ById(id string) (*HostAccess, error) {
+	resp := &HostAccess{}
+	err := c.rancherClient.doById(HOST_ACCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HostAccessClient) Delete(container *HostAccess) error {
+	return c.rancherClient.doResourceDelete(HOST_ACCESS_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_host_api_proxy_token.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_host_api_proxy_token.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	HOST_API_PROXY_TOKEN_TYPE = "hostApiProxyToken"
+)
+
+type HostApiProxyToken struct {
+	Resource
+
+	ReportedUuid string `json:"reportedUuid,omitempty" yaml:"reported_uuid,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type HostApiProxyTokenCollection struct {
+	Collection
+	Data []HostApiProxyToken `json:"data,omitempty"`
+}
+
+type HostApiProxyTokenClient struct {
+	rancherClient *RancherClient
+}
+
+type HostApiProxyTokenOperations interface {
+	List(opts *ListOpts) (*HostApiProxyTokenCollection, error)
+	Create(opts *HostApiProxyToken) (*HostApiProxyToken, error)
+	Update(existing *HostApiProxyToken, updates interface{}) (*HostApiProxyToken, error)
+	ById(id string) (*HostApiProxyToken, error)
+	Delete(container *HostApiProxyToken) error
+}
+
+func newHostApiProxyTokenClient(rancherClient *RancherClient) *HostApiProxyTokenClient {
+	return &HostApiProxyTokenClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *HostApiProxyTokenClient) Create(container *HostApiProxyToken) (*HostApiProxyToken, error) {
+	resp := &HostApiProxyToken{}
+	err := c.rancherClient.doCreate(HOST_API_PROXY_TOKEN_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *HostApiProxyTokenClient) Update(existing *HostApiProxyToken, updates interface{}) (*HostApiProxyToken, error) {
+	resp := &HostApiProxyToken{}
+	err := c.rancherClient.doUpdate(HOST_API_PROXY_TOKEN_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *HostApiProxyTokenClient) List(opts *ListOpts) (*HostApiProxyTokenCollection, error) {
+	resp := &HostApiProxyTokenCollection{}
+	err := c.rancherClient.doList(HOST_API_PROXY_TOKEN_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *HostApiProxyTokenClient) ById(id string) (*HostApiProxyToken, error) {
+	resp := &HostApiProxyToken{}
+	err := c.rancherClient.doById(HOST_API_PROXY_TOKEN_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *HostApiProxyTokenClient) Delete(container *HostApiProxyToken) error {
+	return c.rancherClient.doResourceDelete(HOST_API_PROXY_TOKEN_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_identity.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_identity.go
@@ -1,0 +1,83 @@
+package client
+
+const (
+	IDENTITY_TYPE = "identity"
+)
+
+type Identity struct {
+	Resource
+
+	All string `json:"all,omitempty" yaml:"all,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExternalIdType string `json:"externalIdType,omitempty" yaml:"external_id_type,omitempty"`
+
+	Login string `json:"login,omitempty" yaml:"login,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	ProfilePicture string `json:"profilePicture,omitempty" yaml:"profile_picture,omitempty"`
+
+	ProfileUrl string `json:"profileUrl,omitempty" yaml:"profile_url,omitempty"`
+
+	ProjectId string `json:"projectId,omitempty" yaml:"project_id,omitempty"`
+
+	Role string `json:"role,omitempty" yaml:"role,omitempty"`
+}
+
+type IdentityCollection struct {
+	Collection
+	Data []Identity `json:"data,omitempty"`
+}
+
+type IdentityClient struct {
+	rancherClient *RancherClient
+}
+
+type IdentityOperations interface {
+	List(opts *ListOpts) (*IdentityCollection, error)
+	Create(opts *Identity) (*Identity, error)
+	Update(existing *Identity, updates interface{}) (*Identity, error)
+	ById(id string) (*Identity, error)
+	Delete(container *Identity) error
+}
+
+func newIdentityClient(rancherClient *RancherClient) *IdentityClient {
+	return &IdentityClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *IdentityClient) Create(container *Identity) (*Identity, error) {
+	resp := &Identity{}
+	err := c.rancherClient.doCreate(IDENTITY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *IdentityClient) Update(existing *Identity, updates interface{}) (*Identity, error) {
+	resp := &Identity{}
+	err := c.rancherClient.doUpdate(IDENTITY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *IdentityClient) List(opts *ListOpts) (*IdentityCollection, error) {
+	resp := &IdentityCollection{}
+	err := c.rancherClient.doList(IDENTITY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *IdentityClient) ById(id string) (*Identity, error) {
+	resp := &Identity{}
+	err := c.rancherClient.doById(IDENTITY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *IdentityClient) Delete(container *Identity) error {
+	return c.rancherClient.doResourceDelete(IDENTITY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_image.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_image.go
@@ -1,0 +1,168 @@
+package client
+
+const (
+	IMAGE_TYPE = "image"
+)
+
+type Image struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ImageCollection struct {
+	Collection
+	Data []Image `json:"data,omitempty"`
+}
+
+type ImageClient struct {
+	rancherClient *RancherClient
+}
+
+type ImageOperations interface {
+	List(opts *ListOpts) (*ImageCollection, error)
+	Create(opts *Image) (*Image, error)
+	Update(existing *Image, updates interface{}) (*Image, error)
+	ById(id string) (*Image, error)
+	Delete(container *Image) error
+
+	ActionActivate(*Image) (*Image, error)
+
+	ActionCreate(*Image) (*Image, error)
+
+	ActionDeactivate(*Image) (*Image, error)
+
+	ActionPurge(*Image) (*Image, error)
+
+	ActionRemove(*Image) (*Image, error)
+
+	ActionRestore(*Image) (*Image, error)
+
+	ActionUpdate(*Image) (*Image, error)
+}
+
+func newImageClient(rancherClient *RancherClient) *ImageClient {
+	return &ImageClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ImageClient) Create(container *Image) (*Image, error) {
+	resp := &Image{}
+	err := c.rancherClient.doCreate(IMAGE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ImageClient) Update(existing *Image, updates interface{}) (*Image, error) {
+	resp := &Image{}
+	err := c.rancherClient.doUpdate(IMAGE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ImageClient) List(opts *ListOpts) (*ImageCollection, error) {
+	resp := &ImageCollection{}
+	err := c.rancherClient.doList(IMAGE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ImageClient) ById(id string) (*Image, error) {
+	resp := &Image{}
+	err := c.rancherClient.doById(IMAGE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ImageClient) Delete(container *Image) error {
+	return c.rancherClient.doResourceDelete(IMAGE_TYPE, &container.Resource)
+}
+
+func (c *ImageClient) ActionActivate(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionCreate(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionDeactivate(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionPurge(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionRemove(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionRestore(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ImageClient) ActionUpdate(resource *Image) (*Image, error) {
+
+	resp := &Image{}
+
+	err := c.rancherClient.doAction(IMAGE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_in_service_upgrade_strategy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_in_service_upgrade_strategy.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	IN_SERVICE_UPGRADE_STRATEGY_TYPE = "inServiceUpgradeStrategy"
+)
+
+type InServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	PreviousLaunchConfig *LaunchConfig `json:"previousLaunchConfig,omitempty" yaml:"previous_launch_config,omitempty"`
+
+	PreviousSecondaryLaunchConfigs []interface{} `json:"previousSecondaryLaunchConfigs,omitempty" yaml:"previous_secondary_launch_configs,omitempty"`
+
+	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
+
+	StartFirst bool `json:"startFirst,omitempty" yaml:"start_first,omitempty"`
+}
+
+type InServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []InServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type InServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type InServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*InServiceUpgradeStrategyCollection, error)
+	Create(opts *InServiceUpgradeStrategy) (*InServiceUpgradeStrategy, error)
+	Update(existing *InServiceUpgradeStrategy, updates interface{}) (*InServiceUpgradeStrategy, error)
+	ById(id string) (*InServiceUpgradeStrategy, error)
+	Delete(container *InServiceUpgradeStrategy) error
+}
+
+func newInServiceUpgradeStrategyClient(rancherClient *RancherClient) *InServiceUpgradeStrategyClient {
+	return &InServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InServiceUpgradeStrategyClient) Create(container *InServiceUpgradeStrategy) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(IN_SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) Update(existing *InServiceUpgradeStrategy, updates interface{}) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(IN_SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) List(opts *ListOpts) (*InServiceUpgradeStrategyCollection, error) {
+	resp := &InServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(IN_SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) ById(id string) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(IN_SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) Delete(container *InServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(IN_SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance.go
@@ -1,0 +1,271 @@
+package client
+
+const (
+	INSTANCE_TYPE = "instance"
+)
+
+type Instance struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type InstanceCollection struct {
+	Collection
+	Data []Instance `json:"data,omitempty"`
+}
+
+type InstanceClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceOperations interface {
+	List(opts *ListOpts) (*InstanceCollection, error)
+	Create(opts *Instance) (*Instance, error)
+	Update(existing *Instance, updates interface{}) (*Instance, error)
+	ById(id string) (*Instance, error)
+	Delete(container *Instance) error
+
+	ActionAllocate(*Instance) (*Instance, error)
+
+	ActionConsole(*Instance, *InstanceConsoleInput) (*InstanceConsole, error)
+
+	ActionCreate(*Instance) (*Instance, error)
+
+	ActionDeallocate(*Instance) (*Instance, error)
+
+	ActionError(*Instance) (*Instance, error)
+
+	ActionMigrate(*Instance) (*Instance, error)
+
+	ActionPurge(*Instance) (*Instance, error)
+
+	ActionRemove(*Instance) (*Instance, error)
+
+	ActionRestart(*Instance) (*Instance, error)
+
+	ActionRestore(*Instance) (*Instance, error)
+
+	ActionStart(*Instance) (*Instance, error)
+
+	ActionStop(*Instance, *InstanceStop) (*Instance, error)
+
+	ActionUpdate(*Instance) (*Instance, error)
+
+	ActionUpdatehealthy(*Instance) (*Instance, error)
+
+	ActionUpdatereinitializing(*Instance) (*Instance, error)
+
+	ActionUpdateunhealthy(*Instance) (*Instance, error)
+}
+
+func newInstanceClient(rancherClient *RancherClient) *InstanceClient {
+	return &InstanceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceClient) Create(container *Instance) (*Instance, error) {
+	resp := &Instance{}
+	err := c.rancherClient.doCreate(INSTANCE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceClient) Update(existing *Instance, updates interface{}) (*Instance, error) {
+	resp := &Instance{}
+	err := c.rancherClient.doUpdate(INSTANCE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceClient) List(opts *ListOpts) (*InstanceCollection, error) {
+	resp := &InstanceCollection{}
+	err := c.rancherClient.doList(INSTANCE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceClient) ById(id string) (*Instance, error) {
+	resp := &Instance{}
+	err := c.rancherClient.doById(INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceClient) Delete(container *Instance) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_TYPE, &container.Resource)
+}
+
+func (c *InstanceClient) ActionAllocate(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionConsole(resource *Instance, input *InstanceConsoleInput) (*InstanceConsole, error) {
+
+	resp := &InstanceConsole{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "console", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionCreate(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionDeallocate(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionError(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionMigrate(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionPurge(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionRemove(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionRestart(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "restart", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionRestore(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionStart(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "start", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionStop(resource *Instance, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionUpdate(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionUpdatehealthy(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "updatehealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionUpdatereinitializing(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "updatereinitializing", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionUpdateunhealthy(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "updateunhealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance_console.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance_console.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	INSTANCE_CONSOLE_TYPE = "instanceConsole"
+)
+
+type InstanceConsole struct {
+	Resource
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type InstanceConsoleCollection struct {
+	Collection
+	Data []InstanceConsole `json:"data,omitempty"`
+}
+
+type InstanceConsoleClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceConsoleOperations interface {
+	List(opts *ListOpts) (*InstanceConsoleCollection, error)
+	Create(opts *InstanceConsole) (*InstanceConsole, error)
+	Update(existing *InstanceConsole, updates interface{}) (*InstanceConsole, error)
+	ById(id string) (*InstanceConsole, error)
+	Delete(container *InstanceConsole) error
+}
+
+func newInstanceConsoleClient(rancherClient *RancherClient) *InstanceConsoleClient {
+	return &InstanceConsoleClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceConsoleClient) Create(container *InstanceConsole) (*InstanceConsole, error) {
+	resp := &InstanceConsole{}
+	err := c.rancherClient.doCreate(INSTANCE_CONSOLE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleClient) Update(existing *InstanceConsole, updates interface{}) (*InstanceConsole, error) {
+	resp := &InstanceConsole{}
+	err := c.rancherClient.doUpdate(INSTANCE_CONSOLE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleClient) List(opts *ListOpts) (*InstanceConsoleCollection, error) {
+	resp := &InstanceConsoleCollection{}
+	err := c.rancherClient.doList(INSTANCE_CONSOLE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleClient) ById(id string) (*InstanceConsole, error) {
+	resp := &InstanceConsole{}
+	err := c.rancherClient.doById(INSTANCE_CONSOLE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceConsoleClient) Delete(container *InstanceConsole) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_CONSOLE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance_console_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance_console_input.go
@@ -1,0 +1,65 @@
+package client
+
+const (
+	INSTANCE_CONSOLE_INPUT_TYPE = "instanceConsoleInput"
+)
+
+type InstanceConsoleInput struct {
+	Resource
+}
+
+type InstanceConsoleInputCollection struct {
+	Collection
+	Data []InstanceConsoleInput `json:"data,omitempty"`
+}
+
+type InstanceConsoleInputClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceConsoleInputOperations interface {
+	List(opts *ListOpts) (*InstanceConsoleInputCollection, error)
+	Create(opts *InstanceConsoleInput) (*InstanceConsoleInput, error)
+	Update(existing *InstanceConsoleInput, updates interface{}) (*InstanceConsoleInput, error)
+	ById(id string) (*InstanceConsoleInput, error)
+	Delete(container *InstanceConsoleInput) error
+}
+
+func newInstanceConsoleInputClient(rancherClient *RancherClient) *InstanceConsoleInputClient {
+	return &InstanceConsoleInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceConsoleInputClient) Create(container *InstanceConsoleInput) (*InstanceConsoleInput, error) {
+	resp := &InstanceConsoleInput{}
+	err := c.rancherClient.doCreate(INSTANCE_CONSOLE_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleInputClient) Update(existing *InstanceConsoleInput, updates interface{}) (*InstanceConsoleInput, error) {
+	resp := &InstanceConsoleInput{}
+	err := c.rancherClient.doUpdate(INSTANCE_CONSOLE_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleInputClient) List(opts *ListOpts) (*InstanceConsoleInputCollection, error) {
+	resp := &InstanceConsoleInputCollection{}
+	err := c.rancherClient.doList(INSTANCE_CONSOLE_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceConsoleInputClient) ById(id string) (*InstanceConsoleInput, error) {
+	resp := &InstanceConsoleInput{}
+	err := c.rancherClient.doById(INSTANCE_CONSOLE_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceConsoleInputClient) Delete(container *InstanceConsoleInput) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_CONSOLE_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance_health_check.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance_health_check.go
@@ -1,0 +1,87 @@
+package client
+
+const (
+	INSTANCE_HEALTH_CHECK_TYPE = "instanceHealthCheck"
+)
+
+type InstanceHealthCheck struct {
+	Resource
+
+	HealthyThreshold int64 `json:"healthyThreshold,omitempty" yaml:"healthy_threshold,omitempty"`
+
+	InitializingTimeout int64 `json:"initializingTimeout,omitempty" yaml:"initializing_timeout,omitempty"`
+
+	Interval int64 `json:"interval,omitempty" yaml:"interval,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	RecreateOnQuorumStrategyConfig *RecreateOnQuorumStrategyConfig `json:"recreateOnQuorumStrategyConfig,omitempty" yaml:"recreate_on_quorum_strategy_config,omitempty"`
+
+	ReinitializingTimeout int64 `json:"reinitializingTimeout,omitempty" yaml:"reinitializing_timeout,omitempty"`
+
+	RequestLine string `json:"requestLine,omitempty" yaml:"request_line,omitempty"`
+
+	ResponseTimeout int64 `json:"responseTimeout,omitempty" yaml:"response_timeout,omitempty"`
+
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+
+	UnhealthyThreshold int64 `json:"unhealthyThreshold,omitempty" yaml:"unhealthy_threshold,omitempty"`
+}
+
+type InstanceHealthCheckCollection struct {
+	Collection
+	Data []InstanceHealthCheck `json:"data,omitempty"`
+}
+
+type InstanceHealthCheckClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceHealthCheckOperations interface {
+	List(opts *ListOpts) (*InstanceHealthCheckCollection, error)
+	Create(opts *InstanceHealthCheck) (*InstanceHealthCheck, error)
+	Update(existing *InstanceHealthCheck, updates interface{}) (*InstanceHealthCheck, error)
+	ById(id string) (*InstanceHealthCheck, error)
+	Delete(container *InstanceHealthCheck) error
+}
+
+func newInstanceHealthCheckClient(rancherClient *RancherClient) *InstanceHealthCheckClient {
+	return &InstanceHealthCheckClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceHealthCheckClient) Create(container *InstanceHealthCheck) (*InstanceHealthCheck, error) {
+	resp := &InstanceHealthCheck{}
+	err := c.rancherClient.doCreate(INSTANCE_HEALTH_CHECK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceHealthCheckClient) Update(existing *InstanceHealthCheck, updates interface{}) (*InstanceHealthCheck, error) {
+	resp := &InstanceHealthCheck{}
+	err := c.rancherClient.doUpdate(INSTANCE_HEALTH_CHECK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceHealthCheckClient) List(opts *ListOpts) (*InstanceHealthCheckCollection, error) {
+	resp := &InstanceHealthCheckCollection{}
+	err := c.rancherClient.doList(INSTANCE_HEALTH_CHECK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceHealthCheckClient) ById(id string) (*InstanceHealthCheck, error) {
+	resp := &InstanceHealthCheck{}
+	err := c.rancherClient.doById(INSTANCE_HEALTH_CHECK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceHealthCheckClient) Delete(container *InstanceHealthCheck) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_HEALTH_CHECK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance_link.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance_link.go
@@ -1,0 +1,176 @@
+package client
+
+const (
+	INSTANCE_LINK_TYPE = "instanceLink"
+)
+
+type InstanceLink struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LinkName string `json:"linkName,omitempty" yaml:"link_name,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Ports []interface{} `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	TargetInstanceId string `json:"targetInstanceId,omitempty" yaml:"target_instance_id,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type InstanceLinkCollection struct {
+	Collection
+	Data []InstanceLink `json:"data,omitempty"`
+}
+
+type InstanceLinkClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceLinkOperations interface {
+	List(opts *ListOpts) (*InstanceLinkCollection, error)
+	Create(opts *InstanceLink) (*InstanceLink, error)
+	Update(existing *InstanceLink, updates interface{}) (*InstanceLink, error)
+	ById(id string) (*InstanceLink, error)
+	Delete(container *InstanceLink) error
+
+	ActionActivate(*InstanceLink) (*InstanceLink, error)
+
+	ActionCreate(*InstanceLink) (*InstanceLink, error)
+
+	ActionDeactivate(*InstanceLink) (*InstanceLink, error)
+
+	ActionPurge(*InstanceLink) (*InstanceLink, error)
+
+	ActionRemove(*InstanceLink) (*InstanceLink, error)
+
+	ActionRestore(*InstanceLink) (*InstanceLink, error)
+
+	ActionUpdate(*InstanceLink) (*InstanceLink, error)
+}
+
+func newInstanceLinkClient(rancherClient *RancherClient) *InstanceLinkClient {
+	return &InstanceLinkClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceLinkClient) Create(container *InstanceLink) (*InstanceLink, error) {
+	resp := &InstanceLink{}
+	err := c.rancherClient.doCreate(INSTANCE_LINK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceLinkClient) Update(existing *InstanceLink, updates interface{}) (*InstanceLink, error) {
+	resp := &InstanceLink{}
+	err := c.rancherClient.doUpdate(INSTANCE_LINK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceLinkClient) List(opts *ListOpts) (*InstanceLinkCollection, error) {
+	resp := &InstanceLinkCollection{}
+	err := c.rancherClient.doList(INSTANCE_LINK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ById(id string) (*InstanceLink, error) {
+	resp := &InstanceLink{}
+	err := c.rancherClient.doById(INSTANCE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceLinkClient) Delete(container *InstanceLink) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_LINK_TYPE, &container.Resource)
+}
+
+func (c *InstanceLinkClient) ActionActivate(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionCreate(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionDeactivate(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionPurge(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionRemove(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionRestore(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceLinkClient) ActionUpdate(resource *InstanceLink) (*InstanceLink, error) {
+
+	resp := &InstanceLink{}
+
+	err := c.rancherClient.doAction(INSTANCE_LINK_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_instance_stop.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_instance_stop.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	INSTANCE_STOP_TYPE = "instanceStop"
+)
+
+type InstanceStop struct {
+	Resource
+
+	Remove bool `json:"remove,omitempty" yaml:"remove,omitempty"`
+
+	Timeout int64 `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+type InstanceStopCollection struct {
+	Collection
+	Data []InstanceStop `json:"data,omitempty"`
+}
+
+type InstanceStopClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceStopOperations interface {
+	List(opts *ListOpts) (*InstanceStopCollection, error)
+	Create(opts *InstanceStop) (*InstanceStop, error)
+	Update(existing *InstanceStop, updates interface{}) (*InstanceStop, error)
+	ById(id string) (*InstanceStop, error)
+	Delete(container *InstanceStop) error
+}
+
+func newInstanceStopClient(rancherClient *RancherClient) *InstanceStopClient {
+	return &InstanceStopClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceStopClient) Create(container *InstanceStop) (*InstanceStop, error) {
+	resp := &InstanceStop{}
+	err := c.rancherClient.doCreate(INSTANCE_STOP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceStopClient) Update(existing *InstanceStop, updates interface{}) (*InstanceStop, error) {
+	resp := &InstanceStop{}
+	err := c.rancherClient.doUpdate(INSTANCE_STOP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceStopClient) List(opts *ListOpts) (*InstanceStopCollection, error) {
+	resp := &InstanceStopCollection{}
+	err := c.rancherClient.doList(INSTANCE_STOP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InstanceStopClient) ById(id string) (*InstanceStop, error) {
+	resp := &InstanceStop{}
+	err := c.rancherClient.doById(INSTANCE_STOP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceStopClient) Delete(container *InstanceStop) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_STOP_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_ip_address.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_ip_address.go
@@ -1,0 +1,183 @@
+package client
+
+const (
+	IP_ADDRESS_TYPE = "ipAddress"
+)
+
+type IpAddress struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NetworkId string `json:"networkId,omitempty" yaml:"network_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type IpAddressCollection struct {
+	Collection
+	Data []IpAddress `json:"data,omitempty"`
+}
+
+type IpAddressClient struct {
+	rancherClient *RancherClient
+}
+
+type IpAddressOperations interface {
+	List(opts *ListOpts) (*IpAddressCollection, error)
+	Create(opts *IpAddress) (*IpAddress, error)
+	Update(existing *IpAddress, updates interface{}) (*IpAddress, error)
+	ById(id string) (*IpAddress, error)
+	Delete(container *IpAddress) error
+
+	ActionActivate(*IpAddress) (*IpAddress, error)
+
+	ActionCreate(*IpAddress) (*IpAddress, error)
+
+	ActionDeactivate(*IpAddress) (*IpAddress, error)
+
+	ActionDisassociate(*IpAddress) (*IpAddress, error)
+
+	ActionPurge(*IpAddress) (*IpAddress, error)
+
+	ActionRemove(*IpAddress) (*IpAddress, error)
+
+	ActionRestore(*IpAddress) (*IpAddress, error)
+
+	ActionUpdate(*IpAddress) (*IpAddress, error)
+}
+
+func newIpAddressClient(rancherClient *RancherClient) *IpAddressClient {
+	return &IpAddressClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *IpAddressClient) Create(container *IpAddress) (*IpAddress, error) {
+	resp := &IpAddress{}
+	err := c.rancherClient.doCreate(IP_ADDRESS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *IpAddressClient) Update(existing *IpAddress, updates interface{}) (*IpAddress, error) {
+	resp := &IpAddress{}
+	err := c.rancherClient.doUpdate(IP_ADDRESS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *IpAddressClient) List(opts *ListOpts) (*IpAddressCollection, error) {
+	resp := &IpAddressCollection{}
+	err := c.rancherClient.doList(IP_ADDRESS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *IpAddressClient) ById(id string) (*IpAddress, error) {
+	resp := &IpAddress{}
+	err := c.rancherClient.doById(IP_ADDRESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *IpAddressClient) Delete(container *IpAddress) error {
+	return c.rancherClient.doResourceDelete(IP_ADDRESS_TYPE, &container.Resource)
+}
+
+func (c *IpAddressClient) ActionActivate(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionCreate(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionDeactivate(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionDisassociate(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "disassociate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionPurge(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionRemove(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionRestore(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *IpAddressClient) ActionUpdate(resource *IpAddress) (*IpAddress, error) {
+
+	resp := &IpAddress{}
+
+	err := c.rancherClient.doAction(IP_ADDRESS_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_ip_address_associate_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_ip_address_associate_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	IP_ADDRESS_ASSOCIATE_INPUT_TYPE = "ipAddressAssociateInput"
+)
+
+type IpAddressAssociateInput struct {
+	Resource
+
+	IpAddressId string `json:"ipAddressId,omitempty" yaml:"ip_address_id,omitempty"`
+}
+
+type IpAddressAssociateInputCollection struct {
+	Collection
+	Data []IpAddressAssociateInput `json:"data,omitempty"`
+}
+
+type IpAddressAssociateInputClient struct {
+	rancherClient *RancherClient
+}
+
+type IpAddressAssociateInputOperations interface {
+	List(opts *ListOpts) (*IpAddressAssociateInputCollection, error)
+	Create(opts *IpAddressAssociateInput) (*IpAddressAssociateInput, error)
+	Update(existing *IpAddressAssociateInput, updates interface{}) (*IpAddressAssociateInput, error)
+	ById(id string) (*IpAddressAssociateInput, error)
+	Delete(container *IpAddressAssociateInput) error
+}
+
+func newIpAddressAssociateInputClient(rancherClient *RancherClient) *IpAddressAssociateInputClient {
+	return &IpAddressAssociateInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *IpAddressAssociateInputClient) Create(container *IpAddressAssociateInput) (*IpAddressAssociateInput, error) {
+	resp := &IpAddressAssociateInput{}
+	err := c.rancherClient.doCreate(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *IpAddressAssociateInputClient) Update(existing *IpAddressAssociateInput, updates interface{}) (*IpAddressAssociateInput, error) {
+	resp := &IpAddressAssociateInput{}
+	err := c.rancherClient.doUpdate(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *IpAddressAssociateInputClient) List(opts *ListOpts) (*IpAddressAssociateInputCollection, error) {
+	resp := &IpAddressAssociateInputCollection{}
+	err := c.rancherClient.doList(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *IpAddressAssociateInputClient) ById(id string) (*IpAddressAssociateInput, error) {
+	resp := &IpAddressAssociateInput{}
+	err := c.rancherClient.doById(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *IpAddressAssociateInputClient) Delete(container *IpAddressAssociateInput) error {
+	return c.rancherClient.doResourceDelete(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_service.go
@@ -1,0 +1,257 @@
+package client
+
+const (
+	KUBERNETES_SERVICE_TYPE = "kubernetesService"
+)
+
+type KubernetesService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Template interface{} `json:"template,omitempty" yaml:"template,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vip string `json:"vip,omitempty" yaml:"vip,omitempty"`
+}
+
+type KubernetesServiceCollection struct {
+	Collection
+	Data []KubernetesService `json:"data,omitempty"`
+}
+
+type KubernetesServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type KubernetesServiceOperations interface {
+	List(opts *ListOpts) (*KubernetesServiceCollection, error)
+	Create(opts *KubernetesService) (*KubernetesService, error)
+	Update(existing *KubernetesService, updates interface{}) (*KubernetesService, error)
+	ById(id string) (*KubernetesService, error)
+	Delete(container *KubernetesService) error
+
+	ActionActivate(*KubernetesService) (*Service, error)
+
+	ActionAddservicelink(*KubernetesService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionCancelrollback(*KubernetesService) (*Service, error)
+
+	ActionCancelupgrade(*KubernetesService) (*Service, error)
+
+	ActionCreate(*KubernetesService) (*Service, error)
+
+	ActionDeactivate(*KubernetesService) (*Service, error)
+
+	ActionFinishupgrade(*KubernetesService) (*Service, error)
+
+	ActionRemove(*KubernetesService) (*Service, error)
+
+	ActionRemoveservicelink(*KubernetesService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRestart(*KubernetesService, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*KubernetesService) (*Service, error)
+
+	ActionSetservicelinks(*KubernetesService, *SetServiceLinksInput) (*Service, error)
+
+	ActionUpdate(*KubernetesService) (*Service, error)
+
+	ActionUpgrade(*KubernetesService, *ServiceUpgrade) (*Service, error)
+}
+
+func newKubernetesServiceClient(rancherClient *RancherClient) *KubernetesServiceClient {
+	return &KubernetesServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *KubernetesServiceClient) Create(container *KubernetesService) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doCreate(KUBERNETES_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) Update(existing *KubernetesService, updates interface{}) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doUpdate(KUBERNETES_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) List(opts *ListOpts) (*KubernetesServiceCollection, error) {
+	resp := &KubernetesServiceCollection{}
+	err := c.rancherClient.doList(KUBERNETES_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ById(id string) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doById(KUBERNETES_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) Delete(container *KubernetesService) error {
+	return c.rancherClient.doResourceDelete(KUBERNETES_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *KubernetesServiceClient) ActionActivate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionAddservicelink(resource *KubernetesService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCancelrollback(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCancelupgrade(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCreate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionDeactivate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionFinishupgrade(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRemove(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRemoveservicelink(resource *KubernetesService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRestart(resource *KubernetesService, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRollback(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionSetservicelinks(resource *KubernetesService, input *SetServiceLinksInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "setservicelinks", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionUpdate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionUpgrade(resource *KubernetesService, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_stack.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_stack.go
@@ -1,0 +1,193 @@
+package client
+
+const (
+	KUBERNETES_STACK_TYPE = "kubernetesStack"
+)
+
+type KubernetesStack struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+
+	PreviousEnvironment map[string]interface{} `json:"previousEnvironment,omitempty" yaml:"previous_environment,omitempty"`
+
+	PreviousExternalId string `json:"previousExternalId,omitempty" yaml:"previous_external_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Templates map[string]interface{} `json:"templates,omitempty" yaml:"templates,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type KubernetesStackCollection struct {
+	Collection
+	Data []KubernetesStack `json:"data,omitempty"`
+}
+
+type KubernetesStackClient struct {
+	rancherClient *RancherClient
+}
+
+type KubernetesStackOperations interface {
+	List(opts *ListOpts) (*KubernetesStackCollection, error)
+	Create(opts *KubernetesStack) (*KubernetesStack, error)
+	Update(existing *KubernetesStack, updates interface{}) (*KubernetesStack, error)
+	ById(id string) (*KubernetesStack, error)
+	Delete(container *KubernetesStack) error
+
+	ActionCancelrollback(*KubernetesStack) (*Environment, error)
+
+	ActionCancelupgrade(*KubernetesStack) (*Environment, error)
+
+	ActionCreate(*KubernetesStack) (*Environment, error)
+
+	ActionError(*KubernetesStack) (*Environment, error)
+
+	ActionFinishupgrade(*KubernetesStack) (*Environment, error)
+
+	ActionRemove(*KubernetesStack) (*Environment, error)
+
+	ActionRollback(*KubernetesStack) (*Environment, error)
+
+	ActionUpgrade(*KubernetesStack, *KubernetesStackUpgrade) (*KubernetesStack, error)
+}
+
+func newKubernetesStackClient(rancherClient *RancherClient) *KubernetesStackClient {
+	return &KubernetesStackClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *KubernetesStackClient) Create(container *KubernetesStack) (*KubernetesStack, error) {
+	resp := &KubernetesStack{}
+	err := c.rancherClient.doCreate(KUBERNETES_STACK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackClient) Update(existing *KubernetesStack, updates interface{}) (*KubernetesStack, error) {
+	resp := &KubernetesStack{}
+	err := c.rancherClient.doUpdate(KUBERNETES_STACK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackClient) List(opts *ListOpts) (*KubernetesStackCollection, error) {
+	resp := &KubernetesStackCollection{}
+	err := c.rancherClient.doList(KUBERNETES_STACK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ById(id string) (*KubernetesStack, error) {
+	resp := &KubernetesStack{}
+	err := c.rancherClient.doById(KUBERNETES_STACK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *KubernetesStackClient) Delete(container *KubernetesStack) error {
+	return c.rancherClient.doResourceDelete(KUBERNETES_STACK_TYPE, &container.Resource)
+}
+
+func (c *KubernetesStackClient) ActionCancelrollback(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionCancelupgrade(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionCreate(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionError(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionFinishupgrade(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionRemove(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionRollback(resource *KubernetesStack) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesStackClient) ActionUpgrade(resource *KubernetesStack, input *KubernetesStackUpgrade) (*KubernetesStack, error) {
+
+	resp := &KubernetesStack{}
+
+	err := c.rancherClient.doAction(KUBERNETES_STACK_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_stack_upgrade.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_kubernetes_stack_upgrade.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	KUBERNETES_STACK_UPGRADE_TYPE = "kubernetesStackUpgrade"
+)
+
+type KubernetesStackUpgrade struct {
+	Resource
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Templates map[string]interface{} `json:"templates,omitempty" yaml:"templates,omitempty"`
+}
+
+type KubernetesStackUpgradeCollection struct {
+	Collection
+	Data []KubernetesStackUpgrade `json:"data,omitempty"`
+}
+
+type KubernetesStackUpgradeClient struct {
+	rancherClient *RancherClient
+}
+
+type KubernetesStackUpgradeOperations interface {
+	List(opts *ListOpts) (*KubernetesStackUpgradeCollection, error)
+	Create(opts *KubernetesStackUpgrade) (*KubernetesStackUpgrade, error)
+	Update(existing *KubernetesStackUpgrade, updates interface{}) (*KubernetesStackUpgrade, error)
+	ById(id string) (*KubernetesStackUpgrade, error)
+	Delete(container *KubernetesStackUpgrade) error
+}
+
+func newKubernetesStackUpgradeClient(rancherClient *RancherClient) *KubernetesStackUpgradeClient {
+	return &KubernetesStackUpgradeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *KubernetesStackUpgradeClient) Create(container *KubernetesStackUpgrade) (*KubernetesStackUpgrade, error) {
+	resp := &KubernetesStackUpgrade{}
+	err := c.rancherClient.doCreate(KUBERNETES_STACK_UPGRADE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackUpgradeClient) Update(existing *KubernetesStackUpgrade, updates interface{}) (*KubernetesStackUpgrade, error) {
+	resp := &KubernetesStackUpgrade{}
+	err := c.rancherClient.doUpdate(KUBERNETES_STACK_UPGRADE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackUpgradeClient) List(opts *ListOpts) (*KubernetesStackUpgradeCollection, error) {
+	resp := &KubernetesStackUpgradeCollection{}
+	err := c.rancherClient.doList(KUBERNETES_STACK_UPGRADE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *KubernetesStackUpgradeClient) ById(id string) (*KubernetesStackUpgrade, error) {
+	resp := &KubernetesStackUpgrade{}
+	err := c.rancherClient.doById(KUBERNETES_STACK_UPGRADE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *KubernetesStackUpgradeClient) Delete(container *KubernetesStackUpgrade) error {
+	return c.rancherClient.doResourceDelete(KUBERNETES_STACK_UPGRADE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_label.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_label.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	LABEL_TYPE = "label"
+)
+
+type Label struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+type LabelCollection struct {
+	Collection
+	Data []Label `json:"data,omitempty"`
+}
+
+type LabelClient struct {
+	rancherClient *RancherClient
+}
+
+type LabelOperations interface {
+	List(opts *ListOpts) (*LabelCollection, error)
+	Create(opts *Label) (*Label, error)
+	Update(existing *Label, updates interface{}) (*Label, error)
+	ById(id string) (*Label, error)
+	Delete(container *Label) error
+
+	ActionCreate(*Label) (*Label, error)
+
+	ActionRemove(*Label) (*Label, error)
+}
+
+func newLabelClient(rancherClient *RancherClient) *LabelClient {
+	return &LabelClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LabelClient) Create(container *Label) (*Label, error) {
+	resp := &Label{}
+	err := c.rancherClient.doCreate(LABEL_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LabelClient) Update(existing *Label, updates interface{}) (*Label, error) {
+	resp := &Label{}
+	err := c.rancherClient.doUpdate(LABEL_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LabelClient) List(opts *ListOpts) (*LabelCollection, error) {
+	resp := &LabelCollection{}
+	err := c.rancherClient.doList(LABEL_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LabelClient) ById(id string) (*Label, error) {
+	resp := &Label{}
+	err := c.rancherClient.doById(LABEL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LabelClient) Delete(container *Label) error {
+	return c.rancherClient.doResourceDelete(LABEL_TYPE, &container.Resource)
+}
+
+func (c *LabelClient) ActionCreate(resource *Label) (*Label, error) {
+
+	resp := &Label{}
+
+	err := c.rancherClient.doAction(LABEL_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LabelClient) ActionRemove(resource *Label) (*Label, error) {
+
+	resp := &Label{}
+
+	err := c.rancherClient.doAction(LABEL_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_launch_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_launch_config.go
@@ -1,0 +1,430 @@
+package client
+
+const (
+	LAUNCH_CONFIG_TYPE = "launchConfig"
+)
+
+type LaunchConfig struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AllocationState string `json:"allocationState,omitempty" yaml:"allocation_state,omitempty"`
+
+	BlkioDeviceOptions map[string]interface{} `json:"blkioDeviceOptions,omitempty" yaml:"blkio_device_options,omitempty"`
+
+	Build *DockerBuild `json:"build,omitempty" yaml:"build,omitempty"`
+
+	CapAdd []string `json:"capAdd,omitempty" yaml:"cap_add,omitempty"`
+
+	CapDrop []string `json:"capDrop,omitempty" yaml:"cap_drop,omitempty"`
+
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Count int64 `json:"count,omitempty" yaml:"count,omitempty"`
+
+	CpuSet string `json:"cpuSet,omitempty" yaml:"cpu_set,omitempty"`
+
+	CpuShares int64 `json:"cpuShares,omitempty" yaml:"cpu_shares,omitempty"`
+
+	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
+	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
+
+	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`
+
+	DataVolumesFromLaunchConfigs []string `json:"dataVolumesFromLaunchConfigs,omitempty" yaml:"data_volumes_from_launch_configs,omitempty"`
+
+	DeploymentUnitUuid string `json:"deploymentUnitUuid,omitempty" yaml:"deployment_unit_uuid,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Devices []string `json:"devices,omitempty" yaml:"devices,omitempty"`
+
+	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+
+	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
+
+	DnsSearch []string `json:"dnsSearch,omitempty" yaml:"dns_search,omitempty"`
+
+	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
+
+	EntryPoint []string `json:"entryPoint,omitempty" yaml:"entry_point,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	Expose []string `json:"expose,omitempty" yaml:"expose,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExtraHosts []string `json:"extraHosts,omitempty" yaml:"extra_hosts,omitempty"`
+
+	FirstRunning string `json:"firstRunning,omitempty" yaml:"first_running,omitempty"`
+
+	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	ImageUuid string `json:"imageUuid,omitempty" yaml:"image_uuid,omitempty"`
+
+	InstanceLinks map[string]interface{} `json:"instanceLinks,omitempty" yaml:"instance_links,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	LogConfig *LogConfig `json:"logConfig,omitempty" yaml:"log_config,omitempty"`
+
+	LxcConf map[string]interface{} `json:"lxcConf,omitempty" yaml:"lxc_conf,omitempty"`
+
+	Memory int64 `json:"memory,omitempty" yaml:"memory,omitempty"`
+
+	MemoryMb int64 `json:"memoryMb,omitempty" yaml:"memory_mb,omitempty"`
+
+	MemorySwap int64 `json:"memorySwap,omitempty" yaml:"memory_swap,omitempty"`
+
+	NativeContainer bool `json:"nativeContainer,omitempty" yaml:"native_container,omitempty"`
+
+	NetworkContainerId string `json:"networkContainerId,omitempty" yaml:"network_container_id,omitempty"`
+
+	NetworkIds []string `json:"networkIds,omitempty" yaml:"network_ids,omitempty"`
+
+	NetworkLaunchConfig string `json:"networkLaunchConfig,omitempty" yaml:"network_launch_config,omitempty"`
+
+	NetworkMode string `json:"networkMode,omitempty" yaml:"network_mode,omitempty"`
+
+	PidMode string `json:"pidMode,omitempty" yaml:"pid_mode,omitempty"`
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	PrimaryIpAddress string `json:"primaryIpAddress,omitempty" yaml:"primary_ip_address,omitempty"`
+
+	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+
+	PublishAllPorts bool `json:"publishAllPorts,omitempty" yaml:"publish_all_ports,omitempty"`
+
+	ReadOnly bool `json:"readOnly,omitempty" yaml:"read_only,omitempty"`
+
+	RegistryCredentialId string `json:"registryCredentialId,omitempty" yaml:"registry_credential_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
+
+	RequestedIpAddress string `json:"requestedIpAddress,omitempty" yaml:"requested_ip_address,omitempty"`
+
+	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	StdinOpen bool `json:"stdinOpen,omitempty" yaml:"stdin_open,omitempty"`
+
+	SystemContainer string `json:"systemContainer,omitempty" yaml:"system_container,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Tty bool `json:"tty,omitempty" yaml:"tty,omitempty"`
+
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
+
+	Userdata string `json:"userdata,omitempty" yaml:"userdata,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vcpu int64 `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	VolumeDriver string `json:"volumeDriver,omitempty" yaml:"volume_driver,omitempty"`
+
+	WorkingDir string `json:"workingDir,omitempty" yaml:"working_dir,omitempty"`
+}
+
+type LaunchConfigCollection struct {
+	Collection
+	Data []LaunchConfig `json:"data,omitempty"`
+}
+
+type LaunchConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type LaunchConfigOperations interface {
+	List(opts *ListOpts) (*LaunchConfigCollection, error)
+	Create(opts *LaunchConfig) (*LaunchConfig, error)
+	Update(existing *LaunchConfig, updates interface{}) (*LaunchConfig, error)
+	ById(id string) (*LaunchConfig, error)
+	Delete(container *LaunchConfig) error
+
+	ActionAllocate(*LaunchConfig) (*Instance, error)
+
+	ActionConsole(*LaunchConfig, *InstanceConsoleInput) (*InstanceConsole, error)
+
+	ActionCreate(*LaunchConfig) (*Instance, error)
+
+	ActionDeallocate(*LaunchConfig) (*Instance, error)
+
+	ActionError(*LaunchConfig) (*Instance, error)
+
+	ActionExecute(*LaunchConfig, *ContainerExec) (*HostAccess, error)
+
+	ActionMigrate(*LaunchConfig) (*Instance, error)
+
+	ActionProxy(*LaunchConfig, *ContainerProxy) (*HostAccess, error)
+
+	ActionPurge(*LaunchConfig) (*Instance, error)
+
+	ActionRemove(*LaunchConfig) (*Instance, error)
+
+	ActionRestart(*LaunchConfig) (*Instance, error)
+
+	ActionRestore(*LaunchConfig) (*Instance, error)
+
+	ActionSetlabels(*LaunchConfig, *SetLabelsInput) (*Container, error)
+
+	ActionStart(*LaunchConfig) (*Instance, error)
+
+	ActionStop(*LaunchConfig, *InstanceStop) (*Instance, error)
+
+	ActionUpdate(*LaunchConfig) (*Instance, error)
+
+	ActionUpdatehealthy(*LaunchConfig) (*Instance, error)
+
+	ActionUpdatereinitializing(*LaunchConfig) (*Instance, error)
+
+	ActionUpdateunhealthy(*LaunchConfig) (*Instance, error)
+}
+
+func newLaunchConfigClient(rancherClient *RancherClient) *LaunchConfigClient {
+	return &LaunchConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LaunchConfigClient) Create(container *LaunchConfig) (*LaunchConfig, error) {
+	resp := &LaunchConfig{}
+	err := c.rancherClient.doCreate(LAUNCH_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LaunchConfigClient) Update(existing *LaunchConfig, updates interface{}) (*LaunchConfig, error) {
+	resp := &LaunchConfig{}
+	err := c.rancherClient.doUpdate(LAUNCH_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LaunchConfigClient) List(opts *ListOpts) (*LaunchConfigCollection, error) {
+	resp := &LaunchConfigCollection{}
+	err := c.rancherClient.doList(LAUNCH_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ById(id string) (*LaunchConfig, error) {
+	resp := &LaunchConfig{}
+	err := c.rancherClient.doById(LAUNCH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LaunchConfigClient) Delete(container *LaunchConfig) error {
+	return c.rancherClient.doResourceDelete(LAUNCH_CONFIG_TYPE, &container.Resource)
+}
+
+func (c *LaunchConfigClient) ActionAllocate(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionConsole(resource *LaunchConfig, input *InstanceConsoleInput) (*InstanceConsole, error) {
+
+	resp := &InstanceConsole{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "console", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionCreate(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionDeallocate(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionError(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionExecute(resource *LaunchConfig, input *ContainerExec) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "execute", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionMigrate(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionProxy(resource *LaunchConfig, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "proxy", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionPurge(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionRemove(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionRestart(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "restart", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionRestore(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionSetlabels(resource *LaunchConfig, input *SetLabelsInput) (*Container, error) {
+
+	resp := &Container{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "setlabels", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionStart(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "start", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionStop(resource *LaunchConfig, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionUpdate(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionUpdatehealthy(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "updatehealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionUpdatereinitializing(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "updatereinitializing", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionUpdateunhealthy(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "updateunhealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_ldapconfig.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_ldapconfig.go
@@ -1,0 +1,111 @@
+package client
+
+const (
+	LDAPCONFIG_TYPE = "ldapconfig"
+)
+
+type Ldapconfig struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	AllowedIdentities []interface{} `json:"allowedIdentities,omitempty" yaml:"allowed_identities,omitempty"`
+
+	ConnectionTimeout int64 `json:"connectionTimeout,omitempty" yaml:"connection_timeout,omitempty"`
+
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	GroupMemberMappingAttribute string `json:"groupMemberMappingAttribute,omitempty" yaml:"group_member_mapping_attribute,omitempty"`
+
+	GroupNameField string `json:"groupNameField,omitempty" yaml:"group_name_field,omitempty"`
+
+	GroupObjectClass string `json:"groupObjectClass,omitempty" yaml:"group_object_class,omitempty"`
+
+	GroupSearchField string `json:"groupSearchField,omitempty" yaml:"group_search_field,omitempty"`
+
+	LoginDomain string `json:"loginDomain,omitempty" yaml:"login_domain,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Server string `json:"server,omitempty" yaml:"server,omitempty"`
+
+	ServiceAccountPassword string `json:"serviceAccountPassword,omitempty" yaml:"service_account_password,omitempty"`
+
+	ServiceAccountUsername string `json:"serviceAccountUsername,omitempty" yaml:"service_account_username,omitempty"`
+
+	Tls bool `json:"tls,omitempty" yaml:"tls,omitempty"`
+
+	UserDisabledBitMask int64 `json:"userDisabledBitMask,omitempty" yaml:"user_disabled_bit_mask,omitempty"`
+
+	UserEnabledAttribute string `json:"userEnabledAttribute,omitempty" yaml:"user_enabled_attribute,omitempty"`
+
+	UserLoginField string `json:"userLoginField,omitempty" yaml:"user_login_field,omitempty"`
+
+	UserMemberAttribute string `json:"userMemberAttribute,omitempty" yaml:"user_member_attribute,omitempty"`
+
+	UserNameField string `json:"userNameField,omitempty" yaml:"user_name_field,omitempty"`
+
+	UserObjectClass string `json:"userObjectClass,omitempty" yaml:"user_object_class,omitempty"`
+
+	UserSearchField string `json:"userSearchField,omitempty" yaml:"user_search_field,omitempty"`
+}
+
+type LdapconfigCollection struct {
+	Collection
+	Data []Ldapconfig `json:"data,omitempty"`
+}
+
+type LdapconfigClient struct {
+	rancherClient *RancherClient
+}
+
+type LdapconfigOperations interface {
+	List(opts *ListOpts) (*LdapconfigCollection, error)
+	Create(opts *Ldapconfig) (*Ldapconfig, error)
+	Update(existing *Ldapconfig, updates interface{}) (*Ldapconfig, error)
+	ById(id string) (*Ldapconfig, error)
+	Delete(container *Ldapconfig) error
+}
+
+func newLdapconfigClient(rancherClient *RancherClient) *LdapconfigClient {
+	return &LdapconfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LdapconfigClient) Create(container *Ldapconfig) (*Ldapconfig, error) {
+	resp := &Ldapconfig{}
+	err := c.rancherClient.doCreate(LDAPCONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LdapconfigClient) Update(existing *Ldapconfig, updates interface{}) (*Ldapconfig, error) {
+	resp := &Ldapconfig{}
+	err := c.rancherClient.doUpdate(LDAPCONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LdapconfigClient) List(opts *ListOpts) (*LdapconfigCollection, error) {
+	resp := &LdapconfigCollection{}
+	err := c.rancherClient.doList(LDAPCONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LdapconfigClient) ById(id string) (*Ldapconfig, error) {
+	resp := &Ldapconfig{}
+	err := c.rancherClient.doById(LDAPCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LdapconfigClient) Delete(container *Ldapconfig) error {
+	return c.rancherClient.doResourceDelete(LDAPCONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_app_cookie_stickiness_policy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_app_cookie_stickiness_policy.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE = "loadBalancerAppCookieStickinessPolicy"
+)
+
+type LoadBalancerAppCookieStickinessPolicy struct {
+	Resource
+
+	Cookie string `json:"cookie,omitempty" yaml:"cookie,omitempty"`
+
+	MaxLength int64 `json:"maxLength,omitempty" yaml:"max_length,omitempty"`
+
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Prefix bool `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+
+	RequestLearn bool `json:"requestLearn,omitempty" yaml:"request_learn,omitempty"`
+
+	Timeout int64 `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+type LoadBalancerAppCookieStickinessPolicyCollection struct {
+	Collection
+	Data []LoadBalancerAppCookieStickinessPolicy `json:"data,omitempty"`
+}
+
+type LoadBalancerAppCookieStickinessPolicyClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerAppCookieStickinessPolicyOperations interface {
+	List(opts *ListOpts) (*LoadBalancerAppCookieStickinessPolicyCollection, error)
+	Create(opts *LoadBalancerAppCookieStickinessPolicy) (*LoadBalancerAppCookieStickinessPolicy, error)
+	Update(existing *LoadBalancerAppCookieStickinessPolicy, updates interface{}) (*LoadBalancerAppCookieStickinessPolicy, error)
+	ById(id string) (*LoadBalancerAppCookieStickinessPolicy, error)
+	Delete(container *LoadBalancerAppCookieStickinessPolicy) error
+}
+
+func newLoadBalancerAppCookieStickinessPolicyClient(rancherClient *RancherClient) *LoadBalancerAppCookieStickinessPolicyClient {
+	return &LoadBalancerAppCookieStickinessPolicyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerAppCookieStickinessPolicyClient) Create(container *LoadBalancerAppCookieStickinessPolicy) (*LoadBalancerAppCookieStickinessPolicy, error) {
+	resp := &LoadBalancerAppCookieStickinessPolicy{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerAppCookieStickinessPolicyClient) Update(existing *LoadBalancerAppCookieStickinessPolicy, updates interface{}) (*LoadBalancerAppCookieStickinessPolicy, error) {
+	resp := &LoadBalancerAppCookieStickinessPolicy{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerAppCookieStickinessPolicyClient) List(opts *ListOpts) (*LoadBalancerAppCookieStickinessPolicyCollection, error) {
+	resp := &LoadBalancerAppCookieStickinessPolicyCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerAppCookieStickinessPolicyClient) ById(id string) (*LoadBalancerAppCookieStickinessPolicy, error) {
+	resp := &LoadBalancerAppCookieStickinessPolicy{}
+	err := c.rancherClient.doById(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LoadBalancerAppCookieStickinessPolicyClient) Delete(container *LoadBalancerAppCookieStickinessPolicy) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_config.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	LOAD_BALANCER_CONFIG_TYPE = "loadBalancerConfig"
+)
+
+type LoadBalancerConfig struct {
+	Resource
+
+	HaproxyConfig *HaproxyConfig `json:"haproxyConfig,omitempty" yaml:"haproxy_config,omitempty"`
+
+	LbCookieStickinessPolicy *LoadBalancerCookieStickinessPolicy `json:"lbCookieStickinessPolicy,omitempty" yaml:"lb_cookie_stickiness_policy,omitempty"`
+}
+
+type LoadBalancerConfigCollection struct {
+	Collection
+	Data []LoadBalancerConfig `json:"data,omitempty"`
+}
+
+type LoadBalancerConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerConfigOperations interface {
+	List(opts *ListOpts) (*LoadBalancerConfigCollection, error)
+	Create(opts *LoadBalancerConfig) (*LoadBalancerConfig, error)
+	Update(existing *LoadBalancerConfig, updates interface{}) (*LoadBalancerConfig, error)
+	ById(id string) (*LoadBalancerConfig, error)
+	Delete(container *LoadBalancerConfig) error
+}
+
+func newLoadBalancerConfigClient(rancherClient *RancherClient) *LoadBalancerConfigClient {
+	return &LoadBalancerConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerConfigClient) Create(container *LoadBalancerConfig) (*LoadBalancerConfig, error) {
+	resp := &LoadBalancerConfig{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerConfigClient) Update(existing *LoadBalancerConfig, updates interface{}) (*LoadBalancerConfig, error) {
+	resp := &LoadBalancerConfig{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerConfigClient) List(opts *ListOpts) (*LoadBalancerConfigCollection, error) {
+	resp := &LoadBalancerConfigCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerConfigClient) ById(id string) (*LoadBalancerConfig, error) {
+	resp := &LoadBalancerConfig{}
+	err := c.rancherClient.doById(LOAD_BALANCER_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LoadBalancerConfigClient) Delete(container *LoadBalancerConfig) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_cookie_stickiness_policy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_cookie_stickiness_policy.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE = "loadBalancerCookieStickinessPolicy"
+)
+
+type LoadBalancerCookieStickinessPolicy struct {
+	Resource
+
+	Cookie string `json:"cookie,omitempty" yaml:"cookie,omitempty"`
+
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
+
+	Indirect bool `json:"indirect,omitempty" yaml:"indirect,omitempty"`
+
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Nocache bool `json:"nocache,omitempty" yaml:"nocache,omitempty"`
+
+	Postonly bool `json:"postonly,omitempty" yaml:"postonly,omitempty"`
+}
+
+type LoadBalancerCookieStickinessPolicyCollection struct {
+	Collection
+	Data []LoadBalancerCookieStickinessPolicy `json:"data,omitempty"`
+}
+
+type LoadBalancerCookieStickinessPolicyClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerCookieStickinessPolicyOperations interface {
+	List(opts *ListOpts) (*LoadBalancerCookieStickinessPolicyCollection, error)
+	Create(opts *LoadBalancerCookieStickinessPolicy) (*LoadBalancerCookieStickinessPolicy, error)
+	Update(existing *LoadBalancerCookieStickinessPolicy, updates interface{}) (*LoadBalancerCookieStickinessPolicy, error)
+	ById(id string) (*LoadBalancerCookieStickinessPolicy, error)
+	Delete(container *LoadBalancerCookieStickinessPolicy) error
+}
+
+func newLoadBalancerCookieStickinessPolicyClient(rancherClient *RancherClient) *LoadBalancerCookieStickinessPolicyClient {
+	return &LoadBalancerCookieStickinessPolicyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerCookieStickinessPolicyClient) Create(container *LoadBalancerCookieStickinessPolicy) (*LoadBalancerCookieStickinessPolicy, error) {
+	resp := &LoadBalancerCookieStickinessPolicy{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerCookieStickinessPolicyClient) Update(existing *LoadBalancerCookieStickinessPolicy, updates interface{}) (*LoadBalancerCookieStickinessPolicy, error) {
+	resp := &LoadBalancerCookieStickinessPolicy{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerCookieStickinessPolicyClient) List(opts *ListOpts) (*LoadBalancerCookieStickinessPolicyCollection, error) {
+	resp := &LoadBalancerCookieStickinessPolicyCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerCookieStickinessPolicyClient) ById(id string) (*LoadBalancerCookieStickinessPolicy, error) {
+	resp := &LoadBalancerCookieStickinessPolicy{}
+	err := c.rancherClient.doById(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LoadBalancerCookieStickinessPolicyClient) Delete(container *LoadBalancerCookieStickinessPolicy) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
@@ -1,0 +1,283 @@
+package client
+
+const (
+	LOAD_BALANCER_SERVICE_TYPE = "loadBalancerService"
+)
+
+type LoadBalancerService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
+	CertificateIds []string `json:"certificateIds,omitempty" yaml:"certificate_ids,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	CurrentScale int64 `json:"currentScale,omitempty" yaml:"current_scale,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DefaultCertificateId string `json:"defaultCertificateId,omitempty" yaml:"default_certificate_id,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	LoadBalancerConfig *LoadBalancerConfig `json:"loadBalancerConfig,omitempty" yaml:"load_balancer_config,omitempty"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RetainIp bool `json:"retainIp,omitempty" yaml:"retain_ip,omitempty"`
+
+	Scale int64 `json:"scale,omitempty" yaml:"scale,omitempty"`
+
+	ScalePolicy *ScalePolicy `json:"scalePolicy,omitempty" yaml:"scale_policy,omitempty"`
+
+	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vip string `json:"vip,omitempty" yaml:"vip,omitempty"`
+}
+
+type LoadBalancerServiceCollection struct {
+	Collection
+	Data []LoadBalancerService `json:"data,omitempty"`
+}
+
+type LoadBalancerServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerServiceOperations interface {
+	List(opts *ListOpts) (*LoadBalancerServiceCollection, error)
+	Create(opts *LoadBalancerService) (*LoadBalancerService, error)
+	Update(existing *LoadBalancerService, updates interface{}) (*LoadBalancerService, error)
+	ById(id string) (*LoadBalancerService, error)
+	Delete(container *LoadBalancerService) error
+
+	ActionActivate(*LoadBalancerService) (*Service, error)
+
+	ActionAddservicelink(*LoadBalancerService, *AddRemoveLoadBalancerServiceLinkInput) (*Service, error)
+
+	ActionCancelrollback(*LoadBalancerService) (*Service, error)
+
+	ActionCancelupgrade(*LoadBalancerService) (*Service, error)
+
+	ActionCreate(*LoadBalancerService) (*Service, error)
+
+	ActionDeactivate(*LoadBalancerService) (*Service, error)
+
+	ActionFinishupgrade(*LoadBalancerService) (*Service, error)
+
+	ActionRemove(*LoadBalancerService) (*Service, error)
+
+	ActionRemoveservicelink(*LoadBalancerService, *AddRemoveLoadBalancerServiceLinkInput) (*Service, error)
+
+	ActionRestart(*LoadBalancerService, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*LoadBalancerService) (*Service, error)
+
+	ActionSetservicelinks(*LoadBalancerService, *SetLoadBalancerServiceLinksInput) (*Service, error)
+
+	ActionUpdate(*LoadBalancerService) (*Service, error)
+
+	ActionUpgrade(*LoadBalancerService, *ServiceUpgrade) (*Service, error)
+}
+
+func newLoadBalancerServiceClient(rancherClient *RancherClient) *LoadBalancerServiceClient {
+	return &LoadBalancerServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerServiceClient) Create(container *LoadBalancerService) (*LoadBalancerService, error) {
+	resp := &LoadBalancerService{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) Update(existing *LoadBalancerService, updates interface{}) (*LoadBalancerService, error) {
+	resp := &LoadBalancerService{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) List(opts *ListOpts) (*LoadBalancerServiceCollection, error) {
+	resp := &LoadBalancerServiceCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ById(id string) (*LoadBalancerService, error) {
+	resp := &LoadBalancerService{}
+	err := c.rancherClient.doById(LOAD_BALANCER_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) Delete(container *LoadBalancerService) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *LoadBalancerServiceClient) ActionActivate(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionAddservicelink(resource *LoadBalancerService, input *AddRemoveLoadBalancerServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionCancelrollback(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionCancelupgrade(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionCreate(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionDeactivate(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionFinishupgrade(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionRemove(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionRemoveservicelink(resource *LoadBalancerService, input *AddRemoveLoadBalancerServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionRestart(resource *LoadBalancerService, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionRollback(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionSetservicelinks(resource *LoadBalancerService, input *SetLoadBalancerServiceLinksInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "setservicelinks", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionUpdate(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionUpgrade(resource *LoadBalancerService, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_service_link.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_load_balancer_service_link.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	LOAD_BALANCER_SERVICE_LINK_TYPE = "loadBalancerServiceLink"
+)
+
+type LoadBalancerServiceLink struct {
+	Resource
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	ServiceId string `json:"serviceId,omitempty" yaml:"service_id,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type LoadBalancerServiceLinkCollection struct {
+	Collection
+	Data []LoadBalancerServiceLink `json:"data,omitempty"`
+}
+
+type LoadBalancerServiceLinkClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerServiceLinkOperations interface {
+	List(opts *ListOpts) (*LoadBalancerServiceLinkCollection, error)
+	Create(opts *LoadBalancerServiceLink) (*LoadBalancerServiceLink, error)
+	Update(existing *LoadBalancerServiceLink, updates interface{}) (*LoadBalancerServiceLink, error)
+	ById(id string) (*LoadBalancerServiceLink, error)
+	Delete(container *LoadBalancerServiceLink) error
+}
+
+func newLoadBalancerServiceLinkClient(rancherClient *RancherClient) *LoadBalancerServiceLinkClient {
+	return &LoadBalancerServiceLinkClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerServiceLinkClient) Create(container *LoadBalancerServiceLink) (*LoadBalancerServiceLink, error) {
+	resp := &LoadBalancerServiceLink{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_SERVICE_LINK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceLinkClient) Update(existing *LoadBalancerServiceLink, updates interface{}) (*LoadBalancerServiceLink, error) {
+	resp := &LoadBalancerServiceLink{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_SERVICE_LINK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceLinkClient) List(opts *ListOpts) (*LoadBalancerServiceLinkCollection, error) {
+	resp := &LoadBalancerServiceLinkCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_SERVICE_LINK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerServiceLinkClient) ById(id string) (*LoadBalancerServiceLink, error) {
+	resp := &LoadBalancerServiceLink{}
+	err := c.rancherClient.doById(LOAD_BALANCER_SERVICE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LoadBalancerServiceLinkClient) Delete(container *LoadBalancerServiceLink) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_SERVICE_LINK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_local_auth_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_local_auth_config.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	LOCAL_AUTH_CONFIG_TYPE = "localAuthConfig"
+)
+
+type LocalAuthConfig struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+}
+
+type LocalAuthConfigCollection struct {
+	Collection
+	Data []LocalAuthConfig `json:"data,omitempty"`
+}
+
+type LocalAuthConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type LocalAuthConfigOperations interface {
+	List(opts *ListOpts) (*LocalAuthConfigCollection, error)
+	Create(opts *LocalAuthConfig) (*LocalAuthConfig, error)
+	Update(existing *LocalAuthConfig, updates interface{}) (*LocalAuthConfig, error)
+	ById(id string) (*LocalAuthConfig, error)
+	Delete(container *LocalAuthConfig) error
+}
+
+func newLocalAuthConfigClient(rancherClient *RancherClient) *LocalAuthConfigClient {
+	return &LocalAuthConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LocalAuthConfigClient) Create(container *LocalAuthConfig) (*LocalAuthConfig, error) {
+	resp := &LocalAuthConfig{}
+	err := c.rancherClient.doCreate(LOCAL_AUTH_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LocalAuthConfigClient) Update(existing *LocalAuthConfig, updates interface{}) (*LocalAuthConfig, error) {
+	resp := &LocalAuthConfig{}
+	err := c.rancherClient.doUpdate(LOCAL_AUTH_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LocalAuthConfigClient) List(opts *ListOpts) (*LocalAuthConfigCollection, error) {
+	resp := &LocalAuthConfigCollection{}
+	err := c.rancherClient.doList(LOCAL_AUTH_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LocalAuthConfigClient) ById(id string) (*LocalAuthConfig, error) {
+	resp := &LocalAuthConfig{}
+	err := c.rancherClient.doById(LOCAL_AUTH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LocalAuthConfigClient) Delete(container *LocalAuthConfig) error {
+	return c.rancherClient.doResourceDelete(LOCAL_AUTH_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_log_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_log_config.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	LOG_CONFIG_TYPE = "logConfig"
+)
+
+type LogConfig struct {
+	Resource
+
+	Config map[string]interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+}
+
+type LogConfigCollection struct {
+	Collection
+	Data []LogConfig `json:"data,omitempty"`
+}
+
+type LogConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type LogConfigOperations interface {
+	List(opts *ListOpts) (*LogConfigCollection, error)
+	Create(opts *LogConfig) (*LogConfig, error)
+	Update(existing *LogConfig, updates interface{}) (*LogConfig, error)
+	ById(id string) (*LogConfig, error)
+	Delete(container *LogConfig) error
+}
+
+func newLogConfigClient(rancherClient *RancherClient) *LogConfigClient {
+	return &LogConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LogConfigClient) Create(container *LogConfig) (*LogConfig, error) {
+	resp := &LogConfig{}
+	err := c.rancherClient.doCreate(LOG_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LogConfigClient) Update(existing *LogConfig, updates interface{}) (*LogConfig, error) {
+	resp := &LogConfig{}
+	err := c.rancherClient.doUpdate(LOG_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LogConfigClient) List(opts *ListOpts) (*LogConfigCollection, error) {
+	resp := &LogConfigCollection{}
+	err := c.rancherClient.doList(LOG_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LogConfigClient) ById(id string) (*LogConfig, error) {
+	resp := &LogConfig{}
+	err := c.rancherClient.doById(LOG_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *LogConfigClient) Delete(container *LogConfig) error {
+	return c.rancherClient.doResourceDelete(LOG_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_machine.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_machine.go
@@ -1,0 +1,182 @@
+package client
+
+const (
+	MACHINE_TYPE = "machine"
+)
+
+type Machine struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Amazonec2Config *Amazonec2Config `json:"amazonec2Config,omitempty" yaml:"amazonec2config,omitempty"`
+
+	AuthCertificateAuthority string `json:"authCertificateAuthority,omitempty" yaml:"auth_certificate_authority,omitempty"`
+
+	AuthKey string `json:"authKey,omitempty" yaml:"auth_key,omitempty"`
+
+	AzureConfig *AzureConfig `json:"azureConfig,omitempty" yaml:"azure_config,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	DigitaloceanConfig *DigitaloceanConfig `json:"digitaloceanConfig,omitempty" yaml:"digitalocean_config,omitempty"`
+
+	DockerVersion string `json:"dockerVersion,omitempty" yaml:"docker_version,omitempty"`
+
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+
+	EngineEnv map[string]interface{} `json:"engineEnv,omitempty" yaml:"engine_env,omitempty"`
+
+	EngineInsecureRegistry []string `json:"engineInsecureRegistry,omitempty" yaml:"engine_insecure_registry,omitempty"`
+
+	EngineInstallUrl string `json:"engineInstallUrl,omitempty" yaml:"engine_install_url,omitempty"`
+
+	EngineLabel map[string]interface{} `json:"engineLabel,omitempty" yaml:"engine_label,omitempty"`
+
+	EngineOpt map[string]interface{} `json:"engineOpt,omitempty" yaml:"engine_opt,omitempty"`
+
+	EngineRegistryMirror []string `json:"engineRegistryMirror,omitempty" yaml:"engine_registry_mirror,omitempty"`
+
+	EngineStorageDriver string `json:"engineStorageDriver,omitempty" yaml:"engine_storage_driver,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExtractedConfig string `json:"extractedConfig,omitempty" yaml:"extracted_config,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PacketConfig *PacketConfig `json:"packetConfig,omitempty" yaml:"packet_config,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type MachineCollection struct {
+	Collection
+	Data []Machine `json:"data,omitempty"`
+}
+
+type MachineClient struct {
+	rancherClient *RancherClient
+}
+
+type MachineOperations interface {
+	List(opts *ListOpts) (*MachineCollection, error)
+	Create(opts *Machine) (*Machine, error)
+	Update(existing *Machine, updates interface{}) (*Machine, error)
+	ById(id string) (*Machine, error)
+	Delete(container *Machine) error
+
+	ActionBootstrap(*Machine) (*PhysicalHost, error)
+
+	ActionCreate(*Machine) (*PhysicalHost, error)
+
+	ActionError(*Machine) (*PhysicalHost, error)
+
+	ActionRemove(*Machine) (*PhysicalHost, error)
+
+	ActionUpdate(*Machine) (*PhysicalHost, error)
+}
+
+func newMachineClient(rancherClient *RancherClient) *MachineClient {
+	return &MachineClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *MachineClient) Create(container *Machine) (*Machine, error) {
+	resp := &Machine{}
+	err := c.rancherClient.doCreate(MACHINE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Update(existing *Machine, updates interface{}) (*Machine, error) {
+	resp := &Machine{}
+	err := c.rancherClient.doUpdate(MACHINE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *MachineClient) List(opts *ListOpts) (*MachineCollection, error) {
+	resp := &MachineCollection{}
+	err := c.rancherClient.doList(MACHINE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *MachineClient) ById(id string) (*Machine, error) {
+	resp := &Machine{}
+	err := c.rancherClient.doById(MACHINE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *MachineClient) Delete(container *Machine) error {
+	return c.rancherClient.doResourceDelete(MACHINE_TYPE, &container.Resource)
+}
+
+func (c *MachineClient) ActionBootstrap(resource *Machine) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(MACHINE_TYPE, "bootstrap", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineClient) ActionCreate(resource *Machine) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(MACHINE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineClient) ActionError(resource *Machine) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(MACHINE_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineClient) ActionRemove(resource *Machine) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(MACHINE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineClient) ActionUpdate(resource *Machine) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(MACHINE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_machine_driver.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_machine_driver.go
@@ -1,0 +1,169 @@
+package client
+
+const (
+	MACHINE_DRIVER_TYPE = "machineDriver"
+)
+
+type MachineDriver struct {
+	Resource
+
+	ActivateOnCreate bool `json:"activateOnCreate,omitempty" yaml:"activate_on_create,omitempty"`
+
+	Builtin bool `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+
+	Checksum string `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DefaultActive bool `json:"defaultActive,omitempty" yaml:"default_active,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	UiUrl string `json:"uiUrl,omitempty" yaml:"ui_url,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type MachineDriverCollection struct {
+	Collection
+	Data []MachineDriver `json:"data,omitempty"`
+}
+
+type MachineDriverClient struct {
+	rancherClient *RancherClient
+}
+
+type MachineDriverOperations interface {
+	List(opts *ListOpts) (*MachineDriverCollection, error)
+	Create(opts *MachineDriver) (*MachineDriver, error)
+	Update(existing *MachineDriver, updates interface{}) (*MachineDriver, error)
+	ById(id string) (*MachineDriver, error)
+	Delete(container *MachineDriver) error
+
+	ActionActivate(*MachineDriver) (*MachineDriver, error)
+
+	ActionDeactivate(*MachineDriver) (*MachineDriver, error)
+
+	ActionError(*MachineDriver) (*MachineDriver, error)
+
+	ActionReactivate(*MachineDriver) (*MachineDriver, error)
+
+	ActionRemove(*MachineDriver) (*MachineDriver, error)
+
+	ActionUpdate(*MachineDriver) (*MachineDriver, error)
+}
+
+func newMachineDriverClient(rancherClient *RancherClient) *MachineDriverClient {
+	return &MachineDriverClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *MachineDriverClient) Create(container *MachineDriver) (*MachineDriver, error) {
+	resp := &MachineDriver{}
+	err := c.rancherClient.doCreate(MACHINE_DRIVER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *MachineDriverClient) Update(existing *MachineDriver, updates interface{}) (*MachineDriver, error) {
+	resp := &MachineDriver{}
+	err := c.rancherClient.doUpdate(MACHINE_DRIVER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *MachineDriverClient) List(opts *ListOpts) (*MachineDriverCollection, error) {
+	resp := &MachineDriverCollection{}
+	err := c.rancherClient.doList(MACHINE_DRIVER_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *MachineDriverClient) ById(id string) (*MachineDriver, error) {
+	resp := &MachineDriver{}
+	err := c.rancherClient.doById(MACHINE_DRIVER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *MachineDriverClient) Delete(container *MachineDriver) error {
+	return c.rancherClient.doResourceDelete(MACHINE_DRIVER_TYPE, &container.Resource)
+}
+
+func (c *MachineDriverClient) ActionActivate(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionDeactivate(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionError(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionReactivate(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "reactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionRemove(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionUpdate(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_mount.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_mount.go
@@ -1,0 +1,132 @@
+package client
+
+const (
+	MOUNT_TYPE = "mount"
+)
+
+type Mount struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+
+	Permissions string `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VolumeId string `json:"volumeId,omitempty" yaml:"volume_id,omitempty"`
+}
+
+type MountCollection struct {
+	Collection
+	Data []Mount `json:"data,omitempty"`
+}
+
+type MountClient struct {
+	rancherClient *RancherClient
+}
+
+type MountOperations interface {
+	List(opts *ListOpts) (*MountCollection, error)
+	Create(opts *Mount) (*Mount, error)
+	Update(existing *Mount, updates interface{}) (*Mount, error)
+	ById(id string) (*Mount, error)
+	Delete(container *Mount) error
+
+	ActionCreate(*Mount) (*Mount, error)
+
+	ActionDeactivate(*Mount) (*Mount, error)
+
+	ActionRemove(*Mount) (*Mount, error)
+}
+
+func newMountClient(rancherClient *RancherClient) *MountClient {
+	return &MountClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *MountClient) Create(container *Mount) (*Mount, error) {
+	resp := &Mount{}
+	err := c.rancherClient.doCreate(MOUNT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *MountClient) Update(existing *Mount, updates interface{}) (*Mount, error) {
+	resp := &Mount{}
+	err := c.rancherClient.doUpdate(MOUNT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *MountClient) List(opts *ListOpts) (*MountCollection, error) {
+	resp := &MountCollection{}
+	err := c.rancherClient.doList(MOUNT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *MountClient) ById(id string) (*Mount, error) {
+	resp := &Mount{}
+	err := c.rancherClient.doById(MOUNT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *MountClient) Delete(container *Mount) error {
+	return c.rancherClient.doResourceDelete(MOUNT_TYPE, &container.Resource)
+}
+
+func (c *MountClient) ActionCreate(resource *Mount) (*Mount, error) {
+
+	resp := &Mount{}
+
+	err := c.rancherClient.doAction(MOUNT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MountClient) ActionDeactivate(resource *Mount) (*Mount, error) {
+
+	resp := &Mount{}
+
+	err := c.rancherClient.doAction(MOUNT_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MountClient) ActionRemove(resource *Mount) (*Mount, error) {
+
+	resp := &Mount{}
+
+	err := c.rancherClient.doAction(MOUNT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_network.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_network.go
@@ -1,0 +1,168 @@
+package client
+
+const (
+	NETWORK_TYPE = "network"
+)
+
+type Network struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type NetworkCollection struct {
+	Collection
+	Data []Network `json:"data,omitempty"`
+}
+
+type NetworkClient struct {
+	rancherClient *RancherClient
+}
+
+type NetworkOperations interface {
+	List(opts *ListOpts) (*NetworkCollection, error)
+	Create(opts *Network) (*Network, error)
+	Update(existing *Network, updates interface{}) (*Network, error)
+	ById(id string) (*Network, error)
+	Delete(container *Network) error
+
+	ActionActivate(*Network) (*Network, error)
+
+	ActionCreate(*Network) (*Network, error)
+
+	ActionDeactivate(*Network) (*Network, error)
+
+	ActionPurge(*Network) (*Network, error)
+
+	ActionRemove(*Network) (*Network, error)
+
+	ActionRestore(*Network) (*Network, error)
+
+	ActionUpdate(*Network) (*Network, error)
+}
+
+func newNetworkClient(rancherClient *RancherClient) *NetworkClient {
+	return &NetworkClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *NetworkClient) Create(container *Network) (*Network, error) {
+	resp := &Network{}
+	err := c.rancherClient.doCreate(NETWORK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *NetworkClient) Update(existing *Network, updates interface{}) (*Network, error) {
+	resp := &Network{}
+	err := c.rancherClient.doUpdate(NETWORK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *NetworkClient) List(opts *ListOpts) (*NetworkCollection, error) {
+	resp := &NetworkCollection{}
+	err := c.rancherClient.doList(NETWORK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *NetworkClient) ById(id string) (*Network, error) {
+	resp := &Network{}
+	err := c.rancherClient.doById(NETWORK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *NetworkClient) Delete(container *Network) error {
+	return c.rancherClient.doResourceDelete(NETWORK_TYPE, &container.Resource)
+}
+
+func (c *NetworkClient) ActionActivate(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionCreate(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionDeactivate(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionPurge(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionRemove(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionRestore(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *NetworkClient) ActionUpdate(resource *Network) (*Network, error) {
+
+	resp := &Network{}
+
+	err := c.rancherClient.doAction(NETWORK_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_nfs_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_nfs_config.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	NFS_CONFIG_TYPE = "nfsConfig"
+)
+
+type NfsConfig struct {
+	Resource
+
+	MountOptions string `json:"mountOptions,omitempty" yaml:"mount_options,omitempty"`
+
+	Server string `json:"server,omitempty" yaml:"server,omitempty"`
+
+	Share string `json:"share,omitempty" yaml:"share,omitempty"`
+}
+
+type NfsConfigCollection struct {
+	Collection
+	Data []NfsConfig `json:"data,omitempty"`
+}
+
+type NfsConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type NfsConfigOperations interface {
+	List(opts *ListOpts) (*NfsConfigCollection, error)
+	Create(opts *NfsConfig) (*NfsConfig, error)
+	Update(existing *NfsConfig, updates interface{}) (*NfsConfig, error)
+	ById(id string) (*NfsConfig, error)
+	Delete(container *NfsConfig) error
+}
+
+func newNfsConfigClient(rancherClient *RancherClient) *NfsConfigClient {
+	return &NfsConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *NfsConfigClient) Create(container *NfsConfig) (*NfsConfig, error) {
+	resp := &NfsConfig{}
+	err := c.rancherClient.doCreate(NFS_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *NfsConfigClient) Update(existing *NfsConfig, updates interface{}) (*NfsConfig, error) {
+	resp := &NfsConfig{}
+	err := c.rancherClient.doUpdate(NFS_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *NfsConfigClient) List(opts *ListOpts) (*NfsConfigCollection, error) {
+	resp := &NfsConfigCollection{}
+	err := c.rancherClient.doList(NFS_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *NfsConfigClient) ById(id string) (*NfsConfig, error) {
+	resp := &NfsConfig{}
+	err := c.rancherClient.doById(NFS_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *NfsConfigClient) Delete(container *NfsConfig) error {
+	return c.rancherClient.doResourceDelete(NFS_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_openldapconfig.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_openldapconfig.go
@@ -1,0 +1,109 @@
+package client
+
+const (
+	OPENLDAPCONFIG_TYPE = "openldapconfig"
+)
+
+type Openldapconfig struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	ConnectionTimeout int64 `json:"connectionTimeout,omitempty" yaml:"connection_timeout,omitempty"`
+
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
+
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	GroupMemberMappingAttribute string `json:"groupMemberMappingAttribute,omitempty" yaml:"group_member_mapping_attribute,omitempty"`
+
+	GroupNameField string `json:"groupNameField,omitempty" yaml:"group_name_field,omitempty"`
+
+	GroupObjectClass string `json:"groupObjectClass,omitempty" yaml:"group_object_class,omitempty"`
+
+	GroupSearchField string `json:"groupSearchField,omitempty" yaml:"group_search_field,omitempty"`
+
+	LoginDomain string `json:"loginDomain,omitempty" yaml:"login_domain,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Server string `json:"server,omitempty" yaml:"server,omitempty"`
+
+	ServiceAccountPassword string `json:"serviceAccountPassword,omitempty" yaml:"service_account_password,omitempty"`
+
+	ServiceAccountUsername string `json:"serviceAccountUsername,omitempty" yaml:"service_account_username,omitempty"`
+
+	Tls bool `json:"tls,omitempty" yaml:"tls,omitempty"`
+
+	UserDisabledBitMask int64 `json:"userDisabledBitMask,omitempty" yaml:"user_disabled_bit_mask,omitempty"`
+
+	UserEnabledAttribute string `json:"userEnabledAttribute,omitempty" yaml:"user_enabled_attribute,omitempty"`
+
+	UserLoginField string `json:"userLoginField,omitempty" yaml:"user_login_field,omitempty"`
+
+	UserMemberAttribute string `json:"userMemberAttribute,omitempty" yaml:"user_member_attribute,omitempty"`
+
+	UserNameField string `json:"userNameField,omitempty" yaml:"user_name_field,omitempty"`
+
+	UserObjectClass string `json:"userObjectClass,omitempty" yaml:"user_object_class,omitempty"`
+
+	UserSearchField string `json:"userSearchField,omitempty" yaml:"user_search_field,omitempty"`
+}
+
+type OpenldapconfigCollection struct {
+	Collection
+	Data []Openldapconfig `json:"data,omitempty"`
+}
+
+type OpenldapconfigClient struct {
+	rancherClient *RancherClient
+}
+
+type OpenldapconfigOperations interface {
+	List(opts *ListOpts) (*OpenldapconfigCollection, error)
+	Create(opts *Openldapconfig) (*Openldapconfig, error)
+	Update(existing *Openldapconfig, updates interface{}) (*Openldapconfig, error)
+	ById(id string) (*Openldapconfig, error)
+	Delete(container *Openldapconfig) error
+}
+
+func newOpenldapconfigClient(rancherClient *RancherClient) *OpenldapconfigClient {
+	return &OpenldapconfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *OpenldapconfigClient) Create(container *Openldapconfig) (*Openldapconfig, error) {
+	resp := &Openldapconfig{}
+	err := c.rancherClient.doCreate(OPENLDAPCONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *OpenldapconfigClient) Update(existing *Openldapconfig, updates interface{}) (*Openldapconfig, error) {
+	resp := &Openldapconfig{}
+	err := c.rancherClient.doUpdate(OPENLDAPCONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *OpenldapconfigClient) List(opts *ListOpts) (*OpenldapconfigCollection, error) {
+	resp := &OpenldapconfigCollection{}
+	err := c.rancherClient.doList(OPENLDAPCONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *OpenldapconfigClient) ById(id string) (*Openldapconfig, error) {
+	resp := &Openldapconfig{}
+	err := c.rancherClient.doById(OPENLDAPCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *OpenldapconfigClient) Delete(container *Openldapconfig) error {
+	return c.rancherClient.doResourceDelete(OPENLDAPCONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_packet_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_packet_config.go
@@ -1,0 +1,77 @@
+package client
+
+const (
+	PACKET_CONFIG_TYPE = "packetConfig"
+)
+
+type PacketConfig struct {
+	Resource
+
+	ApiKey string `json:"apiKey,omitempty" yaml:"api_key,omitempty"`
+
+	BillingCycle string `json:"billingCycle,omitempty" yaml:"billing_cycle,omitempty"`
+
+	FacilityCode string `json:"facilityCode,omitempty" yaml:"facility_code,omitempty"`
+
+	Os string `json:"os,omitempty" yaml:"os,omitempty"`
+
+	Plan string `json:"plan,omitempty" yaml:"plan,omitempty"`
+
+	ProjectId string `json:"projectId,omitempty" yaml:"project_id,omitempty"`
+}
+
+type PacketConfigCollection struct {
+	Collection
+	Data []PacketConfig `json:"data,omitempty"`
+}
+
+type PacketConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type PacketConfigOperations interface {
+	List(opts *ListOpts) (*PacketConfigCollection, error)
+	Create(opts *PacketConfig) (*PacketConfig, error)
+	Update(existing *PacketConfig, updates interface{}) (*PacketConfig, error)
+	ById(id string) (*PacketConfig, error)
+	Delete(container *PacketConfig) error
+}
+
+func newPacketConfigClient(rancherClient *RancherClient) *PacketConfigClient {
+	return &PacketConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PacketConfigClient) Create(container *PacketConfig) (*PacketConfig, error) {
+	resp := &PacketConfig{}
+	err := c.rancherClient.doCreate(PACKET_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PacketConfigClient) Update(existing *PacketConfig, updates interface{}) (*PacketConfig, error) {
+	resp := &PacketConfig{}
+	err := c.rancherClient.doUpdate(PACKET_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PacketConfigClient) List(opts *ListOpts) (*PacketConfigCollection, error) {
+	resp := &PacketConfigCollection{}
+	err := c.rancherClient.doList(PACKET_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PacketConfigClient) ById(id string) (*PacketConfig, error) {
+	resp := &PacketConfig{}
+	err := c.rancherClient.doById(PACKET_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PacketConfigClient) Delete(container *PacketConfig) error {
+	return c.rancherClient.doResourceDelete(PACKET_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_password.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_password.go
@@ -1,0 +1,172 @@
+package client
+
+const (
+	PASSWORD_TYPE = "password"
+)
+
+type Password struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicValue string `json:"publicValue,omitempty" yaml:"public_value,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SecretValue string `json:"secretValue,omitempty" yaml:"secret_value,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type PasswordCollection struct {
+	Collection
+	Data []Password `json:"data,omitempty"`
+}
+
+type PasswordClient struct {
+	rancherClient *RancherClient
+}
+
+type PasswordOperations interface {
+	List(opts *ListOpts) (*PasswordCollection, error)
+	Create(opts *Password) (*Password, error)
+	Update(existing *Password, updates interface{}) (*Password, error)
+	ById(id string) (*Password, error)
+	Delete(container *Password) error
+
+	ActionActivate(*Password) (*Credential, error)
+
+	ActionChangesecret(*Password, *ChangeSecretInput) (*ChangeSecretInput, error)
+
+	ActionCreate(*Password) (*Credential, error)
+
+	ActionDeactivate(*Password) (*Credential, error)
+
+	ActionPurge(*Password) (*Credential, error)
+
+	ActionRemove(*Password) (*Credential, error)
+
+	ActionUpdate(*Password) (*Credential, error)
+}
+
+func newPasswordClient(rancherClient *RancherClient) *PasswordClient {
+	return &PasswordClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PasswordClient) Create(container *Password) (*Password, error) {
+	resp := &Password{}
+	err := c.rancherClient.doCreate(PASSWORD_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PasswordClient) Update(existing *Password, updates interface{}) (*Password, error) {
+	resp := &Password{}
+	err := c.rancherClient.doUpdate(PASSWORD_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PasswordClient) List(opts *ListOpts) (*PasswordCollection, error) {
+	resp := &PasswordCollection{}
+	err := c.rancherClient.doList(PASSWORD_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PasswordClient) ById(id string) (*Password, error) {
+	resp := &Password{}
+	err := c.rancherClient.doById(PASSWORD_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PasswordClient) Delete(container *Password) error {
+	return c.rancherClient.doResourceDelete(PASSWORD_TYPE, &container.Resource)
+}
+
+func (c *PasswordClient) ActionActivate(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionChangesecret(resource *Password, input *ChangeSecretInput) (*ChangeSecretInput, error) {
+
+	resp := &ChangeSecretInput{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "changesecret", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionCreate(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionDeactivate(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionPurge(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionRemove(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PasswordClient) ActionUpdate(resource *Password) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(PASSWORD_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_physical_host.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_physical_host.go
@@ -1,0 +1,150 @@
+package client
+
+const (
+	PHYSICAL_HOST_TYPE = "physicalHost"
+)
+
+type PhysicalHost struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type PhysicalHostCollection struct {
+	Collection
+	Data []PhysicalHost `json:"data,omitempty"`
+}
+
+type PhysicalHostClient struct {
+	rancherClient *RancherClient
+}
+
+type PhysicalHostOperations interface {
+	List(opts *ListOpts) (*PhysicalHostCollection, error)
+	Create(opts *PhysicalHost) (*PhysicalHost, error)
+	Update(existing *PhysicalHost, updates interface{}) (*PhysicalHost, error)
+	ById(id string) (*PhysicalHost, error)
+	Delete(container *PhysicalHost) error
+
+	ActionBootstrap(*PhysicalHost) (*PhysicalHost, error)
+
+	ActionCreate(*PhysicalHost) (*PhysicalHost, error)
+
+	ActionError(*PhysicalHost) (*PhysicalHost, error)
+
+	ActionRemove(*PhysicalHost) (*PhysicalHost, error)
+
+	ActionUpdate(*PhysicalHost) (*PhysicalHost, error)
+}
+
+func newPhysicalHostClient(rancherClient *RancherClient) *PhysicalHostClient {
+	return &PhysicalHostClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PhysicalHostClient) Create(container *PhysicalHost) (*PhysicalHost, error) {
+	resp := &PhysicalHost{}
+	err := c.rancherClient.doCreate(PHYSICAL_HOST_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PhysicalHostClient) Update(existing *PhysicalHost, updates interface{}) (*PhysicalHost, error) {
+	resp := &PhysicalHost{}
+	err := c.rancherClient.doUpdate(PHYSICAL_HOST_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PhysicalHostClient) List(opts *ListOpts) (*PhysicalHostCollection, error) {
+	resp := &PhysicalHostCollection{}
+	err := c.rancherClient.doList(PHYSICAL_HOST_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PhysicalHostClient) ById(id string) (*PhysicalHost, error) {
+	resp := &PhysicalHost{}
+	err := c.rancherClient.doById(PHYSICAL_HOST_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PhysicalHostClient) Delete(container *PhysicalHost) error {
+	return c.rancherClient.doResourceDelete(PHYSICAL_HOST_TYPE, &container.Resource)
+}
+
+func (c *PhysicalHostClient) ActionBootstrap(resource *PhysicalHost) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(PHYSICAL_HOST_TYPE, "bootstrap", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PhysicalHostClient) ActionCreate(resource *PhysicalHost) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(PHYSICAL_HOST_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PhysicalHostClient) ActionError(resource *PhysicalHost) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(PHYSICAL_HOST_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PhysicalHostClient) ActionRemove(resource *PhysicalHost) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(PHYSICAL_HOST_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PhysicalHostClient) ActionUpdate(resource *PhysicalHost) (*PhysicalHost, error) {
+
+	resp := &PhysicalHost{}
+
+	err := c.rancherClient.doAction(PHYSICAL_HOST_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_port.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_port.go
@@ -1,0 +1,182 @@
+package client
+
+const (
+	PORT_TYPE = "port"
+)
+
+type Port struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	BindAddress string `json:"bindAddress,omitempty" yaml:"bind_address,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PrivateIpAddressId string `json:"privateIpAddressId,omitempty" yaml:"private_ip_address_id,omitempty"`
+
+	PrivatePort int64 `json:"privatePort,omitempty" yaml:"private_port,omitempty"`
+
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+
+	PublicIpAddressId string `json:"publicIpAddressId,omitempty" yaml:"public_ip_address_id,omitempty"`
+
+	PublicPort int64 `json:"publicPort,omitempty" yaml:"public_port,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type PortCollection struct {
+	Collection
+	Data []Port `json:"data,omitempty"`
+}
+
+type PortClient struct {
+	rancherClient *RancherClient
+}
+
+type PortOperations interface {
+	List(opts *ListOpts) (*PortCollection, error)
+	Create(opts *Port) (*Port, error)
+	Update(existing *Port, updates interface{}) (*Port, error)
+	ById(id string) (*Port, error)
+	Delete(container *Port) error
+
+	ActionActivate(*Port) (*Port, error)
+
+	ActionCreate(*Port) (*Port, error)
+
+	ActionDeactivate(*Port) (*Port, error)
+
+	ActionPurge(*Port) (*Port, error)
+
+	ActionRemove(*Port) (*Port, error)
+
+	ActionRestore(*Port) (*Port, error)
+
+	ActionUpdate(*Port) (*Port, error)
+}
+
+func newPortClient(rancherClient *RancherClient) *PortClient {
+	return &PortClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PortClient) Create(container *Port) (*Port, error) {
+	resp := &Port{}
+	err := c.rancherClient.doCreate(PORT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PortClient) Update(existing *Port, updates interface{}) (*Port, error) {
+	resp := &Port{}
+	err := c.rancherClient.doUpdate(PORT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PortClient) List(opts *ListOpts) (*PortCollection, error) {
+	resp := &PortCollection{}
+	err := c.rancherClient.doList(PORT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PortClient) ById(id string) (*Port, error) {
+	resp := &Port{}
+	err := c.rancherClient.doById(PORT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PortClient) Delete(container *Port) error {
+	return c.rancherClient.doResourceDelete(PORT_TYPE, &container.Resource)
+}
+
+func (c *PortClient) ActionActivate(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionCreate(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionDeactivate(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionPurge(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionRemove(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionRestore(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *PortClient) ActionUpdate(resource *Port) (*Port, error) {
+
+	resp := &Port{}
+
+	err := c.rancherClient.doAction(PORT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_process_definition.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_process_definition.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	PROCESS_DEFINITION_TYPE = "processDefinition"
+)
+
+type ProcessDefinition struct {
+	Resource
+
+	ExtensionBased bool `json:"extensionBased,omitempty" yaml:"extension_based,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PostProcessListeners interface{} `json:"postProcessListeners,omitempty" yaml:"post_process_listeners,omitempty"`
+
+	PreProcessListeners interface{} `json:"preProcessListeners,omitempty" yaml:"pre_process_listeners,omitempty"`
+
+	ProcessHandlers interface{} `json:"processHandlers,omitempty" yaml:"process_handlers,omitempty"`
+
+	ResourceType string `json:"resourceType,omitempty" yaml:"resource_type,omitempty"`
+
+	StateTransitions []interface{} `json:"stateTransitions,omitempty" yaml:"state_transitions,omitempty"`
+}
+
+type ProcessDefinitionCollection struct {
+	Collection
+	Data []ProcessDefinition `json:"data,omitempty"`
+}
+
+type ProcessDefinitionClient struct {
+	rancherClient *RancherClient
+}
+
+type ProcessDefinitionOperations interface {
+	List(opts *ListOpts) (*ProcessDefinitionCollection, error)
+	Create(opts *ProcessDefinition) (*ProcessDefinition, error)
+	Update(existing *ProcessDefinition, updates interface{}) (*ProcessDefinition, error)
+	ById(id string) (*ProcessDefinition, error)
+	Delete(container *ProcessDefinition) error
+}
+
+func newProcessDefinitionClient(rancherClient *RancherClient) *ProcessDefinitionClient {
+	return &ProcessDefinitionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ProcessDefinitionClient) Create(container *ProcessDefinition) (*ProcessDefinition, error) {
+	resp := &ProcessDefinition{}
+	err := c.rancherClient.doCreate(PROCESS_DEFINITION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ProcessDefinitionClient) Update(existing *ProcessDefinition, updates interface{}) (*ProcessDefinition, error) {
+	resp := &ProcessDefinition{}
+	err := c.rancherClient.doUpdate(PROCESS_DEFINITION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ProcessDefinitionClient) List(opts *ListOpts) (*ProcessDefinitionCollection, error) {
+	resp := &ProcessDefinitionCollection{}
+	err := c.rancherClient.doList(PROCESS_DEFINITION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ProcessDefinitionClient) ById(id string) (*ProcessDefinition, error) {
+	resp := &ProcessDefinition{}
+	err := c.rancherClient.doById(PROCESS_DEFINITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ProcessDefinitionClient) Delete(container *ProcessDefinition) error {
+	return c.rancherClient.doResourceDelete(PROCESS_DEFINITION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_process_execution.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_process_execution.go
@@ -1,0 +1,73 @@
+package client
+
+const (
+	PROCESS_EXECUTION_TYPE = "processExecution"
+)
+
+type ProcessExecution struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Log map[string]interface{} `json:"log,omitempty" yaml:"log,omitempty"`
+
+	ProcessInstanceId string `json:"processInstanceId,omitempty" yaml:"process_instance_id,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ProcessExecutionCollection struct {
+	Collection
+	Data []ProcessExecution `json:"data,omitempty"`
+}
+
+type ProcessExecutionClient struct {
+	rancherClient *RancherClient
+}
+
+type ProcessExecutionOperations interface {
+	List(opts *ListOpts) (*ProcessExecutionCollection, error)
+	Create(opts *ProcessExecution) (*ProcessExecution, error)
+	Update(existing *ProcessExecution, updates interface{}) (*ProcessExecution, error)
+	ById(id string) (*ProcessExecution, error)
+	Delete(container *ProcessExecution) error
+}
+
+func newProcessExecutionClient(rancherClient *RancherClient) *ProcessExecutionClient {
+	return &ProcessExecutionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ProcessExecutionClient) Create(container *ProcessExecution) (*ProcessExecution, error) {
+	resp := &ProcessExecution{}
+	err := c.rancherClient.doCreate(PROCESS_EXECUTION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ProcessExecutionClient) Update(existing *ProcessExecution, updates interface{}) (*ProcessExecution, error) {
+	resp := &ProcessExecution{}
+	err := c.rancherClient.doUpdate(PROCESS_EXECUTION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ProcessExecutionClient) List(opts *ListOpts) (*ProcessExecutionCollection, error) {
+	resp := &ProcessExecutionCollection{}
+	err := c.rancherClient.doList(PROCESS_EXECUTION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ProcessExecutionClient) ById(id string) (*ProcessExecution, error) {
+	resp := &ProcessExecution{}
+	err := c.rancherClient.doById(PROCESS_EXECUTION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ProcessExecutionClient) Delete(container *ProcessExecution) error {
+	return c.rancherClient.doResourceDelete(PROCESS_EXECUTION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_process_instance.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_process_instance.go
@@ -1,0 +1,89 @@
+package client
+
+const (
+	PROCESS_INSTANCE_TYPE = "processInstance"
+)
+
+type ProcessInstance struct {
+	Resource
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EndTime string `json:"endTime,omitempty" yaml:"end_time,omitempty"`
+
+	ExitReason string `json:"exitReason,omitempty" yaml:"exit_reason,omitempty"`
+
+	Phase string `json:"phase,omitempty" yaml:"phase,omitempty"`
+
+	Priority int64 `json:"priority,omitempty" yaml:"priority,omitempty"`
+
+	ProcessName string `json:"processName,omitempty" yaml:"process_name,omitempty"`
+
+	ResourceId string `json:"resourceId,omitempty" yaml:"resource_id,omitempty"`
+
+	ResourceType string `json:"resourceType,omitempty" yaml:"resource_type,omitempty"`
+
+	Result string `json:"result,omitempty" yaml:"result,omitempty"`
+
+	RunningProcessServerId string `json:"runningProcessServerId,omitempty" yaml:"running_process_server_id,omitempty"`
+
+	StartProcessServerId string `json:"startProcessServerId,omitempty" yaml:"start_process_server_id,omitempty"`
+
+	StartTime string `json:"startTime,omitempty" yaml:"start_time,omitempty"`
+}
+
+type ProcessInstanceCollection struct {
+	Collection
+	Data []ProcessInstance `json:"data,omitempty"`
+}
+
+type ProcessInstanceClient struct {
+	rancherClient *RancherClient
+}
+
+type ProcessInstanceOperations interface {
+	List(opts *ListOpts) (*ProcessInstanceCollection, error)
+	Create(opts *ProcessInstance) (*ProcessInstance, error)
+	Update(existing *ProcessInstance, updates interface{}) (*ProcessInstance, error)
+	ById(id string) (*ProcessInstance, error)
+	Delete(container *ProcessInstance) error
+}
+
+func newProcessInstanceClient(rancherClient *RancherClient) *ProcessInstanceClient {
+	return &ProcessInstanceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ProcessInstanceClient) Create(container *ProcessInstance) (*ProcessInstance, error) {
+	resp := &ProcessInstance{}
+	err := c.rancherClient.doCreate(PROCESS_INSTANCE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ProcessInstanceClient) Update(existing *ProcessInstance, updates interface{}) (*ProcessInstance, error) {
+	resp := &ProcessInstance{}
+	err := c.rancherClient.doUpdate(PROCESS_INSTANCE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ProcessInstanceClient) List(opts *ListOpts) (*ProcessInstanceCollection, error) {
+	resp := &ProcessInstanceCollection{}
+	err := c.rancherClient.doList(PROCESS_INSTANCE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ProcessInstanceClient) ById(id string) (*ProcessInstance, error) {
+	resp := &ProcessInstance{}
+	err := c.rancherClient.doById(PROCESS_INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ProcessInstanceClient) Delete(container *ProcessInstance) error {
+	return c.rancherClient.doResourceDelete(PROCESS_INSTANCE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_project.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_project.go
@@ -1,0 +1,193 @@
+package client
+
+const (
+	PROJECT_TYPE = "project"
+)
+
+type Project struct {
+	Resource
+
+	AllowSystemRole bool `json:"allowSystemRole,omitempty" yaml:"allow_system_role,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Kubernetes bool `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
+
+	Members []interface{} `json:"members,omitempty" yaml:"members,omitempty"`
+
+	Mesos bool `json:"mesos,omitempty" yaml:"mesos,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicDns bool `json:"publicDns,omitempty" yaml:"public_dns,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	ServicesPortRange *ServicesPortRange `json:"servicesPortRange,omitempty" yaml:"services_port_range,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Swarm bool `json:"swarm,omitempty" yaml:"swarm,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VirtualMachine bool `json:"virtualMachine,omitempty" yaml:"virtual_machine,omitempty"`
+}
+
+type ProjectCollection struct {
+	Collection
+	Data []Project `json:"data,omitempty"`
+}
+
+type ProjectClient struct {
+	rancherClient *RancherClient
+}
+
+type ProjectOperations interface {
+	List(opts *ListOpts) (*ProjectCollection, error)
+	Create(opts *Project) (*Project, error)
+	Update(existing *Project, updates interface{}) (*Project, error)
+	ById(id string) (*Project, error)
+	Delete(container *Project) error
+
+	ActionActivate(*Project) (*Account, error)
+
+	ActionCreate(*Project) (*Account, error)
+
+	ActionDeactivate(*Project) (*Account, error)
+
+	ActionPurge(*Project) (*Account, error)
+
+	ActionRemove(*Project) (*Account, error)
+
+	ActionRestore(*Project) (*Account, error)
+
+	ActionSetmembers(*Project, *SetProjectMembersInput) (*SetProjectMembersInput, error)
+
+	ActionUpdate(*Project) (*Account, error)
+}
+
+func newProjectClient(rancherClient *RancherClient) *ProjectClient {
+	return &ProjectClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ProjectClient) Create(container *Project) (*Project, error) {
+	resp := &Project{}
+	err := c.rancherClient.doCreate(PROJECT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ProjectClient) Update(existing *Project, updates interface{}) (*Project, error) {
+	resp := &Project{}
+	err := c.rancherClient.doUpdate(PROJECT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ProjectClient) List(opts *ListOpts) (*ProjectCollection, error) {
+	resp := &ProjectCollection{}
+	err := c.rancherClient.doList(PROJECT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ProjectClient) ById(id string) (*Project, error) {
+	resp := &Project{}
+	err := c.rancherClient.doById(PROJECT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ProjectClient) Delete(container *Project) error {
+	return c.rancherClient.doResourceDelete(PROJECT_TYPE, &container.Resource)
+}
+
+func (c *ProjectClient) ActionActivate(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionCreate(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionDeactivate(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionPurge(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionRemove(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionRestore(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionSetmembers(resource *Project, input *SetProjectMembersInput) (*SetProjectMembersInput, error) {
+
+	resp := &SetProjectMembersInput{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "setmembers", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ProjectClient) ActionUpdate(resource *Project) (*Account, error) {
+
+	resp := &Account{}
+
+	err := c.rancherClient.doAction(PROJECT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_project_member.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_project_member.go
@@ -1,0 +1,174 @@
+package client
+
+const (
+	PROJECT_MEMBER_TYPE = "projectMember"
+)
+
+type ProjectMember struct {
+	Resource
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExternalIdType string `json:"externalIdType,omitempty" yaml:"external_id_type,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	ProjectId string `json:"projectId,omitempty" yaml:"project_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	Role string `json:"role,omitempty" yaml:"role,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ProjectMemberCollection struct {
+	Collection
+	Data []ProjectMember `json:"data,omitempty"`
+}
+
+type ProjectMemberClient struct {
+	rancherClient *RancherClient
+}
+
+type ProjectMemberOperations interface {
+	List(opts *ListOpts) (*ProjectMemberCollection, error)
+	Create(opts *ProjectMember) (*ProjectMember, error)
+	Update(existing *ProjectMember, updates interface{}) (*ProjectMember, error)
+	ById(id string) (*ProjectMember, error)
+	Delete(container *ProjectMember) error
+
+	ActionActivate(*ProjectMember) (*ProjectMember, error)
+
+	ActionCreate(*ProjectMember) (*ProjectMember, error)
+
+	ActionDeactivate(*ProjectMember) (*ProjectMember, error)
+
+	ActionPurge(*ProjectMember) (*ProjectMember, error)
+
+	ActionRemove(*ProjectMember) (*ProjectMember, error)
+
+	ActionRestore(*ProjectMember) (*ProjectMember, error)
+
+	ActionUpdate(*ProjectMember) (*ProjectMember, error)
+}
+
+func newProjectMemberClient(rancherClient *RancherClient) *ProjectMemberClient {
+	return &ProjectMemberClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ProjectMemberClient) Create(container *ProjectMember) (*ProjectMember, error) {
+	resp := &ProjectMember{}
+	err := c.rancherClient.doCreate(PROJECT_MEMBER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ProjectMemberClient) Update(existing *ProjectMember, updates interface{}) (*ProjectMember, error) {
+	resp := &ProjectMember{}
+	err := c.rancherClient.doUpdate(PROJECT_MEMBER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ProjectMemberClient) List(opts *ListOpts) (*ProjectMemberCollection, error) {
+	resp := &ProjectMemberCollection{}
+	err := c.rancherClient.doList(PROJECT_MEMBER_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ById(id string) (*ProjectMember, error) {
+	resp := &ProjectMember{}
+	err := c.rancherClient.doById(PROJECT_MEMBER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ProjectMemberClient) Delete(container *ProjectMember) error {
+	return c.rancherClient.doResourceDelete(PROJECT_MEMBER_TYPE, &container.Resource)
+}
+
+func (c *ProjectMemberClient) ActionActivate(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionCreate(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionDeactivate(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionPurge(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionRemove(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionRestore(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ProjectMemberClient) ActionUpdate(resource *ProjectMember) (*ProjectMember, error) {
+
+	resp := &ProjectMember{}
+
+	err := c.rancherClient.doAction(PROJECT_MEMBER_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_public_endpoint.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_public_endpoint.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	PUBLIC_ENDPOINT_TYPE = "publicEndpoint"
+)
+
+type PublicEndpoint struct {
+	Resource
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	IpAddress string `json:"ipAddress,omitempty" yaml:"ip_address,omitempty"`
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	ServiceId string `json:"serviceId,omitempty" yaml:"service_id,omitempty"`
+}
+
+type PublicEndpointCollection struct {
+	Collection
+	Data []PublicEndpoint `json:"data,omitempty"`
+}
+
+type PublicEndpointClient struct {
+	rancherClient *RancherClient
+}
+
+type PublicEndpointOperations interface {
+	List(opts *ListOpts) (*PublicEndpointCollection, error)
+	Create(opts *PublicEndpoint) (*PublicEndpoint, error)
+	Update(existing *PublicEndpoint, updates interface{}) (*PublicEndpoint, error)
+	ById(id string) (*PublicEndpoint, error)
+	Delete(container *PublicEndpoint) error
+}
+
+func newPublicEndpointClient(rancherClient *RancherClient) *PublicEndpointClient {
+	return &PublicEndpointClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PublicEndpointClient) Create(container *PublicEndpoint) (*PublicEndpoint, error) {
+	resp := &PublicEndpoint{}
+	err := c.rancherClient.doCreate(PUBLIC_ENDPOINT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PublicEndpointClient) Update(existing *PublicEndpoint, updates interface{}) (*PublicEndpoint, error) {
+	resp := &PublicEndpoint{}
+	err := c.rancherClient.doUpdate(PUBLIC_ENDPOINT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PublicEndpointClient) List(opts *ListOpts) (*PublicEndpointCollection, error) {
+	resp := &PublicEndpointCollection{}
+	err := c.rancherClient.doList(PUBLIC_ENDPOINT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PublicEndpointClient) ById(id string) (*PublicEndpoint, error) {
+	resp := &PublicEndpoint{}
+	err := c.rancherClient.doById(PUBLIC_ENDPOINT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PublicEndpointClient) Delete(container *PublicEndpoint) error {
+	return c.rancherClient.doResourceDelete(PUBLIC_ENDPOINT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_publish.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_publish.go
@@ -1,0 +1,87 @@
+package client
+
+const (
+	PUBLISH_TYPE = "publish"
+)
+
+type Publish struct {
+	Resource
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PreviousIds []string `json:"previousIds,omitempty" yaml:"previous_ids,omitempty"`
+
+	Publisher string `json:"publisher,omitempty" yaml:"publisher,omitempty"`
+
+	ResourceId string `json:"resourceId,omitempty" yaml:"resource_id,omitempty"`
+
+	ResourceType string `json:"resourceType,omitempty" yaml:"resource_type,omitempty"`
+
+	Time int64 `json:"time,omitempty" yaml:"time,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningInternalMessage string `json:"transitioningInternalMessage,omitempty" yaml:"transitioning_internal_message,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+}
+
+type PublishCollection struct {
+	Collection
+	Data []Publish `json:"data,omitempty"`
+}
+
+type PublishClient struct {
+	rancherClient *RancherClient
+}
+
+type PublishOperations interface {
+	List(opts *ListOpts) (*PublishCollection, error)
+	Create(opts *Publish) (*Publish, error)
+	Update(existing *Publish, updates interface{}) (*Publish, error)
+	ById(id string) (*Publish, error)
+	Delete(container *Publish) error
+}
+
+func newPublishClient(rancherClient *RancherClient) *PublishClient {
+	return &PublishClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PublishClient) Create(container *Publish) (*Publish, error) {
+	resp := &Publish{}
+	err := c.rancherClient.doCreate(PUBLISH_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PublishClient) Update(existing *Publish, updates interface{}) (*Publish, error) {
+	resp := &Publish{}
+	err := c.rancherClient.doUpdate(PUBLISH_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PublishClient) List(opts *ListOpts) (*PublishCollection, error) {
+	resp := &PublishCollection{}
+	err := c.rancherClient.doList(PUBLISH_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PublishClient) ById(id string) (*Publish, error) {
+	resp := &Publish{}
+	err := c.rancherClient.doById(PUBLISH_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PublishClient) Delete(container *Publish) error {
+	return c.rancherClient.doResourceDelete(PUBLISH_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_pull_task.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_pull_task.go
@@ -1,0 +1,99 @@
+package client
+
+const (
+	PULL_TASK_TYPE = "pullTask"
+)
+
+type PullTask struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Status map[string]interface{} `json:"status,omitempty" yaml:"status,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type PullTaskCollection struct {
+	Collection
+	Data []PullTask `json:"data,omitempty"`
+}
+
+type PullTaskClient struct {
+	rancherClient *RancherClient
+}
+
+type PullTaskOperations interface {
+	List(opts *ListOpts) (*PullTaskCollection, error)
+	Create(opts *PullTask) (*PullTask, error)
+	Update(existing *PullTask, updates interface{}) (*PullTask, error)
+	ById(id string) (*PullTask, error)
+	Delete(container *PullTask) error
+}
+
+func newPullTaskClient(rancherClient *RancherClient) *PullTaskClient {
+	return &PullTaskClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *PullTaskClient) Create(container *PullTask) (*PullTask, error) {
+	resp := &PullTask{}
+	err := c.rancherClient.doCreate(PULL_TASK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *PullTaskClient) Update(existing *PullTask, updates interface{}) (*PullTask, error) {
+	resp := &PullTask{}
+	err := c.rancherClient.doUpdate(PULL_TASK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *PullTaskClient) List(opts *ListOpts) (*PullTaskCollection, error) {
+	resp := &PullTaskCollection{}
+	err := c.rancherClient.doList(PULL_TASK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *PullTaskClient) ById(id string) (*PullTask, error) {
+	resp := &PullTask{}
+	err := c.rancherClient.doById(PULL_TASK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *PullTaskClient) Delete(container *PullTask) error {
+	return c.rancherClient.doResourceDelete(PULL_TASK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_recreate_on_quorum_strategy_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_recreate_on_quorum_strategy_config.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE = "recreateOnQuorumStrategyConfig"
+)
+
+type RecreateOnQuorumStrategyConfig struct {
+	Resource
+
+	Quorum int64 `json:"quorum,omitempty" yaml:"quorum,omitempty"`
+}
+
+type RecreateOnQuorumStrategyConfigCollection struct {
+	Collection
+	Data []RecreateOnQuorumStrategyConfig `json:"data,omitempty"`
+}
+
+type RecreateOnQuorumStrategyConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type RecreateOnQuorumStrategyConfigOperations interface {
+	List(opts *ListOpts) (*RecreateOnQuorumStrategyConfigCollection, error)
+	Create(opts *RecreateOnQuorumStrategyConfig) (*RecreateOnQuorumStrategyConfig, error)
+	Update(existing *RecreateOnQuorumStrategyConfig, updates interface{}) (*RecreateOnQuorumStrategyConfig, error)
+	ById(id string) (*RecreateOnQuorumStrategyConfig, error)
+	Delete(container *RecreateOnQuorumStrategyConfig) error
+}
+
+func newRecreateOnQuorumStrategyConfigClient(rancherClient *RancherClient) *RecreateOnQuorumStrategyConfigClient {
+	return &RecreateOnQuorumStrategyConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RecreateOnQuorumStrategyConfigClient) Create(container *RecreateOnQuorumStrategyConfig) (*RecreateOnQuorumStrategyConfig, error) {
+	resp := &RecreateOnQuorumStrategyConfig{}
+	err := c.rancherClient.doCreate(RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RecreateOnQuorumStrategyConfigClient) Update(existing *RecreateOnQuorumStrategyConfig, updates interface{}) (*RecreateOnQuorumStrategyConfig, error) {
+	resp := &RecreateOnQuorumStrategyConfig{}
+	err := c.rancherClient.doUpdate(RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RecreateOnQuorumStrategyConfigClient) List(opts *ListOpts) (*RecreateOnQuorumStrategyConfigCollection, error) {
+	resp := &RecreateOnQuorumStrategyConfigCollection{}
+	err := c.rancherClient.doList(RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RecreateOnQuorumStrategyConfigClient) ById(id string) (*RecreateOnQuorumStrategyConfig, error) {
+	resp := &RecreateOnQuorumStrategyConfig{}
+	err := c.rancherClient.doById(RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RecreateOnQuorumStrategyConfigClient) Delete(container *RecreateOnQuorumStrategyConfig) error {
+	return c.rancherClient.doResourceDelete(RECREATE_ON_QUORUM_STRATEGY_CONFIG_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_register.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_register.go
@@ -1,0 +1,108 @@
+package client
+
+const (
+	REGISTER_TYPE = "register"
+)
+
+type Register struct {
+	Resource
+
+	AccessKey string `json:"accessKey,omitempty" yaml:"access_key,omitempty"`
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SecretKey string `json:"secretKey,omitempty" yaml:"secret_key,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type RegisterCollection struct {
+	Collection
+	Data []Register `json:"data,omitempty"`
+}
+
+type RegisterClient struct {
+	rancherClient *RancherClient
+}
+
+type RegisterOperations interface {
+	List(opts *ListOpts) (*RegisterCollection, error)
+	Create(opts *Register) (*Register, error)
+	Update(existing *Register, updates interface{}) (*Register, error)
+	ById(id string) (*Register, error)
+	Delete(container *Register) error
+
+	ActionStop(*Register, *InstanceStop) (*Instance, error)
+}
+
+func newRegisterClient(rancherClient *RancherClient) *RegisterClient {
+	return &RegisterClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RegisterClient) Create(container *Register) (*Register, error) {
+	resp := &Register{}
+	err := c.rancherClient.doCreate(REGISTER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RegisterClient) Update(existing *Register, updates interface{}) (*Register, error) {
+	resp := &Register{}
+	err := c.rancherClient.doUpdate(REGISTER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RegisterClient) List(opts *ListOpts) (*RegisterCollection, error) {
+	resp := &RegisterCollection{}
+	err := c.rancherClient.doList(REGISTER_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RegisterClient) ById(id string) (*Register, error) {
+	resp := &Register{}
+	err := c.rancherClient.doById(REGISTER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RegisterClient) Delete(container *Register) error {
+	return c.rancherClient.doResourceDelete(REGISTER_TYPE, &container.Resource)
+}
+
+func (c *RegisterClient) ActionStop(resource *Register, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(REGISTER_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_registration_token.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_registration_token.go
@@ -1,0 +1,165 @@
+package client
+
+const (
+	REGISTRATION_TOKEN_TYPE = "registrationToken"
+)
+
+type RegistrationToken struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Command string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RegistrationUrl string `json:"registrationUrl,omitempty" yaml:"registration_url,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type RegistrationTokenCollection struct {
+	Collection
+	Data []RegistrationToken `json:"data,omitempty"`
+}
+
+type RegistrationTokenClient struct {
+	rancherClient *RancherClient
+}
+
+type RegistrationTokenOperations interface {
+	List(opts *ListOpts) (*RegistrationTokenCollection, error)
+	Create(opts *RegistrationToken) (*RegistrationToken, error)
+	Update(existing *RegistrationToken, updates interface{}) (*RegistrationToken, error)
+	ById(id string) (*RegistrationToken, error)
+	Delete(container *RegistrationToken) error
+
+	ActionActivate(*RegistrationToken) (*Credential, error)
+
+	ActionCreate(*RegistrationToken) (*Credential, error)
+
+	ActionDeactivate(*RegistrationToken) (*Credential, error)
+
+	ActionPurge(*RegistrationToken) (*Credential, error)
+
+	ActionRemove(*RegistrationToken) (*Credential, error)
+
+	ActionUpdate(*RegistrationToken) (*Credential, error)
+}
+
+func newRegistrationTokenClient(rancherClient *RancherClient) *RegistrationTokenClient {
+	return &RegistrationTokenClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RegistrationTokenClient) Create(container *RegistrationToken) (*RegistrationToken, error) {
+	resp := &RegistrationToken{}
+	err := c.rancherClient.doCreate(REGISTRATION_TOKEN_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) Update(existing *RegistrationToken, updates interface{}) (*RegistrationToken, error) {
+	resp := &RegistrationToken{}
+	err := c.rancherClient.doUpdate(REGISTRATION_TOKEN_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) List(opts *ListOpts) (*RegistrationTokenCollection, error) {
+	resp := &RegistrationTokenCollection{}
+	err := c.rancherClient.doList(REGISTRATION_TOKEN_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ById(id string) (*RegistrationToken, error) {
+	resp := &RegistrationToken{}
+	err := c.rancherClient.doById(REGISTRATION_TOKEN_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) Delete(container *RegistrationToken) error {
+	return c.rancherClient.doResourceDelete(REGISTRATION_TOKEN_TYPE, &container.Resource)
+}
+
+func (c *RegistrationTokenClient) ActionActivate(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ActionCreate(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ActionDeactivate(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ActionPurge(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ActionRemove(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistrationTokenClient) ActionUpdate(resource *RegistrationToken) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRATION_TOKEN_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_registry.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_registry.go
@@ -1,0 +1,180 @@
+package client
+
+const (
+	REGISTRY_TYPE = "registry"
+)
+
+type Registry struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	BlockDevicePath string `json:"blockDevicePath,omitempty" yaml:"block_device_path,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	DriverName string `json:"driverName,omitempty" yaml:"driver_name,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	ServerAddress string `json:"serverAddress,omitempty" yaml:"server_address,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VolumeAccessMode string `json:"volumeAccessMode,omitempty" yaml:"volume_access_mode,omitempty"`
+
+	VolumeCapabilities []string `json:"volumeCapabilities,omitempty" yaml:"volume_capabilities,omitempty"`
+}
+
+type RegistryCollection struct {
+	Collection
+	Data []Registry `json:"data,omitempty"`
+}
+
+type RegistryClient struct {
+	rancherClient *RancherClient
+}
+
+type RegistryOperations interface {
+	List(opts *ListOpts) (*RegistryCollection, error)
+	Create(opts *Registry) (*Registry, error)
+	Update(existing *Registry, updates interface{}) (*Registry, error)
+	ById(id string) (*Registry, error)
+	Delete(container *Registry) error
+
+	ActionActivate(*Registry) (*StoragePool, error)
+
+	ActionCreate(*Registry) (*StoragePool, error)
+
+	ActionDeactivate(*Registry) (*StoragePool, error)
+
+	ActionPurge(*Registry) (*StoragePool, error)
+
+	ActionRemove(*Registry) (*StoragePool, error)
+
+	ActionRestore(*Registry) (*StoragePool, error)
+
+	ActionUpdate(*Registry) (*StoragePool, error)
+}
+
+func newRegistryClient(rancherClient *RancherClient) *RegistryClient {
+	return &RegistryClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RegistryClient) Create(container *Registry) (*Registry, error) {
+	resp := &Registry{}
+	err := c.rancherClient.doCreate(REGISTRY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RegistryClient) Update(existing *Registry, updates interface{}) (*Registry, error) {
+	resp := &Registry{}
+	err := c.rancherClient.doUpdate(REGISTRY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RegistryClient) List(opts *ListOpts) (*RegistryCollection, error) {
+	resp := &RegistryCollection{}
+	err := c.rancherClient.doList(REGISTRY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RegistryClient) ById(id string) (*Registry, error) {
+	resp := &Registry{}
+	err := c.rancherClient.doById(REGISTRY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RegistryClient) Delete(container *Registry) error {
+	return c.rancherClient.doResourceDelete(REGISTRY_TYPE, &container.Resource)
+}
+
+func (c *RegistryClient) ActionActivate(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionCreate(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionDeactivate(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionPurge(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionRemove(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionRestore(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryClient) ActionUpdate(resource *Registry) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(REGISTRY_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_registry_credential.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_registry_credential.go
@@ -1,0 +1,165 @@
+package client
+
+const (
+	REGISTRY_CREDENTIAL_TYPE = "registryCredential"
+)
+
+type RegistryCredential struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicValue string `json:"publicValue,omitempty" yaml:"public_value,omitempty"`
+
+	RegistryId string `json:"registryId,omitempty" yaml:"registry_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SecretValue string `json:"secretValue,omitempty" yaml:"secret_value,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type RegistryCredentialCollection struct {
+	Collection
+	Data []RegistryCredential `json:"data,omitempty"`
+}
+
+type RegistryCredentialClient struct {
+	rancherClient *RancherClient
+}
+
+type RegistryCredentialOperations interface {
+	List(opts *ListOpts) (*RegistryCredentialCollection, error)
+	Create(opts *RegistryCredential) (*RegistryCredential, error)
+	Update(existing *RegistryCredential, updates interface{}) (*RegistryCredential, error)
+	ById(id string) (*RegistryCredential, error)
+	Delete(container *RegistryCredential) error
+
+	ActionActivate(*RegistryCredential) (*Credential, error)
+
+	ActionCreate(*RegistryCredential) (*Credential, error)
+
+	ActionDeactivate(*RegistryCredential) (*Credential, error)
+
+	ActionPurge(*RegistryCredential) (*Credential, error)
+
+	ActionRemove(*RegistryCredential) (*Credential, error)
+
+	ActionUpdate(*RegistryCredential) (*Credential, error)
+}
+
+func newRegistryCredentialClient(rancherClient *RancherClient) *RegistryCredentialClient {
+	return &RegistryCredentialClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RegistryCredentialClient) Create(container *RegistryCredential) (*RegistryCredential, error) {
+	resp := &RegistryCredential{}
+	err := c.rancherClient.doCreate(REGISTRY_CREDENTIAL_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) Update(existing *RegistryCredential, updates interface{}) (*RegistryCredential, error) {
+	resp := &RegistryCredential{}
+	err := c.rancherClient.doUpdate(REGISTRY_CREDENTIAL_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) List(opts *ListOpts) (*RegistryCredentialCollection, error) {
+	resp := &RegistryCredentialCollection{}
+	err := c.rancherClient.doList(REGISTRY_CREDENTIAL_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ById(id string) (*RegistryCredential, error) {
+	resp := &RegistryCredential{}
+	err := c.rancherClient.doById(REGISTRY_CREDENTIAL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) Delete(container *RegistryCredential) error {
+	return c.rancherClient.doResourceDelete(REGISTRY_CREDENTIAL_TYPE, &container.Resource)
+}
+
+func (c *RegistryCredentialClient) ActionActivate(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ActionCreate(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ActionDeactivate(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ActionPurge(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ActionRemove(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *RegistryCredentialClient) ActionUpdate(resource *RegistryCredential) (*Credential, error) {
+
+	resp := &Credential{}
+
+	err := c.rancherClient.doAction(REGISTRY_CREDENTIAL_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_resource_definition.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_resource_definition.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	RESOURCE_DEFINITION_TYPE = "resourceDefinition"
+)
+
+type ResourceDefinition struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type ResourceDefinitionCollection struct {
+	Collection
+	Data []ResourceDefinition `json:"data,omitempty"`
+}
+
+type ResourceDefinitionClient struct {
+	rancherClient *RancherClient
+}
+
+type ResourceDefinitionOperations interface {
+	List(opts *ListOpts) (*ResourceDefinitionCollection, error)
+	Create(opts *ResourceDefinition) (*ResourceDefinition, error)
+	Update(existing *ResourceDefinition, updates interface{}) (*ResourceDefinition, error)
+	ById(id string) (*ResourceDefinition, error)
+	Delete(container *ResourceDefinition) error
+}
+
+func newResourceDefinitionClient(rancherClient *RancherClient) *ResourceDefinitionClient {
+	return &ResourceDefinitionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ResourceDefinitionClient) Create(container *ResourceDefinition) (*ResourceDefinition, error) {
+	resp := &ResourceDefinition{}
+	err := c.rancherClient.doCreate(RESOURCE_DEFINITION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ResourceDefinitionClient) Update(existing *ResourceDefinition, updates interface{}) (*ResourceDefinition, error) {
+	resp := &ResourceDefinition{}
+	err := c.rancherClient.doUpdate(RESOURCE_DEFINITION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ResourceDefinitionClient) List(opts *ListOpts) (*ResourceDefinitionCollection, error) {
+	resp := &ResourceDefinitionCollection{}
+	err := c.rancherClient.doList(RESOURCE_DEFINITION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ResourceDefinitionClient) ById(id string) (*ResourceDefinition, error) {
+	resp := &ResourceDefinition{}
+	err := c.rancherClient.doById(RESOURCE_DEFINITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ResourceDefinitionClient) Delete(container *ResourceDefinition) error {
+	return c.rancherClient.doResourceDelete(RESOURCE_DEFINITION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_restart_policy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_restart_policy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	RESTART_POLICY_TYPE = "restartPolicy"
+)
+
+type RestartPolicy struct {
+	Resource
+
+	MaximumRetryCount int64 `json:"maximumRetryCount,omitempty" yaml:"maximum_retry_count,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type RestartPolicyCollection struct {
+	Collection
+	Data []RestartPolicy `json:"data,omitempty"`
+}
+
+type RestartPolicyClient struct {
+	rancherClient *RancherClient
+}
+
+type RestartPolicyOperations interface {
+	List(opts *ListOpts) (*RestartPolicyCollection, error)
+	Create(opts *RestartPolicy) (*RestartPolicy, error)
+	Update(existing *RestartPolicy, updates interface{}) (*RestartPolicy, error)
+	ById(id string) (*RestartPolicy, error)
+	Delete(container *RestartPolicy) error
+}
+
+func newRestartPolicyClient(rancherClient *RancherClient) *RestartPolicyClient {
+	return &RestartPolicyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RestartPolicyClient) Create(container *RestartPolicy) (*RestartPolicy, error) {
+	resp := &RestartPolicy{}
+	err := c.rancherClient.doCreate(RESTART_POLICY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RestartPolicyClient) Update(existing *RestartPolicy, updates interface{}) (*RestartPolicy, error) {
+	resp := &RestartPolicy{}
+	err := c.rancherClient.doUpdate(RESTART_POLICY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RestartPolicyClient) List(opts *ListOpts) (*RestartPolicyCollection, error) {
+	resp := &RestartPolicyCollection{}
+	err := c.rancherClient.doList(RESTART_POLICY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RestartPolicyClient) ById(id string) (*RestartPolicy, error) {
+	resp := &RestartPolicy{}
+	err := c.rancherClient.doById(RESTART_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RestartPolicyClient) Delete(container *RestartPolicy) error {
+	return c.rancherClient.doResourceDelete(RESTART_POLICY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_restore_from_backup_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_restore_from_backup_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	RESTORE_FROM_BACKUP_INPUT_TYPE = "restoreFromBackupInput"
+)
+
+type RestoreFromBackupInput struct {
+	Resource
+
+	BackupId string `json:"backupId,omitempty" yaml:"backup_id,omitempty"`
+}
+
+type RestoreFromBackupInputCollection struct {
+	Collection
+	Data []RestoreFromBackupInput `json:"data,omitempty"`
+}
+
+type RestoreFromBackupInputClient struct {
+	rancherClient *RancherClient
+}
+
+type RestoreFromBackupInputOperations interface {
+	List(opts *ListOpts) (*RestoreFromBackupInputCollection, error)
+	Create(opts *RestoreFromBackupInput) (*RestoreFromBackupInput, error)
+	Update(existing *RestoreFromBackupInput, updates interface{}) (*RestoreFromBackupInput, error)
+	ById(id string) (*RestoreFromBackupInput, error)
+	Delete(container *RestoreFromBackupInput) error
+}
+
+func newRestoreFromBackupInputClient(rancherClient *RancherClient) *RestoreFromBackupInputClient {
+	return &RestoreFromBackupInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RestoreFromBackupInputClient) Create(container *RestoreFromBackupInput) (*RestoreFromBackupInput, error) {
+	resp := &RestoreFromBackupInput{}
+	err := c.rancherClient.doCreate(RESTORE_FROM_BACKUP_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RestoreFromBackupInputClient) Update(existing *RestoreFromBackupInput, updates interface{}) (*RestoreFromBackupInput, error) {
+	resp := &RestoreFromBackupInput{}
+	err := c.rancherClient.doUpdate(RESTORE_FROM_BACKUP_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RestoreFromBackupInputClient) List(opts *ListOpts) (*RestoreFromBackupInputCollection, error) {
+	resp := &RestoreFromBackupInputCollection{}
+	err := c.rancherClient.doList(RESTORE_FROM_BACKUP_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RestoreFromBackupInputClient) ById(id string) (*RestoreFromBackupInput, error) {
+	resp := &RestoreFromBackupInput{}
+	err := c.rancherClient.doById(RESTORE_FROM_BACKUP_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RestoreFromBackupInputClient) Delete(container *RestoreFromBackupInput) error {
+	return c.rancherClient.doResourceDelete(RESTORE_FROM_BACKUP_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_revert_to_snapshot_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_revert_to_snapshot_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	REVERT_TO_SNAPSHOT_INPUT_TYPE = "revertToSnapshotInput"
+)
+
+type RevertToSnapshotInput struct {
+	Resource
+
+	SnapshotId string `json:"snapshotId,omitempty" yaml:"snapshot_id,omitempty"`
+}
+
+type RevertToSnapshotInputCollection struct {
+	Collection
+	Data []RevertToSnapshotInput `json:"data,omitempty"`
+}
+
+type RevertToSnapshotInputClient struct {
+	rancherClient *RancherClient
+}
+
+type RevertToSnapshotInputOperations interface {
+	List(opts *ListOpts) (*RevertToSnapshotInputCollection, error)
+	Create(opts *RevertToSnapshotInput) (*RevertToSnapshotInput, error)
+	Update(existing *RevertToSnapshotInput, updates interface{}) (*RevertToSnapshotInput, error)
+	ById(id string) (*RevertToSnapshotInput, error)
+	Delete(container *RevertToSnapshotInput) error
+}
+
+func newRevertToSnapshotInputClient(rancherClient *RancherClient) *RevertToSnapshotInputClient {
+	return &RevertToSnapshotInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RevertToSnapshotInputClient) Create(container *RevertToSnapshotInput) (*RevertToSnapshotInput, error) {
+	resp := &RevertToSnapshotInput{}
+	err := c.rancherClient.doCreate(REVERT_TO_SNAPSHOT_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RevertToSnapshotInputClient) Update(existing *RevertToSnapshotInput, updates interface{}) (*RevertToSnapshotInput, error) {
+	resp := &RevertToSnapshotInput{}
+	err := c.rancherClient.doUpdate(REVERT_TO_SNAPSHOT_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RevertToSnapshotInputClient) List(opts *ListOpts) (*RevertToSnapshotInputCollection, error) {
+	resp := &RevertToSnapshotInputCollection{}
+	err := c.rancherClient.doList(REVERT_TO_SNAPSHOT_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RevertToSnapshotInputClient) ById(id string) (*RevertToSnapshotInput, error) {
+	resp := &RevertToSnapshotInput{}
+	err := c.rancherClient.doById(REVERT_TO_SNAPSHOT_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RevertToSnapshotInputClient) Delete(container *RevertToSnapshotInput) error {
+	return c.rancherClient.doResourceDelete(REVERT_TO_SNAPSHOT_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_rolling_restart_strategy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_rolling_restart_strategy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	ROLLING_RESTART_STRATEGY_TYPE = "rollingRestartStrategy"
+)
+
+type RollingRestartStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+}
+
+type RollingRestartStrategyCollection struct {
+	Collection
+	Data []RollingRestartStrategy `json:"data,omitempty"`
+}
+
+type RollingRestartStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type RollingRestartStrategyOperations interface {
+	List(opts *ListOpts) (*RollingRestartStrategyCollection, error)
+	Create(opts *RollingRestartStrategy) (*RollingRestartStrategy, error)
+	Update(existing *RollingRestartStrategy, updates interface{}) (*RollingRestartStrategy, error)
+	ById(id string) (*RollingRestartStrategy, error)
+	Delete(container *RollingRestartStrategy) error
+}
+
+func newRollingRestartStrategyClient(rancherClient *RancherClient) *RollingRestartStrategyClient {
+	return &RollingRestartStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *RollingRestartStrategyClient) Create(container *RollingRestartStrategy) (*RollingRestartStrategy, error) {
+	resp := &RollingRestartStrategy{}
+	err := c.rancherClient.doCreate(ROLLING_RESTART_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *RollingRestartStrategyClient) Update(existing *RollingRestartStrategy, updates interface{}) (*RollingRestartStrategy, error) {
+	resp := &RollingRestartStrategy{}
+	err := c.rancherClient.doUpdate(ROLLING_RESTART_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *RollingRestartStrategyClient) List(opts *ListOpts) (*RollingRestartStrategyCollection, error) {
+	resp := &RollingRestartStrategyCollection{}
+	err := c.rancherClient.doList(ROLLING_RESTART_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *RollingRestartStrategyClient) ById(id string) (*RollingRestartStrategy, error) {
+	resp := &RollingRestartStrategy{}
+	err := c.rancherClient.doById(ROLLING_RESTART_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *RollingRestartStrategyClient) Delete(container *RollingRestartStrategy) error {
+	return c.rancherClient.doResourceDelete(ROLLING_RESTART_STRATEGY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_scale_policy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_scale_policy.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	SCALE_POLICY_TYPE = "scalePolicy"
+)
+
+type ScalePolicy struct {
+	Resource
+
+	Increment int64 `json:"increment,omitempty" yaml:"increment,omitempty"`
+
+	Max int64 `json:"max,omitempty" yaml:"max,omitempty"`
+
+	Min int64 `json:"min,omitempty" yaml:"min,omitempty"`
+}
+
+type ScalePolicyCollection struct {
+	Collection
+	Data []ScalePolicy `json:"data,omitempty"`
+}
+
+type ScalePolicyClient struct {
+	rancherClient *RancherClient
+}
+
+type ScalePolicyOperations interface {
+	List(opts *ListOpts) (*ScalePolicyCollection, error)
+	Create(opts *ScalePolicy) (*ScalePolicy, error)
+	Update(existing *ScalePolicy, updates interface{}) (*ScalePolicy, error)
+	ById(id string) (*ScalePolicy, error)
+	Delete(container *ScalePolicy) error
+}
+
+func newScalePolicyClient(rancherClient *RancherClient) *ScalePolicyClient {
+	return &ScalePolicyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ScalePolicyClient) Create(container *ScalePolicy) (*ScalePolicy, error) {
+	resp := &ScalePolicy{}
+	err := c.rancherClient.doCreate(SCALE_POLICY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ScalePolicyClient) Update(existing *ScalePolicy, updates interface{}) (*ScalePolicy, error) {
+	resp := &ScalePolicy{}
+	err := c.rancherClient.doUpdate(SCALE_POLICY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ScalePolicyClient) List(opts *ListOpts) (*ScalePolicyCollection, error) {
+	resp := &ScalePolicyCollection{}
+	err := c.rancherClient.doList(SCALE_POLICY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ScalePolicyClient) ById(id string) (*ScalePolicy, error) {
+	resp := &ScalePolicy{}
+	err := c.rancherClient.doById(SCALE_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ScalePolicyClient) Delete(container *ScalePolicy) error {
+	return c.rancherClient.doResourceDelete(SCALE_POLICY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
@@ -1,0 +1,432 @@
+package client
+
+const (
+	SECONDARY_LAUNCH_CONFIG_TYPE = "secondaryLaunchConfig"
+)
+
+type SecondaryLaunchConfig struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AllocationState string `json:"allocationState,omitempty" yaml:"allocation_state,omitempty"`
+
+	BlkioDeviceOptions map[string]interface{} `json:"blkioDeviceOptions,omitempty" yaml:"blkio_device_options,omitempty"`
+
+	Build *DockerBuild `json:"build,omitempty" yaml:"build,omitempty"`
+
+	CapAdd []string `json:"capAdd,omitempty" yaml:"cap_add,omitempty"`
+
+	CapDrop []string `json:"capDrop,omitempty" yaml:"cap_drop,omitempty"`
+
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Count int64 `json:"count,omitempty" yaml:"count,omitempty"`
+
+	CpuSet string `json:"cpuSet,omitempty" yaml:"cpu_set,omitempty"`
+
+	CpuShares int64 `json:"cpuShares,omitempty" yaml:"cpu_shares,omitempty"`
+
+	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
+	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
+
+	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`
+
+	DataVolumesFromLaunchConfigs []string `json:"dataVolumesFromLaunchConfigs,omitempty" yaml:"data_volumes_from_launch_configs,omitempty"`
+
+	DeploymentUnitUuid string `json:"deploymentUnitUuid,omitempty" yaml:"deployment_unit_uuid,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Devices []string `json:"devices,omitempty" yaml:"devices,omitempty"`
+
+	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+
+	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
+
+	DnsSearch []string `json:"dnsSearch,omitempty" yaml:"dns_search,omitempty"`
+
+	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
+
+	EntryPoint []string `json:"entryPoint,omitempty" yaml:"entry_point,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	Expose []string `json:"expose,omitempty" yaml:"expose,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExtraHosts []string `json:"extraHosts,omitempty" yaml:"extra_hosts,omitempty"`
+
+	FirstRunning string `json:"firstRunning,omitempty" yaml:"first_running,omitempty"`
+
+	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	ImageUuid string `json:"imageUuid,omitempty" yaml:"image_uuid,omitempty"`
+
+	InstanceLinks map[string]interface{} `json:"instanceLinks,omitempty" yaml:"instance_links,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	LogConfig *LogConfig `json:"logConfig,omitempty" yaml:"log_config,omitempty"`
+
+	LxcConf map[string]interface{} `json:"lxcConf,omitempty" yaml:"lxc_conf,omitempty"`
+
+	Memory int64 `json:"memory,omitempty" yaml:"memory,omitempty"`
+
+	MemoryMb int64 `json:"memoryMb,omitempty" yaml:"memory_mb,omitempty"`
+
+	MemorySwap int64 `json:"memorySwap,omitempty" yaml:"memory_swap,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NativeContainer bool `json:"nativeContainer,omitempty" yaml:"native_container,omitempty"`
+
+	NetworkContainerId string `json:"networkContainerId,omitempty" yaml:"network_container_id,omitempty"`
+
+	NetworkIds []string `json:"networkIds,omitempty" yaml:"network_ids,omitempty"`
+
+	NetworkLaunchConfig string `json:"networkLaunchConfig,omitempty" yaml:"network_launch_config,omitempty"`
+
+	NetworkMode string `json:"networkMode,omitempty" yaml:"network_mode,omitempty"`
+
+	PidMode string `json:"pidMode,omitempty" yaml:"pid_mode,omitempty"`
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	PrimaryIpAddress string `json:"primaryIpAddress,omitempty" yaml:"primary_ip_address,omitempty"`
+
+	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+
+	PublishAllPorts bool `json:"publishAllPorts,omitempty" yaml:"publish_all_ports,omitempty"`
+
+	ReadOnly bool `json:"readOnly,omitempty" yaml:"read_only,omitempty"`
+
+	RegistryCredentialId string `json:"registryCredentialId,omitempty" yaml:"registry_credential_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
+
+	RequestedIpAddress string `json:"requestedIpAddress,omitempty" yaml:"requested_ip_address,omitempty"`
+
+	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	StdinOpen bool `json:"stdinOpen,omitempty" yaml:"stdin_open,omitempty"`
+
+	SystemContainer string `json:"systemContainer,omitempty" yaml:"system_container,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Tty bool `json:"tty,omitempty" yaml:"tty,omitempty"`
+
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
+
+	Userdata string `json:"userdata,omitempty" yaml:"userdata,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vcpu int64 `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	VolumeDriver string `json:"volumeDriver,omitempty" yaml:"volume_driver,omitempty"`
+
+	WorkingDir string `json:"workingDir,omitempty" yaml:"working_dir,omitempty"`
+}
+
+type SecondaryLaunchConfigCollection struct {
+	Collection
+	Data []SecondaryLaunchConfig `json:"data,omitempty"`
+}
+
+type SecondaryLaunchConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type SecondaryLaunchConfigOperations interface {
+	List(opts *ListOpts) (*SecondaryLaunchConfigCollection, error)
+	Create(opts *SecondaryLaunchConfig) (*SecondaryLaunchConfig, error)
+	Update(existing *SecondaryLaunchConfig, updates interface{}) (*SecondaryLaunchConfig, error)
+	ById(id string) (*SecondaryLaunchConfig, error)
+	Delete(container *SecondaryLaunchConfig) error
+
+	ActionAllocate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionConsole(*SecondaryLaunchConfig, *InstanceConsoleInput) (*InstanceConsole, error)
+
+	ActionCreate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionDeallocate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionError(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionExecute(*SecondaryLaunchConfig, *ContainerExec) (*HostAccess, error)
+
+	ActionMigrate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionProxy(*SecondaryLaunchConfig, *ContainerProxy) (*HostAccess, error)
+
+	ActionPurge(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionRemove(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionRestart(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionRestore(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionSetlabels(*SecondaryLaunchConfig, *SetLabelsInput) (*Container, error)
+
+	ActionStart(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionStop(*SecondaryLaunchConfig, *InstanceStop) (*Instance, error)
+
+	ActionUpdate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionUpdatehealthy(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionUpdatereinitializing(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionUpdateunhealthy(*SecondaryLaunchConfig) (*Instance, error)
+}
+
+func newSecondaryLaunchConfigClient(rancherClient *RancherClient) *SecondaryLaunchConfigClient {
+	return &SecondaryLaunchConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SecondaryLaunchConfigClient) Create(container *SecondaryLaunchConfig) (*SecondaryLaunchConfig, error) {
+	resp := &SecondaryLaunchConfig{}
+	err := c.rancherClient.doCreate(SECONDARY_LAUNCH_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) Update(existing *SecondaryLaunchConfig, updates interface{}) (*SecondaryLaunchConfig, error) {
+	resp := &SecondaryLaunchConfig{}
+	err := c.rancherClient.doUpdate(SECONDARY_LAUNCH_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) List(opts *ListOpts) (*SecondaryLaunchConfigCollection, error) {
+	resp := &SecondaryLaunchConfigCollection{}
+	err := c.rancherClient.doList(SECONDARY_LAUNCH_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ById(id string) (*SecondaryLaunchConfig, error) {
+	resp := &SecondaryLaunchConfig{}
+	err := c.rancherClient.doById(SECONDARY_LAUNCH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) Delete(container *SecondaryLaunchConfig) error {
+	return c.rancherClient.doResourceDelete(SECONDARY_LAUNCH_CONFIG_TYPE, &container.Resource)
+}
+
+func (c *SecondaryLaunchConfigClient) ActionAllocate(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionConsole(resource *SecondaryLaunchConfig, input *InstanceConsoleInput) (*InstanceConsole, error) {
+
+	resp := &InstanceConsole{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "console", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionCreate(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionDeallocate(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionError(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionExecute(resource *SecondaryLaunchConfig, input *ContainerExec) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "execute", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionMigrate(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionProxy(resource *SecondaryLaunchConfig, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "proxy", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionPurge(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionRemove(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionRestart(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "restart", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionRestore(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionSetlabels(resource *SecondaryLaunchConfig, input *SetLabelsInput) (*Container, error) {
+
+	resp := &Container{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "setlabels", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionStart(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "start", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionStop(resource *SecondaryLaunchConfig, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionUpdate(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionUpdatehealthy(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "updatehealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionUpdatereinitializing(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "updatereinitializing", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionUpdateunhealthy(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "updateunhealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service.go
@@ -1,0 +1,283 @@
+package client
+
+const (
+	SERVICE_TYPE = "service"
+)
+
+type Service struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
+	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	CurrentScale int64 `json:"currentScale,omitempty" yaml:"current_scale,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RetainIp bool `json:"retainIp,omitempty" yaml:"retain_ip,omitempty"`
+
+	Scale int64 `json:"scale,omitempty" yaml:"scale,omitempty"`
+
+	ScalePolicy *ScalePolicy `json:"scalePolicy,omitempty" yaml:"scale_policy,omitempty"`
+
+	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
+
+	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
+
+	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vip string `json:"vip,omitempty" yaml:"vip,omitempty"`
+}
+
+type ServiceCollection struct {
+	Collection
+	Data []Service `json:"data,omitempty"`
+}
+
+type ServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceOperations interface {
+	List(opts *ListOpts) (*ServiceCollection, error)
+	Create(opts *Service) (*Service, error)
+	Update(existing *Service, updates interface{}) (*Service, error)
+	ById(id string) (*Service, error)
+	Delete(container *Service) error
+
+	ActionActivate(*Service) (*Service, error)
+
+	ActionAddservicelink(*Service, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionCancelrollback(*Service) (*Service, error)
+
+	ActionCancelupgrade(*Service) (*Service, error)
+
+	ActionCreate(*Service) (*Service, error)
+
+	ActionDeactivate(*Service) (*Service, error)
+
+	ActionFinishupgrade(*Service) (*Service, error)
+
+	ActionRemove(*Service) (*Service, error)
+
+	ActionRemoveservicelink(*Service, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRestart(*Service, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*Service) (*Service, error)
+
+	ActionSetservicelinks(*Service, *SetServiceLinksInput) (*Service, error)
+
+	ActionUpdate(*Service) (*Service, error)
+
+	ActionUpgrade(*Service, *ServiceUpgrade) (*Service, error)
+}
+
+func newServiceClient(rancherClient *RancherClient) *ServiceClient {
+	return &ServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceClient) Create(container *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doCreate(SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) Update(existing *Service, updates interface{}) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doUpdate(SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) List(opts *ListOpts) (*ServiceCollection, error) {
+	resp := &ServiceCollection{}
+	err := c.rancherClient.doList(SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) ById(id string) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doById(SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceClient) Delete(container *Service) error {
+	return c.rancherClient.doResourceDelete(SERVICE_TYPE, &container.Resource)
+}
+
+func (c *ServiceClient) ActionActivate(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionAddservicelink(resource *Service, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionCancelrollback(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionCancelupgrade(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionCreate(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionDeactivate(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionFinishupgrade(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRemove(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRemoveservicelink(resource *Service, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRestart(resource *Service, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRollback(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionSetservicelinks(resource *Service, input *SetServiceLinksInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "setservicelinks", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionUpdate(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionUpgrade(resource *Service, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_consume_map.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_consume_map.go
@@ -1,0 +1,130 @@
+package client
+
+const (
+	SERVICE_CONSUME_MAP_TYPE = "serviceConsumeMap"
+)
+
+type ServiceConsumeMap struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	ConsumedServiceId string `json:"consumedServiceId,omitempty" yaml:"consumed_service_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	ServiceId string `json:"serviceId,omitempty" yaml:"service_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ServiceConsumeMapCollection struct {
+	Collection
+	Data []ServiceConsumeMap `json:"data,omitempty"`
+}
+
+type ServiceConsumeMapClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceConsumeMapOperations interface {
+	List(opts *ListOpts) (*ServiceConsumeMapCollection, error)
+	Create(opts *ServiceConsumeMap) (*ServiceConsumeMap, error)
+	Update(existing *ServiceConsumeMap, updates interface{}) (*ServiceConsumeMap, error)
+	ById(id string) (*ServiceConsumeMap, error)
+	Delete(container *ServiceConsumeMap) error
+
+	ActionCreate(*ServiceConsumeMap) (*ServiceConsumeMap, error)
+
+	ActionRemove(*ServiceConsumeMap) (*ServiceConsumeMap, error)
+
+	ActionUpdate(*ServiceConsumeMap) (*ServiceConsumeMap, error)
+}
+
+func newServiceConsumeMapClient(rancherClient *RancherClient) *ServiceConsumeMapClient {
+	return &ServiceConsumeMapClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceConsumeMapClient) Create(container *ServiceConsumeMap) (*ServiceConsumeMap, error) {
+	resp := &ServiceConsumeMap{}
+	err := c.rancherClient.doCreate(SERVICE_CONSUME_MAP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) Update(existing *ServiceConsumeMap, updates interface{}) (*ServiceConsumeMap, error) {
+	resp := &ServiceConsumeMap{}
+	err := c.rancherClient.doUpdate(SERVICE_CONSUME_MAP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) List(opts *ListOpts) (*ServiceConsumeMapCollection, error) {
+	resp := &ServiceConsumeMapCollection{}
+	err := c.rancherClient.doList(SERVICE_CONSUME_MAP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) ById(id string) (*ServiceConsumeMap, error) {
+	resp := &ServiceConsumeMap{}
+	err := c.rancherClient.doById(SERVICE_CONSUME_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) Delete(container *ServiceConsumeMap) error {
+	return c.rancherClient.doResourceDelete(SERVICE_CONSUME_MAP_TYPE, &container.Resource)
+}
+
+func (c *ServiceConsumeMapClient) ActionCreate(resource *ServiceConsumeMap) (*ServiceConsumeMap, error) {
+
+	resp := &ServiceConsumeMap{}
+
+	err := c.rancherClient.doAction(SERVICE_CONSUME_MAP_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) ActionRemove(resource *ServiceConsumeMap) (*ServiceConsumeMap, error) {
+
+	resp := &ServiceConsumeMap{}
+
+	err := c.rancherClient.doAction(SERVICE_CONSUME_MAP_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceConsumeMapClient) ActionUpdate(resource *ServiceConsumeMap) (*ServiceConsumeMap, error) {
+
+	resp := &ServiceConsumeMap{}
+
+	err := c.rancherClient.doAction(SERVICE_CONSUME_MAP_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_event.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_event.go
@@ -1,0 +1,123 @@
+package client
+
+const (
+	SERVICE_EVENT_TYPE = "serviceEvent"
+)
+
+type ServiceEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ExternalTimestamp int64 `json:"externalTimestamp,omitempty" yaml:"external_timestamp,omitempty"`
+
+	HealthcheckUuid string `json:"healthcheckUuid,omitempty" yaml:"healthcheck_uuid,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	ReportedHealth string `json:"reportedHealth,omitempty" yaml:"reported_health,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ServiceEventCollection struct {
+	Collection
+	Data []ServiceEvent `json:"data,omitempty"`
+}
+
+type ServiceEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceEventOperations interface {
+	List(opts *ListOpts) (*ServiceEventCollection, error)
+	Create(opts *ServiceEvent) (*ServiceEvent, error)
+	Update(existing *ServiceEvent, updates interface{}) (*ServiceEvent, error)
+	ById(id string) (*ServiceEvent, error)
+	Delete(container *ServiceEvent) error
+
+	ActionCreate(*ServiceEvent) (*ServiceEvent, error)
+
+	ActionRemove(*ServiceEvent) (*ServiceEvent, error)
+}
+
+func newServiceEventClient(rancherClient *RancherClient) *ServiceEventClient {
+	return &ServiceEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceEventClient) Create(container *ServiceEvent) (*ServiceEvent, error) {
+	resp := &ServiceEvent{}
+	err := c.rancherClient.doCreate(SERVICE_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceEventClient) Update(existing *ServiceEvent, updates interface{}) (*ServiceEvent, error) {
+	resp := &ServiceEvent{}
+	err := c.rancherClient.doUpdate(SERVICE_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceEventClient) List(opts *ListOpts) (*ServiceEventCollection, error) {
+	resp := &ServiceEventCollection{}
+	err := c.rancherClient.doList(SERVICE_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceEventClient) ById(id string) (*ServiceEvent, error) {
+	resp := &ServiceEvent{}
+	err := c.rancherClient.doById(SERVICE_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceEventClient) Delete(container *ServiceEvent) error {
+	return c.rancherClient.doResourceDelete(SERVICE_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ServiceEventClient) ActionCreate(resource *ServiceEvent) (*ServiceEvent, error) {
+
+	resp := &ServiceEvent{}
+
+	err := c.rancherClient.doAction(SERVICE_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceEventClient) ActionRemove(resource *ServiceEvent) (*ServiceEvent, error) {
+
+	resp := &ServiceEvent{}
+
+	err := c.rancherClient.doAction(SERVICE_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_expose_map.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_expose_map.go
@@ -1,0 +1,121 @@
+package client
+
+const (
+	SERVICE_EXPOSE_MAP_TYPE = "serviceExposeMap"
+)
+
+type ServiceExposeMap struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	IpAddress string `json:"ipAddress,omitempty" yaml:"ip_address,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Managed bool `json:"managed,omitempty" yaml:"managed,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	ServiceId string `json:"serviceId,omitempty" yaml:"service_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ServiceExposeMapCollection struct {
+	Collection
+	Data []ServiceExposeMap `json:"data,omitempty"`
+}
+
+type ServiceExposeMapClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceExposeMapOperations interface {
+	List(opts *ListOpts) (*ServiceExposeMapCollection, error)
+	Create(opts *ServiceExposeMap) (*ServiceExposeMap, error)
+	Update(existing *ServiceExposeMap, updates interface{}) (*ServiceExposeMap, error)
+	ById(id string) (*ServiceExposeMap, error)
+	Delete(container *ServiceExposeMap) error
+
+	ActionCreate(*ServiceExposeMap) (*ServiceExposeMap, error)
+
+	ActionRemove(*ServiceExposeMap) (*ServiceExposeMap, error)
+}
+
+func newServiceExposeMapClient(rancherClient *RancherClient) *ServiceExposeMapClient {
+	return &ServiceExposeMapClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceExposeMapClient) Create(container *ServiceExposeMap) (*ServiceExposeMap, error) {
+	resp := &ServiceExposeMap{}
+	err := c.rancherClient.doCreate(SERVICE_EXPOSE_MAP_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceExposeMapClient) Update(existing *ServiceExposeMap, updates interface{}) (*ServiceExposeMap, error) {
+	resp := &ServiceExposeMap{}
+	err := c.rancherClient.doUpdate(SERVICE_EXPOSE_MAP_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceExposeMapClient) List(opts *ListOpts) (*ServiceExposeMapCollection, error) {
+	resp := &ServiceExposeMapCollection{}
+	err := c.rancherClient.doList(SERVICE_EXPOSE_MAP_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceExposeMapClient) ById(id string) (*ServiceExposeMap, error) {
+	resp := &ServiceExposeMap{}
+	err := c.rancherClient.doById(SERVICE_EXPOSE_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceExposeMapClient) Delete(container *ServiceExposeMap) error {
+	return c.rancherClient.doResourceDelete(SERVICE_EXPOSE_MAP_TYPE, &container.Resource)
+}
+
+func (c *ServiceExposeMapClient) ActionCreate(resource *ServiceExposeMap) (*ServiceExposeMap, error) {
+
+	resp := &ServiceExposeMap{}
+
+	err := c.rancherClient.doAction(SERVICE_EXPOSE_MAP_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ServiceExposeMapClient) ActionRemove(resource *ServiceExposeMap) (*ServiceExposeMap, error) {
+
+	resp := &ServiceExposeMap{}
+
+	err := c.rancherClient.doAction(SERVICE_EXPOSE_MAP_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_link.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_link.go
@@ -1,0 +1,71 @@
+package client
+
+const (
+	SERVICE_LINK_TYPE = "serviceLink"
+)
+
+type ServiceLink struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	ServiceId string `json:"serviceId,omitempty" yaml:"service_id,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ServiceLinkCollection struct {
+	Collection
+	Data []ServiceLink `json:"data,omitempty"`
+}
+
+type ServiceLinkClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceLinkOperations interface {
+	List(opts *ListOpts) (*ServiceLinkCollection, error)
+	Create(opts *ServiceLink) (*ServiceLink, error)
+	Update(existing *ServiceLink, updates interface{}) (*ServiceLink, error)
+	ById(id string) (*ServiceLink, error)
+	Delete(container *ServiceLink) error
+}
+
+func newServiceLinkClient(rancherClient *RancherClient) *ServiceLinkClient {
+	return &ServiceLinkClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceLinkClient) Create(container *ServiceLink) (*ServiceLink, error) {
+	resp := &ServiceLink{}
+	err := c.rancherClient.doCreate(SERVICE_LINK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceLinkClient) Update(existing *ServiceLink, updates interface{}) (*ServiceLink, error) {
+	resp := &ServiceLink{}
+	err := c.rancherClient.doUpdate(SERVICE_LINK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceLinkClient) List(opts *ListOpts) (*ServiceLinkCollection, error) {
+	resp := &ServiceLinkCollection{}
+	err := c.rancherClient.doList(SERVICE_LINK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceLinkClient) ById(id string) (*ServiceLink, error) {
+	resp := &ServiceLink{}
+	err := c.rancherClient.doById(SERVICE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceLinkClient) Delete(container *ServiceLink) error {
+	return c.rancherClient.doResourceDelete(SERVICE_LINK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_proxy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_proxy.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	SERVICE_PROXY_TYPE = "serviceProxy"
+)
+
+type ServiceProxy struct {
+	Resource
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+
+	Service string `json:"service,omitempty" yaml:"service,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type ServiceProxyCollection struct {
+	Collection
+	Data []ServiceProxy `json:"data,omitempty"`
+}
+
+type ServiceProxyClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceProxyOperations interface {
+	List(opts *ListOpts) (*ServiceProxyCollection, error)
+	Create(opts *ServiceProxy) (*ServiceProxy, error)
+	Update(existing *ServiceProxy, updates interface{}) (*ServiceProxy, error)
+	ById(id string) (*ServiceProxy, error)
+	Delete(container *ServiceProxy) error
+}
+
+func newServiceProxyClient(rancherClient *RancherClient) *ServiceProxyClient {
+	return &ServiceProxyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceProxyClient) Create(container *ServiceProxy) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doCreate(SERVICE_PROXY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) Update(existing *ServiceProxy, updates interface{}) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doUpdate(SERVICE_PROXY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) List(opts *ListOpts) (*ServiceProxyCollection, error) {
+	resp := &ServiceProxyCollection{}
+	err := c.rancherClient.doList(SERVICE_PROXY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) ById(id string) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doById(SERVICE_PROXY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceProxyClient) Delete(container *ServiceProxy) error {
+	return c.rancherClient.doResourceDelete(SERVICE_PROXY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_restart.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_restart.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	SERVICE_RESTART_TYPE = "serviceRestart"
+)
+
+type ServiceRestart struct {
+	Resource
+
+	RollingRestartStrategy RollingRestartStrategy `json:"rollingRestartStrategy,omitempty" yaml:"rolling_restart_strategy,omitempty"`
+}
+
+type ServiceRestartCollection struct {
+	Collection
+	Data []ServiceRestart `json:"data,omitempty"`
+}
+
+type ServiceRestartClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceRestartOperations interface {
+	List(opts *ListOpts) (*ServiceRestartCollection, error)
+	Create(opts *ServiceRestart) (*ServiceRestart, error)
+	Update(existing *ServiceRestart, updates interface{}) (*ServiceRestart, error)
+	ById(id string) (*ServiceRestart, error)
+	Delete(container *ServiceRestart) error
+}
+
+func newServiceRestartClient(rancherClient *RancherClient) *ServiceRestartClient {
+	return &ServiceRestartClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceRestartClient) Create(container *ServiceRestart) (*ServiceRestart, error) {
+	resp := &ServiceRestart{}
+	err := c.rancherClient.doCreate(SERVICE_RESTART_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceRestartClient) Update(existing *ServiceRestart, updates interface{}) (*ServiceRestart, error) {
+	resp := &ServiceRestart{}
+	err := c.rancherClient.doUpdate(SERVICE_RESTART_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceRestartClient) List(opts *ListOpts) (*ServiceRestartCollection, error) {
+	resp := &ServiceRestartCollection{}
+	err := c.rancherClient.doList(SERVICE_RESTART_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceRestartClient) ById(id string) (*ServiceRestart, error) {
+	resp := &ServiceRestart{}
+	err := c.rancherClient.doById(SERVICE_RESTART_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceRestartClient) Delete(container *ServiceRestart) error {
+	return c.rancherClient.doResourceDelete(SERVICE_RESTART_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_upgrade.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_upgrade.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	SERVICE_UPGRADE_TYPE = "serviceUpgrade"
+)
+
+type ServiceUpgrade struct {
+	Resource
+
+	InServiceStrategy *InServiceUpgradeStrategy `json:"inServiceStrategy,omitempty" yaml:"in_service_strategy,omitempty"`
+
+	ToServiceStrategy *ToServiceUpgradeStrategy `json:"toServiceStrategy,omitempty" yaml:"to_service_strategy,omitempty"`
+}
+
+type ServiceUpgradeCollection struct {
+	Collection
+	Data []ServiceUpgrade `json:"data,omitempty"`
+}
+
+type ServiceUpgradeClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceUpgradeOperations interface {
+	List(opts *ListOpts) (*ServiceUpgradeCollection, error)
+	Create(opts *ServiceUpgrade) (*ServiceUpgrade, error)
+	Update(existing *ServiceUpgrade, updates interface{}) (*ServiceUpgrade, error)
+	ById(id string) (*ServiceUpgrade, error)
+	Delete(container *ServiceUpgrade) error
+}
+
+func newServiceUpgradeClient(rancherClient *RancherClient) *ServiceUpgradeClient {
+	return &ServiceUpgradeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceUpgradeClient) Create(container *ServiceUpgrade) (*ServiceUpgrade, error) {
+	resp := &ServiceUpgrade{}
+	err := c.rancherClient.doCreate(SERVICE_UPGRADE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeClient) Update(existing *ServiceUpgrade, updates interface{}) (*ServiceUpgrade, error) {
+	resp := &ServiceUpgrade{}
+	err := c.rancherClient.doUpdate(SERVICE_UPGRADE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeClient) List(opts *ListOpts) (*ServiceUpgradeCollection, error) {
+	resp := &ServiceUpgradeCollection{}
+	err := c.rancherClient.doList(SERVICE_UPGRADE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeClient) ById(id string) (*ServiceUpgrade, error) {
+	resp := &ServiceUpgrade{}
+	err := c.rancherClient.doById(SERVICE_UPGRADE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceUpgradeClient) Delete(container *ServiceUpgrade) error {
+	return c.rancherClient.doResourceDelete(SERVICE_UPGRADE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_service_upgrade_strategy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_service_upgrade_strategy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	SERVICE_UPGRADE_STRATEGY_TYPE = "serviceUpgradeStrategy"
+)
+
+type ServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+}
+
+type ServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []ServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type ServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*ServiceUpgradeStrategyCollection, error)
+	Create(opts *ServiceUpgradeStrategy) (*ServiceUpgradeStrategy, error)
+	Update(existing *ServiceUpgradeStrategy, updates interface{}) (*ServiceUpgradeStrategy, error)
+	ById(id string) (*ServiceUpgradeStrategy, error)
+	Delete(container *ServiceUpgradeStrategy) error
+}
+
+func newServiceUpgradeStrategyClient(rancherClient *RancherClient) *ServiceUpgradeStrategyClient {
+	return &ServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceUpgradeStrategyClient) Create(container *ServiceUpgradeStrategy) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) Update(existing *ServiceUpgradeStrategy, updates interface{}) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) List(opts *ListOpts) (*ServiceUpgradeStrategyCollection, error) {
+	resp := &ServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) ById(id string) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) Delete(container *ServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_services_port_range.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_services_port_range.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	SERVICES_PORT_RANGE_TYPE = "servicesPortRange"
+)
+
+type ServicesPortRange struct {
+	Resource
+
+	EndPort int64 `json:"endPort,omitempty" yaml:"end_port,omitempty"`
+
+	StartPort int64 `json:"startPort,omitempty" yaml:"start_port,omitempty"`
+}
+
+type ServicesPortRangeCollection struct {
+	Collection
+	Data []ServicesPortRange `json:"data,omitempty"`
+}
+
+type ServicesPortRangeClient struct {
+	rancherClient *RancherClient
+}
+
+type ServicesPortRangeOperations interface {
+	List(opts *ListOpts) (*ServicesPortRangeCollection, error)
+	Create(opts *ServicesPortRange) (*ServicesPortRange, error)
+	Update(existing *ServicesPortRange, updates interface{}) (*ServicesPortRange, error)
+	ById(id string) (*ServicesPortRange, error)
+	Delete(container *ServicesPortRange) error
+}
+
+func newServicesPortRangeClient(rancherClient *RancherClient) *ServicesPortRangeClient {
+	return &ServicesPortRangeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServicesPortRangeClient) Create(container *ServicesPortRange) (*ServicesPortRange, error) {
+	resp := &ServicesPortRange{}
+	err := c.rancherClient.doCreate(SERVICES_PORT_RANGE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServicesPortRangeClient) Update(existing *ServicesPortRange, updates interface{}) (*ServicesPortRange, error) {
+	resp := &ServicesPortRange{}
+	err := c.rancherClient.doUpdate(SERVICES_PORT_RANGE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServicesPortRangeClient) List(opts *ListOpts) (*ServicesPortRangeCollection, error) {
+	resp := &ServicesPortRangeCollection{}
+	err := c.rancherClient.doList(SERVICES_PORT_RANGE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServicesPortRangeClient) ById(id string) (*ServicesPortRange, error) {
+	resp := &ServicesPortRange{}
+	err := c.rancherClient.doById(SERVICES_PORT_RANGE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServicesPortRangeClient) Delete(container *ServicesPortRange) error {
+	return c.rancherClient.doResourceDelete(SERVICES_PORT_RANGE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_set_labels_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_set_labels_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	SET_LABELS_INPUT_TYPE = "setLabelsInput"
+)
+
+type SetLabelsInput struct {
+	Resource
+
+	Labels interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+type SetLabelsInputCollection struct {
+	Collection
+	Data []SetLabelsInput `json:"data,omitempty"`
+}
+
+type SetLabelsInputClient struct {
+	rancherClient *RancherClient
+}
+
+type SetLabelsInputOperations interface {
+	List(opts *ListOpts) (*SetLabelsInputCollection, error)
+	Create(opts *SetLabelsInput) (*SetLabelsInput, error)
+	Update(existing *SetLabelsInput, updates interface{}) (*SetLabelsInput, error)
+	ById(id string) (*SetLabelsInput, error)
+	Delete(container *SetLabelsInput) error
+}
+
+func newSetLabelsInputClient(rancherClient *RancherClient) *SetLabelsInputClient {
+	return &SetLabelsInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SetLabelsInputClient) Create(container *SetLabelsInput) (*SetLabelsInput, error) {
+	resp := &SetLabelsInput{}
+	err := c.rancherClient.doCreate(SET_LABELS_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SetLabelsInputClient) Update(existing *SetLabelsInput, updates interface{}) (*SetLabelsInput, error) {
+	resp := &SetLabelsInput{}
+	err := c.rancherClient.doUpdate(SET_LABELS_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SetLabelsInputClient) List(opts *ListOpts) (*SetLabelsInputCollection, error) {
+	resp := &SetLabelsInputCollection{}
+	err := c.rancherClient.doList(SET_LABELS_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SetLabelsInputClient) ById(id string) (*SetLabelsInput, error) {
+	resp := &SetLabelsInput{}
+	err := c.rancherClient.doById(SET_LABELS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SetLabelsInputClient) Delete(container *SetLabelsInput) error {
+	return c.rancherClient.doResourceDelete(SET_LABELS_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_set_load_balancer_service_links_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_set_load_balancer_service_links_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE = "setLoadBalancerServiceLinksInput"
+)
+
+type SetLoadBalancerServiceLinksInput struct {
+	Resource
+
+	ServiceLinks []interface{} `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
+}
+
+type SetLoadBalancerServiceLinksInputCollection struct {
+	Collection
+	Data []SetLoadBalancerServiceLinksInput `json:"data,omitempty"`
+}
+
+type SetLoadBalancerServiceLinksInputClient struct {
+	rancherClient *RancherClient
+}
+
+type SetLoadBalancerServiceLinksInputOperations interface {
+	List(opts *ListOpts) (*SetLoadBalancerServiceLinksInputCollection, error)
+	Create(opts *SetLoadBalancerServiceLinksInput) (*SetLoadBalancerServiceLinksInput, error)
+	Update(existing *SetLoadBalancerServiceLinksInput, updates interface{}) (*SetLoadBalancerServiceLinksInput, error)
+	ById(id string) (*SetLoadBalancerServiceLinksInput, error)
+	Delete(container *SetLoadBalancerServiceLinksInput) error
+}
+
+func newSetLoadBalancerServiceLinksInputClient(rancherClient *RancherClient) *SetLoadBalancerServiceLinksInputClient {
+	return &SetLoadBalancerServiceLinksInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SetLoadBalancerServiceLinksInputClient) Create(container *SetLoadBalancerServiceLinksInput) (*SetLoadBalancerServiceLinksInput, error) {
+	resp := &SetLoadBalancerServiceLinksInput{}
+	err := c.rancherClient.doCreate(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SetLoadBalancerServiceLinksInputClient) Update(existing *SetLoadBalancerServiceLinksInput, updates interface{}) (*SetLoadBalancerServiceLinksInput, error) {
+	resp := &SetLoadBalancerServiceLinksInput{}
+	err := c.rancherClient.doUpdate(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SetLoadBalancerServiceLinksInputClient) List(opts *ListOpts) (*SetLoadBalancerServiceLinksInputCollection, error) {
+	resp := &SetLoadBalancerServiceLinksInputCollection{}
+	err := c.rancherClient.doList(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SetLoadBalancerServiceLinksInputClient) ById(id string) (*SetLoadBalancerServiceLinksInput, error) {
+	resp := &SetLoadBalancerServiceLinksInput{}
+	err := c.rancherClient.doById(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SetLoadBalancerServiceLinksInputClient) Delete(container *SetLoadBalancerServiceLinksInput) error {
+	return c.rancherClient.doResourceDelete(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_set_project_members_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_set_project_members_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	SET_PROJECT_MEMBERS_INPUT_TYPE = "setProjectMembersInput"
+)
+
+type SetProjectMembersInput struct {
+	Resource
+
+	Members []interface{} `json:"members,omitempty" yaml:"members,omitempty"`
+}
+
+type SetProjectMembersInputCollection struct {
+	Collection
+	Data []SetProjectMembersInput `json:"data,omitempty"`
+}
+
+type SetProjectMembersInputClient struct {
+	rancherClient *RancherClient
+}
+
+type SetProjectMembersInputOperations interface {
+	List(opts *ListOpts) (*SetProjectMembersInputCollection, error)
+	Create(opts *SetProjectMembersInput) (*SetProjectMembersInput, error)
+	Update(existing *SetProjectMembersInput, updates interface{}) (*SetProjectMembersInput, error)
+	ById(id string) (*SetProjectMembersInput, error)
+	Delete(container *SetProjectMembersInput) error
+}
+
+func newSetProjectMembersInputClient(rancherClient *RancherClient) *SetProjectMembersInputClient {
+	return &SetProjectMembersInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SetProjectMembersInputClient) Create(container *SetProjectMembersInput) (*SetProjectMembersInput, error) {
+	resp := &SetProjectMembersInput{}
+	err := c.rancherClient.doCreate(SET_PROJECT_MEMBERS_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SetProjectMembersInputClient) Update(existing *SetProjectMembersInput, updates interface{}) (*SetProjectMembersInput, error) {
+	resp := &SetProjectMembersInput{}
+	err := c.rancherClient.doUpdate(SET_PROJECT_MEMBERS_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SetProjectMembersInputClient) List(opts *ListOpts) (*SetProjectMembersInputCollection, error) {
+	resp := &SetProjectMembersInputCollection{}
+	err := c.rancherClient.doList(SET_PROJECT_MEMBERS_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SetProjectMembersInputClient) ById(id string) (*SetProjectMembersInput, error) {
+	resp := &SetProjectMembersInput{}
+	err := c.rancherClient.doById(SET_PROJECT_MEMBERS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SetProjectMembersInputClient) Delete(container *SetProjectMembersInput) error {
+	return c.rancherClient.doResourceDelete(SET_PROJECT_MEMBERS_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_set_service_links_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_set_service_links_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	SET_SERVICE_LINKS_INPUT_TYPE = "setServiceLinksInput"
+)
+
+type SetServiceLinksInput struct {
+	Resource
+
+	ServiceLinks []interface{} `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
+}
+
+type SetServiceLinksInputCollection struct {
+	Collection
+	Data []SetServiceLinksInput `json:"data,omitempty"`
+}
+
+type SetServiceLinksInputClient struct {
+	rancherClient *RancherClient
+}
+
+type SetServiceLinksInputOperations interface {
+	List(opts *ListOpts) (*SetServiceLinksInputCollection, error)
+	Create(opts *SetServiceLinksInput) (*SetServiceLinksInput, error)
+	Update(existing *SetServiceLinksInput, updates interface{}) (*SetServiceLinksInput, error)
+	ById(id string) (*SetServiceLinksInput, error)
+	Delete(container *SetServiceLinksInput) error
+}
+
+func newSetServiceLinksInputClient(rancherClient *RancherClient) *SetServiceLinksInputClient {
+	return &SetServiceLinksInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SetServiceLinksInputClient) Create(container *SetServiceLinksInput) (*SetServiceLinksInput, error) {
+	resp := &SetServiceLinksInput{}
+	err := c.rancherClient.doCreate(SET_SERVICE_LINKS_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SetServiceLinksInputClient) Update(existing *SetServiceLinksInput, updates interface{}) (*SetServiceLinksInput, error) {
+	resp := &SetServiceLinksInput{}
+	err := c.rancherClient.doUpdate(SET_SERVICE_LINKS_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SetServiceLinksInputClient) List(opts *ListOpts) (*SetServiceLinksInputCollection, error) {
+	resp := &SetServiceLinksInputCollection{}
+	err := c.rancherClient.doList(SET_SERVICE_LINKS_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SetServiceLinksInputClient) ById(id string) (*SetServiceLinksInput, error) {
+	resp := &SetServiceLinksInput{}
+	err := c.rancherClient.doById(SET_SERVICE_LINKS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SetServiceLinksInputClient) Delete(container *SetServiceLinksInput) error {
+	return c.rancherClient.doResourceDelete(SET_SERVICE_LINKS_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_setting.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_setting.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	SETTING_TYPE = "setting"
+)
+
+type Setting struct {
+	Resource
+
+	ActiveValue string `json:"activeValue,omitempty" yaml:"active_value,omitempty"`
+
+	InDb bool `json:"inDb,omitempty" yaml:"in_db,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+type SettingCollection struct {
+	Collection
+	Data []Setting `json:"data,omitempty"`
+}
+
+type SettingClient struct {
+	rancherClient *RancherClient
+}
+
+type SettingOperations interface {
+	List(opts *ListOpts) (*SettingCollection, error)
+	Create(opts *Setting) (*Setting, error)
+	Update(existing *Setting, updates interface{}) (*Setting, error)
+	ById(id string) (*Setting, error)
+	Delete(container *Setting) error
+}
+
+func newSettingClient(rancherClient *RancherClient) *SettingClient {
+	return &SettingClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SettingClient) Create(container *Setting) (*Setting, error) {
+	resp := &Setting{}
+	err := c.rancherClient.doCreate(SETTING_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SettingClient) Update(existing *Setting, updates interface{}) (*Setting, error) {
+	resp := &Setting{}
+	err := c.rancherClient.doUpdate(SETTING_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SettingClient) List(opts *ListOpts) (*SettingCollection, error) {
+	resp := &SettingCollection{}
+	err := c.rancherClient.doList(SETTING_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SettingClient) ById(id string) (*Setting, error) {
+	resp := &Setting{}
+	err := c.rancherClient.doById(SETTING_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SettingClient) Delete(container *Setting) error {
+	return c.rancherClient.doResourceDelete(SETTING_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_snapshot.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_snapshot.go
@@ -1,0 +1,126 @@
+package client
+
+const (
+	SNAPSHOT_TYPE = "snapshot"
+)
+
+type Snapshot struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VolumeId string `json:"volumeId,omitempty" yaml:"volume_id,omitempty"`
+}
+
+type SnapshotCollection struct {
+	Collection
+	Data []Snapshot `json:"data,omitempty"`
+}
+
+type SnapshotClient struct {
+	rancherClient *RancherClient
+}
+
+type SnapshotOperations interface {
+	List(opts *ListOpts) (*SnapshotCollection, error)
+	Create(opts *Snapshot) (*Snapshot, error)
+	Update(existing *Snapshot, updates interface{}) (*Snapshot, error)
+	ById(id string) (*Snapshot, error)
+	Delete(container *Snapshot) error
+
+	ActionBackup(*Snapshot, *SnapshotBackupInput) (*Backup, error)
+
+	ActionCreate(*Snapshot) (*Snapshot, error)
+
+	ActionRemove(*Snapshot) (*Snapshot, error)
+}
+
+func newSnapshotClient(rancherClient *RancherClient) *SnapshotClient {
+	return &SnapshotClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SnapshotClient) Create(container *Snapshot) (*Snapshot, error) {
+	resp := &Snapshot{}
+	err := c.rancherClient.doCreate(SNAPSHOT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SnapshotClient) Update(existing *Snapshot, updates interface{}) (*Snapshot, error) {
+	resp := &Snapshot{}
+	err := c.rancherClient.doUpdate(SNAPSHOT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SnapshotClient) List(opts *ListOpts) (*SnapshotCollection, error) {
+	resp := &SnapshotCollection{}
+	err := c.rancherClient.doList(SNAPSHOT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SnapshotClient) ById(id string) (*Snapshot, error) {
+	resp := &Snapshot{}
+	err := c.rancherClient.doById(SNAPSHOT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SnapshotClient) Delete(container *Snapshot) error {
+	return c.rancherClient.doResourceDelete(SNAPSHOT_TYPE, &container.Resource)
+}
+
+func (c *SnapshotClient) ActionBackup(resource *Snapshot, input *SnapshotBackupInput) (*Backup, error) {
+
+	resp := &Backup{}
+
+	err := c.rancherClient.doAction(SNAPSHOT_TYPE, "backup", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *SnapshotClient) ActionCreate(resource *Snapshot) (*Snapshot, error) {
+
+	resp := &Snapshot{}
+
+	err := c.rancherClient.doAction(SNAPSHOT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SnapshotClient) ActionRemove(resource *Snapshot) (*Snapshot, error) {
+
+	resp := &Snapshot{}
+
+	err := c.rancherClient.doAction(SNAPSHOT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_snapshot_backup_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_snapshot_backup_input.go
@@ -1,0 +1,95 @@
+package client
+
+const (
+	SNAPSHOT_BACKUP_INPUT_TYPE = "snapshotBackupInput"
+)
+
+type SnapshotBackupInput struct {
+	Resource
+
+	BackupTargetId string `json:"backupTargetId,omitempty" yaml:"backup_target_id,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+}
+
+type SnapshotBackupInputCollection struct {
+	Collection
+	Data []SnapshotBackupInput `json:"data,omitempty"`
+}
+
+type SnapshotBackupInputClient struct {
+	rancherClient *RancherClient
+}
+
+type SnapshotBackupInputOperations interface {
+	List(opts *ListOpts) (*SnapshotBackupInputCollection, error)
+	Create(opts *SnapshotBackupInput) (*SnapshotBackupInput, error)
+	Update(existing *SnapshotBackupInput, updates interface{}) (*SnapshotBackupInput, error)
+	ById(id string) (*SnapshotBackupInput, error)
+	Delete(container *SnapshotBackupInput) error
+
+	ActionCreate(*SnapshotBackupInput) (*Backup, error)
+
+	ActionRemove(*SnapshotBackupInput) (*Backup, error)
+}
+
+func newSnapshotBackupInputClient(rancherClient *RancherClient) *SnapshotBackupInputClient {
+	return &SnapshotBackupInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SnapshotBackupInputClient) Create(container *SnapshotBackupInput) (*SnapshotBackupInput, error) {
+	resp := &SnapshotBackupInput{}
+	err := c.rancherClient.doCreate(SNAPSHOT_BACKUP_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SnapshotBackupInputClient) Update(existing *SnapshotBackupInput, updates interface{}) (*SnapshotBackupInput, error) {
+	resp := &SnapshotBackupInput{}
+	err := c.rancherClient.doUpdate(SNAPSHOT_BACKUP_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SnapshotBackupInputClient) List(opts *ListOpts) (*SnapshotBackupInputCollection, error) {
+	resp := &SnapshotBackupInputCollection{}
+	err := c.rancherClient.doList(SNAPSHOT_BACKUP_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SnapshotBackupInputClient) ById(id string) (*SnapshotBackupInput, error) {
+	resp := &SnapshotBackupInput{}
+	err := c.rancherClient.doById(SNAPSHOT_BACKUP_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SnapshotBackupInputClient) Delete(container *SnapshotBackupInput) error {
+	return c.rancherClient.doResourceDelete(SNAPSHOT_BACKUP_INPUT_TYPE, &container.Resource)
+}
+
+func (c *SnapshotBackupInputClient) ActionCreate(resource *SnapshotBackupInput) (*Backup, error) {
+
+	resp := &Backup{}
+
+	err := c.rancherClient.doAction(SNAPSHOT_BACKUP_INPUT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SnapshotBackupInputClient) ActionRemove(resource *SnapshotBackupInput) (*Backup, error) {
+
+	resp := &Backup{}
+
+	err := c.rancherClient.doAction(SNAPSHOT_BACKUP_INPUT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_state_transition.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_state_transition.go
@@ -1,0 +1,65 @@
+package client
+
+const (
+	STATE_TRANSITION_TYPE = "stateTransition"
+)
+
+type StateTransition struct {
+	Resource
+}
+
+type StateTransitionCollection struct {
+	Collection
+	Data []StateTransition `json:"data,omitempty"`
+}
+
+type StateTransitionClient struct {
+	rancherClient *RancherClient
+}
+
+type StateTransitionOperations interface {
+	List(opts *ListOpts) (*StateTransitionCollection, error)
+	Create(opts *StateTransition) (*StateTransition, error)
+	Update(existing *StateTransition, updates interface{}) (*StateTransition, error)
+	ById(id string) (*StateTransition, error)
+	Delete(container *StateTransition) error
+}
+
+func newStateTransitionClient(rancherClient *RancherClient) *StateTransitionClient {
+	return &StateTransitionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *StateTransitionClient) Create(container *StateTransition) (*StateTransition, error) {
+	resp := &StateTransition{}
+	err := c.rancherClient.doCreate(STATE_TRANSITION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *StateTransitionClient) Update(existing *StateTransition, updates interface{}) (*StateTransition, error) {
+	resp := &StateTransition{}
+	err := c.rancherClient.doUpdate(STATE_TRANSITION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *StateTransitionClient) List(opts *ListOpts) (*StateTransitionCollection, error) {
+	resp := &StateTransitionCollection{}
+	err := c.rancherClient.doList(STATE_TRANSITION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *StateTransitionClient) ById(id string) (*StateTransition, error) {
+	resp := &StateTransition{}
+	err := c.rancherClient.doById(STATE_TRANSITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *StateTransitionClient) Delete(container *StateTransition) error {
+	return c.rancherClient.doResourceDelete(STATE_TRANSITION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_stats_access.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_stats_access.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	STATS_ACCESS_TYPE = "statsAccess"
+)
+
+type StatsAccess struct {
+	Resource
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type StatsAccessCollection struct {
+	Collection
+	Data []StatsAccess `json:"data,omitempty"`
+}
+
+type StatsAccessClient struct {
+	rancherClient *RancherClient
+}
+
+type StatsAccessOperations interface {
+	List(opts *ListOpts) (*StatsAccessCollection, error)
+	Create(opts *StatsAccess) (*StatsAccess, error)
+	Update(existing *StatsAccess, updates interface{}) (*StatsAccess, error)
+	ById(id string) (*StatsAccess, error)
+	Delete(container *StatsAccess) error
+}
+
+func newStatsAccessClient(rancherClient *RancherClient) *StatsAccessClient {
+	return &StatsAccessClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *StatsAccessClient) Create(container *StatsAccess) (*StatsAccess, error) {
+	resp := &StatsAccess{}
+	err := c.rancherClient.doCreate(STATS_ACCESS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *StatsAccessClient) Update(existing *StatsAccess, updates interface{}) (*StatsAccess, error) {
+	resp := &StatsAccess{}
+	err := c.rancherClient.doUpdate(STATS_ACCESS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *StatsAccessClient) List(opts *ListOpts) (*StatsAccessCollection, error) {
+	resp := &StatsAccessCollection{}
+	err := c.rancherClient.doList(STATS_ACCESS_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *StatsAccessClient) ById(id string) (*StatsAccess, error) {
+	resp := &StatsAccess{}
+	err := c.rancherClient.doById(STATS_ACCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *StatsAccessClient) Delete(container *StatsAccess) error {
+	return c.rancherClient.doResourceDelete(STATS_ACCESS_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_storage_pool.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_storage_pool.go
@@ -1,0 +1,178 @@
+package client
+
+const (
+	STORAGE_POOL_TYPE = "storagePool"
+)
+
+type StoragePool struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	BlockDevicePath string `json:"blockDevicePath,omitempty" yaml:"block_device_path,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	DriverName string `json:"driverName,omitempty" yaml:"driver_name,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	VolumeAccessMode string `json:"volumeAccessMode,omitempty" yaml:"volume_access_mode,omitempty"`
+
+	VolumeCapabilities []string `json:"volumeCapabilities,omitempty" yaml:"volume_capabilities,omitempty"`
+}
+
+type StoragePoolCollection struct {
+	Collection
+	Data []StoragePool `json:"data,omitempty"`
+}
+
+type StoragePoolClient struct {
+	rancherClient *RancherClient
+}
+
+type StoragePoolOperations interface {
+	List(opts *ListOpts) (*StoragePoolCollection, error)
+	Create(opts *StoragePool) (*StoragePool, error)
+	Update(existing *StoragePool, updates interface{}) (*StoragePool, error)
+	ById(id string) (*StoragePool, error)
+	Delete(container *StoragePool) error
+
+	ActionActivate(*StoragePool) (*StoragePool, error)
+
+	ActionCreate(*StoragePool) (*StoragePool, error)
+
+	ActionDeactivate(*StoragePool) (*StoragePool, error)
+
+	ActionPurge(*StoragePool) (*StoragePool, error)
+
+	ActionRemove(*StoragePool) (*StoragePool, error)
+
+	ActionRestore(*StoragePool) (*StoragePool, error)
+
+	ActionUpdate(*StoragePool) (*StoragePool, error)
+}
+
+func newStoragePoolClient(rancherClient *RancherClient) *StoragePoolClient {
+	return &StoragePoolClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *StoragePoolClient) Create(container *StoragePool) (*StoragePool, error) {
+	resp := &StoragePool{}
+	err := c.rancherClient.doCreate(STORAGE_POOL_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *StoragePoolClient) Update(existing *StoragePool, updates interface{}) (*StoragePool, error) {
+	resp := &StoragePool{}
+	err := c.rancherClient.doUpdate(STORAGE_POOL_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *StoragePoolClient) List(opts *ListOpts) (*StoragePoolCollection, error) {
+	resp := &StoragePoolCollection{}
+	err := c.rancherClient.doList(STORAGE_POOL_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *StoragePoolClient) ById(id string) (*StoragePool, error) {
+	resp := &StoragePool{}
+	err := c.rancherClient.doById(STORAGE_POOL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *StoragePoolClient) Delete(container *StoragePool) error {
+	return c.rancherClient.doResourceDelete(STORAGE_POOL_TYPE, &container.Resource)
+}
+
+func (c *StoragePoolClient) ActionActivate(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionCreate(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionDeactivate(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionPurge(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionRemove(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionRestore(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *StoragePoolClient) ActionUpdate(resource *StoragePool) (*StoragePool, error) {
+
+	resp := &StoragePool{}
+
+	err := c.rancherClient.doAction(STORAGE_POOL_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_subscribe.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_subscribe.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	SUBSCRIBE_TYPE = "subscribe"
+)
+
+type Subscribe struct {
+	Resource
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	EventNames []string `json:"eventNames,omitempty" yaml:"event_names,omitempty"`
+}
+
+type SubscribeCollection struct {
+	Collection
+	Data []Subscribe `json:"data,omitempty"`
+}
+
+type SubscribeClient struct {
+	rancherClient *RancherClient
+}
+
+type SubscribeOperations interface {
+	List(opts *ListOpts) (*SubscribeCollection, error)
+	Create(opts *Subscribe) (*Subscribe, error)
+	Update(existing *Subscribe, updates interface{}) (*Subscribe, error)
+	ById(id string) (*Subscribe, error)
+	Delete(container *Subscribe) error
+}
+
+func newSubscribeClient(rancherClient *RancherClient) *SubscribeClient {
+	return &SubscribeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SubscribeClient) Create(container *Subscribe) (*Subscribe, error) {
+	resp := &Subscribe{}
+	err := c.rancherClient.doCreate(SUBSCRIBE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SubscribeClient) Update(existing *Subscribe, updates interface{}) (*Subscribe, error) {
+	resp := &Subscribe{}
+	err := c.rancherClient.doUpdate(SUBSCRIBE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SubscribeClient) List(opts *ListOpts) (*SubscribeCollection, error) {
+	resp := &SubscribeCollection{}
+	err := c.rancherClient.doList(SUBSCRIBE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *SubscribeClient) ById(id string) (*Subscribe, error) {
+	resp := &Subscribe{}
+	err := c.rancherClient.doById(SUBSCRIBE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SubscribeClient) Delete(container *Subscribe) error {
+	return c.rancherClient.doResourceDelete(SUBSCRIBE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_task.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_task.go
@@ -1,0 +1,78 @@
+package client
+
+const (
+	TASK_TYPE = "task"
+)
+
+type Task struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type TaskCollection struct {
+	Collection
+	Data []Task `json:"data,omitempty"`
+}
+
+type TaskClient struct {
+	rancherClient *RancherClient
+}
+
+type TaskOperations interface {
+	List(opts *ListOpts) (*TaskCollection, error)
+	Create(opts *Task) (*Task, error)
+	Update(existing *Task, updates interface{}) (*Task, error)
+	ById(id string) (*Task, error)
+	Delete(container *Task) error
+
+	ActionExecute(*Task) (*Task, error)
+}
+
+func newTaskClient(rancherClient *RancherClient) *TaskClient {
+	return &TaskClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *TaskClient) Create(container *Task) (*Task, error) {
+	resp := &Task{}
+	err := c.rancherClient.doCreate(TASK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *TaskClient) Update(existing *Task, updates interface{}) (*Task, error) {
+	resp := &Task{}
+	err := c.rancherClient.doUpdate(TASK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *TaskClient) List(opts *ListOpts) (*TaskCollection, error) {
+	resp := &TaskCollection{}
+	err := c.rancherClient.doList(TASK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *TaskClient) ById(id string) (*Task, error) {
+	resp := &Task{}
+	err := c.rancherClient.doById(TASK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *TaskClient) Delete(container *Task) error {
+	return c.rancherClient.doResourceDelete(TASK_TYPE, &container.Resource)
+}
+
+func (c *TaskClient) ActionExecute(resource *Task) (*Task, error) {
+
+	resp := &Task{}
+
+	err := c.rancherClient.doAction(TASK_TYPE, "execute", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_task_instance.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_task_instance.go
@@ -1,0 +1,77 @@
+package client
+
+const (
+	TASK_INSTANCE_TYPE = "taskInstance"
+)
+
+type TaskInstance struct {
+	Resource
+
+	EndTime string `json:"endTime,omitempty" yaml:"end_time,omitempty"`
+
+	Exception string `json:"exception,omitempty" yaml:"exception,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	ServerId string `json:"serverId,omitempty" yaml:"server_id,omitempty"`
+
+	StartTime string `json:"startTime,omitempty" yaml:"start_time,omitempty"`
+
+	TaskId string `json:"taskId,omitempty" yaml:"task_id,omitempty"`
+}
+
+type TaskInstanceCollection struct {
+	Collection
+	Data []TaskInstance `json:"data,omitempty"`
+}
+
+type TaskInstanceClient struct {
+	rancherClient *RancherClient
+}
+
+type TaskInstanceOperations interface {
+	List(opts *ListOpts) (*TaskInstanceCollection, error)
+	Create(opts *TaskInstance) (*TaskInstance, error)
+	Update(existing *TaskInstance, updates interface{}) (*TaskInstance, error)
+	ById(id string) (*TaskInstance, error)
+	Delete(container *TaskInstance) error
+}
+
+func newTaskInstanceClient(rancherClient *RancherClient) *TaskInstanceClient {
+	return &TaskInstanceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *TaskInstanceClient) Create(container *TaskInstance) (*TaskInstance, error) {
+	resp := &TaskInstance{}
+	err := c.rancherClient.doCreate(TASK_INSTANCE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *TaskInstanceClient) Update(existing *TaskInstance, updates interface{}) (*TaskInstance, error) {
+	resp := &TaskInstance{}
+	err := c.rancherClient.doUpdate(TASK_INSTANCE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *TaskInstanceClient) List(opts *ListOpts) (*TaskInstanceCollection, error) {
+	resp := &TaskInstanceCollection{}
+	err := c.rancherClient.doList(TASK_INSTANCE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *TaskInstanceClient) ById(id string) (*TaskInstance, error) {
+	resp := &TaskInstance{}
+	err := c.rancherClient.doById(TASK_INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *TaskInstanceClient) Delete(container *TaskInstance) error {
+	return c.rancherClient.doResourceDelete(TASK_INSTANCE_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_to_service_upgrade_strategy.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_to_service_upgrade_strategy.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	TO_SERVICE_UPGRADE_STRATEGY_TYPE = "toServiceUpgradeStrategy"
+)
+
+type ToServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	FinalScale int64 `json:"finalScale,omitempty" yaml:"final_scale,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+
+	ToServiceId string `json:"toServiceId,omitempty" yaml:"to_service_id,omitempty"`
+
+	UpdateLinks bool `json:"updateLinks,omitempty" yaml:"update_links,omitempty"`
+}
+
+type ToServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []ToServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type ToServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type ToServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*ToServiceUpgradeStrategyCollection, error)
+	Create(opts *ToServiceUpgradeStrategy) (*ToServiceUpgradeStrategy, error)
+	Update(existing *ToServiceUpgradeStrategy, updates interface{}) (*ToServiceUpgradeStrategy, error)
+	ById(id string) (*ToServiceUpgradeStrategy, error)
+	Delete(container *ToServiceUpgradeStrategy) error
+}
+
+func newToServiceUpgradeStrategyClient(rancherClient *RancherClient) *ToServiceUpgradeStrategyClient {
+	return &ToServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ToServiceUpgradeStrategyClient) Create(container *ToServiceUpgradeStrategy) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(TO_SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) Update(existing *ToServiceUpgradeStrategy, updates interface{}) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(TO_SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) List(opts *ListOpts) (*ToServiceUpgradeStrategyCollection, error) {
+	resp := &ToServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(TO_SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) ById(id string) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(TO_SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) Delete(container *ToServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(TO_SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_type_documentation.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_type_documentation.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	TYPE_DOCUMENTATION_TYPE = "typeDocumentation"
+)
+
+type TypeDocumentation struct {
+	Resource
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	ResourceFields map[string]interface{} `json:"resourceFields,omitempty" yaml:"resource_fields,omitempty"`
+}
+
+type TypeDocumentationCollection struct {
+	Collection
+	Data []TypeDocumentation `json:"data,omitempty"`
+}
+
+type TypeDocumentationClient struct {
+	rancherClient *RancherClient
+}
+
+type TypeDocumentationOperations interface {
+	List(opts *ListOpts) (*TypeDocumentationCollection, error)
+	Create(opts *TypeDocumentation) (*TypeDocumentation, error)
+	Update(existing *TypeDocumentation, updates interface{}) (*TypeDocumentation, error)
+	ById(id string) (*TypeDocumentation, error)
+	Delete(container *TypeDocumentation) error
+}
+
+func newTypeDocumentationClient(rancherClient *RancherClient) *TypeDocumentationClient {
+	return &TypeDocumentationClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *TypeDocumentationClient) Create(container *TypeDocumentation) (*TypeDocumentation, error) {
+	resp := &TypeDocumentation{}
+	err := c.rancherClient.doCreate(TYPE_DOCUMENTATION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *TypeDocumentationClient) Update(existing *TypeDocumentation, updates interface{}) (*TypeDocumentation, error) {
+	resp := &TypeDocumentation{}
+	err := c.rancherClient.doUpdate(TYPE_DOCUMENTATION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *TypeDocumentationClient) List(opts *ListOpts) (*TypeDocumentationCollection, error) {
+	resp := &TypeDocumentationCollection{}
+	err := c.rancherClient.doList(TYPE_DOCUMENTATION_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *TypeDocumentationClient) ById(id string) (*TypeDocumentation, error) {
+	resp := &TypeDocumentation{}
+	err := c.rancherClient.doById(TYPE_DOCUMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *TypeDocumentationClient) Delete(container *TypeDocumentation) error {
+	return c.rancherClient.doResourceDelete(TYPE_DOCUMENTATION_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_virtual_machine.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_virtual_machine.go
@@ -1,0 +1,401 @@
+package client
+
+const (
+	VIRTUAL_MACHINE_TYPE = "virtualMachine"
+)
+
+type VirtualMachine struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	AgentId string `json:"agentId,omitempty" yaml:"agent_id,omitempty"`
+
+	AllocationState string `json:"allocationState,omitempty" yaml:"allocation_state,omitempty"`
+
+	BlkioDeviceOptions map[string]interface{} `json:"blkioDeviceOptions,omitempty" yaml:"blkio_device_options,omitempty"`
+
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	Count int64 `json:"count,omitempty" yaml:"count,omitempty"`
+
+	CpuSet string `json:"cpuSet,omitempty" yaml:"cpu_set,omitempty"`
+
+	CpuShares int64 `json:"cpuShares,omitempty" yaml:"cpu_shares,omitempty"`
+
+	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DeploymentUnitUuid string `json:"deploymentUnitUuid,omitempty" yaml:"deployment_unit_uuid,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+
+	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
+
+	DnsSearch []string `json:"dnsSearch,omitempty" yaml:"dns_search,omitempty"`
+
+	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
+
+	Expose []string `json:"expose,omitempty" yaml:"expose,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ExtraHosts []string `json:"extraHosts,omitempty" yaml:"extra_hosts,omitempty"`
+
+	FirstRunning string `json:"firstRunning,omitempty" yaml:"first_running,omitempty"`
+
+	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+
+	ImageUuid string `json:"imageUuid,omitempty" yaml:"image_uuid,omitempty"`
+
+	InstanceLinks map[string]interface{} `json:"instanceLinks,omitempty" yaml:"instance_links,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Labels map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	LogConfig *LogConfig `json:"logConfig,omitempty" yaml:"log_config,omitempty"`
+
+	Memory int64 `json:"memory,omitempty" yaml:"memory,omitempty"`
+
+	MemoryMb int64 `json:"memoryMb,omitempty" yaml:"memory_mb,omitempty"`
+
+	MemorySwap int64 `json:"memorySwap,omitempty" yaml:"memory_swap,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NativeContainer bool `json:"nativeContainer,omitempty" yaml:"native_container,omitempty"`
+
+	NetworkIds []string `json:"networkIds,omitempty" yaml:"network_ids,omitempty"`
+
+	NetworkMode string `json:"networkMode,omitempty" yaml:"network_mode,omitempty"`
+
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
+
+	PrimaryIpAddress string `json:"primaryIpAddress,omitempty" yaml:"primary_ip_address,omitempty"`
+
+	RegistryCredentialId string `json:"registryCredentialId,omitempty" yaml:"registry_credential_id,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
+
+	RestartPolicy *RestartPolicy `json:"restartPolicy,omitempty" yaml:"restart_policy,omitempty"`
+
+	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
+
+	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	SystemContainer string `json:"systemContainer,omitempty" yaml:"system_container,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Userdata string `json:"userdata,omitempty" yaml:"userdata,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vcpu int64 `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	VolumeDriver string `json:"volumeDriver,omitempty" yaml:"volume_driver,omitempty"`
+}
+
+type VirtualMachineCollection struct {
+	Collection
+	Data []VirtualMachine `json:"data,omitempty"`
+}
+
+type VirtualMachineClient struct {
+	rancherClient *RancherClient
+}
+
+type VirtualMachineOperations interface {
+	List(opts *ListOpts) (*VirtualMachineCollection, error)
+	Create(opts *VirtualMachine) (*VirtualMachine, error)
+	Update(existing *VirtualMachine, updates interface{}) (*VirtualMachine, error)
+	ById(id string) (*VirtualMachine, error)
+	Delete(container *VirtualMachine) error
+
+	ActionAllocate(*VirtualMachine) (*Instance, error)
+
+	ActionConsole(*VirtualMachine, *InstanceConsoleInput) (*InstanceConsole, error)
+
+	ActionCreate(*VirtualMachine) (*Instance, error)
+
+	ActionDeallocate(*VirtualMachine) (*Instance, error)
+
+	ActionError(*VirtualMachine) (*Instance, error)
+
+	ActionExecute(*VirtualMachine, *ContainerExec) (*HostAccess, error)
+
+	ActionLogs(*VirtualMachine, *ContainerLogs) (*HostAccess, error)
+
+	ActionMigrate(*VirtualMachine) (*Instance, error)
+
+	ActionProxy(*VirtualMachine, *ContainerProxy) (*HostAccess, error)
+
+	ActionPurge(*VirtualMachine) (*Instance, error)
+
+	ActionRemove(*VirtualMachine) (*Instance, error)
+
+	ActionRestart(*VirtualMachine) (*Instance, error)
+
+	ActionRestore(*VirtualMachine) (*Instance, error)
+
+	ActionSetlabels(*VirtualMachine, *SetLabelsInput) (*Container, error)
+
+	ActionStart(*VirtualMachine) (*Instance, error)
+
+	ActionStop(*VirtualMachine, *InstanceStop) (*Instance, error)
+
+	ActionUpdate(*VirtualMachine) (*Instance, error)
+
+	ActionUpdatehealthy(*VirtualMachine) (*Instance, error)
+
+	ActionUpdatereinitializing(*VirtualMachine) (*Instance, error)
+
+	ActionUpdateunhealthy(*VirtualMachine) (*Instance, error)
+}
+
+func newVirtualMachineClient(rancherClient *RancherClient) *VirtualMachineClient {
+	return &VirtualMachineClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *VirtualMachineClient) Create(container *VirtualMachine) (*VirtualMachine, error) {
+	resp := &VirtualMachine{}
+	err := c.rancherClient.doCreate(VIRTUAL_MACHINE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineClient) Update(existing *VirtualMachine, updates interface{}) (*VirtualMachine, error) {
+	resp := &VirtualMachine{}
+	err := c.rancherClient.doUpdate(VIRTUAL_MACHINE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineClient) List(opts *ListOpts) (*VirtualMachineCollection, error) {
+	resp := &VirtualMachineCollection{}
+	err := c.rancherClient.doList(VIRTUAL_MACHINE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ById(id string) (*VirtualMachine, error) {
+	resp := &VirtualMachine{}
+	err := c.rancherClient.doById(VIRTUAL_MACHINE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *VirtualMachineClient) Delete(container *VirtualMachine) error {
+	return c.rancherClient.doResourceDelete(VIRTUAL_MACHINE_TYPE, &container.Resource)
+}
+
+func (c *VirtualMachineClient) ActionAllocate(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionConsole(resource *VirtualMachine, input *InstanceConsoleInput) (*InstanceConsole, error) {
+
+	resp := &InstanceConsole{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "console", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionCreate(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionDeallocate(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionError(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionExecute(resource *VirtualMachine, input *ContainerExec) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "execute", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionLogs(resource *VirtualMachine, input *ContainerLogs) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "logs", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionMigrate(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionProxy(resource *VirtualMachine, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "proxy", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionPurge(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionRemove(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionRestart(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "restart", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionRestore(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionSetlabels(resource *VirtualMachine, input *SetLabelsInput) (*Container, error) {
+
+	resp := &Container{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "setlabels", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionStart(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "start", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionStop(resource *VirtualMachine, input *InstanceStop) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "stop", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionUpdate(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionUpdatehealthy(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "updatehealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionUpdatereinitializing(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "updatereinitializing", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionUpdateunhealthy(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "updateunhealthy", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_virtual_machine_disk.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_virtual_machine_disk.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	VIRTUAL_MACHINE_DISK_TYPE = "virtualMachineDisk"
+)
+
+type VirtualMachineDisk struct {
+	Resource
+
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Opts map[string]interface{} `json:"opts,omitempty" yaml:"opts,omitempty"`
+
+	ReadIops int64 `json:"readIops,omitempty" yaml:"read_iops,omitempty"`
+
+	Root bool `json:"root,omitempty" yaml:"root,omitempty"`
+
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
+
+	WriteIops int64 `json:"writeIops,omitempty" yaml:"write_iops,omitempty"`
+}
+
+type VirtualMachineDiskCollection struct {
+	Collection
+	Data []VirtualMachineDisk `json:"data,omitempty"`
+}
+
+type VirtualMachineDiskClient struct {
+	rancherClient *RancherClient
+}
+
+type VirtualMachineDiskOperations interface {
+	List(opts *ListOpts) (*VirtualMachineDiskCollection, error)
+	Create(opts *VirtualMachineDisk) (*VirtualMachineDisk, error)
+	Update(existing *VirtualMachineDisk, updates interface{}) (*VirtualMachineDisk, error)
+	ById(id string) (*VirtualMachineDisk, error)
+	Delete(container *VirtualMachineDisk) error
+}
+
+func newVirtualMachineDiskClient(rancherClient *RancherClient) *VirtualMachineDiskClient {
+	return &VirtualMachineDiskClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *VirtualMachineDiskClient) Create(container *VirtualMachineDisk) (*VirtualMachineDisk, error) {
+	resp := &VirtualMachineDisk{}
+	err := c.rancherClient.doCreate(VIRTUAL_MACHINE_DISK_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineDiskClient) Update(existing *VirtualMachineDisk, updates interface{}) (*VirtualMachineDisk, error) {
+	resp := &VirtualMachineDisk{}
+	err := c.rancherClient.doUpdate(VIRTUAL_MACHINE_DISK_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineDiskClient) List(opts *ListOpts) (*VirtualMachineDiskCollection, error) {
+	resp := &VirtualMachineDiskCollection{}
+	err := c.rancherClient.doList(VIRTUAL_MACHINE_DISK_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *VirtualMachineDiskClient) ById(id string) (*VirtualMachineDisk, error) {
+	resp := &VirtualMachineDisk{}
+	err := c.rancherClient.doById(VIRTUAL_MACHINE_DISK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *VirtualMachineDiskClient) Delete(container *VirtualMachineDisk) error {
+	return c.rancherClient.doResourceDelete(VIRTUAL_MACHINE_DISK_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_volume.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_volume.go
@@ -1,0 +1,228 @@
+package client
+
+const (
+	VOLUME_TYPE = "volume"
+)
+
+type Volume struct {
+	Resource
+
+	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+
+	DriverOpts map[string]interface{} `json:"driverOpts,omitempty" yaml:"driver_opts,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	ImageId string `json:"imageId,omitempty" yaml:"image_id,omitempty"`
+
+	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
+
+	IsHostPath bool `json:"isHostPath,omitempty" yaml:"is_host_path,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type VolumeCollection struct {
+	Collection
+	Data []Volume `json:"data,omitempty"`
+}
+
+type VolumeClient struct {
+	rancherClient *RancherClient
+}
+
+type VolumeOperations interface {
+	List(opts *ListOpts) (*VolumeCollection, error)
+	Create(opts *Volume) (*Volume, error)
+	Update(existing *Volume, updates interface{}) (*Volume, error)
+	ById(id string) (*Volume, error)
+	Delete(container *Volume) error
+
+	ActionActivate(*Volume) (*Volume, error)
+
+	ActionAllocate(*Volume) (*Volume, error)
+
+	ActionCreate(*Volume) (*Volume, error)
+
+	ActionDeallocate(*Volume) (*Volume, error)
+
+	ActionPurge(*Volume) (*Volume, error)
+
+	ActionRemove(*Volume) (*Volume, error)
+
+	ActionRestore(*Volume) (*Volume, error)
+
+	ActionRestorefrombackup(*Volume, *RestoreFromBackupInput) (*Volume, error)
+
+	ActionReverttosnapshot(*Volume, *RevertToSnapshotInput) (*Volume, error)
+
+	ActionSnapshot(*Volume, *VolumeSnapshotInput) (*Snapshot, error)
+
+	ActionUpdate(*Volume) (*Volume, error)
+}
+
+func newVolumeClient(rancherClient *RancherClient) *VolumeClient {
+	return &VolumeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *VolumeClient) Create(container *Volume) (*Volume, error) {
+	resp := &Volume{}
+	err := c.rancherClient.doCreate(VOLUME_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *VolumeClient) Update(existing *Volume, updates interface{}) (*Volume, error) {
+	resp := &Volume{}
+	err := c.rancherClient.doUpdate(VOLUME_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *VolumeClient) List(opts *ListOpts) (*VolumeCollection, error) {
+	resp := &VolumeCollection{}
+	err := c.rancherClient.doList(VOLUME_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *VolumeClient) ById(id string) (*Volume, error) {
+	resp := &Volume{}
+	err := c.rancherClient.doById(VOLUME_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *VolumeClient) Delete(container *Volume) error {
+	return c.rancherClient.doResourceDelete(VOLUME_TYPE, &container.Resource)
+}
+
+func (c *VolumeClient) ActionActivate(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionAllocate(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "allocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionCreate(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionDeallocate(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionPurge(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "purge", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionRemove(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionRestore(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "restore", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionRestorefrombackup(resource *Volume, input *RestoreFromBackupInput) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "restorefrombackup", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionReverttosnapshot(resource *Volume, input *RevertToSnapshotInput) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "reverttosnapshot", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionSnapshot(resource *Volume, input *VolumeSnapshotInput) (*Snapshot, error) {
+
+	resp := &Snapshot{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshot", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionUpdate(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/vendor/github.com/rancher/go-rancher/client/generated_volume_snapshot_input.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_volume_snapshot_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	VOLUME_SNAPSHOT_INPUT_TYPE = "volumeSnapshotInput"
+)
+
+type VolumeSnapshotInput struct {
+	Resource
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type VolumeSnapshotInputCollection struct {
+	Collection
+	Data []VolumeSnapshotInput `json:"data,omitempty"`
+}
+
+type VolumeSnapshotInputClient struct {
+	rancherClient *RancherClient
+}
+
+type VolumeSnapshotInputOperations interface {
+	List(opts *ListOpts) (*VolumeSnapshotInputCollection, error)
+	Create(opts *VolumeSnapshotInput) (*VolumeSnapshotInput, error)
+	Update(existing *VolumeSnapshotInput, updates interface{}) (*VolumeSnapshotInput, error)
+	ById(id string) (*VolumeSnapshotInput, error)
+	Delete(container *VolumeSnapshotInput) error
+}
+
+func newVolumeSnapshotInputClient(rancherClient *RancherClient) *VolumeSnapshotInputClient {
+	return &VolumeSnapshotInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *VolumeSnapshotInputClient) Create(container *VolumeSnapshotInput) (*VolumeSnapshotInput, error) {
+	resp := &VolumeSnapshotInput{}
+	err := c.rancherClient.doCreate(VOLUME_SNAPSHOT_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *VolumeSnapshotInputClient) Update(existing *VolumeSnapshotInput, updates interface{}) (*VolumeSnapshotInput, error) {
+	resp := &VolumeSnapshotInput{}
+	err := c.rancherClient.doUpdate(VOLUME_SNAPSHOT_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *VolumeSnapshotInputClient) List(opts *ListOpts) (*VolumeSnapshotInputCollection, error) {
+	resp := &VolumeSnapshotInputCollection{}
+	err := c.rancherClient.doList(VOLUME_SNAPSHOT_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *VolumeSnapshotInputClient) ById(id string) (*VolumeSnapshotInput, error) {
+	resp := &VolumeSnapshotInput{}
+	err := c.rancherClient.doById(VOLUME_SNAPSHOT_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *VolumeSnapshotInputClient) Delete(container *VolumeSnapshotInput) error {
+	return c.rancherClient.doResourceDelete(VOLUME_SNAPSHOT_INPUT_TYPE, &container.Resource)
+}

--- a/vendor/github.com/rancher/go-rancher/client/schemas.go
+++ b/vendor/github.com/rancher/go-rancher/client/schemas.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"reflect"
+	"strings"
+)
+
+type Schemas struct {
+	Collection
+	Data          []Schema `json:"data,omitempty"`
+	schemasByName map[string]*Schema
+}
+
+func (s *Schema) CheckField(name string) (Field, bool) {
+	for fieldName := range s.ResourceFields {
+		if fieldName == name {
+			v, ok := s.ResourceFields[fieldName]
+			return v, ok
+		}
+	}
+	return Field{}, false
+}
+
+func (s *Schema) Field(name string) Field {
+	f, _ := s.CheckField(name)
+	return f
+}
+
+func (s *Schemas) CheckSchema(name string) (Schema, bool) {
+	for i := range s.Data {
+		if s.Data[i].Id == name {
+			return s.Data[i], true
+		}
+	}
+	return Schema{}, false
+}
+
+func (s *Schemas) Schema(name string) Schema {
+	r, _ := s.CheckSchema(name)
+	return r
+}
+
+func typeToFields(t reflect.Type) map[string]Field {
+	result := map[string]Field{}
+
+	for i := 0; i < t.NumField(); i++ {
+		schemaField := Field{}
+
+		typeField := t.Field(i)
+		if typeField.Anonymous && typeField.Type.Kind() == reflect.Struct {
+			parentFields := typeToFields(typeField.Type)
+			for k, v := range result {
+				parentFields[k] = v
+			}
+			result = parentFields
+			continue
+		} else if typeField.Anonymous {
+			continue
+		}
+
+		fieldString := strings.ToLower(typeField.Type.Kind().String())
+
+		switch {
+		case strings.HasPrefix(fieldString, "int") || strings.HasPrefix(fieldString, "uint"):
+			schemaField.Type = "int"
+		case fieldString == "bool":
+			schemaField.Type = fieldString
+		case fieldString == "float32" || fieldString == "float64":
+			schemaField.Type = "float"
+		case fieldString == "string":
+			schemaField.Type = "string"
+		case fieldString == "map":
+			// HACK
+			schemaField.Type = "map[string]"
+		case fieldString == "slice":
+			// HACK
+			schemaField.Type = "array[string]"
+		}
+
+		name := strings.Split(typeField.Tag.Get("json"), ",")[0]
+		if name == "" && len(typeField.Name) > 1 {
+			name = strings.ToLower(typeField.Name[0:1]) + typeField.Name[1:]
+		} else if name == "" {
+			name = typeField.Name
+		}
+
+		if schemaField.Type != "" {
+			result[name] = schemaField
+		}
+	}
+
+	return result
+}
+
+func (s *Schemas) AddType(schemaName string, obj interface{}) *Schema {
+	t := reflect.TypeOf(obj)
+	schema := Schema{
+		Resource: Resource{
+			Id:    schemaName,
+			Type:  "schema",
+			Links: map[string]string{},
+		},
+		PluralName:        guessPluralName(schemaName),
+		ResourceFields:    typeToFields(t),
+		CollectionMethods: []string{"GET"},
+		ResourceMethods:   []string{"GET"},
+	}
+
+	if s.Data == nil {
+		s.Data = []Schema{}
+	}
+
+	s.Data = append(s.Data, schema)
+
+	return &s.Data[len(s.Data)-1]
+}
+
+func guessPluralName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	if strings.HasSuffix(name, "s") ||
+		strings.HasSuffix(name, "ch") ||
+		strings.HasSuffix(name, "x") {
+		return name + "es"
+	}
+	return name + "s"
+}

--- a/vendor/github.com/rancher/go-rancher/client/types.go
+++ b/vendor/github.com/rancher/go-rancher/client/types.go
@@ -1,0 +1,95 @@
+package client
+
+type Collection struct {
+	Type         string                 `json:"type,omitempty"`
+	ResourceType string                 `json:"resourceType,omitempty"`
+	Links        map[string]string      `json:"links,omitempty"`
+	CreateTypes  map[string]string      `json:"createTypes,omitempty"`
+	Actions      map[string]string      `json:"actions,omitempty"`
+	SortLinks    map[string]string      `json:"sortLinks,omitempty"`
+	Pagination   *Pagination            `json:"pagination,omitempty"`
+	Sort         *Sort                  `json:"sort,omitempty"`
+	Filters      map[string][]Condition `json:"filters,omitempty"`
+}
+
+type GenericCollection struct {
+	Collection
+	Data []interface{} `json:"data,omitempty"`
+}
+
+type ResourceCollection struct {
+	Collection
+	Data []Resource `json:"data,omitempty"`
+}
+
+type Sort struct {
+	Name    string `json:"name,omitempty"`
+	Order   string `json:"order,omitempty"`
+	Reverse string `json:"reverse,omitempty"`
+}
+
+type Condition struct {
+	Modifier string      `json:"modifier,omitempty"`
+	Value    interface{} `json:"value,omitempty"`
+}
+
+type Pagination struct {
+	Marker   string `json:"marker,omitempty"`
+	First    string `json:"first,omitempty"`
+	Previous string `json:"previous,omitempty"`
+	Next     string `json:"next,omitempty"`
+	Limit    *int64 `json:"limit,omitempty"`
+	Total    *int64 `json:"total,omitempty"`
+	Partial  bool   `json:"partial,omitempty"`
+}
+
+type Resource struct {
+	Id      string            `json:"id,omitempty"`
+	Type    string            `json:"type,omitempty"`
+	Links   map[string]string `json:"links"`
+	Actions map[string]string `json:"actions"`
+}
+
+type Schema struct {
+	Resource
+	PluralName        string            `json:"pluralName,omitempty"`
+	ResourceMethods   []string          `json:"resourceMethods,omitempty"`
+	ResourceFields    map[string]Field  `json:"resourceFields,omitempty"`
+	ResourceActions   map[string]Action `json:"resourceActions,omitempty"`
+	CollectionMethods []string          `json:"collectionMethods,omitempty"`
+	CollectionFields  map[string]Field  `json:"collectionFields,omitempty"`
+	CollectionActions map[string]Action `json:"collectionActions,omitempty"`
+	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty"`
+	IncludeableLinks  []string          `json:"includeableLinks,omitempty"`
+}
+
+type Field struct {
+	Type         string      `json:"type,omitempty"`
+	Default      interface{} `json:"default,omitempty"`
+	Unique       bool        `json:"unique,omitempty"`
+	Nullable     bool        `json:"nullable,omitempty"`
+	Create       bool        `json:"create,omitempty"`
+	Required     bool        `json:"required,omitempty"`
+	Update       bool        `json:"update,omitempty"`
+	MinLength    *int64      `json:"minLength,omitempty"`
+	MaxLength    *int64      `json:"maxLength,omitempty"`
+	Min          *int64      `json:"min,omitempty"`
+	Max          *int64      `json:"max,omitempty"`
+	Options      []string    `json:"options,omitempty"`
+	ValidChars   string      `json:"validChars,omitempty"`
+	InvalidChars string      `json:"invalidChars,omitempty"`
+	Description  string      `json:"description,omitempty"`
+}
+
+type Action struct {
+	Input  string `json:"input,omitempty"`
+	Output string `json:"output,omitempty"`
+}
+
+type Filter struct {
+	Modifiers []string `json:"modifiers,omitempty"`
+}
+
+type ListOpts struct {
+	Filters map[string]interface{}
+}


### PR DESCRIPTION
This PR adds `rancher` as a cloud provider to Kubernetes.

Rancher is a multi cloud, multi tenant container management platform. Rancher uses Kubernetes as one of its orchestration engines. We maintained our own fork of Kubernetes to support rancher networking, load balancing and volumes in Kubernetes. Since we moved to CNI based networking and Flex volumes, we found that there is no need to maintain a separate fork anymore. 

This PR specifically adds support for rancher cloud provider, and rancher credential provider to Kubernetes.  Rancher cloud provider is vital for registering rancher hosts as Kubernetes nodes. Once added into the Kubernetes cluster, the nodes can leverage Rancher DNS, Rancher Load balancer using native `kubectl` commands. Rancher credential provider allows nodes to use Rancher managed credentials. 

We've been running this code (+ other rancher specific networking code) for over a year now. It has also been deployed by many of our customers. 

CC (code reviewers from Rancher Labs) @ibuildthecloud @alena1108

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32419)

<!-- Reviewable:end -->
