### PR TITLE
Node Conformance Test: Add system verification unit test

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -48,6 +48,7 @@ kube::test::find_dirs() {
     find -L . \
         -path './_output' -prune \
         -o -path './vendor/k8s.io/client-go/*' \
+        -o -path './test/e2e_node/system/*' \
       -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
   )
 }

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -494,6 +494,7 @@ system-cgroups
 system-container
 system-pods-startup-timeout
 system-reserved
+system-verification
 target-port
 target-ram-mb
 tcp-services

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -36,6 +36,7 @@ import (
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e_node/services"
+	"k8s.io/kubernetes/test/e2e_node/system"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
@@ -49,6 +50,7 @@ var e2es *services.E2EServices
 
 var prePullImages = flag.Bool("prepull-images", true, "If true, prepull images so image pull failures do not cause test failures.")
 var runServicesMode = flag.Bool("run-services-mode", false, "If true, only run services (etcd, apiserver) in current process, and not run test.")
+var systemVerification = flag.Bool("system-verification", true, "If true, run system verification to verify the system configuration before functionality test, including the configuration of os, kernel, cgroup etc.")
 
 func init() {
 	framework.RegisterCommonFlags()
@@ -98,6 +100,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		glog.Infof("Pre-pulling images so that they are cached for the tests.")
 		err := PrePullAllImages()
 		Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	// TODO(random-liu): Add system verification only mode.
+	// Run system verification test.
+	if *systemVerification {
+		Expect(system.Validate()).To(Succeed(), "system verification")
 	}
 
 	// TODO(yifan): Temporary workaround to disable coreos from auto restart

--- a/test/e2e_node/system/cgroup_validator.go
+++ b/test/e2e_node/system/cgroup_validator.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var _ Validator = &CgroupsValidator{}
+
+type CgroupsValidator struct{}
+
+func (c *CgroupsValidator) Name() string {
+	return "cgroups"
+}
+
+const (
+	cgroupsConfigPrefix = "CGROUPS_"
+)
+
+func (c *CgroupsValidator) Validate(spec SysSpec) error {
+	subsystems, err := c.getCgroupSubsystems()
+	if err != nil {
+		return fmt.Errorf("failed to get cgroup subsystems: %v", err)
+	}
+	missing := []string{}
+	for _, cgroup := range spec.Cgroups {
+		found := false
+		for _, subsystem := range subsystems {
+			if cgroup == subsystem {
+				found = true
+				break
+			}
+		}
+		item := cgroupsConfigPrefix + strings.ToUpper(cgroup)
+		if found {
+			report(item, "enabled", good)
+		} else {
+			report(item, "missing", bad)
+			missing = append(missing, cgroup)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing cgroups: %s", strings.Join(missing, " "))
+	}
+	return nil
+}
+
+func (c *CgroupsValidator) getCgroupSubsystems() ([]string, error) {
+	f, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	subsystems := []string{}
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+		text := s.Text()
+		if text[0] != '#' {
+			parts := strings.Fields(text)
+			if len(parts) >= 4 && parts[3] != "0" {
+				subsystems = append(subsystems, parts[0])
+			}
+		}
+	}
+	return subsystems, nil
+}

--- a/test/e2e_node/system/cgroup_validator.go
+++ b/test/e2e_node/system/cgroup_validator.go
@@ -40,8 +40,12 @@ func (c *CgroupsValidator) Validate(spec SysSpec) error {
 	if err != nil {
 		return fmt.Errorf("failed to get cgroup subsystems: %v", err)
 	}
+	return c.validateCgroupSubsystems(spec.Cgroups, subsystems)
+}
+
+func (c *CgroupsValidator) validateCgroupSubsystems(cgroupSpec, subsystems []string) error {
 	missing := []string{}
-	for _, cgroup := range spec.Cgroups {
+	for _, cgroup := range cgroupSpec {
 		found := false
 		for _, subsystem := range subsystems {
 			if cgroup == subsystem {
@@ -61,6 +65,7 @@ func (c *CgroupsValidator) Validate(spec SysSpec) error {
 		return fmt.Errorf("missing cgroups: %s", strings.Join(missing, " "))
 	}
 	return nil
+
 }
 
 func (c *CgroupsValidator) getCgroupSubsystems() ([]string, error) {

--- a/test/e2e_node/system/cgroup_validator_test.go
+++ b/test/e2e_node/system/cgroup_validator_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCgroupSubsystem(t *testing.T) {
+	v := &CgroupsValidator{}
+	cgroupSpec := []string{"system1", "system2"}
+	for desc, test := range map[string]struct {
+		cgroupSpec []string
+		subsystems []string
+		err        bool
+	}{
+		"missing cgroup subsystem should report error": {
+			subsystems: []string{"system1"},
+			err:        true,
+		},
+		"extra cgroup subsystems should not report error": {
+			subsystems: []string{"system1", "system2", "system3"},
+			err:        false,
+		},
+		"subsystems the same with spec should not report error": {
+			subsystems: []string{"system1", "system2"},
+			err:        false,
+		},
+	} {
+		err := v.validateCgroupSubsystems(cgroupSpec, test.subsystems)
+		if !test.err {
+			assert.Nil(t, err, "%q: Expect error not to occur with cgroup", desc)
+		} else {
+			assert.NotNil(t, err, "%q: Expect error to occur with docker info", desc)
+		}
+
+	}
+}

--- a/test/e2e_node/system/docker_validator.go
+++ b/test/e2e_node/system/docker_validator.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+var _ Validator = &DockerValidator{}
+
+// DockerValidator validates docker configuration.
+type DockerValidator struct{}
+
+func (d *DockerValidator) Name() string {
+	return "docker"
+}
+
+const (
+	dockerEndpoint     = "unix:///var/run/docker.sock"
+	dockerConfigPrefix = "DOCKER_"
+)
+
+// TODO(random-liu): Add more validating items.
+func (d *DockerValidator) Validate(spec SysSpec) error {
+	if spec.RuntimeSpec.DockerSpec == nil {
+		// If DockerSpec is not specified, assume current runtime is not
+		// docker, skip the docker configuration validation.
+		return nil
+	}
+	c, err := client.NewClient(dockerEndpoint, "", nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create docker client: %v", err)
+	}
+	info, err := c.Info(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get docker info: %v", err)
+	}
+	return d.validateDockerInfo(spec.RuntimeSpec.DockerSpec, info)
+}
+
+func (d *DockerValidator) validateDockerInfo(spec *DockerSpec, info types.Info) error {
+	// Validate docker version.
+	matched := false
+	for _, v := range spec.Version {
+		r := regexp.MustCompile(v)
+		if r.MatchString(info.ServerVersion) {
+			report(dockerConfigPrefix+"VERSION", info.ServerVersion, good)
+			matched = true
+		}
+	}
+	if !matched {
+		report(dockerConfigPrefix+"VERSION", info.ServerVersion, bad)
+		return fmt.Errorf("unsupported docker version: %s", info.ServerVersion)
+	}
+	// Validate graph driver.
+	item := dockerConfigPrefix + "GRAPH_DRIVER"
+	for _, d := range spec.GraphDriver {
+		if info.Driver == d {
+			report(item, info.Driver, good)
+			return nil
+		}
+	}
+	report(item, info.Driver, bad)
+	return fmt.Errorf("unsupported graph driver: %s", info.Driver)
+}

--- a/test/e2e_node/system/docker_validator_test.go
+++ b/test/e2e_node/system/docker_validator_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+
+	"github.com/docker/engine-api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateDockerInfo(t *testing.T) {
+	v := &DockerValidator{}
+	spec := &DockerSpec{
+		Version:     []string{`1\.(9|\d{2,})\..*`},
+		GraphDriver: []string{"driver_1", "driver_2"},
+	}
+	for _, test := range []struct {
+		info types.Info
+		err  bool
+	}{
+		{
+			info: types.Info{Driver: "driver_1", ServerVersion: "1.10.1"},
+			err:  false,
+		},
+		{
+			info: types.Info{Driver: "bad_driver", ServerVersion: "1.9.1"},
+			err:  true,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "1.8.1"},
+			err:  true,
+		},
+	} {
+		err := v.validateDockerInfo(spec, test.info)
+		if !test.err {
+			assert.Nil(t, err, "Expect error not to occur with docker info %+v", test.info)
+		} else {
+			assert.NotNil(t, err, "Expect error to occur with docker info %+v", test.info)
+		}
+
+	}
+}

--- a/test/e2e_node/system/kernel_validator.go
+++ b/test/e2e_node/system/kernel_validator.go
@@ -92,6 +92,11 @@ func (k *KernelValidator) validateKernelConfig(kConfig KernelConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse kernel config: %v", err)
 	}
+	return k.validateCachedKernelConfig(allConfig, kConfig)
+}
+
+// validateCachedKernelConfig validates the kernel confgiurations cached in internal data type.
+func (k *KernelValidator) validateCachedKernelConfig(allConfig map[string]kConfigOption, kConfig KernelConfig) error {
 	badConfigs := []string{}
 	// reportAndRecord is a helper function to record bad config when
 	// report.
@@ -190,11 +195,17 @@ func (k *KernelValidator) getKernelConfigReader() (io.Reader, error) {
 	return nil, fmt.Errorf("no config path in %v is available", possibePaths)
 }
 
+// getKernelConfig gets kernel config from kernel config file and convert kernel config to internal type.
 func (k *KernelValidator) getKernelConfig() (map[string]kConfigOption, error) {
 	r, err := k.getKernelConfigReader()
 	if err != nil {
 		return nil, err
 	}
+	return k.parseKernelConfig(r)
+}
+
+// parseKernelConfig converts kernel config to internal type.
+func (k *KernelValidator) parseKernelConfig(r io.Reader) (map[string]kConfigOption, error) {
 	config := map[string]kConfigOption{}
 	regex := regexp.MustCompile(validKConfigRegex)
 	s := bufio.NewScanner(r)
@@ -214,4 +225,5 @@ func (k *KernelValidator) getKernelConfig() (map[string]kConfigOption, error) {
 		config[fields[0]] = kConfigOption(fields[1])
 	}
 	return config, nil
+
 }

--- a/test/e2e_node/system/kernel_validator.go
+++ b/test/e2e_node/system/kernel_validator.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+var _ Validator = &KernelValidator{}
+
+// KernelValidator validates kernel. Currently only validate kernel version
+// and kernel configuration.
+type KernelValidator struct {
+	kernelRelease string
+}
+
+func (k *KernelValidator) Name() string {
+	return "kernel"
+}
+
+// kConfigOption is the possible kernel config option.
+type kConfigOption string
+
+const (
+	builtIn  kConfigOption = "y"
+	asModule kConfigOption = "m"
+	leftOut  kConfigOption = "n"
+
+	// validKConfigRegex is the regex matching kernel configuration line.
+	validKConfigRegex = "^CONFIG_[A-Z0-9_]+=[myn]"
+	// kConfigPrefix is the prefix of kernel configuration.
+	kConfigPrefix = "CONFIG_"
+)
+
+func (k *KernelValidator) Validate(spec SysSpec) error {
+	out, err := exec.Command("uname", "-r").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get kernel release: %v", err)
+	}
+	k.kernelRelease = strings.TrimSpace(string(out))
+	var errs []error
+	errs = append(errs, k.validateKernelVersion(spec.KernelVersion))
+	errs = append(errs, k.validateKernelConfig(spec.KernelConfig))
+	return errors.NewAggregate(errs)
+}
+
+// validateKernelVersion validates the kernel version.
+func (k *KernelValidator) validateKernelVersion(versionRegexps []string) error {
+	glog.Infof("Validating kernel version")
+	for _, versionRegexp := range versionRegexps {
+		r := regexp.MustCompile(versionRegexp)
+		if r.MatchString(k.kernelRelease) {
+			report("KERNEL_VERSION", k.kernelRelease, good)
+			return nil
+		}
+	}
+	report("KERNEL_VERSION", k.kernelRelease, bad)
+	return fmt.Errorf("unsupported kernel release: %s", k.kernelRelease)
+}
+
+// validateKernelConfig validates the kernel configurations.
+func (k *KernelValidator) validateKernelConfig(kConfig KernelConfig) error {
+	glog.Infof("Validating kernel config")
+	allConfig, err := k.getKernelConfig()
+	if err != nil {
+		return fmt.Errorf("failed to parse kernel config: %v", err)
+	}
+	badConfigs := []string{}
+	// reportAndRecord is a helper function to record bad config when
+	// report.
+	reportAndRecord := func(name, msg string, result resultType) {
+		if result == bad {
+			badConfigs = append(badConfigs, name)
+		}
+		report(name, msg, result)
+	}
+	validateOpt := func(name string, expectFound bool) {
+		found, missing := good, bad
+		if !expectFound {
+			found, missing = bad, good
+		}
+		opt, ok := allConfig[name]
+		if !ok {
+			reportAndRecord(name, "not set", missing)
+			return
+		}
+		switch opt {
+		case builtIn:
+			reportAndRecord(name, "enabled", found)
+		case asModule:
+			reportAndRecord(name, "enabled (as module)", found)
+		case leftOut:
+			reportAndRecord(name, "disabled", missing)
+		default:
+			reportAndRecord(name, fmt.Sprintf("unknown option: %s", opt), missing)
+		}
+	}
+	for _, name := range kConfig.Required {
+		validateOpt(kConfigPrefix+name, true)
+	}
+	for _, name := range kConfig.Forbidden {
+		validateOpt(kConfigPrefix+name, false)
+	}
+	if len(badConfigs) > 0 {
+		return fmt.Errorf("unexpected kernel config: %s", strings.Join(badConfigs, " "))
+	}
+	return nil
+}
+
+// getKernelConfigReader search kernel config file in a predefined list. Once the kernel config
+// file is found it will read the configurations into a byte buffer and return. If the kernel
+// config file is not found, it will try to load kernel config module and retry again.
+func (k *KernelValidator) getKernelConfigReader() (io.Reader, error) {
+	possibePaths := []string{
+		"/proc/config.gz",
+		"/boot/config-" + k.kernelRelease,
+		"/usr/src/linux-" + k.kernelRelease + "/.config",
+		"/usr/src/linux/.config",
+	}
+	configsModule := "configs"
+	modprobeCmd := "modprobe"
+	// loadModule indicates whether we've tried to load kernel config module ourselves.
+	loadModule := false
+	for {
+		for _, path := range possibePaths {
+			_, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			// Buffer the whole file, so that we can close the file and unload
+			// kernel config module in this function.
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			var r io.Reader
+			r = bytes.NewReader(b)
+			// This is a gzip file (config.gz), unzip it.
+			if filepath.Ext(path) == ".gz" {
+				r, err = gzip.NewReader(r)
+				if err != nil {
+					return nil, err
+				}
+			}
+			return r, nil
+		}
+		// If we've tried to load kernel config module, break and return error.
+		if loadModule {
+			break
+		}
+		// If the kernel config file is not found, try to load the kernel
+		// config module and check again.
+		// TODO(random-liu): Remove "sudo" in containerize test PR #31093
+		output, err := exec.Command("sudo", modprobeCmd, configsModule).CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("unable to load kernel module %q: output - %q, err - %v",
+				configsModule, output, err)
+		}
+		// Unload the kernel config module to make sure the validation have no side effect.
+		defer exec.Command("sudo", modprobeCmd, "-r", configsModule).Run()
+		loadModule = true
+	}
+	return nil, fmt.Errorf("no config path in %v is available", possibePaths)
+}
+
+func (k *KernelValidator) getKernelConfig() (map[string]kConfigOption, error) {
+	r, err := k.getKernelConfigReader()
+	if err != nil {
+		return nil, err
+	}
+	config := map[string]kConfigOption{}
+	regex := regexp.MustCompile(validKConfigRegex)
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+		line := strings.TrimSpace(s.Text())
+		if !regex.MatchString(line) {
+			continue
+		}
+		fields := strings.Split(line, "=")
+		if len(fields) != 2 {
+			glog.Errorf("Unexpected fields number in config %q", line)
+			continue
+		}
+		config[fields[0]] = kConfigOption(fields[1])
+	}
+	return config, nil
+}

--- a/test/e2e_node/system/kernel_validator_test.go
+++ b/test/e2e_node/system/kernel_validator_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateKernelVersion(t *testing.T) {
+	v := &KernelValidator{}
+	// Currently, testRegex is align with DefaultSysSpec.KernelVersion, but in the future
+	// they may be different.
+	// This is fine, because the test mainly tests the kernel version validation logic,
+	// not the DefaultSysSpec. The DefaultSysSpec should be tested with node e2e.
+	testRegex := []string{`3\.[1-9][0-9].*`, `4\..*`}
+	for _, test := range []struct {
+		version string
+		err     bool
+	}{
+		// first version regex matches
+		{
+			version: "3.19.9-99-test",
+			err:     false,
+		},
+		// one of version regexes matches
+		{
+			version: "4.4.14+",
+			err:     false,
+		},
+		// no version regex matches
+		{
+			version: "2.0.0",
+			err:     true,
+		},
+		{
+			version: "5.0.0",
+			err:     true,
+		},
+		{
+			version: "3.9.0",
+			err:     true,
+		},
+	} {
+		v.kernelRelease = test.version
+		err := v.validateKernelVersion(testRegex)
+		if !test.err {
+			assert.Nil(t, err, "Expect error not to occur with kernel version %q", test.version)
+		} else {
+			assert.NotNil(t, err, "Expect error to occur with kenrel version %q", test.version)
+		}
+	}
+}
+
+func TestValidateCachedKernelConfig(t *testing.T) {
+	v := &KernelValidator{}
+	testKernelConfig := KernelConfig{
+		Required:  []string{"REQUIRED_1", "REQUIRED_2"},
+		Forbidden: []string{"FORBIDDEN_1", "FORBIDDEN_2"},
+	}
+	for _, test := range []struct {
+		config map[string]kConfigOption
+		err    bool
+	}{
+		// meet all required configurations should not report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1": builtIn,
+				"REQUIRED_2": asModule,
+			},
+			err: false,
+		},
+		// one required configuration disabled should report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1": leftOut,
+				"REQUIRED_2": builtIn,
+			},
+			err: true,
+		},
+		// one required configuration missing should report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1": builtIn,
+			},
+			err: true,
+		},
+		// forbidden configuration disabled should not report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1":  builtIn,
+				"REQUIRED_2":  asModule,
+				"FORBIDDEN_1": leftOut,
+			},
+			err: false,
+		},
+		// forbidden configuration built-in should report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1":  builtIn,
+				"REQUIRED_2":  asModule,
+				"FORBIDDEN_1": builtIn,
+			},
+			err: true,
+		},
+		// forbidden configuration built as module should report error.
+		{
+			config: map[string]kConfigOption{
+				"REQUIRED_1":  builtIn,
+				"REQUIRED_2":  asModule,
+				"FORBIDDEN_1": asModule,
+			},
+			err: true,
+		},
+	} {
+		// Add kernel config prefix.
+		for k, v := range test.config {
+			delete(test.config, k)
+			test.config[kConfigPrefix+k] = v
+		}
+		err := v.validateCachedKernelConfig(test.config, testKernelConfig)
+		if !test.err {
+			assert.Nil(t, err, "Expect error not to occur with kernel config %q", test.config)
+		} else {
+			assert.NotNil(t, err, "Expect error to occur with kenrel config %q", test.config)
+		}
+	}
+}
+
+func TestValidateParseKernelConfig(t *testing.T) {
+	config := `CONFIG_1=y
+CONFIG_2=m
+CONFIG_3=n`
+	expected := map[string]kConfigOption{
+		"CONFIG_1": builtIn,
+		"CONFIG_2": asModule,
+		"CONFIG_3": leftOut,
+	}
+	v := &KernelValidator{}
+	got, err := v.parseKernelConfig(bytes.NewReader([]byte(config)))
+	assert.Nil(t, err, "Expect error not to occur when parse kernel configuration %q", config)
+	assert.Equal(t, expected, got)
+}

