### PR TITLE
List pods for deployment just once

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -554,7 +554,7 @@ func FindOldReplicaSets(deployment *extensions.Deployment, rsList []*extensions.
 
 // WaitForReplicaSetUpdated polls the replica set until it is updated.
 func WaitForReplicaSetUpdated(c clientset.Interface, desiredGeneration int64, namespace, name string) error {
-	return wait.Poll(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		rs, err := c.Extensions().ReplicaSets(namespace).Get(name)
 		if err != nil {
 			return false, err
@@ -565,7 +565,7 @@ func WaitForReplicaSetUpdated(c clientset.Interface, desiredGeneration int64, na
 
 // WaitForPodsHashPopulated polls the replica set until updated and fully labeled.
 func WaitForPodsHashPopulated(c clientset.Interface, desiredGeneration int64, namespace, name string) error {
-	return wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		rs, err := c.Extensions().ReplicaSets(namespace).Get(name)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This PR addresses an issue mentioned here: https://github.com/kubernetes/kubernetes/issues/31780
- Pod lists: there are two places in rsAndPodsWithHashKeySynced where we do a pod list. We should have only one.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32487)

<!-- Reviewable:end -->
