### PR TITLE
e2e: only tear down existing cluster if it exists

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -94,7 +94,9 @@ func main() {
 		}
 	}
 
-	if *up {
+	// TODO: remove the IsUp() check after we stop testing 1.2 and earlier
+	// (or if we figure out a better way to handle TearDown failing on nonexisting clusters on old releases).
+	if *up && IsUp() {
 		if err := TearDown(); err != nil {
 			log.Fatalf("error tearing down previous cluster: %v", err)
 		}


### PR DESCRIPTION
Jenkins won't actually test this change, since `e2e.go` is now sourced from `kubekins-e2e`. :(

Probably fixes https://github.com/kubernetes/test-infra/issues/539, once a new `kubekins-e2e` is pushed.

cc @maisem @davidopp

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32420)

<!-- Reviewable:end -->
