### PR TITLE
Revert "Use a Deployment for kube-dns"

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
+
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # __MACHINE_GENERATED_WARNING__
 
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
   name: kube-dns-v19
   namespace: kube-system
@@ -28,9 +30,8 @@ metadata:
 spec:
   replicas: __PILLAR__DNS__REPLICAS__
   selector:
-    matchLabels:
-      k8s-app: kube-dns
-      version: v19
+    k8s-app: kube-dns
+    version: v19
   template:
     metadata:
       labels:

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
+
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
 
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
   name: kube-dns-v19
   namespace: kube-system
@@ -28,9 +30,8 @@ metadata:
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
-    matchLabels:
-      k8s-app: kube-dns
-      version: v19
+    k8s-app: kube-dns
+    version: v19
   template:
     metadata:
       labels:

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
+
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
 
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
   name: kube-dns-v19
   namespace: kube-system
@@ -28,9 +30,8 @@ metadata:
 spec:
   replicas: $DNS_REPLICAS
   selector:
-    matchLabels:
-      k8s-app: kube-dns
-      version: v19
+    k8s-app: kube-dns
+    version: v19
   template:
     metadata:
       labels:

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -1,27 +1,23 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v15
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v15
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: ${DNS_REPLICAS}
   selector:
-    matchLabels:
-      k8s-app: kube-dns
-      version: v19
+    k8s-app: kube-dns
+    version: v15
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
+        version: v15
         kubernetes.io/cluster-service: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
@@ -67,7 +63,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+        image: gcr.io/google_containers/dnsmasq:1.1
         args:
         - --cache-size=1000
         - --no-resolv
@@ -80,23 +76,18 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.1
+        image: gcr.io/google_containers/exechealthz-amd64:1.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:
             cpu: 10m
-            memory: 50Mi
+            memory: 20Mi
           requests:
             cpu: 10m
-            # Note that this container shouldn't really need 50Mi of memory. The
-            # limits are set higher than expected pending investigation on #29688.
-            # The extra memory was stolen from the kubedns container to keep the
-            # net memory requested by the pod constant.
-            memory: 50Mi
+            memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1:10053 >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1 >/dev/null
         - -port=8080
-        - -quiet
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -12,32 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
+
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
 
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v18
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v18
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
-    matchLabels:
-      k8s-app: kube-dns
-      version: v19
+    k8s-app: kube-dns
+    version: v18
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
+        version: v18
         kubernetes.io/cluster-service: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
@@ -98,19 +96,15 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.1
+        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:
             cpu: 10m
-            memory: 50Mi
+            memory: 20Mi
           requests:
             cpu: 10m
-            # Note that this container shouldn't really need 50Mi of memory. The
-            # limits are set higher than expected pending investigation on #29688.
-            # The extra memory was stolen from the kubedns container to keep the
-            # net memory requested by the pod constant.
-            memory: 50Mi
+            memory: 20Mi
         args:
         - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
         - -port=8080


### PR DESCRIPTION
Reverts #32018.

Above PR has not been tested carefully, and should wait for the addon manager upgrade before migrate from RC to Deployment.

@bprashanth @mikedanese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32452)

<!-- Reviewable:end -->
