### PR TITLE
Replenishment metrics are not shown because of same name

### DIFF
--- a/pkg/controller/resourcequota/replenishment_controller.go
+++ b/pkg/controller/resourcequota/replenishment_controller.go
@@ -18,6 +18,7 @@ package resourcequota
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -51,6 +52,8 @@ type ReplenishmentControllerOptions struct {
 	// The function to invoke when a change is observed that should trigger
 	// replenishment
 	ReplenishmentFunc ReplenishmentFunc
+	// MetricNamePrefix is a name to prefix the rate limit metric with
+	MetricNamePrefix string
 }
 
 // PodReplenishmentUpdateFunc will replenish if the old pod was quota tracked but the new is not
@@ -115,7 +118,15 @@ func NewReplenishmentControllerFactoryFromClient(kubeClient clientset.Interface)
 func (r *replenishmentControllerFactory) NewController(options *ReplenishmentControllerOptions) (framework.ControllerInterface, error) {
 	var result framework.ControllerInterface
 	if r.kubeClient != nil && r.kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("replenishment_controller", r.kubeClient.Core().GetRESTClient().GetRateLimiter())
+		name := []string{"replenishment_controller"}
+		if len(options.MetricNamePrefix) > 0 {
+			name = append(name, options.MetricNamePrefix)
+		}
+		if len(options.GroupKind.Group) > 0 {
+			name = append(name, options.GroupKind.Group)
+		}
+		name = append(name, strings.ToLower(options.GroupKind.Kind))
+		metrics.RegisterMetricAndTrackRateLimiterUsage(strings.Join(name, "_"), r.kubeClient.Core().GetRESTClient().GetRateLimiter())
 	}
 
 	switch options.GroupKind {


### PR DESCRIPTION
Allow replenishment to have their own names. Also allow prefix
to be provided so that multiple quota controllers can coexist (future
ClusterQuota controller)

@deads2k

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32460)

<!-- Reviewable:end -->
