### PR TITLE
Fix glbc name to match image version

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.7.0
+  name: l7-lb-controller-v0.7.1
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.7.0
+    version: v0.7.1
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:


### PR DESCRIPTION
Risk is low, we should get it into 1.4 to avoid confusion. Image is 0.7.1 (bumped in 1.3.6) so name and label should match.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32424)

<!-- Reviewable:end -->
