### PR TITLE
Cacher logging is not actually a warning

### DIFF
--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -244,6 +244,7 @@ func (c *Cacher) startCaching(stopChannel <-chan struct{}) {
 		if successfulList {
 			c.ready.set(false)
 		}
+		glog.V(4).Infof("Cacher exited %v: %t", c.objectType, successfulList)
 	}()
 
 	c.terminateAllWatchers()
@@ -465,7 +466,7 @@ func (c *Cacher) dispatchEvent(event *watchCacheEvent) {
 }
 
 func (c *Cacher) terminateAllWatchers() {
-	glog.Warningf("Terminating all watchers from cacher %v", c.objectType)
+	glog.V(4).Infof("Terminating all watchers from cacher %v", c.objectType)
 	c.Lock()
 	defer c.Unlock()
 	c.watchers.terminateAll()


### PR DESCRIPTION
Every cache that starts up prints this message, which when you have lots
of cachers is a waste of space.  Bump to v(4)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32463)

<!-- Reviewable:end -->