--- a/test/e2e_node/system/os_validator.go
+++ b/test/e2e_node/system/os_validator.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var _ Validator = &OSValidator{}
+
+type OSValidator struct{}
+
+func (c *OSValidator) Name() string {
+	return "os"
+}
+
+func (c *OSValidator) Validate(spec SysSpec) error {
+	out, err := exec.Command("uname").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get os name: %v", err)
+	}
+	os := strings.TrimSpace(string(out))
+	if os != spec.OS {
+		report("OS", os, bad)
+		return fmt.Errorf("unsupported operating system: %s", os)
+	}
+	report("OS", os, good)
+	return nil
+}

--- a/test/e2e_node/system/os_validator_test.go
+++ b/test/e2e_node/system/os_validator_test.go
@@ -17,32 +17,36 @@ limitations under the License.
 package system
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-var _ Validator = &OSValidator{}
-
-type OSValidator struct{}
-
-func (c *OSValidator) Name() string {
-	return "os"
-}
-
-func (c *OSValidator) Validate(spec SysSpec) error {
-	out, err := exec.Command("uname").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get os name: %v", err)
+func TestValidateOS(t *testing.T) {
+	v := &OSValidator{}
+	specOS := "Linux"
+	for _, test := range []struct {
+		os  string
+		err bool
+	}{
+		{
+			os:  "Linux",
+			err: false,
+		},
+		{
+			os:  "Windows",
+			err: true,
+		},
+		{
+			os:  "Darwin",
+			err: true,
+		},
+	} {
+		err := v.validateOS(test.os, specOS)
+		if !test.err {
+			assert.Nil(t, err, "Expect error not to occur with os %q", test.os)
+		} else {
+			assert.NotNil(t, err, "Expect error to occur with os %q", test.os)
+		}
 	}
-	return c.validateOS(strings.TrimSpace(string(out)), spec.OS)
-}
-
-func (c *OSValidator) validateOS(os, specOS string) error {
-	if os != specOS {
-		report("OS", os, bad)
-		return fmt.Errorf("unsupported operating system: %s", os)
-	}
-	report("OS", os, good)
-	return nil
 }

--- a/test/e2e_node/system/types.go
+++ b/test/e2e_node/system/types.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+// KernelConfig is the configuration required or forbidden
+// for kubernetes.
+// TODO(random-liu): Add Optional, and report warning for optional config.
+type KernelConfig struct {
+	// Required is all kernel configurations required to be enabled (built in
+	// or as module).
+	Required []string
+	// Forbidden is all kernel configurations forbidden (disabled or not set)
+	Forbidden []string
+}
+
+// DockerSpec defines the requirement configuration for docker. Currently, it only
+// contains spec for graph driver.
+type DockerSpec struct {
+	// Version is a group of regex matching supported docker versions.
+	Version []string
+	// GraphDriver is the graph drivers supported by kubelet.
+	GraphDriver []string
+}
+
+// RuntimeSpec is the abstract layer for different runtimes. Different runtimes
+// should put their spec inside the RuntimeSpec.
+type RuntimeSpec struct {
+	*DockerSpec
+}
+
+// SysSpec defines the requirement of supported system. Currently, it only contains
+// spec for OS, Kernel and Cgroups.
+type SysSpec struct {
+	// OS is the operating system of the SysSpec.
+	OS string
+	// KernelVersion is a group of regex matching supported kernel versions.
+	KernelVersion []string
+	// KernelConfig defines the kernel configurations which are required or
+	// forbidden.
+	KernelConfig KernelConfig
+	// Cgroups is the required cgroups.
+	Cgroups []string
+	// RuntimeSpec defines the spec for runtime.
+	RuntimeSpec RuntimeSpec
+}
+
+// DefaultSysSpec is the default SysSpec.
+var DefaultSysSpec = SysSpec{
+	OS:            "Linux",
+	KernelVersion: []string{`3\.[1-9][0-9].*`, `4\..*`}, // Requires 3.10+ or 4+
+	// TODO(random-liu): Add more config
+	KernelConfig: KernelConfig{
+		Required: []string{
+			"NAMESPACES", "NET_NS", "PID_NS", "IPC_NS", "UTS_NS",
+			"CGROUPS", "CGROUP_CPUACCT", "CGROUP_DEVICE", "CGROUP_FREEZER",
+			"CGROUP_SCHED", "CPUSETS", "MEMCG",
+		},
+		Forbidden: []string{},
+	},
+	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
+	RuntimeSpec: RuntimeSpec{
+		DockerSpec: &DockerSpec{
+			Version: []string{`1\.(9|\d{2,})\..*`}, // Requires 1.9+
+			// TODO(random-liu): Validate overlay2.
+			GraphDriver: []string{"aufs", "overlay", "devicemapper"},
+		},
+	},
+}

--- a/test/e2e_node/system/util.go
+++ b/test/e2e_node/system/util.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+)
+
+// resultType is type of the validation result. Different validation results
+// corresponds to different colors.
+type resultType int
+
+const (
+	good resultType = iota
+	bad
+	warn
+)
+
+// color is the color of the message.
+type color int
+
+const (
+	red    color = 31
+	green        = 32
+	yellow       = 33
+	white        = 37
+)
+
+func wrap(s string, c color) string {
+	return fmt.Sprintf("\033[0;%dm%s\033[0m", c, s)
+}
+
+// report reports "item: r". item is white, and the color of r depends on the
+// result type.
+func report(item, r string, t resultType) {
+	var c color
+	switch t {
+	case good:
+		c = green
+	case bad:
+		c = red
+	case warn:
+		c = yellow
+	default:
+		c = white
+	}
+	fmt.Printf("%s: %s\n", wrap(item, white), wrap(r, c))
+}

--- a/test/e2e_node/system/validators.go
+++ b/test/e2e_node/system/validators.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+// Validator is the interface for all validators.
+type Validator interface {
+	// Name is the name of the validator.
+	Name() string
+	// Validate is the validate function.
+	Validate(SysSpec) error
+}
+
+// validators are all the validators.
+var validators = []Validator{
+	&OSValidator{},
+	&KernelValidator{},
+	&CgroupsValidator{},
+	&DockerValidator{},
+}
+
+// Validate uses all validators to validate the system.
+func Validate() error {
+	var errs []error
+	spec := DefaultSysSpec
+	for _, v := range validators {
+		glog.Infof("Validating %s...", v.Name())
+		errs = append(errs, v.Validate(spec))
+	}
+	return errors.NewAggregate(errs)
+}


### PR DESCRIPTION
For #30122 and #29081.
Based on https://github.com/kubernetes/kubernetes/pull/32427.

Please only review the second commit.

This PR added unit test for system verification test and enabled it in Kubernetes unit test.

@dchen1107 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32454)

<!-- Reviewable:end -->
