### PR TITLE
Check if default config is invalid before comparing it

### DIFF
--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -113,6 +113,9 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 		// TODO: this shouldn't be a global - the client config rules should be
 		//   handling this.
 		defaultConfig, err := DefaultClientConfig.ClientConfig()
+		if IsConfigurationInvalid(err) {
+			return mergedConfig, nil
+		}
 		if err == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
 			return mergedConfig, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes made in #31947 cause kube-proxy to ignore `--kubeconfig`
and `--master` flags and use in-cluster configuration, which is
unusable due to the fact that VIP hasn't been created yet.

**Special notes for your reviewer**:

**_This must get into the release branch.**_

[cc @smarterclayton @deads2k @lavalamp]

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32438)

<!-- Reviewable:end -->
