### PR TITLE
Add kubectl run ScheduledJob e2e test

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -120,6 +120,12 @@ func NewDefaultFederatedFramework(baseName string) *Framework {
 	return f
 }
 
+func NewDefaultGroupVersionFramework(baseName string, groupVersion unversioned.GroupVersion) *Framework {
+	f := NewDefaultFramework(baseName)
+	f.options.GroupVersion = &groupVersion
+	return f
+}
+
 func NewFramework(baseName string, options FrameworkOptions, client *client.Client) *Framework {
 	f := &Framework{
 		BaseName:                 baseName,

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -171,7 +171,7 @@ func runKubectlRetryOrDie(args ...string) string {
 
 var _ = framework.KubeDescribe("Kubectl client", func() {
 	defer GinkgoRecover()
-	f := framework.NewDefaultFramework("kubectl")
+	f := framework.NewDefaultGroupVersionFramework("kubectl", BatchV2Alpha1GroupVersion)
 
 	// Reustable cluster state function.  This won't be adversly affected by lazy initialization of framework.
 	clusterState := func() *framework.ClusterVerification {
@@ -1073,10 +1073,47 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			}
 			containers := job.Spec.Template.Spec.Containers
 			if containers == nil || len(containers) != 1 || containers[0].Image != nginxImage {
-				framework.Failf("Failed creating job %s for 1 pod with expected image %s", jobName, nginxImage)
+				framework.Failf("Failed creating job %s for 1 pod with expected image %s: %#v", jobName, nginxImage, containers)
 			}
 			if job.Spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure {
 				framework.Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
+			}
+		})
+	})
+
+	framework.KubeDescribe("Kubectl run ScheduledJob", func() {
+		var nsFlag string
+		var sjName string
+
+		BeforeEach(func() {
+			nsFlag = fmt.Sprintf("--namespace=%v", ns)
+			sjName = "e2e-test-echo-scheduledjob"
+		})
+
+		AfterEach(func() {
+			framework.RunKubectlOrDie("delete", "scheduledjobs", sjName, nsFlag)
+		})
+
+		It("should create a ScheduledJob", func() {
+			framework.SkipIfMissingResource(f.ClientPool, ScheduledJobGroupVersionResource, f.Namespace.Name)
+
+			schedule := "*/5 * * * ?"
+			framework.RunKubectlOrDie("run", sjName, "--restart=OnFailure", "--generator=scheduledjob/v2alpha1",
+				"--schedule="+schedule, "--image="+busyboxImage, nsFlag)
+			By("verifying the ScheduledJob " + sjName + " was created")
+			sj, err := c.Batch().ScheduledJobs(ns).Get(sjName)
+			if err != nil {
+				framework.Failf("Failed getting ScheduledJob %s: %v", sjName, err)
+			}
+			if sj.Spec.Schedule != schedule {
+				framework.Failf("Failed creating a ScheduledJob with correct schedule %s", schedule)
+			}
+			containers := sj.Spec.JobTemplate.Spec.Template.Spec.Containers
+			if containers == nil || len(containers) != 1 || containers[0].Image != busyboxImage {
+				framework.Failf("Failed creating ScheduledJob %s for 1 pod with expected image %s: %#v", sjName, busyboxImage, containers)
+			}
+			if sj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure {
+				framework.Failf("Failed creating a ScheduledJob with correct restart policy for --restart=OnFailure")
 			}
 		})
 	})

--- a/test/e2e/scheduledjob.go
+++ b/test/e2e/scheduledjob.go
@@ -37,16 +37,16 @@ const (
 	scheduledJobTimeout = 5 * time.Minute
 )
 
+var (
+	ScheduledJobGroupVersionResource = unversioned.GroupVersionResource{Group: batch.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}
+	BatchV2Alpha1GroupVersion        = unversioned.GroupVersion{Group: batch.GroupName, Version: "v2alpha1"}
+)
+
 var _ = framework.KubeDescribe("ScheduledJob", func() {
-	options := framework.FrameworkOptions{
-		ClientQPS:    20,
-		ClientBurst:  50,
-		GroupVersion: &unversioned.GroupVersion{Group: batch.GroupName, Version: "v2alpha1"},
-	}
-	f := framework.NewFramework("scheduledjob", options, nil)
+	f := framework.NewDefaultGroupVersionFramework("scheduledjob", BatchV2Alpha1GroupVersion)
 
 	BeforeEach(func() {
-		framework.SkipIfMissingResource(f.ClientPool, unversioned.GroupVersionResource{Group: batch.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}, f.Namespace.Name)
+		framework.SkipIfMissingResource(f.ClientPool, ScheduledJobGroupVersionResource, f.Namespace.Name)
 	})
 
 	// multiple jobs running at once


### PR DESCRIPTION
**What this PR does / why we need it**:
This add another `kubectl run` e2e test, this time verifying proper creation of a ScheduledJob. 

@janetkuo ptal
@deads2k that should give you more confidence when ditching manual clients

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32484)

<!-- Reviewable:end -->
