### PR TITLE
Filter GroupVersions based on what is actually enabled

### DIFF
--- a/federation/cmd/federation-apiserver/app/core.go
+++ b/federation/cmd/federation-apiserver/app/core.go
@@ -40,7 +40,7 @@ import (
 	serviceetcd "k8s.io/kubernetes/pkg/registry/service/etcd"
 )
 
-func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, resourceConfig genericapiserver.APIResourceConfigSource, f genericapiserver.StorageFactory) {
 	serviceStore, serviceStatusStore := serviceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("service")))
 	namespaceStore, namespaceStatusStore, namespaceFinalizeStore := namespaceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("namespaces")))
 	secretStore := secretetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("secrets")))
@@ -66,7 +66,7 @@ func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPI
 		ParameterCodec:         core.ParameterCodec,
 		NegotiatedSerializer:   core.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallAPIGroup(&apiGroupInfo, resourceConfig); err != nil {
 		glog.Fatalf("Error in registering group version: %+v.\n Error: %v\n", apiGroupInfo, err)
 	}
 }

--- a/federation/cmd/federation-apiserver/app/extensions.go
+++ b/federation/cmd/federation-apiserver/app/extensions.go
@@ -29,7 +29,7 @@ import (
 	replicasetetcd "k8s.io/kubernetes/pkg/registry/replicaset/etcd"
 )
 
-func installExtensionsAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+func installExtensionsAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, resourceConfig genericapiserver.APIResourceConfigSource, f genericapiserver.StorageFactory) {
 	replicaSetStorage := replicasetetcd.NewStorage(createRESTOptionsOrDie(s, g, f, extensions.Resource("replicasets")))
 	ingressStorage, ingressStatusStorage := ingressetcd.NewREST(createRESTOptionsOrDie(s, g, f, extensions.Resource("ingresses")))
 	extensionsResources := map[string]rest.Storage{
@@ -50,7 +50,7 @@ func installExtensionsAPIs(s *options.ServerRunOptions, g *genericapiserver.Gene
 		ParameterCodec:         api.ParameterCodec,
 		NegotiatedSerializer:   api.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallAPIGroup(&apiGroupInfo, resourceConfig); err != nil {
 		glog.Fatalf("Error in registering group versions: %v", err)
 	}
 }

--- a/federation/cmd/federation-apiserver/app/federation.go
+++ b/federation/cmd/federation-apiserver/app/federation.go
@@ -30,7 +30,7 @@ import (
 	clusteretcd "k8s.io/kubernetes/federation/registry/cluster/etcd"
 )
 
-func installFederationAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+func installFederationAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, resourceConfig genericapiserver.APIResourceConfigSource, f genericapiserver.StorageFactory) {
 	clusterStorage, clusterStatusStorage := clusteretcd.NewREST(createRESTOptionsOrDie(s, g, f, federation.Resource("clusters")))
 	federationResources := map[string]rest.Storage{
 		"clusters":        clusterStorage,
@@ -47,7 +47,7 @@ func installFederationAPIs(s *options.ServerRunOptions, g *genericapiserver.Gene
 		ParameterCodec:         api.ParameterCodec,
 		NegotiatedSerializer:   api.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallAPIGroup(&apiGroupInfo, resourceConfig); err != nil {
 		glog.Fatalf("Error in registering group versions: %v", err)
 	}
 }

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -196,9 +196,9 @@ func Run(s *options.ServerRunOptions) error {
 		return err
 	}
 
-	installFederationAPIs(s, m, storageFactory)
-	installCoreAPIs(s, m, storageFactory)
-	installExtensionsAPIs(s, m, storageFactory)
+	installFederationAPIs(s, m, resourceConfig, storageFactory)
+	installCoreAPIs(s, m, resourceConfig, storageFactory)
+	installExtensionsAPIs(s, m, resourceConfig, storageFactory)
 
 	sharedInformers.Start(wait.NeverStop)
 	m.Run(s.ServerRunOptions)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -324,7 +324,7 @@ func (m *Master) InstallAPIs(c *Config) {
 		apiGroupsInfo = append(apiGroupsInfo, apiGroupInfo)
 	}
 
-	if err := m.InstallAPIGroups(apiGroupsInfo); err != nil {
+	if err := m.InstallAPIGroups(apiGroupsInfo, c.APIResourceConfigSource); err != nil {
 		glog.Fatalf("Error in registering group versions: %v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #29998. We need to filter versions returned for discovery to only those that are enabled.

@deads2k ptal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32490)

<!-- Reviewable:end -->
