### PR TITLE
Adds in configuration option to set the cAdvisor collector certificates.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -212,6 +212,13 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.OutOfDiskTransitionFrequency.Duration, "outofdisk-transition-frequency", s.OutOfDiskTransitionFrequency.Duration, "Duration for which the kubelet has to wait before transitioning out of out-of-disk node condition status. Default: 5m0s")
 	fs.StringVar(&s.NodeIP, "node-ip", s.NodeIP, "IP address of the node. If set, kubelet will use this IP address for the node")
 	fs.BoolVar(&s.EnableCustomMetrics, "enable-custom-metrics", s.EnableCustomMetrics, "Support for gathering custom metrics.")
+	fs.StringVar(&s.CustomMetricsCollectorClientCertFile, "custom-metrics-collector-client-cert-file", s.CustomMetricsCollectorClientCertFile, ""+
+		"File containing an x509 Certificate used for client identification by the cAdvisor custom metric collectors (CA cert, if any, concatenated after server cert). "+
+		"If --custom-metrics-collector-client-cert-file and --custom-metrics-collector-client-private-key-file are not provided, the default empty certificate will be presented for client verification "+
+		"to the custom metric endpoints.")
+	fs.StringVar(&s.CustomMetricsCollectorClientPrivateKeyFile, "custom-metrics-collector-client-private-key-file", s.CustomMetricsCollectorClientPrivateKeyFile, "File containing x509 private key matching --custom-metrics-collector-client-cert-file.")
+	fs.BoolVar(&s.CustomMetricsInsecureSkipVerify, "custom-metrics-insecure-skip-tls-verify", s.CustomMetricsInsecureSkipVerify, "Support accessing insecure metric endpoints.")
+	fs.StringVar(&s.CustomMetricsRootCAFile, "custom-metrics-root-ca-file", s.CustomMetricsRootCAFile, "If set, this root certificate authority will be used to verify custom metric endpoints. This must be a valid PEM-encoded CA bundle. If not set, the system's default root CA bundle is used instead.")
 	fs.StringVar(&s.RuntimeCgroups, "runtime-cgroups", s.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
 	fs.StringVar(&s.EvictionHard, "eviction-hard", s.EvictionHard, "A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction.")
 	fs.StringVar(&s.EvictionSoft, "eviction-soft", s.EvictionSoft, "A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -398,7 +398,15 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 	}
 
 	if kubeDeps.CAdvisorInterface == nil {
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(uint(s.CAdvisorPort), s.ContainerRuntime)
+
+		customMetricsConfig := cadvisor.CAdvisorCustomMetricsConfig{
+			CollectorClientCertFile:       s.CustomMetricsCollectorClientCertFile,
+			CollectorClientPrivateKeyFile: s.CustomMetricsCollectorClientPrivateKeyFile,
+			RootCAFile:                    s.CustomMetricsRootCAFile,
+			InsecureSkipVerify:            s.CustomMetricsInsecureSkipVerify,
+		}
+
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(uint(s.CAdvisorPort), s.ContainerRuntime, customMetricsConfig)
 		if err != nil {
 			return err
 		}

--- a/contrib/mesos/pkg/executor/service/cadvisor.go
+++ b/contrib/mesos/pkg/executor/service/cadvisor.go
@@ -28,8 +28,9 @@ type MesosCadvisor struct {
 	mem   uint64
 }
 
-func NewMesosCadvisor(cores int, mem uint64, port uint, runtime string) (*MesosCadvisor, error) {
-	c, err := cadvisor.New(port, runtime)
+func NewMesosCadvisor(cores int, mem uint64, port uint, runtime string, customMetricsConfig cadvisor.CAdvisorCustomMetricsConfig) (*MesosCadvisor, error) {
+
+	c, err := cadvisor.New(port, runtime, customMetricsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -40,6 +40,7 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet"
+	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kconfig "k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
@@ -209,7 +210,15 @@ func (s *KubeletExecutorServer) runKubelet(
 
 	// create custom cAdvisor interface which return the resource values that Mesos reports
 	ni := <-nodeInfos
-	cAdvisorInterface, err := NewMesosCadvisor(ni.Cores, ni.Mem, uint(s.CAdvisorPort), s.ContainerRuntime)
+
+	customMetricsConfig := cadvisor.CAdvisorCustomMetricsConfig{
+		CollectorClientCertFile:       s.CustomMetricsCollectorClientCertFile,
+		CollectorClientPrivateKeyFile: s.CustomMetricsCollectorClientPrivateKeyFile,
+		RootCAFile:                    s.CustomMetricsRootCAFile,
+		InsecureSkipVerify:            s.CustomMetricsInsecureSkipVerify,
+	}
+
+	cAdvisorInterface, err := NewMesosCadvisor(ni.Cores, ni.Mem, uint(s.CAdvisorPort), s.ContainerRuntime, customMetricsConfig)
 	if err != nil {
 		return err
 	}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -101,6 +101,10 @@ cpu-percent
 create-external-load-balancer
 current-release-pr
 current-replicas
+custom-metrics-collector-client-cert-file
+custom-metrics-collector-client-private-key-file
+custom-metrics-insecure-skip-tls-verify
+custom-metrics-root-ca-file
 daemonset-lookup-cache-size
 data-dir
 default-container-cpu-limit

--- a/pkg/apis/componentconfig/types.generated.go
+++ b/pkg/apis/componentconfig/types.generated.go
@@ -1218,37 +1218,37 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep130 := !z.EncBinary()
 			yy2arr130 := z.EncBasicHandle().StructToArray
-			var yyq130 [108]bool
+			var yyq130 [112]bool
 			_, _, _ = yysep130, yyq130, yy2arr130
 			const yyr130 bool = false
 			yyq130[0] = x.Kind != ""
 			yyq130[1] = x.APIVersion != ""
-			yyq130[53] = x.CloudProvider != ""
-			yyq130[54] = x.CloudConfigFile != ""
-			yyq130[55] = x.KubeletCgroups != ""
-			yyq130[56] = x.CgroupsPerQOS != false
-			yyq130[57] = x.RuntimeCgroups != ""
-			yyq130[58] = x.SystemCgroups != ""
-			yyq130[59] = x.CgroupRoot != ""
-			yyq130[63] = true
-			yyq130[64] = x.RktPath != ""
-			yyq130[65] = x.RktAPIEndpoint != ""
-			yyq130[66] = x.RktStage1Image != ""
-			yyq130[87] = true
-			yyq130[88] = x.NodeIP != ""
-			yyq130[92] = x.EvictionHard != ""
-			yyq130[93] = x.EvictionSoft != ""
-			yyq130[94] = x.EvictionSoftGracePeriod != ""
-			yyq130[95] = true
-			yyq130[96] = x.EvictionMaxPodGracePeriod != 0
-			yyq130[97] = x.EvictionMinimumReclaim != ""
-			yyq130[106] = len(x.AllowedUnsafeSysctls) != 0
-			yyq130[107] = x.ExperimentalRuntimeIntegrationType != ""
+			yyq130[57] = x.CloudProvider != ""
+			yyq130[58] = x.CloudConfigFile != ""
+			yyq130[59] = x.KubeletCgroups != ""
+			yyq130[60] = x.CgroupsPerQOS != false
+			yyq130[61] = x.RuntimeCgroups != ""
+			yyq130[62] = x.SystemCgroups != ""
+			yyq130[63] = x.CgroupRoot != ""
+			yyq130[67] = true
+			yyq130[68] = x.RktPath != ""
+			yyq130[69] = x.RktAPIEndpoint != ""
+			yyq130[70] = x.RktStage1Image != ""
+			yyq130[91] = true
+			yyq130[92] = x.NodeIP != ""
+			yyq130[96] = x.EvictionHard != ""
+			yyq130[97] = x.EvictionSoft != ""
+			yyq130[98] = x.EvictionSoftGracePeriod != ""
+			yyq130[99] = true
+			yyq130[100] = x.EvictionMaxPodGracePeriod != 0
+			yyq130[101] = x.EvictionMinimumReclaim != ""
+			yyq130[110] = len(x.AllowedUnsafeSysctls) != 0
+			yyq130[111] = x.ExperimentalRuntimeIntegrationType != ""
 			var yynn130 int
 			if yyr130 || yy2arr130 {
-				r.EncodeArrayStart(108)
+				r.EncodeArrayStart(112)
 			} else {
-				yynn130 = 85
+				yynn130 = 89
 				for _, b := range yyq130 {
 					if b {
 						yynn130++
@@ -1958,17 +1958,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym239
 				if false {
 				} else {
-					r.EncodeInt(int64(x.HealthzPort))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsCollectorClientCertFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
+				r.EncodeString(codecSelferC_UTF81234, string("customMetricsCollectorClientCertFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym240 := z.EncBinary()
 				_ = yym240
 				if false {
 				} else {
-					r.EncodeInt(int64(x.HealthzPort))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsCollectorClientCertFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1977,17 +1977,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym242
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsCollectorClientPrivateKeyFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
+				r.EncodeString(codecSelferC_UTF81234, string("customMetricsCollectorClientPrivateKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym243 := z.EncBinary()
 				_ = yym243
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsCollectorClientPrivateKeyFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -1996,17 +1996,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym245
 				if false {
 				} else {
-					r.EncodeInt(int64(x.OOMScoreAdj))
+					r.EncodeBool(bool(x.CustomMetricsInsecureSkipVerify))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
+				r.EncodeString(codecSelferC_UTF81234, string("customMetricsInsecureSkipVerify"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym246 := z.EncBinary()
 				_ = yym246
 				if false {
 				} else {
-					r.EncodeInt(int64(x.OOMScoreAdj))
+					r.EncodeBool(bool(x.CustomMetricsInsecureSkipVerify))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2015,17 +2015,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym248
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterNode))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsRootCAFile))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("registerNode"))
+				r.EncodeString(codecSelferC_UTF81234, string("customMetricsRootCAFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym249 := z.EncBinary()
 				_ = yym249
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterNode))
+					r.EncodeString(codecSelferC_UTF81234, string(x.CustomMetricsRootCAFile))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2034,17 +2034,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym251
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+					r.EncodeInt(int64(x.HealthzPort))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("clusterDomain"))
+				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym252 := z.EncBinary()
 				_ = yym252
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+					r.EncodeInt(int64(x.HealthzPort))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2053,17 +2053,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym254
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("masterServiceNamespace"))
+				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym255 := z.EncBinary()
 				_ = yym255
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2072,14 +2072,90 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym257
 				if false {
 				} else {
+					r.EncodeInt(int64(x.OOMScoreAdj))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym258 := z.EncBinary()
+				_ = yym258
+				if false {
+				} else {
+					r.EncodeInt(int64(x.OOMScoreAdj))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym260 := z.EncBinary()
+				_ = yym260
+				if false {
+				} else {
+					r.EncodeBool(bool(x.RegisterNode))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("registerNode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym261 := z.EncBinary()
+				_ = yym261
+				if false {
+				} else {
+					r.EncodeBool(bool(x.RegisterNode))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym263 := z.EncBinary()
+				_ = yym263
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("clusterDomain"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym264 := z.EncBinary()
+				_ = yym264
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDomain))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym266 := z.EncBinary()
+				_ = yym266
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("masterServiceNamespace"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym267 := z.EncBinary()
+				_ = yym267
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.MasterServiceNamespace))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym269 := z.EncBinary()
+				_ = yym269
+				if false {
+				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDNS))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterDNS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym258 := z.EncBinary()
-				_ = yym258
+				yym270 := z.EncBinary()
+				_ = yym270
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterDNS))
@@ -2087,75 +2163,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy260 := &x.StreamingConnectionIdleTimeout
-				yym261 := z.EncBinary()
-				_ = yym261
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy260) {
-				} else if !yym261 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy260)
-				} else {
-					z.EncFallback(yy260)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("streamingConnectionIdleTimeout"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy262 := &x.StreamingConnectionIdleTimeout
-				yym263 := z.EncBinary()
-				_ = yym263
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy262) {
-				} else if !yym263 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy262)
-				} else {
-					z.EncFallback(yy262)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy265 := &x.NodeStatusUpdateFrequency
-				yym266 := z.EncBinary()
-				_ = yym266
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy265) {
-				} else if !yym266 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy265)
-				} else {
-					z.EncFallback(yy265)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nodeStatusUpdateFrequency"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy267 := &x.NodeStatusUpdateFrequency
-				yym268 := z.EncBinary()
-				_ = yym268
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy267) {
-				} else if !yym268 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy267)
-				} else {
-					z.EncFallback(yy267)
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy270 := &x.ImageMinimumGCAge
-				yym271 := z.EncBinary()
-				_ = yym271
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy270) {
-				} else if !yym271 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy270)
-				} else {
-					z.EncFallback(yy270)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("imageMinimumGCAge"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy272 := &x.ImageMinimumGCAge
+				yy272 := &x.StreamingConnectionIdleTimeout
 				yym273 := z.EncBinary()
 				_ = yym273
 				if false {
@@ -2165,67 +2173,65 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy272)
 				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("streamingConnectionIdleTimeout"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy274 := &x.StreamingConnectionIdleTimeout
 				yym275 := z.EncBinary()
 				_ = yym275
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy274) {
+				} else if !yym275 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy274)
 				} else {
-					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("imageGCHighThresholdPercent"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym276 := z.EncBinary()
-				_ = yym276
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
+					z.EncFallback(yy274)
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy277 := &x.NodeStatusUpdateFrequency
 				yym278 := z.EncBinary()
 				_ = yym278
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy277) {
+				} else if !yym278 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy277)
 				} else {
-					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+					z.EncFallback(yy277)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("imageGCLowThresholdPercent"))
+				r.EncodeString(codecSelferC_UTF81234, string("nodeStatusUpdateFrequency"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym279 := z.EncBinary()
-				_ = yym279
+				yy279 := &x.NodeStatusUpdateFrequency
+				yym280 := z.EncBinary()
+				_ = yym280
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy279) {
+				} else if !yym280 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy279)
 				} else {
-					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+					z.EncFallback(yy279)
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym281 := z.EncBinary()
-				_ = yym281
+				yy282 := &x.ImageMinimumGCAge
+				yym283 := z.EncBinary()
+				_ = yym283
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy282) {
+				} else if !yym283 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy282)
 				} else {
-					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
+					z.EncFallback(yy282)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("lowDiskSpaceThresholdMB"))
+				r.EncodeString(codecSelferC_UTF81234, string("imageMinimumGCAge"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym282 := z.EncBinary()
-				_ = yym282
-				if false {
-				} else {
-					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy284 := &x.VolumeStatsAggPeriod
+				yy284 := &x.ImageMinimumGCAge
 				yym285 := z.EncBinary()
 				_ = yym285
 				if false {
@@ -2235,95 +2241,89 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy284)
 				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("volumeStatsAggPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy286 := &x.VolumeStatsAggPeriod
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym287 := z.EncBinary()
 				_ = yym287
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy286) {
-				} else if !yym287 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy286)
 				} else {
-					z.EncFallback(yy286)
+					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("imageGCHighThresholdPercent"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym288 := z.EncBinary()
+				_ = yym288
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ImageGCHighThresholdPercent))
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym289 := z.EncBinary()
-				_ = yym289
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginName"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym290 := z.EncBinary()
 				_ = yym290
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
+					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("imageGCLowThresholdPercent"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym291 := z.EncBinary()
+				_ = yym291
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ImageGCLowThresholdPercent))
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym292 := z.EncBinary()
-				_ = yym292
-				if false {
-				} else {
-					r.EncodeInt(int64(x.NetworkPluginMTU))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginMTU"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym293 := z.EncBinary()
 				_ = yym293
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NetworkPluginMTU))
+					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("lowDiskSpaceThresholdMB"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym294 := z.EncBinary()
+				_ = yym294
+				if false {
+				} else {
+					r.EncodeInt(int64(x.LowDiskSpaceThresholdMB))
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym295 := z.EncBinary()
-				_ = yym295
+				yy296 := &x.VolumeStatsAggPeriod
+				yym297 := z.EncBinary()
+				_ = yym297
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy296) {
+				} else if !yym297 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy296)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+					z.EncFallback(yy296)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("networkPluginDir"))
+				r.EncodeString(codecSelferC_UTF81234, string("volumeStatsAggPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym296 := z.EncBinary()
-				_ = yym296
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym298 := z.EncBinary()
-				_ = yym298
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CNIConfDir))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("cniConfDir"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy298 := &x.VolumeStatsAggPeriod
 				yym299 := z.EncBinary()
 				_ = yym299
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy298) {
+				} else if !yym299 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy298)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CNIConfDir))
+					z.EncFallback(yy298)
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2332,17 +2332,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym301
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CNIBinDir))
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("cniBinDir"))
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym302 := z.EncBinary()
 				_ = yym302
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.CNIBinDir))
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginName))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2351,117 +2351,93 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym304
 				if false {
 				} else {
+					r.EncodeInt(int64(x.NetworkPluginMTU))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginMTU"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym305 := z.EncBinary()
+				_ = yym305
+				if false {
+				} else {
+					r.EncodeInt(int64(x.NetworkPluginMTU))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym307 := z.EncBinary()
+				_ = yym307
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("networkPluginDir"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym308 := z.EncBinary()
+				_ = yym308
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NetworkPluginDir))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym310 := z.EncBinary()
+				_ = yym310
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.CNIConfDir))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("cniConfDir"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym311 := z.EncBinary()
+				_ = yym311
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.CNIConfDir))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym313 := z.EncBinary()
+				_ = yym313
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.CNIBinDir))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("cniBinDir"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym314 := z.EncBinary()
+				_ = yym314
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.CNIBinDir))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym316 := z.EncBinary()
+				_ = yym316
+				if false {
+				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumePluginDir))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumePluginDir"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym305 := z.EncBinary()
-				_ = yym305
+				yym317 := z.EncBinary()
+				_ = yym317
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumePluginDir))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[53] {
-					yym307 := z.EncBinary()
-					_ = yym307
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[53] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym308 := z.EncBinary()
-					_ = yym308
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
-					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[54] {
-					yym310 := z.EncBinary()
-					_ = yym310
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[54] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym311 := z.EncBinary()
-					_ = yym311
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
-					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[55] {
-					yym313 := z.EncBinary()
-					_ = yym313
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq130[55] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kubeletCgroups"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym314 := z.EncBinary()
-					_ = yym314
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
-					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[56] {
-					yym316 := z.EncBinary()
-					_ = yym316
-					if false {
-					} else {
-						r.EncodeBool(bool(x.CgroupsPerQOS))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq130[56] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("CgroupsPerQOS"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym317 := z.EncBinary()
-					_ = yym317
-					if false {
-					} else {
-						r.EncodeBool(bool(x.CgroupsPerQOS))
-					}
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2471,7 +2447,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym319
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2479,13 +2455,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[57] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("runtimeCgroups"))
+					r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym320 := z.EncBinary()
 					_ = yym320
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 					}
 				}
 			}
@@ -2496,7 +2472,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym322
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2504,13 +2480,13 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[58] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("systemCgroups"))
+					r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym323 := z.EncBinary()
 					_ = yym323
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+						r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 					}
 				}
 			}
@@ -2521,7 +2497,7 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym325
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -2529,10 +2505,110 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq130[59] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cgroupRoot"))
+					r.EncodeString(codecSelferC_UTF81234, string("kubeletCgroups"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym326 := z.EncBinary()
 					_ = yym326
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.KubeletCgroups))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[60] {
+					yym328 := z.EncBinary()
+					_ = yym328
+					if false {
+					} else {
+						r.EncodeBool(bool(x.CgroupsPerQOS))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq130[60] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("CgroupsPerQOS"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym329 := z.EncBinary()
+					_ = yym329
+					if false {
+					} else {
+						r.EncodeBool(bool(x.CgroupsPerQOS))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[61] {
+					yym331 := z.EncBinary()
+					_ = yym331
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq130[61] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("runtimeCgroups"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym332 := z.EncBinary()
+					_ = yym332
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.RuntimeCgroups))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[62] {
+					yym334 := z.EncBinary()
+					_ = yym334
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq130[62] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("systemCgroups"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym335 := z.EncBinary()
+					_ = yym335
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SystemCgroups))
+					}
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq130[63] {
+					yym337 := z.EncBinary()
+					_ = yym337
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq130[63] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cgroupRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym338 := z.EncBinary()
+					_ = yym338
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.CgroupRoot))
@@ -2541,8 +2617,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym328 := z.EncBinary()
-				_ = yym328
+				yym340 := z.EncBinary()
+				_ = yym340
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
@@ -2551,8 +2627,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containerRuntime"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym329 := z.EncBinary()
-				_ = yym329
+				yym341 := z.EncBinary()
+				_ = yym341
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntime))
@@ -2560,8 +2636,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym331 := z.EncBinary()
-				_ = yym331
+				yym343 := z.EncBinary()
+				_ = yym343
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
@@ -2570,8 +2646,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("remoteRuntimeEndpoint"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym332 := z.EncBinary()
-				_ = yym332
+				yym344 := z.EncBinary()
+				_ = yym344
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteRuntimeEndpoint))
@@ -2579,8 +2655,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym334 := z.EncBinary()
-				_ = yym334
+				yym346 := z.EncBinary()
+				_ = yym346
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteImageEndpoint))
@@ -2589,8 +2665,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("remoteImageEndpoint"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym335 := z.EncBinary()
-				_ = yym335
+				yym347 := z.EncBinary()
+				_ = yym347
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RemoteImageEndpoint))
@@ -2598,42 +2674,42 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[63] {
-					yy337 := &x.RuntimeRequestTimeout
-					yym338 := z.EncBinary()
-					_ = yym338
+				if yyq130[67] {
+					yy349 := &x.RuntimeRequestTimeout
+					yym350 := z.EncBinary()
+					_ = yym350
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy337) {
-					} else if !yym338 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy337)
+					} else if z.HasExtensions() && z.EncExt(yy349) {
+					} else if !yym350 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy349)
 					} else {
-						z.EncFallback(yy337)
+						z.EncFallback(yy349)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[63] {
+				if yyq130[67] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runtimeRequestTimeout"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy339 := &x.RuntimeRequestTimeout
-					yym340 := z.EncBinary()
-					_ = yym340
+					yy351 := &x.RuntimeRequestTimeout
+					yym352 := z.EncBinary()
+					_ = yym352
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy339) {
-					} else if !yym340 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy339)
+					} else if z.HasExtensions() && z.EncExt(yy351) {
+					} else if !yym352 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy351)
 					} else {
-						z.EncFallback(yy339)
+						z.EncFallback(yy351)
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[64] {
-					yym342 := z.EncBinary()
-					_ = yym342
+				if yyq130[68] {
+					yym354 := z.EncBinary()
+					_ = yym354
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
@@ -2642,12 +2718,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[64] {
+				if yyq130[68] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rktPath"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym343 := z.EncBinary()
-					_ = yym343
+					yym355 := z.EncBinary()
+					_ = yym355
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktPath))
@@ -2656,9 +2732,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[65] {
-					yym345 := z.EncBinary()
-					_ = yym345
+				if yyq130[69] {
+					yym357 := z.EncBinary()
+					_ = yym357
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
@@ -2667,12 +2743,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[65] {
+				if yyq130[69] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rktAPIEndpoint"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym346 := z.EncBinary()
-					_ = yym346
+					yym358 := z.EncBinary()
+					_ = yym358
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktAPIEndpoint))
@@ -2681,9 +2757,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[66] {
-					yym348 := z.EncBinary()
-					_ = yym348
+				if yyq130[70] {
+					yym360 := z.EncBinary()
+					_ = yym360
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
@@ -2692,92 +2768,16 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[66] {
+				if yyq130[70] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rktStage1Image"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym349 := z.EncBinary()
-					_ = yym349
+					yym361 := z.EncBinary()
+					_ = yym361
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.RktStage1Image))
 					}
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym351 := z.EncBinary()
-				_ = yym351
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("lockFilePath"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym352 := z.EncBinary()
-				_ = yym352
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym354 := z.EncBinary()
-				_ = yym354
-				if false {
-				} else {
-					r.EncodeBool(bool(x.ExitOnLockContention))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("exitOnLockContention"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym355 := z.EncBinary()
-				_ = yym355
-				if false {
-				} else {
-					r.EncodeBool(bool(x.ExitOnLockContention))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym357 := z.EncBinary()
-				_ = yym357
-				if false {
-				} else {
-					r.EncodeBool(bool(x.ConfigureCBR0))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("configureCbr0"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym358 := z.EncBinary()
-				_ = yym358
-				if false {
-				} else {
-					r.EncodeBool(bool(x.ConfigureCBR0))
-				}
-			}
-			if yyr130 || yy2arr130 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym360 := z.EncBinary()
-				_ = yym360
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("hairpinMode"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym361 := z.EncBinary()
-				_ = yym361
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2786,17 +2786,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym363
 				if false {
 				} else {
-					r.EncodeBool(bool(x.BabysitDaemons))
+					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("babysitDaemons"))
+				r.EncodeString(codecSelferC_UTF81234, string("lockFilePath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym364 := z.EncBinary()
 				_ = yym364
 				if false {
 				} else {
-					r.EncodeBool(bool(x.BabysitDaemons))
+					r.EncodeString(codecSelferC_UTF81234, string(x.LockFilePath))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2805,17 +2805,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym366
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxPods))
+					r.EncodeBool(bool(x.ExitOnLockContention))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxPods"))
+				r.EncodeString(codecSelferC_UTF81234, string("exitOnLockContention"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym367 := z.EncBinary()
 				_ = yym367
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxPods))
+					r.EncodeBool(bool(x.ExitOnLockContention))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2824,17 +2824,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym369
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NvidiaGPUs))
+					r.EncodeBool(bool(x.ConfigureCBR0))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nvidiaGPUs"))
+				r.EncodeString(codecSelferC_UTF81234, string("configureCbr0"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym370 := z.EncBinary()
 				_ = yym370
 				if false {
 				} else {
-					r.EncodeInt(int64(x.NvidiaGPUs))
+					r.EncodeBool(bool(x.ConfigureCBR0))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2843,17 +2843,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym372
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("dockerExecHandlerName"))
+				r.EncodeString(codecSelferC_UTF81234, string("hairpinMode"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym373 := z.EncBinary()
 				_ = yym373
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
+					r.EncodeString(codecSelferC_UTF81234, string(x.HairpinMode))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2862,17 +2862,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym375
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					r.EncodeBool(bool(x.BabysitDaemons))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
+				r.EncodeString(codecSelferC_UTF81234, string("babysitDaemons"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym376 := z.EncBinary()
 				_ = yym376
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					r.EncodeBool(bool(x.BabysitDaemons))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2881,17 +2881,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym378
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
+					r.EncodeInt(int64(x.MaxPods))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("resolvConf"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxPods"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym379 := z.EncBinary()
 				_ = yym379
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
+					r.EncodeInt(int64(x.MaxPods))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2900,17 +2900,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym381
 				if false {
 				} else {
-					r.EncodeBool(bool(x.CPUCFSQuota))
+					r.EncodeInt(int64(x.NvidiaGPUs))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("cpuCFSQuota"))
+				r.EncodeString(codecSelferC_UTF81234, string("nvidiaGPUs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym382 := z.EncBinary()
 				_ = yym382
 				if false {
 				} else {
-					r.EncodeBool(bool(x.CPUCFSQuota))
+					r.EncodeInt(int64(x.NvidiaGPUs))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2919,17 +2919,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym384
 				if false {
 				} else {
-					r.EncodeBool(bool(x.Containerized))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("containerized"))
+				r.EncodeString(codecSelferC_UTF81234, string("dockerExecHandlerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym385 := z.EncBinary()
 				_ = yym385
 				if false {
 				} else {
-					r.EncodeBool(bool(x.Containerized))
+					r.EncodeString(codecSelferC_UTF81234, string(x.DockerExecHandlerName))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2938,17 +2938,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym387
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxOpenFiles))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxOpenFiles"))
+				r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym388 := z.EncBinary()
 				_ = yym388
 				if false {
 				} else {
-					r.EncodeInt(int64(x.MaxOpenFiles))
+					r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2957,17 +2957,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym390
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ReconcileCIDR))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("reconcileCIDR"))
+				r.EncodeString(codecSelferC_UTF81234, string("resolvConf"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym391 := z.EncBinary()
 				_ = yym391
 				if false {
 				} else {
-					r.EncodeBool(bool(x.ReconcileCIDR))
+					r.EncodeString(codecSelferC_UTF81234, string(x.ResolverConfig))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2976,17 +2976,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym393
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterSchedulable))
+					r.EncodeBool(bool(x.CPUCFSQuota))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("registerSchedulable"))
+				r.EncodeString(codecSelferC_UTF81234, string("cpuCFSQuota"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym394 := z.EncBinary()
 				_ = yym394
 				if false {
 				} else {
-					r.EncodeBool(bool(x.RegisterSchedulable))
+					r.EncodeBool(bool(x.CPUCFSQuota))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -2995,17 +2995,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym396
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+					r.EncodeBool(bool(x.Containerized))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
+				r.EncodeString(codecSelferC_UTF81234, string("containerized"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym397 := z.EncBinary()
 				_ = yym397
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+					r.EncodeBool(bool(x.Containerized))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3014,17 +3014,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym399
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIQPS))
+					r.EncodeInt(int64(x.MaxOpenFiles))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
+				r.EncodeString(codecSelferC_UTF81234, string("maxOpenFiles"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym400 := z.EncBinary()
 				_ = yym400
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIQPS))
+					r.EncodeInt(int64(x.MaxOpenFiles))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3033,17 +3033,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym402
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIBurst))
+					r.EncodeBool(bool(x.ReconcileCIDR))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
+				r.EncodeString(codecSelferC_UTF81234, string("reconcileCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym403 := z.EncBinary()
 				_ = yym403
 				if false {
 				} else {
-					r.EncodeInt(int64(x.KubeAPIBurst))
+					r.EncodeBool(bool(x.ReconcileCIDR))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3052,17 +3052,17 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym405
 				if false {
 				} else {
-					r.EncodeBool(bool(x.SerializeImagePulls))
+					r.EncodeBool(bool(x.RegisterSchedulable))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serializeImagePulls"))
+				r.EncodeString(codecSelferC_UTF81234, string("registerSchedulable"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym406 := z.EncBinary()
 				_ = yym406
 				if false {
 				} else {
-					r.EncodeBool(bool(x.SerializeImagePulls))
+					r.EncodeBool(bool(x.RegisterSchedulable))
 				}
 			}
 			if yyr130 || yy2arr130 {
@@ -3071,14 +3071,90 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym408
 				if false {
 				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym409 := z.EncBinary()
+				_ = yym409
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym411 := z.EncBinary()
+				_ = yym411
+				if false {
+				} else {
+					r.EncodeInt(int64(x.KubeAPIQPS))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym412 := z.EncBinary()
+				_ = yym412
+				if false {
+				} else {
+					r.EncodeInt(int64(x.KubeAPIQPS))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym414 := z.EncBinary()
+				_ = yym414
+				if false {
+				} else {
+					r.EncodeInt(int64(x.KubeAPIBurst))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym415 := z.EncBinary()
+				_ = yym415
+				if false {
+				} else {
+					r.EncodeInt(int64(x.KubeAPIBurst))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym417 := z.EncBinary()
+				_ = yym417
+				if false {
+				} else {
+					r.EncodeBool(bool(x.SerializeImagePulls))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("serializeImagePulls"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym418 := z.EncBinary()
+				_ = yym418
+				if false {
+				} else {
+					r.EncodeBool(bool(x.SerializeImagePulls))
+				}
+			}
+			if yyr130 || yy2arr130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym420 := z.EncBinary()
+				_ = yym420
+				if false {
+				} else {
 					r.EncodeBool(bool(x.ExperimentalFlannelOverlay))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("experimentalFlannelOverlay"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym409 := z.EncBinary()
-				_ = yym409
+				yym421 := z.EncBinary()
+				_ = yym421
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ExperimentalFlannelOverlay))
@@ -3086,42 +3162,42 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[87] {
-					yy411 := &x.OutOfDiskTransitionFrequency
-					yym412 := z.EncBinary()
-					_ = yym412
+				if yyq130[91] {
+					yy423 := &x.OutOfDiskTransitionFrequency
+					yym424 := z.EncBinary()
+					_ = yym424
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy411) {
-					} else if !yym412 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy411)
+					} else if z.HasExtensions() && z.EncExt(yy423) {
+					} else if !yym424 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy423)
 					} else {
-						z.EncFallback(yy411)
+						z.EncFallback(yy423)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[87] {
+				if yyq130[91] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("outOfDiskTransitionFrequency"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy413 := &x.OutOfDiskTransitionFrequency
-					yym414 := z.EncBinary()
-					_ = yym414
+					yy425 := &x.OutOfDiskTransitionFrequency
+					yym426 := z.EncBinary()
+					_ = yym426
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy413) {
-					} else if !yym414 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy413)
+					} else if z.HasExtensions() && z.EncExt(yy425) {
+					} else if !yym426 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy425)
 					} else {
-						z.EncFallback(yy413)
+						z.EncFallback(yy425)
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[88] {
-					yym416 := z.EncBinary()
-					_ = yym416
+				if yyq130[92] {
+					yym428 := z.EncBinary()
+					_ = yym428
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeIP))
@@ -3130,12 +3206,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[88] {
+				if yyq130[92] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeIP"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym417 := z.EncBinary()
-					_ = yym417
+					yym429 := z.EncBinary()
+					_ = yym429
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeIP))
@@ -3147,8 +3223,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.NodeLabels == nil {
 					r.EncodeNil()
 				} else {
-					yym419 := z.EncBinary()
-					_ = yym419
+					yym431 := z.EncBinary()
+					_ = yym431
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.NodeLabels, false, e)
@@ -3161,8 +3237,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.NodeLabels == nil {
 					r.EncodeNil()
 				} else {
-					yym420 := z.EncBinary()
-					_ = yym420
+					yym432 := z.EncBinary()
+					_ = yym432
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.NodeLabels, false, e)
@@ -3171,8 +3247,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym422 := z.EncBinary()
-				_ = yym422
+				yym434 := z.EncBinary()
+				_ = yym434
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.NonMasqueradeCIDR))
@@ -3181,8 +3257,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nonMasqueradeCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym423 := z.EncBinary()
-				_ = yym423
+				yym435 := z.EncBinary()
+				_ = yym435
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.NonMasqueradeCIDR))
@@ -3190,8 +3266,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym425 := z.EncBinary()
-				_ = yym425
+				yym437 := z.EncBinary()
+				_ = yym437
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableCustomMetrics))
@@ -3200,8 +3276,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableCustomMetrics"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym426 := z.EncBinary()
-				_ = yym426
+				yym438 := z.EncBinary()
+				_ = yym438
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableCustomMetrics))
@@ -3209,9 +3285,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[92] {
-					yym428 := z.EncBinary()
-					_ = yym428
+				if yyq130[96] {
+					yym440 := z.EncBinary()
+					_ = yym440
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
@@ -3220,12 +3296,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[92] {
+				if yyq130[96] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionHard"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym429 := z.EncBinary()
-					_ = yym429
+					yym441 := z.EncBinary()
+					_ = yym441
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionHard))
@@ -3234,9 +3310,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[93] {
-					yym431 := z.EncBinary()
-					_ = yym431
+				if yyq130[97] {
+					yym443 := z.EncBinary()
+					_ = yym443
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
@@ -3245,12 +3321,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[93] {
+				if yyq130[97] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionSoft"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym432 := z.EncBinary()
-					_ = yym432
+					yym444 := z.EncBinary()
+					_ = yym444
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoft))
@@ -3259,9 +3335,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[94] {
-					yym434 := z.EncBinary()
-					_ = yym434
+				if yyq130[98] {
+					yym446 := z.EncBinary()
+					_ = yym446
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoftGracePeriod))
@@ -3270,12 +3346,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[94] {
+				if yyq130[98] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionSoftGracePeriod"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym435 := z.EncBinary()
-					_ = yym435
+					yym447 := z.EncBinary()
+					_ = yym447
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionSoftGracePeriod))
@@ -3284,42 +3360,42 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[95] {
-					yy437 := &x.EvictionPressureTransitionPeriod
-					yym438 := z.EncBinary()
-					_ = yym438
+				if yyq130[99] {
+					yy449 := &x.EvictionPressureTransitionPeriod
+					yym450 := z.EncBinary()
+					_ = yym450
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy437) {
-					} else if !yym438 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy437)
+					} else if z.HasExtensions() && z.EncExt(yy449) {
+					} else if !yym450 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy449)
 					} else {
-						z.EncFallback(yy437)
+						z.EncFallback(yy449)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[95] {
+				if yyq130[99] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionPressureTransitionPeriod"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy439 := &x.EvictionPressureTransitionPeriod
-					yym440 := z.EncBinary()
-					_ = yym440
+					yy451 := &x.EvictionPressureTransitionPeriod
+					yym452 := z.EncBinary()
+					_ = yym452
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy439) {
-					} else if !yym440 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy439)
+					} else if z.HasExtensions() && z.EncExt(yy451) {
+					} else if !yym452 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy451)
 					} else {
-						z.EncFallback(yy439)
+						z.EncFallback(yy451)
 					}
 				}
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[96] {
-					yym442 := z.EncBinary()
-					_ = yym442
+				if yyq130[100] {
+					yym454 := z.EncBinary()
+					_ = yym454
 					if false {
 					} else {
 						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
@@ -3328,12 +3404,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq130[96] {
+				if yyq130[100] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionMaxPodGracePeriod"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym443 := z.EncBinary()
-					_ = yym443
+					yym455 := z.EncBinary()
+					_ = yym455
 					if false {
 					} else {
 						r.EncodeInt(int64(x.EvictionMaxPodGracePeriod))
@@ -3342,9 +3418,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[97] {
-					yym445 := z.EncBinary()
-					_ = yym445
+				if yyq130[101] {
+					yym457 := z.EncBinary()
+					_ = yym457
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionMinimumReclaim))
@@ -3353,12 +3429,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[97] {
+				if yyq130[101] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("evictionMinimumReclaim"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym446 := z.EncBinary()
-					_ = yym446
+					yym458 := z.EncBinary()
+					_ = yym458
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.EvictionMinimumReclaim))
@@ -3367,8 +3443,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym448 := z.EncBinary()
-				_ = yym448
+				yym460 := z.EncBinary()
+				_ = yym460
 				if false {
 				} else {
 					r.EncodeInt(int64(x.PodsPerCore))
@@ -3377,8 +3453,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podsPerCore"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym449 := z.EncBinary()
-				_ = yym449
+				yym461 := z.EncBinary()
+				_ = yym461
 				if false {
 				} else {
 					r.EncodeInt(int64(x.PodsPerCore))
@@ -3386,8 +3462,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym451 := z.EncBinary()
-				_ = yym451
+				yym463 := z.EncBinary()
+				_ = yym463
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableControllerAttachDetach))
@@ -3396,8 +3472,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableControllerAttachDetach"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym452 := z.EncBinary()
-				_ = yym452
+				yym464 := z.EncBinary()
+				_ = yym464
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableControllerAttachDetach))
@@ -3408,8 +3484,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SystemReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym454 := z.EncBinary()
-					_ = yym454
+					yym466 := z.EncBinary()
+					_ = yym466
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SystemReserved) {
 					} else {
@@ -3423,8 +3499,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SystemReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym455 := z.EncBinary()
-					_ = yym455
+					yym467 := z.EncBinary()
+					_ = yym467
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SystemReserved) {
 					} else {
@@ -3437,8 +3513,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.KubeReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym457 := z.EncBinary()
-					_ = yym457
+					yym469 := z.EncBinary()
+					_ = yym469
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.KubeReserved) {
 					} else {
@@ -3452,8 +3528,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.KubeReserved == nil {
 					r.EncodeNil()
 				} else {
-					yym458 := z.EncBinary()
-					_ = yym458
+					yym470 := z.EncBinary()
+					_ = yym470
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.KubeReserved) {
 					} else {
@@ -3463,8 +3539,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym460 := z.EncBinary()
-				_ = yym460
+				yym472 := z.EncBinary()
+				_ = yym472
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ProtectKernelDefaults))
@@ -3473,8 +3549,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("protectKernelDefaults"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym461 := z.EncBinary()
-				_ = yym461
+				yym473 := z.EncBinary()
+				_ = yym473
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ProtectKernelDefaults))
@@ -3482,8 +3558,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym463 := z.EncBinary()
-				_ = yym463
+				yym475 := z.EncBinary()
+				_ = yym475
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
@@ -3492,8 +3568,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("makeIPTablesUtilChains"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym464 := z.EncBinary()
-				_ = yym464
+				yym476 := z.EncBinary()
+				_ = yym476
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MakeIPTablesUtilChains))
@@ -3501,8 +3577,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym466 := z.EncBinary()
-				_ = yym466
+				yym478 := z.EncBinary()
+				_ = yym478
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
@@ -3511,8 +3587,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesMasqueradeBit"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym467 := z.EncBinary()
-				_ = yym467
+				yym479 := z.EncBinary()
+				_ = yym479
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IPTablesMasqueradeBit))
@@ -3520,8 +3596,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym469 := z.EncBinary()
-				_ = yym469
+				yym481 := z.EncBinary()
+				_ = yym481
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IPTablesDropBit))
@@ -3530,8 +3606,8 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesDropBit"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym470 := z.EncBinary()
-				_ = yym470
+				yym482 := z.EncBinary()
+				_ = yym482
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IPTablesDropBit))
@@ -3539,12 +3615,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[106] {
+				if yyq130[110] {
 					if x.AllowedUnsafeSysctls == nil {
 						r.EncodeNil()
 					} else {
-						yym472 := z.EncBinary()
-						_ = yym472
+						yym484 := z.EncBinary()
+						_ = yym484
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.AllowedUnsafeSysctls, false, e)
@@ -3554,15 +3630,15 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq130[106] {
+				if yyq130[110] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("experimentalAllowedUnsafeSysctls"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AllowedUnsafeSysctls == nil {
 						r.EncodeNil()
 					} else {
-						yym473 := z.EncBinary()
-						_ = yym473
+						yym485 := z.EncBinary()
+						_ = yym485
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.AllowedUnsafeSysctls, false, e)
@@ -3572,9 +3648,9 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr130 || yy2arr130 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq130[107] {
-					yym475 := z.EncBinary()
-					_ = yym475
+				if yyq130[111] {
+					yym487 := z.EncBinary()
+					_ = yym487
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ExperimentalRuntimeIntegrationType))
@@ -3583,12 +3659,12 @@ func (x *KubeletConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq130[107] {
+				if yyq130[111] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("experimentalRuntimeIntegrationType"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym476 := z.EncBinary()
-					_ = yym476
+					yym488 := z.EncBinary()
+					_ = yym488
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ExperimentalRuntimeIntegrationType))
@@ -3608,25 +3684,25 @@ func (x *KubeletConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym477 := z.DecBinary()
-	_ = yym477
+	yym489 := z.DecBinary()
+	_ = yym489
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct478 := r.ContainerType()
-		if yyct478 == codecSelferValueTypeMap1234 {
-			yyl478 := r.ReadMapStart()
-			if yyl478 == 0 {
+		yyct490 := r.ContainerType()
+		if yyct490 == codecSelferValueTypeMap1234 {
+			yyl490 := r.ReadMapStart()
+			if yyl490 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl478, d)
+				x.codecDecodeSelfFromMap(yyl490, d)
 			}
-		} else if yyct478 == codecSelferValueTypeArray1234 {
-			yyl478 := r.ReadArrayStart()
-			if yyl478 == 0 {
+		} else if yyct490 == codecSelferValueTypeArray1234 {
+			yyl490 := r.ReadArrayStart()
+			if yyl490 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl478, d)
+				x.codecDecodeSelfFromArray(yyl490, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3638,12 +3714,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys479Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys479Slc
-	var yyhl479 bool = l >= 0
-	for yyj479 := 0; ; yyj479++ {
-		if yyhl479 {
-			if yyj479 >= l {
+	var yys491Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys491Slc
+	var yyhl491 bool = l >= 0
+	for yyj491 := 0; ; yyj491++ {
+		if yyhl491 {
+			if yyj491 >= l {
 				break
 			}
 		} else {
@@ -3652,10 +3728,10 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys479Slc = r.DecodeBytes(yys479Slc, true, true)
-		yys479 := string(yys479Slc)
+		yys491Slc = r.DecodeBytes(yys491Slc, true, true)
+		yys491 := string(yys491Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys479 {
+		switch yys491 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3678,45 +3754,45 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.SyncFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv483 := &x.SyncFrequency
-				yym484 := z.DecBinary()
-				_ = yym484
+				yyv495 := &x.SyncFrequency
+				yym496 := z.DecBinary()
+				_ = yym496
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv483) {
-				} else if !yym484 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv483)
+				} else if z.HasExtensions() && z.DecExt(yyv495) {
+				} else if !yym496 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv495)
 				} else {
-					z.DecFallback(yyv483, false)
+					z.DecFallback(yyv495, false)
 				}
 			}
 		case "fileCheckFrequency":
 			if r.TryDecodeAsNil() {
 				x.FileCheckFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv485 := &x.FileCheckFrequency
-				yym486 := z.DecBinary()
-				_ = yym486
+				yyv497 := &x.FileCheckFrequency
+				yym498 := z.DecBinary()
+				_ = yym498
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv485) {
-				} else if !yym486 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv485)
+				} else if z.HasExtensions() && z.DecExt(yyv497) {
+				} else if !yym498 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv497)
 				} else {
-					z.DecFallback(yyv485, false)
+					z.DecFallback(yyv497, false)
 				}
 			}
 		case "httpCheckFrequency":
 			if r.TryDecodeAsNil() {
 				x.HTTPCheckFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv487 := &x.HTTPCheckFrequency
-				yym488 := z.DecBinary()
-				_ = yym488
+				yyv499 := &x.HTTPCheckFrequency
+				yym500 := z.DecBinary()
+				_ = yym500
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv487) {
-				} else if !yym488 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv487)
+				} else if z.HasExtensions() && z.DecExt(yyv499) {
+				} else if !yym500 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv499)
 				} else {
-					z.DecFallback(yyv487, false)
+					z.DecFallback(yyv499, false)
 				}
 			}
 		case "manifestURL":
@@ -3813,36 +3889,36 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.HostNetworkSources = nil
 			} else {
-				yyv504 := &x.HostNetworkSources
-				yym505 := z.DecBinary()
-				_ = yym505
+				yyv516 := &x.HostNetworkSources
+				yym517 := z.DecBinary()
+				_ = yym517
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv504, false, d)
+					z.F.DecSliceStringX(yyv516, false, d)
 				}
 			}
 		case "hostPIDSources":
 			if r.TryDecodeAsNil() {
 				x.HostPIDSources = nil
 			} else {
-				yyv506 := &x.HostPIDSources
-				yym507 := z.DecBinary()
-				_ = yym507
+				yyv518 := &x.HostPIDSources
+				yym519 := z.DecBinary()
+				_ = yym519
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv506, false, d)
+					z.F.DecSliceStringX(yyv518, false, d)
 				}
 			}
 		case "hostIPCSources":
 			if r.TryDecodeAsNil() {
 				x.HostIPCSources = nil
 			} else {
-				yyv508 := &x.HostIPCSources
-				yym509 := z.DecBinary()
-				_ = yym509
+				yyv520 := &x.HostIPCSources
+				yym521 := z.DecBinary()
+				_ = yym521
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv508, false, d)
+					z.F.DecSliceStringX(yyv520, false, d)
 				}
 			}
 		case "registryPullQPS":
@@ -3879,15 +3955,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.MinimumGCAge = pkg1_unversioned.Duration{}
 			} else {
-				yyv515 := &x.MinimumGCAge
-				yym516 := z.DecBinary()
-				_ = yym516
+				yyv527 := &x.MinimumGCAge
+				yym528 := z.DecBinary()
+				_ = yym528
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv515) {
-				} else if !yym516 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv515)
+				} else if z.HasExtensions() && z.DecExt(yyv527) {
+				} else if !yym528 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv527)
 				} else {
-					z.DecFallback(yyv515, false)
+					z.DecFallback(yyv527, false)
 				}
 			}
 		case "maxPerPodContainerCount":
@@ -3907,6 +3983,30 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.CAdvisorPort = 0
 			} else {
 				x.CAdvisorPort = int32(r.DecodeInt(32))
+			}
+		case "customMetricsCollectorClientCertFile":
+			if r.TryDecodeAsNil() {
+				x.CustomMetricsCollectorClientCertFile = ""
+			} else {
+				x.CustomMetricsCollectorClientCertFile = string(r.DecodeString())
+			}
+		case "customMetricsCollectorClientPrivateKeyFile":
+			if r.TryDecodeAsNil() {
+				x.CustomMetricsCollectorClientPrivateKeyFile = ""
+			} else {
+				x.CustomMetricsCollectorClientPrivateKeyFile = string(r.DecodeString())
+			}
+		case "customMetricsInsecureSkipVerify":
+			if r.TryDecodeAsNil() {
+				x.CustomMetricsInsecureSkipVerify = false
+			} else {
+				x.CustomMetricsInsecureSkipVerify = bool(r.DecodeBool())
+			}
+		case "customMetricsRootCAFile":
+			if r.TryDecodeAsNil() {
+				x.CustomMetricsRootCAFile = ""
+			} else {
+				x.CustomMetricsRootCAFile = string(r.DecodeString())
 			}
 		case "healthzPort":
 			if r.TryDecodeAsNil() {
@@ -3954,45 +4054,45 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.StreamingConnectionIdleTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv527 := &x.StreamingConnectionIdleTimeout
-				yym528 := z.DecBinary()
-				_ = yym528
+				yyv543 := &x.StreamingConnectionIdleTimeout
+				yym544 := z.DecBinary()
+				_ = yym544
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv527) {
-				} else if !yym528 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv527)
+				} else if z.HasExtensions() && z.DecExt(yyv543) {
+				} else if !yym544 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv543)
 				} else {
-					z.DecFallback(yyv527, false)
+					z.DecFallback(yyv543, false)
 				}
 			}
 		case "nodeStatusUpdateFrequency":
 			if r.TryDecodeAsNil() {
 				x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv529 := &x.NodeStatusUpdateFrequency
-				yym530 := z.DecBinary()
-				_ = yym530
+				yyv545 := &x.NodeStatusUpdateFrequency
+				yym546 := z.DecBinary()
+				_ = yym546
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv529) {
-				} else if !yym530 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv529)
+				} else if z.HasExtensions() && z.DecExt(yyv545) {
+				} else if !yym546 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv545)
 				} else {
-					z.DecFallback(yyv529, false)
+					z.DecFallback(yyv545, false)
 				}
 			}
 		case "imageMinimumGCAge":
 			if r.TryDecodeAsNil() {
 				x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
 			} else {
-				yyv531 := &x.ImageMinimumGCAge
-				yym532 := z.DecBinary()
-				_ = yym532
+				yyv547 := &x.ImageMinimumGCAge
+				yym548 := z.DecBinary()
+				_ = yym548
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv531) {
-				} else if !yym532 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv531)
+				} else if z.HasExtensions() && z.DecExt(yyv547) {
+				} else if !yym548 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv547)
 				} else {
-					z.DecFallback(yyv531, false)
+					z.DecFallback(yyv547, false)
 				}
 			}
 		case "imageGCHighThresholdPercent":
@@ -4017,15 +4117,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.VolumeStatsAggPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv536 := &x.VolumeStatsAggPeriod
-				yym537 := z.DecBinary()
-				_ = yym537
+				yyv552 := &x.VolumeStatsAggPeriod
+				yym553 := z.DecBinary()
+				_ = yym553
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv536) {
-				} else if !yym537 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv536)
+				} else if z.HasExtensions() && z.DecExt(yyv552) {
+				} else if !yym553 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv552)
 				} else {
-					z.DecFallback(yyv536, false)
+					z.DecFallback(yyv552, false)
 				}
 			}
 		case "networkPluginName":
@@ -4128,15 +4228,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.RuntimeRequestTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv554 := &x.RuntimeRequestTimeout
-				yym555 := z.DecBinary()
-				_ = yym555
+				yyv570 := &x.RuntimeRequestTimeout
+				yym571 := z.DecBinary()
+				_ = yym571
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv554) {
-				} else if !yym555 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv554)
+				} else if z.HasExtensions() && z.DecExt(yyv570) {
+				} else if !yym571 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv570)
 				} else {
-					z.DecFallback(yyv554, false)
+					z.DecFallback(yyv570, false)
 				}
 			}
 		case "rktPath":
@@ -4281,15 +4381,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.OutOfDiskTransitionFrequency = pkg1_unversioned.Duration{}
 			} else {
-				yyv579 := &x.OutOfDiskTransitionFrequency
-				yym580 := z.DecBinary()
-				_ = yym580
+				yyv595 := &x.OutOfDiskTransitionFrequency
+				yym596 := z.DecBinary()
+				_ = yym596
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv579) {
-				} else if !yym580 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv579)
+				} else if z.HasExtensions() && z.DecExt(yyv595) {
+				} else if !yym596 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv595)
 				} else {
-					z.DecFallback(yyv579, false)
+					z.DecFallback(yyv595, false)
 				}
 			}
 		case "nodeIP":
@@ -4302,12 +4402,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.NodeLabels = nil
 			} else {
-				yyv582 := &x.NodeLabels
-				yym583 := z.DecBinary()
-				_ = yym583
+				yyv598 := &x.NodeLabels
+				yym599 := z.DecBinary()
+				_ = yym599
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv582, false, d)
+					z.F.DecMapStringStringX(yyv598, false, d)
 				}
 			}
 		case "nonMasqueradeCIDR":
@@ -4344,15 +4444,15 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.EvictionPressureTransitionPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv589 := &x.EvictionPressureTransitionPeriod
-				yym590 := z.DecBinary()
-				_ = yym590
+				yyv605 := &x.EvictionPressureTransitionPeriod
+				yym606 := z.DecBinary()
+				_ = yym606
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv589) {
-				} else if !yym590 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv589)
+				} else if z.HasExtensions() && z.DecExt(yyv605) {
+				} else if !yym606 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv605)
 				} else {
-					z.DecFallback(yyv589, false)
+					z.DecFallback(yyv605, false)
 				}
 			}
 		case "evictionMaxPodGracePeriod":
@@ -4383,26 +4483,26 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.SystemReserved = nil
 			} else {
-				yyv595 := &x.SystemReserved
-				yym596 := z.DecBinary()
-				_ = yym596
+				yyv611 := &x.SystemReserved
+				yym612 := z.DecBinary()
+				_ = yym612
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv595) {
+				} else if z.HasExtensions() && z.DecExt(yyv611) {
 				} else {
-					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv595), d)
+					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv611), d)
 				}
 			}
 		case "kubeReserved":
 			if r.TryDecodeAsNil() {
 				x.KubeReserved = nil
 			} else {
-				yyv597 := &x.KubeReserved
-				yym598 := z.DecBinary()
-				_ = yym598
+				yyv613 := &x.KubeReserved
+				yym614 := z.DecBinary()
+				_ = yym614
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv597) {
+				} else if z.HasExtensions() && z.DecExt(yyv613) {
 				} else {
-					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv597), d)
+					h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv613), d)
 				}
 			}
 		case "protectKernelDefaults":
@@ -4433,12 +4533,12 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.AllowedUnsafeSysctls = nil
 			} else {
-				yyv603 := &x.AllowedUnsafeSysctls
-				yym604 := z.DecBinary()
-				_ = yym604
+				yyv619 := &x.AllowedUnsafeSysctls
+				yym620 := z.DecBinary()
+				_ = yym620
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv603, false, d)
+					z.F.DecSliceStringX(yyv619, false, d)
 				}
 			}
 		case "experimentalRuntimeIntegrationType":
@@ -4448,9 +4548,9 @@ func (x *KubeletConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.ExperimentalRuntimeIntegrationType = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys479)
-		} // end switch yys479
-	} // end for yyj479
+			z.DecStructFieldNotFound(-1, yys491)
+		} // end switch yys491
+	} // end for yyj491
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -4458,16 +4558,16 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj606 int
-	var yyb606 bool
-	var yyhl606 bool = l >= 0
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	var yyj622 int
+	var yyb622 bool
+	var yyhl622 bool = l >= 0
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4477,13 +4577,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4493,13 +4593,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4509,13 +4609,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodManifestPath = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4523,24 +4623,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.SyncFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv610 := &x.SyncFrequency
-		yym611 := z.DecBinary()
-		_ = yym611
+		yyv626 := &x.SyncFrequency
+		yym627 := z.DecBinary()
+		_ = yym627
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv610) {
-		} else if !yym611 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv610)
+		} else if z.HasExtensions() && z.DecExt(yyv626) {
+		} else if !yym627 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv626)
 		} else {
-			z.DecFallback(yyv610, false)
+			z.DecFallback(yyv626, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4548,24 +4648,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.FileCheckFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv612 := &x.FileCheckFrequency
-		yym613 := z.DecBinary()
-		_ = yym613
+		yyv628 := &x.FileCheckFrequency
+		yym629 := z.DecBinary()
+		_ = yym629
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv612) {
-		} else if !yym613 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv612)
+		} else if z.HasExtensions() && z.DecExt(yyv628) {
+		} else if !yym629 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv628)
 		} else {
-			z.DecFallback(yyv612, false)
+			z.DecFallback(yyv628, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4573,24 +4673,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HTTPCheckFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv614 := &x.HTTPCheckFrequency
-		yym615 := z.DecBinary()
-		_ = yym615
+		yyv630 := &x.HTTPCheckFrequency
+		yym631 := z.DecBinary()
+		_ = yym631
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv614) {
-		} else if !yym615 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv614)
+		} else if z.HasExtensions() && z.DecExt(yyv630) {
+		} else if !yym631 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv630)
 		} else {
-			z.DecFallback(yyv614, false)
+			z.DecFallback(yyv630, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4600,13 +4700,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ManifestURL = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4616,13 +4716,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ManifestURLHeader = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4632,13 +4732,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableServer = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4648,13 +4748,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4664,13 +4764,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4680,13 +4780,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ReadOnlyPort = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4696,13 +4796,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.TLSCertFile = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4712,13 +4812,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.TLSPrivateKeyFile = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4728,13 +4828,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CertDirectory = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4744,13 +4844,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HostnameOverride = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4760,13 +4860,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodInfraContainerImage = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4776,13 +4876,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.DockerEndpoint = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4792,13 +4892,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RootDirectory = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4808,13 +4908,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SeccompProfileRoot = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4824,13 +4924,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.AllowPrivileged = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4838,21 +4938,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostNetworkSources = nil
 	} else {
-		yyv631 := &x.HostNetworkSources
-		yym632 := z.DecBinary()
-		_ = yym632
+		yyv647 := &x.HostNetworkSources
+		yym648 := z.DecBinary()
+		_ = yym648
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv631, false, d)
+			z.F.DecSliceStringX(yyv647, false, d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4860,21 +4960,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostPIDSources = nil
 	} else {
-		yyv633 := &x.HostPIDSources
-		yym634 := z.DecBinary()
-		_ = yym634
+		yyv649 := &x.HostPIDSources
+		yym650 := z.DecBinary()
+		_ = yym650
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv633, false, d)
+			z.F.DecSliceStringX(yyv649, false, d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4882,21 +4982,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.HostIPCSources = nil
 	} else {
-		yyv635 := &x.HostIPCSources
-		yym636 := z.DecBinary()
-		_ = yym636
+		yyv651 := &x.HostIPCSources
+		yym652 := z.DecBinary()
+		_ = yym652
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv635, false, d)
+			z.F.DecSliceStringX(yyv651, false, d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4906,13 +5006,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegistryPullQPS = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4922,13 +5022,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegistryBurst = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4938,13 +5038,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EventRecordQPS = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4954,13 +5054,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EventBurst = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4970,13 +5070,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableDebuggingHandlers = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4984,242 +5084,7 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.MinimumGCAge = pkg1_unversioned.Duration{}
 	} else {
-		yyv642 := &x.MinimumGCAge
-		yym643 := z.DecBinary()
-		_ = yym643
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv642) {
-		} else if !yym643 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv642)
-		} else {
-			z.DecFallback(yyv642, false)
-		}
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MaxPerPodContainerCount = 0
-	} else {
-		x.MaxPerPodContainerCount = int32(r.DecodeInt(32))
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MaxContainerCount = 0
-	} else {
-		x.MaxContainerCount = int32(r.DecodeInt(32))
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.CAdvisorPort = 0
-	} else {
-		x.CAdvisorPort = int32(r.DecodeInt(32))
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.HealthzPort = 0
-	} else {
-		x.HealthzPort = int32(r.DecodeInt(32))
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.HealthzBindAddress = ""
-	} else {
-		x.HealthzBindAddress = string(r.DecodeString())
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.OOMScoreAdj = 0
-	} else {
-		x.OOMScoreAdj = int32(r.DecodeInt(32))
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.RegisterNode = false
-	} else {
-		x.RegisterNode = bool(r.DecodeBool())
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ClusterDomain = ""
-	} else {
-		x.ClusterDomain = string(r.DecodeString())
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MasterServiceNamespace = ""
-	} else {
-		x.MasterServiceNamespace = string(r.DecodeString())
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ClusterDNS = ""
-	} else {
-		x.ClusterDNS = string(r.DecodeString())
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.StreamingConnectionIdleTimeout = pkg1_unversioned.Duration{}
-	} else {
-		yyv654 := &x.StreamingConnectionIdleTimeout
-		yym655 := z.DecBinary()
-		_ = yym655
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv654) {
-		} else if !yym655 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv654)
-		} else {
-			z.DecFallback(yyv654, false)
-		}
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
-	} else {
-		yyv656 := &x.NodeStatusUpdateFrequency
-		yym657 := z.DecBinary()
-		_ = yym657
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv656) {
-		} else if !yym657 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv656)
-		} else {
-			z.DecFallback(yyv656, false)
-		}
-	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
-	} else {
-		yyb606 = r.CheckBreak()
-	}
-	if yyb606 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
-	} else {
-		yyv658 := &x.ImageMinimumGCAge
+		yyv658 := &x.MinimumGCAge
 		yym659 := z.DecBinary()
 		_ = yym659
 		if false {
@@ -5230,13 +5095,312 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 			z.DecFallback(yyv658, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MaxPerPodContainerCount = 0
+	} else {
+		x.MaxPerPodContainerCount = int32(r.DecodeInt(32))
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MaxContainerCount = 0
+	} else {
+		x.MaxContainerCount = int32(r.DecodeInt(32))
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CAdvisorPort = 0
+	} else {
+		x.CAdvisorPort = int32(r.DecodeInt(32))
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CustomMetricsCollectorClientCertFile = ""
+	} else {
+		x.CustomMetricsCollectorClientCertFile = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CustomMetricsCollectorClientPrivateKeyFile = ""
+	} else {
+		x.CustomMetricsCollectorClientPrivateKeyFile = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CustomMetricsInsecureSkipVerify = false
+	} else {
+		x.CustomMetricsInsecureSkipVerify = bool(r.DecodeBool())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CustomMetricsRootCAFile = ""
+	} else {
+		x.CustomMetricsRootCAFile = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.HealthzPort = 0
+	} else {
+		x.HealthzPort = int32(r.DecodeInt(32))
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.HealthzBindAddress = ""
+	} else {
+		x.HealthzBindAddress = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.OOMScoreAdj = 0
+	} else {
+		x.OOMScoreAdj = int32(r.DecodeInt(32))
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RegisterNode = false
+	} else {
+		x.RegisterNode = bool(r.DecodeBool())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ClusterDomain = ""
+	} else {
+		x.ClusterDomain = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MasterServiceNamespace = ""
+	} else {
+		x.MasterServiceNamespace = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ClusterDNS = ""
+	} else {
+		x.ClusterDNS = string(r.DecodeString())
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.StreamingConnectionIdleTimeout = pkg1_unversioned.Duration{}
+	} else {
+		yyv674 := &x.StreamingConnectionIdleTimeout
+		yym675 := z.DecBinary()
+		_ = yym675
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv674) {
+		} else if !yym675 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv674)
+		} else {
+			z.DecFallback(yyv674, false)
+		}
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeStatusUpdateFrequency = pkg1_unversioned.Duration{}
+	} else {
+		yyv676 := &x.NodeStatusUpdateFrequency
+		yym677 := z.DecBinary()
+		_ = yym677
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv676) {
+		} else if !yym677 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv676)
+		} else {
+			z.DecFallback(yyv676, false)
+		}
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ImageMinimumGCAge = pkg1_unversioned.Duration{}
+	} else {
+		yyv678 := &x.ImageMinimumGCAge
+		yym679 := z.DecBinary()
+		_ = yym679
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv678) {
+		} else if !yym679 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv678)
+		} else {
+			z.DecFallback(yyv678, false)
+		}
+	}
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
+	} else {
+		yyb622 = r.CheckBreak()
+	}
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5246,13 +5410,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ImageGCHighThresholdPercent = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5262,13 +5426,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ImageGCLowThresholdPercent = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5278,13 +5442,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.LowDiskSpaceThresholdMB = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5292,24 +5456,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.VolumeStatsAggPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv663 := &x.VolumeStatsAggPeriod
-		yym664 := z.DecBinary()
-		_ = yym664
+		yyv683 := &x.VolumeStatsAggPeriod
+		yym684 := z.DecBinary()
+		_ = yym684
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv663) {
-		} else if !yym664 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv663)
+		} else if z.HasExtensions() && z.DecExt(yyv683) {
+		} else if !yym684 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv683)
 		} else {
-			z.DecFallback(yyv663, false)
+			z.DecFallback(yyv683, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5319,13 +5483,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginName = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5335,13 +5499,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginMTU = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5351,13 +5515,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NetworkPluginDir = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5367,13 +5531,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CNIConfDir = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5383,13 +5547,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CNIBinDir = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5399,13 +5563,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.VolumePluginDir = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5415,13 +5579,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CloudProvider = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5431,13 +5595,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CloudConfigFile = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5447,13 +5611,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeletCgroups = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5463,13 +5627,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CgroupsPerQOS = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5479,13 +5643,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RuntimeCgroups = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5495,13 +5659,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SystemCgroups = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5511,13 +5675,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CgroupRoot = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5527,13 +5691,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ContainerRuntime = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5543,13 +5707,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RemoteRuntimeEndpoint = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5559,13 +5723,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RemoteImageEndpoint = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5573,24 +5737,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.RuntimeRequestTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv681 := &x.RuntimeRequestTimeout
-		yym682 := z.DecBinary()
-		_ = yym682
+		yyv701 := &x.RuntimeRequestTimeout
+		yym702 := z.DecBinary()
+		_ = yym702
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv681) {
-		} else if !yym682 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv681)
+		} else if z.HasExtensions() && z.DecExt(yyv701) {
+		} else if !yym702 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv701)
 		} else {
-			z.DecFallback(yyv681, false)
+			z.DecFallback(yyv701, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5600,13 +5764,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktPath = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5616,13 +5780,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktAPIEndpoint = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5632,13 +5796,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RktStage1Image = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5648,13 +5812,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.LockFilePath = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5664,13 +5828,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ExitOnLockContention = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5680,13 +5844,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ConfigureCBR0 = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5696,13 +5860,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.HairpinMode = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5712,13 +5876,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.BabysitDaemons = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5728,13 +5892,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxPods = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5744,13 +5908,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NvidiaGPUs = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5760,13 +5924,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.DockerExecHandlerName = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5776,13 +5940,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodCIDR = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5792,13 +5956,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ResolverConfig = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5808,13 +5972,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.CPUCFSQuota = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5824,13 +5988,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Containerized = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5840,13 +6004,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MaxOpenFiles = int64(r.DecodeInt(64))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5856,13 +6020,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ReconcileCIDR = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5872,13 +6036,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.RegisterSchedulable = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5888,13 +6052,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5904,13 +6068,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeAPIQPS = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5920,13 +6084,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5936,13 +6100,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.SerializeImagePulls = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5952,13 +6116,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ExperimentalFlannelOverlay = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5966,24 +6130,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.OutOfDiskTransitionFrequency = pkg1_unversioned.Duration{}
 	} else {
-		yyv706 := &x.OutOfDiskTransitionFrequency
-		yym707 := z.DecBinary()
-		_ = yym707
+		yyv726 := &x.OutOfDiskTransitionFrequency
+		yym727 := z.DecBinary()
+		_ = yym727
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv706) {
-		} else if !yym707 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv706)
+		} else if z.HasExtensions() && z.DecExt(yyv726) {
+		} else if !yym727 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv726)
 		} else {
-			z.DecFallback(yyv706, false)
+			z.DecFallback(yyv726, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5993,13 +6157,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NodeIP = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6007,21 +6171,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.NodeLabels = nil
 	} else {
-		yyv709 := &x.NodeLabels
-		yym710 := z.DecBinary()
-		_ = yym710
+		yyv729 := &x.NodeLabels
+		yym730 := z.DecBinary()
+		_ = yym730
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv709, false, d)
+			z.F.DecMapStringStringX(yyv729, false, d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6031,13 +6195,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.NonMasqueradeCIDR = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6047,13 +6211,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableCustomMetrics = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6063,13 +6227,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionHard = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6079,13 +6243,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionSoft = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6095,13 +6259,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionSoftGracePeriod = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6109,24 +6273,24 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.EvictionPressureTransitionPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv716 := &x.EvictionPressureTransitionPeriod
-		yym717 := z.DecBinary()
-		_ = yym717
+		yyv736 := &x.EvictionPressureTransitionPeriod
+		yym737 := z.DecBinary()
+		_ = yym737
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv716) {
-		} else if !yym717 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv716)
+		} else if z.HasExtensions() && z.DecExt(yyv736) {
+		} else if !yym737 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv736)
 		} else {
-			z.DecFallback(yyv716, false)
+			z.DecFallback(yyv736, false)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6136,13 +6300,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionMaxPodGracePeriod = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6152,13 +6316,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EvictionMinimumReclaim = string(r.DecodeString())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6168,13 +6332,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.PodsPerCore = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6184,13 +6348,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.EnableControllerAttachDetach = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6198,22 +6362,22 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.SystemReserved = nil
 	} else {
-		yyv722 := &x.SystemReserved
-		yym723 := z.DecBinary()
-		_ = yym723
+		yyv742 := &x.SystemReserved
+		yym743 := z.DecBinary()
+		_ = yym743
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv722) {
+		} else if z.HasExtensions() && z.DecExt(yyv742) {
 		} else {
-			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv722), d)
+			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv742), d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6221,22 +6385,22 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.KubeReserved = nil
 	} else {
-		yyv724 := &x.KubeReserved
-		yym725 := z.DecBinary()
-		_ = yym725
+		yyv744 := &x.KubeReserved
+		yym745 := z.DecBinary()
+		_ = yym745
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv724) {
+		} else if z.HasExtensions() && z.DecExt(yyv744) {
 		} else {
-			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv724), d)
+			h.decconfig_ConfigurationMap((*pkg2_config.ConfigurationMap)(yyv744), d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6246,13 +6410,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.ProtectKernelDefaults = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6262,13 +6426,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.MakeIPTablesUtilChains = bool(r.DecodeBool())
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6278,13 +6442,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.IPTablesMasqueradeBit = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6294,13 +6458,13 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.IPTablesDropBit = int32(r.DecodeInt(32))
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6308,21 +6472,21 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.AllowedUnsafeSysctls = nil
 	} else {
-		yyv730 := &x.AllowedUnsafeSysctls
-		yym731 := z.DecBinary()
-		_ = yym731
+		yyv750 := &x.AllowedUnsafeSysctls
+		yym751 := z.DecBinary()
+		_ = yym751
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv730, false, d)
+			z.F.DecSliceStringX(yyv750, false, d)
 		}
 	}
-	yyj606++
-	if yyhl606 {
-		yyb606 = yyj606 > l
+	yyj622++
+	if yyhl622 {
+		yyb622 = yyj622 > l
 	} else {
-		yyb606 = r.CheckBreak()
+		yyb622 = r.CheckBreak()
 	}
-	if yyb606 {
+	if yyb622 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6333,17 +6497,17 @@ func (x *KubeletConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.ExperimentalRuntimeIntegrationType = string(r.DecodeString())
 	}
 	for {
-		yyj606++
-		if yyhl606 {
-			yyb606 = yyj606 > l
+		yyj622++
+		if yyhl622 {
+			yyb622 = yyj622 > l
 		} else {
-			yyb606 = r.CheckBreak()
+			yyb622 = r.CheckBreak()
 		}
-		if yyb606 {
+		if yyb622 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj606-1, "")
+		z.DecStructFieldNotFound(yyj622-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6355,36 +6519,36 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym733 := z.EncBinary()
-		_ = yym733
+		yym753 := z.EncBinary()
+		_ = yym753
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep734 := !z.EncBinary()
-			yy2arr734 := z.EncBasicHandle().StructToArray
-			var yyq734 [14]bool
-			_, _, _ = yysep734, yyq734, yy2arr734
-			const yyr734 bool = false
-			yyq734[0] = x.Kind != ""
-			yyq734[1] = x.APIVersion != ""
-			var yynn734 int
-			if yyr734 || yy2arr734 {
+			yysep754 := !z.EncBinary()
+			yy2arr754 := z.EncBasicHandle().StructToArray
+			var yyq754 [14]bool
+			_, _, _ = yysep754, yyq754, yy2arr754
+			const yyr754 bool = false
+			yyq754[0] = x.Kind != ""
+			yyq754[1] = x.APIVersion != ""
+			var yynn754 int
+			if yyr754 || yy2arr754 {
 				r.EncodeArrayStart(14)
 			} else {
-				yynn734 = 12
-				for _, b := range yyq734 {
+				yynn754 = 12
+				for _, b := range yyq754 {
 					if b {
-						yynn734++
+						yynn754++
 					}
 				}
-				r.EncodeMapStart(yynn734)
-				yynn734 = 0
+				r.EncodeMapStart(yynn754)
+				yynn754 = 0
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq734[0] {
-					yym736 := z.EncBinary()
-					_ = yym736
+				if yyq754[0] {
+					yym756 := z.EncBinary()
+					_ = yym756
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6393,23 +6557,23 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq734[0] {
+				if yyq754[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym737 := z.EncBinary()
-					_ = yym737
+					yym757 := z.EncBinary()
+					_ = yym757
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq734[1] {
-					yym739 := z.EncBinary()
-					_ = yym739
+				if yyq754[1] {
+					yym759 := z.EncBinary()
+					_ = yym759
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6418,22 +6582,22 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq734[1] {
+				if yyq754[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym740 := z.EncBinary()
-					_ = yym740
+					yym760 := z.EncBinary()
+					_ = yym760
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym742 := z.EncBinary()
-				_ = yym742
+				yym762 := z.EncBinary()
+				_ = yym762
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -6442,17 +6606,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym743 := z.EncBinary()
-				_ = yym743
+				yym763 := z.EncBinary()
+				_ = yym763
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym745 := z.EncBinary()
-				_ = yym745
+				yym765 := z.EncBinary()
+				_ = yym765
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -6461,17 +6625,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym746 := z.EncBinary()
-				_ = yym746
+				yym766 := z.EncBinary()
+				_ = yym766
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym748 := z.EncBinary()
-				_ = yym748
+				yym768 := z.EncBinary()
+				_ = yym768
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -6480,17 +6644,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("algorithmProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym749 := z.EncBinary()
-				_ = yym749
+				yym769 := z.EncBinary()
+				_ = yym769
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym751 := z.EncBinary()
-				_ = yym751
+				yym771 := z.EncBinary()
+				_ = yym771
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -6499,17 +6663,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("policyConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym752 := z.EncBinary()
-				_ = yym752
+				yym772 := z.EncBinary()
+				_ = yym772
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym754 := z.EncBinary()
-				_ = yym754
+				yym774 := z.EncBinary()
+				_ = yym774
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -6518,17 +6682,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableProfiling"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym755 := z.EncBinary()
-				_ = yym755
+				yym775 := z.EncBinary()
+				_ = yym775
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym757 := z.EncBinary()
-				_ = yym757
+				yym777 := z.EncBinary()
+				_ = yym777
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
@@ -6537,17 +6701,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym758 := z.EncBinary()
-				_ = yym758
+				yym778 := z.EncBinary()
+				_ = yym778
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym760 := z.EncBinary()
-				_ = yym760
+				yym780 := z.EncBinary()
+				_ = yym780
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -6556,17 +6720,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym761 := z.EncBinary()
-				_ = yym761
+				yym781 := z.EncBinary()
+				_ = yym781
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym763 := z.EncBinary()
-				_ = yym763
+				yym783 := z.EncBinary()
+				_ = yym783
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -6575,17 +6739,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym764 := z.EncBinary()
-				_ = yym764
+				yym784 := z.EncBinary()
+				_ = yym784
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym766 := z.EncBinary()
-				_ = yym766
+				yym786 := z.EncBinary()
+				_ = yym786
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -6594,17 +6758,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("schedulerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym767 := z.EncBinary()
-				_ = yym767
+				yym787 := z.EncBinary()
+				_ = yym787
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym769 := z.EncBinary()
-				_ = yym769
+				yym789 := z.EncBinary()
+				_ = yym789
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HardPodAffinitySymmetricWeight))
@@ -6613,17 +6777,17 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hardPodAffinitySymmetricWeight"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym770 := z.EncBinary()
-				_ = yym770
+				yym790 := z.EncBinary()
+				_ = yym790
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HardPodAffinitySymmetricWeight))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym772 := z.EncBinary()
-				_ = yym772
+				yym792 := z.EncBinary()
+				_ = yym792
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FailureDomains))
@@ -6632,25 +6796,25 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("failureDomains"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym773 := z.EncBinary()
-				_ = yym773
+				yym793 := z.EncBinary()
+				_ = yym793
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FailureDomains))
 				}
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy775 := &x.LeaderElection
-				yy775.CodecEncodeSelf(e)
+				yy795 := &x.LeaderElection
+				yy795.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy776 := &x.LeaderElection
-				yy776.CodecEncodeSelf(e)
+				yy796 := &x.LeaderElection
+				yy796.CodecEncodeSelf(e)
 			}
-			if yyr734 || yy2arr734 {
+			if yyr754 || yy2arr754 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6663,25 +6827,25 @@ func (x *KubeSchedulerConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym777 := z.DecBinary()
-	_ = yym777
+	yym797 := z.DecBinary()
+	_ = yym797
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct778 := r.ContainerType()
-		if yyct778 == codecSelferValueTypeMap1234 {
-			yyl778 := r.ReadMapStart()
-			if yyl778 == 0 {
+		yyct798 := r.ContainerType()
+		if yyct798 == codecSelferValueTypeMap1234 {
+			yyl798 := r.ReadMapStart()
+			if yyl798 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl778, d)
+				x.codecDecodeSelfFromMap(yyl798, d)
 			}
-		} else if yyct778 == codecSelferValueTypeArray1234 {
-			yyl778 := r.ReadArrayStart()
-			if yyl778 == 0 {
+		} else if yyct798 == codecSelferValueTypeArray1234 {
+			yyl798 := r.ReadArrayStart()
+			if yyl798 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl778, d)
+				x.codecDecodeSelfFromArray(yyl798, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6693,12 +6857,12 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys779Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys779Slc
-	var yyhl779 bool = l >= 0
-	for yyj779 := 0; ; yyj779++ {
-		if yyhl779 {
-			if yyj779 >= l {
+	var yys799Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys799Slc
+	var yyhl799 bool = l >= 0
+	for yyj799 := 0; ; yyj799++ {
+		if yyhl799 {
+			if yyj799 >= l {
 				break
 			}
 		} else {
@@ -6707,10 +6871,10 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys779Slc = r.DecodeBytes(yys779Slc, true, true)
-		yys779 := string(yys779Slc)
+		yys799Slc = r.DecodeBytes(yys799Slc, true, true)
+		yys799 := string(yys799Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys779 {
+		switch yys799 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6793,13 +6957,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv793 := &x.LeaderElection
-				yyv793.CodecDecodeSelf(d)
+				yyv813 := &x.LeaderElection
+				yyv813.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys779)
-		} // end switch yys779
-	} // end for yyj779
+			z.DecStructFieldNotFound(-1, yys799)
+		} // end switch yys799
+	} // end for yyj799
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6807,16 +6971,16 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj794 int
-	var yyb794 bool
-	var yyhl794 bool = l >= 0
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	var yyj814 int
+	var yyb814 bool
+	var yyhl814 bool = l >= 0
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6826,13 +6990,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6842,13 +7006,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6858,13 +7022,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6874,13 +7038,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6890,13 +7054,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.AlgorithmProvider = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6906,13 +7070,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.PolicyConfigFile = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6922,13 +7086,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.EnableProfiling = bool(r.DecodeBool())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6938,13 +7102,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6954,13 +7118,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.KubeAPIQPS = float32(r.DecodeFloat(true))
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6970,13 +7134,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6986,13 +7150,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.SchedulerName = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7002,13 +7166,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.HardPodAffinitySymmetricWeight = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7018,13 +7182,13 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.FailureDomains = string(r.DecodeString())
 	}
-	yyj794++
-	if yyhl794 {
-		yyb794 = yyj794 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb794 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb794 {
+	if yyb814 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7032,21 +7196,21 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv808 := &x.LeaderElection
-		yyv808.CodecDecodeSelf(d)
+		yyv828 := &x.LeaderElection
+		yyv828.CodecDecodeSelf(d)
 	}
 	for {
-		yyj794++
-		if yyhl794 {
-			yyb794 = yyj794 > l
+		yyj814++
+		if yyhl814 {
+			yyb814 = yyj814 > l
 		} else {
-			yyb794 = r.CheckBreak()
+			yyb814 = r.CheckBreak()
 		}
-		if yyb794 {
+		if yyb814 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj794-1, "")
+		z.DecStructFieldNotFound(yyj814-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7058,33 +7222,33 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym809 := z.EncBinary()
-		_ = yym809
+		yym829 := z.EncBinary()
+		_ = yym829
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep810 := !z.EncBinary()
-			yy2arr810 := z.EncBasicHandle().StructToArray
-			var yyq810 [4]bool
-			_, _, _ = yysep810, yyq810, yy2arr810
-			const yyr810 bool = false
-			var yynn810 int
-			if yyr810 || yy2arr810 {
+			yysep830 := !z.EncBinary()
+			yy2arr830 := z.EncBasicHandle().StructToArray
+			var yyq830 [4]bool
+			_, _, _ = yysep830, yyq830, yy2arr830
+			const yyr830 bool = false
+			var yynn830 int
+			if yyr830 || yy2arr830 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn810 = 4
-				for _, b := range yyq810 {
+				yynn830 = 4
+				for _, b := range yyq830 {
 					if b {
-						yynn810++
+						yynn830++
 					}
 				}
-				r.EncodeMapStart(yynn810)
-				yynn810 = 0
+				r.EncodeMapStart(yynn830)
+				yynn830 = 0
 			}
-			if yyr810 || yy2arr810 {
+			if yyr830 || yy2arr830 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym812 := z.EncBinary()
-				_ = yym812
+				yym832 := z.EncBinary()
+				_ = yym832
 				if false {
 				} else {
 					r.EncodeBool(bool(x.LeaderElect))
@@ -7093,95 +7257,95 @@ func (x *LeaderElectionConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElect"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym813 := z.EncBinary()
-				_ = yym813
+				yym833 := z.EncBinary()
+				_ = yym833
 				if false {
 				} else {
 					r.EncodeBool(bool(x.LeaderElect))
 				}
 			}
-			if yyr810 || yy2arr810 {
+			if yyr830 || yy2arr830 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy815 := &x.LeaseDuration
-				yym816 := z.EncBinary()
-				_ = yym816
+				yy835 := &x.LeaseDuration
+				yym836 := z.EncBinary()
+				_ = yym836
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy815) {
-				} else if !yym816 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy815)
+				} else if z.HasExtensions() && z.EncExt(yy835) {
+				} else if !yym836 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy835)
 				} else {
-					z.EncFallback(yy815)
+					z.EncFallback(yy835)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaseDuration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy817 := &x.LeaseDuration
-				yym818 := z.EncBinary()
-				_ = yym818
+				yy837 := &x.LeaseDuration
+				yym838 := z.EncBinary()
+				_ = yym838
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy817) {
-				} else if !yym818 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy817)
+				} else if z.HasExtensions() && z.EncExt(yy837) {
+				} else if !yym838 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy837)
 				} else {
-					z.EncFallback(yy817)
+					z.EncFallback(yy837)
 				}
 			}
-			if yyr810 || yy2arr810 {
+			if yyr830 || yy2arr830 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy820 := &x.RenewDeadline
-				yym821 := z.EncBinary()
-				_ = yym821
+				yy840 := &x.RenewDeadline
+				yym841 := z.EncBinary()
+				_ = yym841
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy820) {
-				} else if !yym821 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy820)
+				} else if z.HasExtensions() && z.EncExt(yy840) {
+				} else if !yym841 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy840)
 				} else {
-					z.EncFallback(yy820)
+					z.EncFallback(yy840)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("renewDeadline"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy822 := &x.RenewDeadline
-				yym823 := z.EncBinary()
-				_ = yym823
+				yy842 := &x.RenewDeadline
+				yym843 := z.EncBinary()
+				_ = yym843
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy822) {
-				} else if !yym823 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy822)
+				} else if z.HasExtensions() && z.EncExt(yy842) {
+				} else if !yym843 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy842)
 				} else {
-					z.EncFallback(yy822)
+					z.EncFallback(yy842)
 				}
 			}
-			if yyr810 || yy2arr810 {
+			if yyr830 || yy2arr830 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy825 := &x.RetryPeriod
-				yym826 := z.EncBinary()
-				_ = yym826
+				yy845 := &x.RetryPeriod
+				yym846 := z.EncBinary()
+				_ = yym846
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy825) {
-				} else if !yym826 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy825)
+				} else if z.HasExtensions() && z.EncExt(yy845) {
+				} else if !yym846 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy845)
 				} else {
-					z.EncFallback(yy825)
+					z.EncFallback(yy845)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("retryPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy827 := &x.RetryPeriod
-				yym828 := z.EncBinary()
-				_ = yym828
+				yy847 := &x.RetryPeriod
+				yym848 := z.EncBinary()
+				_ = yym848
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy827) {
-				} else if !yym828 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy827)
+				} else if z.HasExtensions() && z.EncExt(yy847) {
+				} else if !yym848 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy847)
 				} else {
-					z.EncFallback(yy827)
+					z.EncFallback(yy847)
 				}
 			}
-			if yyr810 || yy2arr810 {
+			if yyr830 || yy2arr830 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7194,25 +7358,25 @@ func (x *LeaderElectionConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym829 := z.DecBinary()
-	_ = yym829
+	yym849 := z.DecBinary()
+	_ = yym849
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct830 := r.ContainerType()
-		if yyct830 == codecSelferValueTypeMap1234 {
-			yyl830 := r.ReadMapStart()
-			if yyl830 == 0 {
+		yyct850 := r.ContainerType()
+		if yyct850 == codecSelferValueTypeMap1234 {
+			yyl850 := r.ReadMapStart()
+			if yyl850 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl830, d)
+				x.codecDecodeSelfFromMap(yyl850, d)
 			}
-		} else if yyct830 == codecSelferValueTypeArray1234 {
-			yyl830 := r.ReadArrayStart()
-			if yyl830 == 0 {
+		} else if yyct850 == codecSelferValueTypeArray1234 {
+			yyl850 := r.ReadArrayStart()
+			if yyl850 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl830, d)
+				x.codecDecodeSelfFromArray(yyl850, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7224,12 +7388,12 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys831Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys831Slc
-	var yyhl831 bool = l >= 0
-	for yyj831 := 0; ; yyj831++ {
-		if yyhl831 {
-			if yyj831 >= l {
+	var yys851Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys851Slc
+	var yyhl851 bool = l >= 0
+	for yyj851 := 0; ; yyj851++ {
+		if yyhl851 {
+			if yyj851 >= l {
 				break
 			}
 		} else {
@@ -7238,10 +7402,10 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys831Slc = r.DecodeBytes(yys831Slc, true, true)
-		yys831 := string(yys831Slc)
+		yys851Slc = r.DecodeBytes(yys851Slc, true, true)
+		yys851 := string(yys851Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys831 {
+		switch yys851 {
 		case "leaderElect":
 			if r.TryDecodeAsNil() {
 				x.LeaderElect = false
@@ -7252,51 +7416,51 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.LeaseDuration = pkg1_unversioned.Duration{}
 			} else {
-				yyv833 := &x.LeaseDuration
-				yym834 := z.DecBinary()
-				_ = yym834
+				yyv853 := &x.LeaseDuration
+				yym854 := z.DecBinary()
+				_ = yym854
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv833) {
-				} else if !yym834 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv833)
+				} else if z.HasExtensions() && z.DecExt(yyv853) {
+				} else if !yym854 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv853)
 				} else {
-					z.DecFallback(yyv833, false)
+					z.DecFallback(yyv853, false)
 				}
 			}
 		case "renewDeadline":
 			if r.TryDecodeAsNil() {
 				x.RenewDeadline = pkg1_unversioned.Duration{}
 			} else {
-				yyv835 := &x.RenewDeadline
-				yym836 := z.DecBinary()
-				_ = yym836
+				yyv855 := &x.RenewDeadline
+				yym856 := z.DecBinary()
+				_ = yym856
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv835) {
-				} else if !yym836 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv835)
+				} else if z.HasExtensions() && z.DecExt(yyv855) {
+				} else if !yym856 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv855)
 				} else {
-					z.DecFallback(yyv835, false)
+					z.DecFallback(yyv855, false)
 				}
 			}
 		case "retryPeriod":
 			if r.TryDecodeAsNil() {
 				x.RetryPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv837 := &x.RetryPeriod
-				yym838 := z.DecBinary()
-				_ = yym838
+				yyv857 := &x.RetryPeriod
+				yym858 := z.DecBinary()
+				_ = yym858
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv837) {
-				} else if !yym838 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv837)
+				} else if z.HasExtensions() && z.DecExt(yyv857) {
+				} else if !yym858 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv857)
 				} else {
-					z.DecFallback(yyv837, false)
+					z.DecFallback(yyv857, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys831)
-		} // end switch yys831
-	} // end for yyj831
+			z.DecStructFieldNotFound(-1, yys851)
+		} // end switch yys851
+	} // end for yyj851
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7304,16 +7468,16 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj839 int
-	var yyb839 bool
-	var yyhl839 bool = l >= 0
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	var yyj859 int
+	var yyb859 bool
+	var yyhl859 bool = l >= 0
+	yyj859++
+	if yyhl859 {
+		yyb859 = yyj859 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb859 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb859 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7323,13 +7487,13 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.LeaderElect = bool(r.DecodeBool())
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj859++
+	if yyhl859 {
+		yyb859 = yyj859 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb859 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb859 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7337,24 +7501,24 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.LeaseDuration = pkg1_unversioned.Duration{}
 	} else {
-		yyv841 := &x.LeaseDuration
-		yym842 := z.DecBinary()
-		_ = yym842
+		yyv861 := &x.LeaseDuration
+		yym862 := z.DecBinary()
+		_ = yym862
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv841) {
-		} else if !yym842 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv841)
+		} else if z.HasExtensions() && z.DecExt(yyv861) {
+		} else if !yym862 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv861)
 		} else {
-			z.DecFallback(yyv841, false)
+			z.DecFallback(yyv861, false)
 		}
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj859++
+	if yyhl859 {
+		yyb859 = yyj859 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb859 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb859 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7362,24 +7526,24 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.RenewDeadline = pkg1_unversioned.Duration{}
 	} else {
-		yyv843 := &x.RenewDeadline
-		yym844 := z.DecBinary()
-		_ = yym844
+		yyv863 := &x.RenewDeadline
+		yym864 := z.DecBinary()
+		_ = yym864
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv843) {
-		} else if !yym844 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv843)
+		} else if z.HasExtensions() && z.DecExt(yyv863) {
+		} else if !yym864 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv863)
 		} else {
-			z.DecFallback(yyv843, false)
+			z.DecFallback(yyv863, false)
 		}
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj859++
+	if yyhl859 {
+		yyb859 = yyj859 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb859 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb859 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7387,29 +7551,29 @@ func (x *LeaderElectionConfiguration) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.RetryPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv845 := &x.RetryPeriod
-		yym846 := z.DecBinary()
-		_ = yym846
+		yyv865 := &x.RetryPeriod
+		yym866 := z.DecBinary()
+		_ = yym866
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv845) {
-		} else if !yym846 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv845)
+		} else if z.HasExtensions() && z.DecExt(yyv865) {
+		} else if !yym866 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv865)
 		} else {
-			z.DecFallback(yyv845, false)
+			z.DecFallback(yyv865, false)
 		}
 	}
 	for {
-		yyj839++
-		if yyhl839 {
-			yyb839 = yyj839 > l
+		yyj859++
+		if yyhl859 {
+			yyb859 = yyj859 > l
 		} else {
-			yyb839 = r.CheckBreak()
+			yyb859 = r.CheckBreak()
 		}
-		if yyb839 {
+		if yyb859 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj839-1, "")
+		z.DecStructFieldNotFound(yyj859-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7421,36 +7585,36 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym847 := z.EncBinary()
-		_ = yym847
+		yym867 := z.EncBinary()
+		_ = yym867
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep848 := !z.EncBinary()
-			yy2arr848 := z.EncBasicHandle().StructToArray
-			var yyq848 [60]bool
-			_, _, _ = yysep848, yyq848, yy2arr848
-			const yyr848 bool = false
-			yyq848[0] = x.Kind != ""
-			yyq848[1] = x.APIVersion != ""
-			var yynn848 int
-			if yyr848 || yy2arr848 {
+			yysep868 := !z.EncBinary()
+			yy2arr868 := z.EncBasicHandle().StructToArray
+			var yyq868 [60]bool
+			_, _, _ = yysep868, yyq868, yy2arr868
+			const yyr868 bool = false
+			yyq868[0] = x.Kind != ""
+			yyq868[1] = x.APIVersion != ""
+			var yynn868 int
+			if yyr868 || yy2arr868 {
 				r.EncodeArrayStart(60)
 			} else {
-				yynn848 = 58
-				for _, b := range yyq848 {
+				yynn868 = 58
+				for _, b := range yyq868 {
 					if b {
-						yynn848++
+						yynn868++
 					}
 				}
-				r.EncodeMapStart(yynn848)
-				yynn848 = 0
+				r.EncodeMapStart(yynn868)
+				yynn868 = 0
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq848[0] {
-					yym850 := z.EncBinary()
-					_ = yym850
+				if yyq868[0] {
+					yym870 := z.EncBinary()
+					_ = yym870
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7459,23 +7623,23 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq848[0] {
+				if yyq868[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym851 := z.EncBinary()
-					_ = yym851
+					yym871 := z.EncBinary()
+					_ = yym871
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq848[1] {
-					yym853 := z.EncBinary()
-					_ = yym853
+				if yyq868[1] {
+					yym873 := z.EncBinary()
+					_ = yym873
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7484,22 +7648,22 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq848[1] {
+				if yyq868[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym854 := z.EncBinary()
-					_ = yym854
+					yym874 := z.EncBinary()
+					_ = yym874
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym856 := z.EncBinary()
-				_ = yym856
+				yym876 := z.EncBinary()
+				_ = yym876
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -7508,17 +7672,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym857 := z.EncBinary()
-				_ = yym857
+				yym877 := z.EncBinary()
+				_ = yym877
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym859 := z.EncBinary()
-				_ = yym859
+				yym879 := z.EncBinary()
+				_ = yym879
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -7527,17 +7691,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym860 := z.EncBinary()
-				_ = yym860
+				yym880 := z.EncBinary()
+				_ = yym880
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym862 := z.EncBinary()
-				_ = yym862
+				yym882 := z.EncBinary()
+				_ = yym882
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
@@ -7546,17 +7710,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cloudProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym863 := z.EncBinary()
-				_ = yym863
+				yym883 := z.EncBinary()
+				_ = yym883
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudProvider))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym865 := z.EncBinary()
-				_ = yym865
+				yym885 := z.EncBinary()
+				_ = yym885
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
@@ -7565,17 +7729,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cloudConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym866 := z.EncBinary()
-				_ = yym866
+				yym886 := z.EncBinary()
+				_ = yym886
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.CloudConfigFile))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym868 := z.EncBinary()
-				_ = yym868
+				yym888 := z.EncBinary()
+				_ = yym888
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentEndpointSyncs))
@@ -7584,17 +7748,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentEndpointSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym869 := z.EncBinary()
-				_ = yym869
+				yym889 := z.EncBinary()
+				_ = yym889
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentEndpointSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym871 := z.EncBinary()
-				_ = yym871
+				yym891 := z.EncBinary()
+				_ = yym891
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRSSyncs))
@@ -7603,17 +7767,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentRSSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym872 := z.EncBinary()
-				_ = yym872
+				yym892 := z.EncBinary()
+				_ = yym892
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRSSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym874 := z.EncBinary()
-				_ = yym874
+				yym894 := z.EncBinary()
+				_ = yym894
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRCSyncs))
@@ -7622,17 +7786,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentRCSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym875 := z.EncBinary()
-				_ = yym875
+				yym895 := z.EncBinary()
+				_ = yym895
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentRCSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym877 := z.EncBinary()
-				_ = yym877
+				yym897 := z.EncBinary()
+				_ = yym897
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentServiceSyncs))
@@ -7641,17 +7805,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentServiceSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym878 := z.EncBinary()
-				_ = yym878
+				yym898 := z.EncBinary()
+				_ = yym898
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentServiceSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym880 := z.EncBinary()
-				_ = yym880
+				yym900 := z.EncBinary()
+				_ = yym900
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentResourceQuotaSyncs))
@@ -7660,17 +7824,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentResourceQuotaSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym881 := z.EncBinary()
-				_ = yym881
+				yym901 := z.EncBinary()
+				_ = yym901
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentResourceQuotaSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym883 := z.EncBinary()
-				_ = yym883
+				yym903 := z.EncBinary()
+				_ = yym903
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDeploymentSyncs))
@@ -7679,17 +7843,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentDeploymentSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym884 := z.EncBinary()
-				_ = yym884
+				yym904 := z.EncBinary()
+				_ = yym904
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDeploymentSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym886 := z.EncBinary()
-				_ = yym886
+				yym906 := z.EncBinary()
+				_ = yym906
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDaemonSetSyncs))
@@ -7698,17 +7862,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentDaemonSetSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym887 := z.EncBinary()
-				_ = yym887
+				yym907 := z.EncBinary()
+				_ = yym907
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentDaemonSetSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym889 := z.EncBinary()
-				_ = yym889
+				yym909 := z.EncBinary()
+				_ = yym909
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentJobSyncs))
@@ -7717,17 +7881,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentJobSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym890 := z.EncBinary()
-				_ = yym890
+				yym910 := z.EncBinary()
+				_ = yym910
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentJobSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym892 := z.EncBinary()
-				_ = yym892
+				yym912 := z.EncBinary()
+				_ = yym912
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentNamespaceSyncs))
@@ -7736,17 +7900,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentNamespaceSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym893 := z.EncBinary()
-				_ = yym893
+				yym913 := z.EncBinary()
+				_ = yym913
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentNamespaceSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym895 := z.EncBinary()
-				_ = yym895
+				yym915 := z.EncBinary()
+				_ = yym915
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentSATokenSyncs))
@@ -7755,17 +7919,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentSATokenSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym896 := z.EncBinary()
-				_ = yym896
+				yym916 := z.EncBinary()
+				_ = yym916
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentSATokenSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym898 := z.EncBinary()
-				_ = yym898
+				yym918 := z.EncBinary()
+				_ = yym918
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRC))
@@ -7774,17 +7938,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForRC"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym899 := z.EncBinary()
-				_ = yym899
+				yym919 := z.EncBinary()
+				_ = yym919
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRC))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym901 := z.EncBinary()
-				_ = yym901
+				yym921 := z.EncBinary()
+				_ = yym921
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRS))
@@ -7793,17 +7957,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForRS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym902 := z.EncBinary()
-				_ = yym902
+				yym922 := z.EncBinary()
+				_ = yym922
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForRS))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym904 := z.EncBinary()
-				_ = yym904
+				yym924 := z.EncBinary()
+				_ = yym924
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForDaemonSet))
@@ -7812,124 +7976,16 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lookupCacheSizeForDaemonSet"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym905 := z.EncBinary()
-				_ = yym905
+				yym925 := z.EncBinary()
+				_ = yym925
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LookupCacheSizeForDaemonSet))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy907 := &x.ServiceSyncPeriod
-				yym908 := z.EncBinary()
-				_ = yym908
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy907) {
-				} else if !yym908 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy907)
-				} else {
-					z.EncFallback(yy907)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serviceSyncPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy909 := &x.ServiceSyncPeriod
-				yym910 := z.EncBinary()
-				_ = yym910
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy909) {
-				} else if !yym910 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy909)
-				} else {
-					z.EncFallback(yy909)
-				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy912 := &x.NodeSyncPeriod
-				yym913 := z.EncBinary()
-				_ = yym913
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy912) {
-				} else if !yym913 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy912)
-				} else {
-					z.EncFallback(yy912)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("nodeSyncPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy914 := &x.NodeSyncPeriod
-				yym915 := z.EncBinary()
-				_ = yym915
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy914) {
-				} else if !yym915 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy914)
-				} else {
-					z.EncFallback(yy914)
-				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy917 := &x.RouteReconciliationPeriod
-				yym918 := z.EncBinary()
-				_ = yym918
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy917) {
-				} else if !yym918 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy917)
-				} else {
-					z.EncFallback(yy917)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("routeReconciliationPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy919 := &x.RouteReconciliationPeriod
-				yym920 := z.EncBinary()
-				_ = yym920
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy919) {
-				} else if !yym920 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy919)
-				} else {
-					z.EncFallback(yy919)
-				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy922 := &x.ResourceQuotaSyncPeriod
-				yym923 := z.EncBinary()
-				_ = yym923
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy922) {
-				} else if !yym923 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy922)
-				} else {
-					z.EncFallback(yy922)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("resourceQuotaSyncPeriod"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy924 := &x.ResourceQuotaSyncPeriod
-				yym925 := z.EncBinary()
-				_ = yym925
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy924) {
-				} else if !yym925 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy924)
-				} else {
-					z.EncFallback(yy924)
-				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy927 := &x.NamespaceSyncPeriod
+				yy927 := &x.ServiceSyncPeriod
 				yym928 := z.EncBinary()
 				_ = yym928
 				if false {
@@ -7941,9 +7997,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("namespaceSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("serviceSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy929 := &x.NamespaceSyncPeriod
+				yy929 := &x.ServiceSyncPeriod
 				yym930 := z.EncBinary()
 				_ = yym930
 				if false {
@@ -7954,9 +8010,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy929)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy932 := &x.PVClaimBinderSyncPeriod
+				yy932 := &x.NodeSyncPeriod
 				yym933 := z.EncBinary()
 				_ = yym933
 				if false {
@@ -7968,9 +8024,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("pvClaimBinderSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("nodeSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy934 := &x.PVClaimBinderSyncPeriod
+				yy934 := &x.NodeSyncPeriod
 				yym935 := z.EncBinary()
 				_ = yym935
 				if false {
@@ -7981,9 +8037,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy934)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy937 := &x.MinResyncPeriod
+				yy937 := &x.RouteReconciliationPeriod
 				yym938 := z.EncBinary()
 				_ = yym938
 				if false {
@@ -7995,9 +8051,9 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("minResyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("routeReconciliationPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy939 := &x.MinResyncPeriod
+				yy939 := &x.RouteReconciliationPeriod
 				yym940 := z.EncBinary()
 				_ = yym940
 				if false {
@@ -8008,42 +8064,36 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 					z.EncFallback(yy939)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym942 := z.EncBinary()
-				_ = yym942
-				if false {
-				} else {
-					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("terminatedPodGCThreshold"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy942 := &x.ResourceQuotaSyncPeriod
 				yym943 := z.EncBinary()
 				_ = yym943
 				if false {
+				} else if z.HasExtensions() && z.EncExt(yy942) {
+				} else if !yym943 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy942)
 				} else {
-					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
-				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy945 := &x.HorizontalPodAutoscalerSyncPeriod
-				yym946 := z.EncBinary()
-				_ = yym946
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy945) {
-				} else if !yym946 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy945)
-				} else {
-					z.EncFallback(yy945)
+					z.EncFallback(yy942)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("horizontalPodAutoscalerSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("resourceQuotaSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy947 := &x.HorizontalPodAutoscalerSyncPeriod
+				yy944 := &x.ResourceQuotaSyncPeriod
+				yym945 := z.EncBinary()
+				_ = yym945
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy944) {
+				} else if !yym945 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy944)
+				} else {
+					z.EncFallback(yy944)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy947 := &x.NamespaceSyncPeriod
 				yym948 := z.EncBinary()
 				_ = yym948
 				if false {
@@ -8053,24 +8103,24 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				} else {
 					z.EncFallback(yy947)
 				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy950 := &x.DeploymentControllerSyncPeriod
-				yym951 := z.EncBinary()
-				_ = yym951
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy950) {
-				} else if !yym951 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy950)
-				} else {
-					z.EncFallback(yy950)
-				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("deploymentControllerSyncPeriod"))
+				r.EncodeString(codecSelferC_UTF81234, string("namespaceSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy952 := &x.DeploymentControllerSyncPeriod
+				yy949 := &x.NamespaceSyncPeriod
+				yym950 := z.EncBinary()
+				_ = yym950
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy949) {
+				} else if !yym950 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy949)
+				} else {
+					z.EncFallback(yy949)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy952 := &x.PVClaimBinderSyncPeriod
 				yym953 := z.EncBinary()
 				_ = yym953
 				if false {
@@ -8080,24 +8130,24 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				} else {
 					z.EncFallback(yy952)
 				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy955 := &x.PodEvictionTimeout
-				yym956 := z.EncBinary()
-				_ = yym956
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy955) {
-				} else if !yym956 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy955)
-				} else {
-					z.EncFallback(yy955)
-				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("podEvictionTimeout"))
+				r.EncodeString(codecSelferC_UTF81234, string("pvClaimBinderSyncPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy957 := &x.PodEvictionTimeout
+				yy954 := &x.PVClaimBinderSyncPeriod
+				yym955 := z.EncBinary()
+				_ = yym955
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy954) {
+				} else if !yym955 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy954)
+				} else {
+					z.EncFallback(yy954)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy957 := &x.MinResyncPeriod
 				yym958 := z.EncBinary()
 				_ = yym958
 				if false {
@@ -8107,11 +8157,125 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				} else {
 					z.EncFallback(yy957)
 				}
-			}
-			if yyr848 || yy2arr848 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("minResyncPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy959 := &x.MinResyncPeriod
 				yym960 := z.EncBinary()
 				_ = yym960
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy959) {
+				} else if !yym960 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy959)
+				} else {
+					z.EncFallback(yy959)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym962 := z.EncBinary()
+				_ = yym962
+				if false {
+				} else {
+					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("terminatedPodGCThreshold"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym963 := z.EncBinary()
+				_ = yym963
+				if false {
+				} else {
+					r.EncodeInt(int64(x.TerminatedPodGCThreshold))
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy965 := &x.HorizontalPodAutoscalerSyncPeriod
+				yym966 := z.EncBinary()
+				_ = yym966
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy965) {
+				} else if !yym966 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy965)
+				} else {
+					z.EncFallback(yy965)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("horizontalPodAutoscalerSyncPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy967 := &x.HorizontalPodAutoscalerSyncPeriod
+				yym968 := z.EncBinary()
+				_ = yym968
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy967) {
+				} else if !yym968 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy967)
+				} else {
+					z.EncFallback(yy967)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy970 := &x.DeploymentControllerSyncPeriod
+				yym971 := z.EncBinary()
+				_ = yym971
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy970) {
+				} else if !yym971 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy970)
+				} else {
+					z.EncFallback(yy970)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("deploymentControllerSyncPeriod"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy972 := &x.DeploymentControllerSyncPeriod
+				yym973 := z.EncBinary()
+				_ = yym973
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy972) {
+				} else if !yym973 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy972)
+				} else {
+					z.EncFallback(yy972)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy975 := &x.PodEvictionTimeout
+				yym976 := z.EncBinary()
+				_ = yym976
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy975) {
+				} else if !yym976 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy975)
+				} else {
+					z.EncFallback(yy975)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("podEvictionTimeout"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy977 := &x.PodEvictionTimeout
+				yym978 := z.EncBinary()
+				_ = yym978
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy977) {
+				} else if !yym978 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy977)
+				} else {
+					z.EncFallback(yy977)
+				}
+			}
+			if yyr868 || yy2arr868 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym980 := z.EncBinary()
+				_ = yym980
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.DeletingPodsQps))
@@ -8120,17 +8284,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("deletingPodsQps"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym961 := z.EncBinary()
-				_ = yym961
+				yym981 := z.EncBinary()
+				_ = yym981
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.DeletingPodsQps))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym963 := z.EncBinary()
-				_ = yym963
+				yym983 := z.EncBinary()
+				_ = yym983
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DeletingPodsBurst))
@@ -8139,44 +8303,44 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("deletingPodsBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym964 := z.EncBinary()
-				_ = yym964
+				yym984 := z.EncBinary()
+				_ = yym984
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DeletingPodsBurst))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy966 := &x.NodeMonitorGracePeriod
-				yym967 := z.EncBinary()
-				_ = yym967
+				yy986 := &x.NodeMonitorGracePeriod
+				yym987 := z.EncBinary()
+				_ = yym987
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy966) {
-				} else if !yym967 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy966)
+				} else if z.HasExtensions() && z.EncExt(yy986) {
+				} else if !yym987 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy986)
 				} else {
-					z.EncFallback(yy966)
+					z.EncFallback(yy986)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeMonitorGracePeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy968 := &x.NodeMonitorGracePeriod
-				yym969 := z.EncBinary()
-				_ = yym969
+				yy988 := &x.NodeMonitorGracePeriod
+				yym989 := z.EncBinary()
+				_ = yym989
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy968) {
-				} else if !yym969 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy968)
+				} else if z.HasExtensions() && z.EncExt(yy988) {
+				} else if !yym989 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy988)
 				} else {
-					z.EncFallback(yy968)
+					z.EncFallback(yy988)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym971 := z.EncBinary()
-				_ = yym971
+				yym991 := z.EncBinary()
+				_ = yym991
 				if false {
 				} else {
 					r.EncodeInt(int64(x.RegisterRetryCount))
@@ -8185,71 +8349,71 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("registerRetryCount"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym972 := z.EncBinary()
-				_ = yym972
+				yym992 := z.EncBinary()
+				_ = yym992
 				if false {
 				} else {
 					r.EncodeInt(int64(x.RegisterRetryCount))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy974 := &x.NodeStartupGracePeriod
-				yym975 := z.EncBinary()
-				_ = yym975
+				yy994 := &x.NodeStartupGracePeriod
+				yym995 := z.EncBinary()
+				_ = yym995
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy974) {
-				} else if !yym975 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy974)
+				} else if z.HasExtensions() && z.EncExt(yy994) {
+				} else if !yym995 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy994)
 				} else {
-					z.EncFallback(yy974)
+					z.EncFallback(yy994)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeStartupGracePeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy976 := &x.NodeStartupGracePeriod
-				yym977 := z.EncBinary()
-				_ = yym977
+				yy996 := &x.NodeStartupGracePeriod
+				yym997 := z.EncBinary()
+				_ = yym997
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy976) {
-				} else if !yym977 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy976)
+				} else if z.HasExtensions() && z.EncExt(yy996) {
+				} else if !yym997 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy996)
 				} else {
-					z.EncFallback(yy976)
+					z.EncFallback(yy996)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy979 := &x.NodeMonitorPeriod
-				yym980 := z.EncBinary()
-				_ = yym980
+				yy999 := &x.NodeMonitorPeriod
+				yym1000 := z.EncBinary()
+				_ = yym1000
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy979) {
-				} else if !yym980 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy979)
+				} else if z.HasExtensions() && z.EncExt(yy999) {
+				} else if !yym1000 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy999)
 				} else {
-					z.EncFallback(yy979)
+					z.EncFallback(yy999)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeMonitorPeriod"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy981 := &x.NodeMonitorPeriod
-				yym982 := z.EncBinary()
-				_ = yym982
+				yy1001 := &x.NodeMonitorPeriod
+				yym1002 := z.EncBinary()
+				_ = yym1002
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy981) {
-				} else if !yym982 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy981)
+				} else if z.HasExtensions() && z.EncExt(yy1001) {
+				} else if !yym1002 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1001)
 				} else {
-					z.EncFallback(yy981)
+					z.EncFallback(yy1001)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym984 := z.EncBinary()
-				_ = yym984
+				yym1004 := z.EncBinary()
+				_ = yym1004
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountKeyFile))
@@ -8258,17 +8422,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceAccountKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym985 := z.EncBinary()
-				_ = yym985
+				yym1005 := z.EncBinary()
+				_ = yym1005
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountKeyFile))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym987 := z.EncBinary()
-				_ = yym987
+				yym1007 := z.EncBinary()
+				_ = yym1007
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningCertFile))
@@ -8277,17 +8441,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterSigningCertFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym988 := z.EncBinary()
-				_ = yym988
+				yym1008 := z.EncBinary()
+				_ = yym1008
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningCertFile))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym990 := z.EncBinary()
-				_ = yym990
+				yym1010 := z.EncBinary()
+				_ = yym1010
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningKeyFile))
@@ -8296,17 +8460,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterSigningKeyFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym991 := z.EncBinary()
-				_ = yym991
+				yym1011 := z.EncBinary()
+				_ = yym1011
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterSigningKeyFile))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym993 := z.EncBinary()
-				_ = yym993
+				yym1013 := z.EncBinary()
+				_ = yym1013
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ApproveAllKubeletCSRsForGroup))
@@ -8315,17 +8479,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("approveAllKubeletCSRsForGroup"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym994 := z.EncBinary()
-				_ = yym994
+				yym1014 := z.EncBinary()
+				_ = yym1014
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ApproveAllKubeletCSRsForGroup))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym996 := z.EncBinary()
-				_ = yym996
+				yym1016 := z.EncBinary()
+				_ = yym1016
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -8334,17 +8498,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableProfiling"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym997 := z.EncBinary()
-				_ = yym997
+				yym1017 := z.EncBinary()
+				_ = yym1017
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym999 := z.EncBinary()
-				_ = yym999
+				yym1019 := z.EncBinary()
+				_ = yym1019
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterName))
@@ -8353,17 +8517,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1000 := z.EncBinary()
-				_ = yym1000
+				yym1020 := z.EncBinary()
+				_ = yym1020
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterName))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1002 := z.EncBinary()
-				_ = yym1002
+				yym1022 := z.EncBinary()
+				_ = yym1022
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterCIDR))
@@ -8372,17 +8536,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("clusterCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1003 := z.EncBinary()
-				_ = yym1003
+				yym1023 := z.EncBinary()
+				_ = yym1023
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClusterCIDR))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1005 := z.EncBinary()
-				_ = yym1005
+				yym1025 := z.EncBinary()
+				_ = yym1025
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceCIDR))
@@ -8391,17 +8555,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceCIDR"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1006 := z.EncBinary()
-				_ = yym1006
+				yym1026 := z.EncBinary()
+				_ = yym1026
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceCIDR))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1008 := z.EncBinary()
-				_ = yym1008
+				yym1028 := z.EncBinary()
+				_ = yym1028
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodeCIDRMaskSize))
@@ -8410,17 +8574,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeCIDRMaskSize"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1009 := z.EncBinary()
-				_ = yym1009
+				yym1029 := z.EncBinary()
+				_ = yym1029
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodeCIDRMaskSize))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1011 := z.EncBinary()
-				_ = yym1011
+				yym1031 := z.EncBinary()
+				_ = yym1031
 				if false {
 				} else {
 					r.EncodeBool(bool(x.AllocateNodeCIDRs))
@@ -8429,17 +8593,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("allocateNodeCIDRs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1012 := z.EncBinary()
-				_ = yym1012
+				yym1032 := z.EncBinary()
+				_ = yym1032
 				if false {
 				} else {
 					r.EncodeBool(bool(x.AllocateNodeCIDRs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1014 := z.EncBinary()
-				_ = yym1014
+				yym1034 := z.EncBinary()
+				_ = yym1034
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ConfigureCloudRoutes))
@@ -8448,17 +8612,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("configureCloudRoutes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1015 := z.EncBinary()
-				_ = yym1015
+				yym1035 := z.EncBinary()
+				_ = yym1035
 				if false {
 				} else {
 					r.EncodeBool(bool(x.ConfigureCloudRoutes))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1017 := z.EncBinary()
-				_ = yym1017
+				yym1037 := z.EncBinary()
+				_ = yym1037
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RootCAFile))
@@ -8467,17 +8631,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("rootCAFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1018 := z.EncBinary()
-				_ = yym1018
+				yym1038 := z.EncBinary()
+				_ = yym1038
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RootCAFile))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1020 := z.EncBinary()
-				_ = yym1020
+				yym1040 := z.EncBinary()
+				_ = yym1040
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
@@ -8486,17 +8650,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("contentType"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1021 := z.EncBinary()
-				_ = yym1021
+				yym1041 := z.EncBinary()
+				_ = yym1041
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContentType))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1023 := z.EncBinary()
-				_ = yym1023
+				yym1043 := z.EncBinary()
+				_ = yym1043
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -8505,17 +8669,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1024 := z.EncBinary()
-				_ = yym1024
+				yym1044 := z.EncBinary()
+				_ = yym1044
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1026 := z.EncBinary()
-				_ = yym1026
+				yym1046 := z.EncBinary()
+				_ = yym1046
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -8524,66 +8688,66 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1027 := z.EncBinary()
-				_ = yym1027
+				yym1047 := z.EncBinary()
+				_ = yym1047
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1029 := &x.LeaderElection
-				yy1029.CodecEncodeSelf(e)
+				yy1049 := &x.LeaderElection
+				yy1049.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1030 := &x.LeaderElection
-				yy1030.CodecEncodeSelf(e)
+				yy1050 := &x.LeaderElection
+				yy1050.CodecEncodeSelf(e)
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1032 := &x.VolumeConfiguration
-				yy1032.CodecEncodeSelf(e)
+				yy1052 := &x.VolumeConfiguration
+				yy1052.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeConfiguration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1033 := &x.VolumeConfiguration
-				yy1033.CodecEncodeSelf(e)
+				yy1053 := &x.VolumeConfiguration
+				yy1053.CodecEncodeSelf(e)
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1035 := &x.ControllerStartInterval
-				yym1036 := z.EncBinary()
-				_ = yym1036
+				yy1055 := &x.ControllerStartInterval
+				yym1056 := z.EncBinary()
+				_ = yym1056
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1035) {
-				} else if !yym1036 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1035)
+				} else if z.HasExtensions() && z.EncExt(yy1055) {
+				} else if !yym1056 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1055)
 				} else {
-					z.EncFallback(yy1035)
+					z.EncFallback(yy1055)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("controllerStartInterval"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1037 := &x.ControllerStartInterval
-				yym1038 := z.EncBinary()
-				_ = yym1038
+				yy1057 := &x.ControllerStartInterval
+				yym1058 := z.EncBinary()
+				_ = yym1058
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1037) {
-				} else if !yym1038 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1037)
+				} else if z.HasExtensions() && z.EncExt(yy1057) {
+				} else if !yym1058 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1057)
 				} else {
-					z.EncFallback(yy1037)
+					z.EncFallback(yy1057)
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1040 := z.EncBinary()
-				_ = yym1040
+				yym1060 := z.EncBinary()
+				_ = yym1060
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableGarbageCollector))
@@ -8592,17 +8756,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableGarbageCollector"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1041 := z.EncBinary()
-				_ = yym1041
+				yym1061 := z.EncBinary()
+				_ = yym1061
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableGarbageCollector))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1043 := z.EncBinary()
-				_ = yym1043
+				yym1063 := z.EncBinary()
+				_ = yym1063
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentGCSyncs))
@@ -8611,17 +8775,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("concurrentGCSyncs"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1044 := z.EncBinary()
-				_ = yym1044
+				yym1064 := z.EncBinary()
+				_ = yym1064
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ConcurrentGCSyncs))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1046 := z.EncBinary()
-				_ = yym1046
+				yym1066 := z.EncBinary()
+				_ = yym1066
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.NodeEvictionRate))
@@ -8630,17 +8794,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodeEvictionRate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1047 := z.EncBinary()
-				_ = yym1047
+				yym1067 := z.EncBinary()
+				_ = yym1067
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.NodeEvictionRate))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1049 := z.EncBinary()
-				_ = yym1049
+				yym1069 := z.EncBinary()
+				_ = yym1069
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.SecondaryNodeEvictionRate))
@@ -8649,17 +8813,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secondaryNodeEvictionRate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1050 := z.EncBinary()
-				_ = yym1050
+				yym1070 := z.EncBinary()
+				_ = yym1070
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.SecondaryNodeEvictionRate))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1052 := z.EncBinary()
-				_ = yym1052
+				yym1072 := z.EncBinary()
+				_ = yym1072
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LargeClusterSizeThreshold))
@@ -8668,17 +8832,17 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("largeClusterSizeThreshold"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1053 := z.EncBinary()
-				_ = yym1053
+				yym1073 := z.EncBinary()
+				_ = yym1073
 				if false {
 				} else {
 					r.EncodeInt(int64(x.LargeClusterSizeThreshold))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1055 := z.EncBinary()
-				_ = yym1055
+				yym1075 := z.EncBinary()
+				_ = yym1075
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.UnhealthyZoneThreshold))
@@ -8687,14 +8851,14 @@ func (x *KubeControllerManagerConfiguration) CodecEncodeSelf(e *codec1978.Encode
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("unhealthyZoneThreshold"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1056 := z.EncBinary()
-				_ = yym1056
+				yym1076 := z.EncBinary()
+				_ = yym1076
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.UnhealthyZoneThreshold))
 				}
 			}
-			if yyr848 || yy2arr848 {
+			if yyr868 || yy2arr868 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8707,25 +8871,25 @@ func (x *KubeControllerManagerConfiguration) CodecDecodeSelf(d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1057 := z.DecBinary()
-	_ = yym1057
+	yym1077 := z.DecBinary()
+	_ = yym1077
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1058 := r.ContainerType()
-		if yyct1058 == codecSelferValueTypeMap1234 {
-			yyl1058 := r.ReadMapStart()
-			if yyl1058 == 0 {
+		yyct1078 := r.ContainerType()
+		if yyct1078 == codecSelferValueTypeMap1234 {
+			yyl1078 := r.ReadMapStart()
+			if yyl1078 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1058, d)
+				x.codecDecodeSelfFromMap(yyl1078, d)
 			}
-		} else if yyct1058 == codecSelferValueTypeArray1234 {
-			yyl1058 := r.ReadArrayStart()
-			if yyl1058 == 0 {
+		} else if yyct1078 == codecSelferValueTypeArray1234 {
+			yyl1078 := r.ReadArrayStart()
+			if yyl1078 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1058, d)
+				x.codecDecodeSelfFromArray(yyl1078, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8737,12 +8901,12 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1059Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1059Slc
-	var yyhl1059 bool = l >= 0
-	for yyj1059 := 0; ; yyj1059++ {
-		if yyhl1059 {
-			if yyj1059 >= l {
+	var yys1079Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1079Slc
+	var yyhl1079 bool = l >= 0
+	for yyj1079 := 0; ; yyj1079++ {
+		if yyhl1079 {
+			if yyj1079 >= l {
 				break
 			}
 		} else {
@@ -8751,10 +8915,10 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1059Slc = r.DecodeBytes(yys1059Slc, true, true)
-		yys1059 := string(yys1059Slc)
+		yys1079Slc = r.DecodeBytes(yys1079Slc, true, true)
+		yys1079 := string(yys1079Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1059 {
+		switch yys1079 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8873,105 +9037,105 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.ServiceSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1079 := &x.ServiceSyncPeriod
-				yym1080 := z.DecBinary()
-				_ = yym1080
+				yyv1099 := &x.ServiceSyncPeriod
+				yym1100 := z.DecBinary()
+				_ = yym1100
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1079) {
-				} else if !yym1080 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1079)
+				} else if z.HasExtensions() && z.DecExt(yyv1099) {
+				} else if !yym1100 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1099)
 				} else {
-					z.DecFallback(yyv1079, false)
+					z.DecFallback(yyv1099, false)
 				}
 			}
 		case "nodeSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.NodeSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1081 := &x.NodeSyncPeriod
-				yym1082 := z.DecBinary()
-				_ = yym1082
+				yyv1101 := &x.NodeSyncPeriod
+				yym1102 := z.DecBinary()
+				_ = yym1102
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1081) {
-				} else if !yym1082 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1081)
+				} else if z.HasExtensions() && z.DecExt(yyv1101) {
+				} else if !yym1102 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1101)
 				} else {
-					z.DecFallback(yyv1081, false)
+					z.DecFallback(yyv1101, false)
 				}
 			}
 		case "routeReconciliationPeriod":
 			if r.TryDecodeAsNil() {
 				x.RouteReconciliationPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1083 := &x.RouteReconciliationPeriod
-				yym1084 := z.DecBinary()
-				_ = yym1084
+				yyv1103 := &x.RouteReconciliationPeriod
+				yym1104 := z.DecBinary()
+				_ = yym1104
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1083) {
-				} else if !yym1084 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1083)
+				} else if z.HasExtensions() && z.DecExt(yyv1103) {
+				} else if !yym1104 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1103)
 				} else {
-					z.DecFallback(yyv1083, false)
+					z.DecFallback(yyv1103, false)
 				}
 			}
 		case "resourceQuotaSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.ResourceQuotaSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1085 := &x.ResourceQuotaSyncPeriod
-				yym1086 := z.DecBinary()
-				_ = yym1086
+				yyv1105 := &x.ResourceQuotaSyncPeriod
+				yym1106 := z.DecBinary()
+				_ = yym1106
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1085) {
-				} else if !yym1086 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1085)
+				} else if z.HasExtensions() && z.DecExt(yyv1105) {
+				} else if !yym1106 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1105)
 				} else {
-					z.DecFallback(yyv1085, false)
+					z.DecFallback(yyv1105, false)
 				}
 			}
 		case "namespaceSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.NamespaceSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1087 := &x.NamespaceSyncPeriod
-				yym1088 := z.DecBinary()
-				_ = yym1088
+				yyv1107 := &x.NamespaceSyncPeriod
+				yym1108 := z.DecBinary()
+				_ = yym1108
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1087) {
-				} else if !yym1088 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1087)
+				} else if z.HasExtensions() && z.DecExt(yyv1107) {
+				} else if !yym1108 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1107)
 				} else {
-					z.DecFallback(yyv1087, false)
+					z.DecFallback(yyv1107, false)
 				}
 			}
 		case "pvClaimBinderSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.PVClaimBinderSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1089 := &x.PVClaimBinderSyncPeriod
-				yym1090 := z.DecBinary()
-				_ = yym1090
+				yyv1109 := &x.PVClaimBinderSyncPeriod
+				yym1110 := z.DecBinary()
+				_ = yym1110
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1089) {
-				} else if !yym1090 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1089)
+				} else if z.HasExtensions() && z.DecExt(yyv1109) {
+				} else if !yym1110 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1109)
 				} else {
-					z.DecFallback(yyv1089, false)
+					z.DecFallback(yyv1109, false)
 				}
 			}
 		case "minResyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.MinResyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1091 := &x.MinResyncPeriod
-				yym1092 := z.DecBinary()
-				_ = yym1092
+				yyv1111 := &x.MinResyncPeriod
+				yym1112 := z.DecBinary()
+				_ = yym1112
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1091) {
-				} else if !yym1092 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1091)
+				} else if z.HasExtensions() && z.DecExt(yyv1111) {
+				} else if !yym1112 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1111)
 				} else {
-					z.DecFallback(yyv1091, false)
+					z.DecFallback(yyv1111, false)
 				}
 			}
 		case "terminatedPodGCThreshold":
@@ -8984,45 +9148,45 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1094 := &x.HorizontalPodAutoscalerSyncPeriod
-				yym1095 := z.DecBinary()
-				_ = yym1095
+				yyv1114 := &x.HorizontalPodAutoscalerSyncPeriod
+				yym1115 := z.DecBinary()
+				_ = yym1115
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1094) {
-				} else if !yym1095 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1094)
+				} else if z.HasExtensions() && z.DecExt(yyv1114) {
+				} else if !yym1115 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1114)
 				} else {
-					z.DecFallback(yyv1094, false)
+					z.DecFallback(yyv1114, false)
 				}
 			}
 		case "deploymentControllerSyncPeriod":
 			if r.TryDecodeAsNil() {
 				x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1096 := &x.DeploymentControllerSyncPeriod
-				yym1097 := z.DecBinary()
-				_ = yym1097
+				yyv1116 := &x.DeploymentControllerSyncPeriod
+				yym1117 := z.DecBinary()
+				_ = yym1117
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1096) {
-				} else if !yym1097 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1096)
+				} else if z.HasExtensions() && z.DecExt(yyv1116) {
+				} else if !yym1117 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1116)
 				} else {
-					z.DecFallback(yyv1096, false)
+					z.DecFallback(yyv1116, false)
 				}
 			}
 		case "podEvictionTimeout":
 			if r.TryDecodeAsNil() {
 				x.PodEvictionTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv1098 := &x.PodEvictionTimeout
-				yym1099 := z.DecBinary()
-				_ = yym1099
+				yyv1118 := &x.PodEvictionTimeout
+				yym1119 := z.DecBinary()
+				_ = yym1119
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1098) {
-				} else if !yym1099 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1098)
+				} else if z.HasExtensions() && z.DecExt(yyv1118) {
+				} else if !yym1119 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1118)
 				} else {
-					z.DecFallback(yyv1098, false)
+					z.DecFallback(yyv1118, false)
 				}
 			}
 		case "deletingPodsQps":
@@ -9041,15 +9205,15 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.NodeMonitorGracePeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1102 := &x.NodeMonitorGracePeriod
-				yym1103 := z.DecBinary()
-				_ = yym1103
+				yyv1122 := &x.NodeMonitorGracePeriod
+				yym1123 := z.DecBinary()
+				_ = yym1123
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1102) {
-				} else if !yym1103 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1102)
+				} else if z.HasExtensions() && z.DecExt(yyv1122) {
+				} else if !yym1123 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1122)
 				} else {
-					z.DecFallback(yyv1102, false)
+					z.DecFallback(yyv1122, false)
 				}
 			}
 		case "registerRetryCount":
@@ -9062,30 +9226,30 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1105 := &x.NodeStartupGracePeriod
-				yym1106 := z.DecBinary()
-				_ = yym1106
+				yyv1125 := &x.NodeStartupGracePeriod
+				yym1126 := z.DecBinary()
+				_ = yym1126
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1105) {
-				} else if !yym1106 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1105)
+				} else if z.HasExtensions() && z.DecExt(yyv1125) {
+				} else if !yym1126 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1125)
 				} else {
-					z.DecFallback(yyv1105, false)
+					z.DecFallback(yyv1125, false)
 				}
 			}
 		case "nodeMonitorPeriod":
 			if r.TryDecodeAsNil() {
 				x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv1107 := &x.NodeMonitorPeriod
-				yym1108 := z.DecBinary()
-				_ = yym1108
+				yyv1127 := &x.NodeMonitorPeriod
+				yym1128 := z.DecBinary()
+				_ = yym1128
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1107) {
-				} else if !yym1108 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1107)
+				} else if z.HasExtensions() && z.DecExt(yyv1127) {
+				} else if !yym1128 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1127)
 				} else {
-					z.DecFallback(yyv1107, false)
+					z.DecFallback(yyv1127, false)
 				}
 			}
 		case "serviceAccountKeyFile":
@@ -9182,29 +9346,29 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv1124 := &x.LeaderElection
-				yyv1124.CodecDecodeSelf(d)
+				yyv1144 := &x.LeaderElection
+				yyv1144.CodecDecodeSelf(d)
 			}
 		case "volumeConfiguration":
 			if r.TryDecodeAsNil() {
 				x.VolumeConfiguration = VolumeConfiguration{}
 			} else {
-				yyv1125 := &x.VolumeConfiguration
-				yyv1125.CodecDecodeSelf(d)
+				yyv1145 := &x.VolumeConfiguration
+				yyv1145.CodecDecodeSelf(d)
 			}
 		case "controllerStartInterval":
 			if r.TryDecodeAsNil() {
 				x.ControllerStartInterval = pkg1_unversioned.Duration{}
 			} else {
-				yyv1126 := &x.ControllerStartInterval
-				yym1127 := z.DecBinary()
-				_ = yym1127
+				yyv1146 := &x.ControllerStartInterval
+				yym1147 := z.DecBinary()
+				_ = yym1147
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1126) {
-				} else if !yym1127 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1126)
+				} else if z.HasExtensions() && z.DecExt(yyv1146) {
+				} else if !yym1147 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1146)
 				} else {
-					z.DecFallback(yyv1126, false)
+					z.DecFallback(yyv1146, false)
 				}
 			}
 		case "enableGarbageCollector":
@@ -9244,9 +9408,9 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromMap(l int, d *co
 				x.UnhealthyZoneThreshold = float32(r.DecodeFloat(true))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1059)
-		} // end switch yys1059
-	} // end for yyj1059
+			z.DecStructFieldNotFound(-1, yys1079)
+		} // end switch yys1079
+	} // end for yyj1079
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9254,16 +9418,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1134 int
-	var yyb1134 bool
-	var yyhl1134 bool = l >= 0
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	var yyj1154 int
+	var yyb1154 bool
+	var yyhl1154 bool = l >= 0
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9273,13 +9437,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9289,13 +9453,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9305,13 +9469,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Port = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9321,13 +9485,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.Address = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9337,13 +9501,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.CloudProvider = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9353,13 +9517,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.CloudConfigFile = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9369,13 +9533,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentEndpointSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9385,13 +9549,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentRSSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9401,13 +9565,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentRCSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9417,13 +9581,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentServiceSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9433,13 +9597,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentResourceQuotaSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9449,13 +9613,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentDeploymentSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9465,13 +9629,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentDaemonSetSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9481,13 +9645,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentJobSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9497,13 +9661,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentNamespaceSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9513,13 +9677,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentSATokenSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9529,13 +9693,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForRC = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9545,13 +9709,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForRS = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9561,13 +9725,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LookupCacheSizeForDaemonSet = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9575,24 +9739,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ServiceSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1154 := &x.ServiceSyncPeriod
-		yym1155 := z.DecBinary()
-		_ = yym1155
+		yyv1174 := &x.ServiceSyncPeriod
+		yym1175 := z.DecBinary()
+		_ = yym1175
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1154) {
-		} else if !yym1155 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1154)
+		} else if z.HasExtensions() && z.DecExt(yyv1174) {
+		} else if !yym1175 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1174)
 		} else {
-			z.DecFallback(yyv1154, false)
+			z.DecFallback(yyv1174, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9600,24 +9764,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.NodeSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1156 := &x.NodeSyncPeriod
-		yym1157 := z.DecBinary()
-		_ = yym1157
+		yyv1176 := &x.NodeSyncPeriod
+		yym1177 := z.DecBinary()
+		_ = yym1177
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1156) {
-		} else if !yym1157 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1156)
+		} else if z.HasExtensions() && z.DecExt(yyv1176) {
+		} else if !yym1177 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1176)
 		} else {
-			z.DecFallback(yyv1156, false)
+			z.DecFallback(yyv1176, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9625,24 +9789,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.RouteReconciliationPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1158 := &x.RouteReconciliationPeriod
-		yym1159 := z.DecBinary()
-		_ = yym1159
+		yyv1178 := &x.RouteReconciliationPeriod
+		yym1179 := z.DecBinary()
+		_ = yym1179
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1158) {
-		} else if !yym1159 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1158)
+		} else if z.HasExtensions() && z.DecExt(yyv1178) {
+		} else if !yym1179 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1178)
 		} else {
-			z.DecFallback(yyv1158, false)
+			z.DecFallback(yyv1178, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9650,271 +9814,7 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ResourceQuotaSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1160 := &x.ResourceQuotaSyncPeriod
-		yym1161 := z.DecBinary()
-		_ = yym1161
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1160) {
-		} else if !yym1161 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1160)
-		} else {
-			z.DecFallback(yyv1160, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NamespaceSyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1162 := &x.NamespaceSyncPeriod
-		yym1163 := z.DecBinary()
-		_ = yym1163
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1162) {
-		} else if !yym1163 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1162)
-		} else {
-			z.DecFallback(yyv1162, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.PVClaimBinderSyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1164 := &x.PVClaimBinderSyncPeriod
-		yym1165 := z.DecBinary()
-		_ = yym1165
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1164) {
-		} else if !yym1165 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1164)
-		} else {
-			z.DecFallback(yyv1164, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinResyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1166 := &x.MinResyncPeriod
-		yym1167 := z.DecBinary()
-		_ = yym1167
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1166) {
-		} else if !yym1167 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1166)
-		} else {
-			z.DecFallback(yyv1166, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.TerminatedPodGCThreshold = 0
-	} else {
-		x.TerminatedPodGCThreshold = int32(r.DecodeInt(32))
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1169 := &x.HorizontalPodAutoscalerSyncPeriod
-		yym1170 := z.DecBinary()
-		_ = yym1170
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1169) {
-		} else if !yym1170 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1169)
-		} else {
-			z.DecFallback(yyv1169, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1171 := &x.DeploymentControllerSyncPeriod
-		yym1172 := z.DecBinary()
-		_ = yym1172
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1171) {
-		} else if !yym1172 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1171)
-		} else {
-			z.DecFallback(yyv1171, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.PodEvictionTimeout = pkg1_unversioned.Duration{}
-	} else {
-		yyv1173 := &x.PodEvictionTimeout
-		yym1174 := z.DecBinary()
-		_ = yym1174
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1173) {
-		} else if !yym1174 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1173)
-		} else {
-			z.DecFallback(yyv1173, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.DeletingPodsQps = 0
-	} else {
-		x.DeletingPodsQps = float32(r.DecodeFloat(true))
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.DeletingPodsBurst = 0
-	} else {
-		x.DeletingPodsBurst = int32(r.DecodeInt(32))
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NodeMonitorGracePeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1177 := &x.NodeMonitorGracePeriod
-		yym1178 := z.DecBinary()
-		_ = yym1178
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1177) {
-		} else if !yym1178 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1177)
-		} else {
-			z.DecFallback(yyv1177, false)
-		}
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.RegisterRetryCount = 0
-	} else {
-		x.RegisterRetryCount = int32(r.DecodeInt(32))
-	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
-	} else {
-		yyb1134 = r.CheckBreak()
-	}
-	if yyb1134 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
-	} else {
-		yyv1180 := &x.NodeStartupGracePeriod
+		yyv1180 := &x.ResourceQuotaSyncPeriod
 		yym1181 := z.DecBinary()
 		_ = yym1181
 		if false {
@@ -9925,21 +9825,21 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 			z.DecFallback(yyv1180, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
+		x.NamespaceSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv1182 := &x.NodeMonitorPeriod
+		yyv1182 := &x.NamespaceSyncPeriod
 		yym1183 := z.DecBinary()
 		_ = yym1183
 		if false {
@@ -9950,13 +9850,277 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 			z.DecFallback(yyv1182, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PVClaimBinderSyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1184 := &x.PVClaimBinderSyncPeriod
+		yym1185 := z.DecBinary()
+		_ = yym1185
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1184) {
+		} else if !yym1185 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1184)
+		} else {
+			z.DecFallback(yyv1184, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MinResyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1186 := &x.MinResyncPeriod
+		yym1187 := z.DecBinary()
+		_ = yym1187
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1186) {
+		} else if !yym1187 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1186)
+		} else {
+			z.DecFallback(yyv1186, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.TerminatedPodGCThreshold = 0
+	} else {
+		x.TerminatedPodGCThreshold = int32(r.DecodeInt(32))
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.HorizontalPodAutoscalerSyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1189 := &x.HorizontalPodAutoscalerSyncPeriod
+		yym1190 := z.DecBinary()
+		_ = yym1190
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1189) {
+		} else if !yym1190 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1189)
+		} else {
+			z.DecFallback(yyv1189, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.DeploymentControllerSyncPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1191 := &x.DeploymentControllerSyncPeriod
+		yym1192 := z.DecBinary()
+		_ = yym1192
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1191) {
+		} else if !yym1192 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1191)
+		} else {
+			z.DecFallback(yyv1191, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodEvictionTimeout = pkg1_unversioned.Duration{}
+	} else {
+		yyv1193 := &x.PodEvictionTimeout
+		yym1194 := z.DecBinary()
+		_ = yym1194
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1193) {
+		} else if !yym1194 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1193)
+		} else {
+			z.DecFallback(yyv1193, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.DeletingPodsQps = 0
+	} else {
+		x.DeletingPodsQps = float32(r.DecodeFloat(true))
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.DeletingPodsBurst = 0
+	} else {
+		x.DeletingPodsBurst = int32(r.DecodeInt(32))
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeMonitorGracePeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1197 := &x.NodeMonitorGracePeriod
+		yym1198 := z.DecBinary()
+		_ = yym1198
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1197) {
+		} else if !yym1198 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1197)
+		} else {
+			z.DecFallback(yyv1197, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RegisterRetryCount = 0
+	} else {
+		x.RegisterRetryCount = int32(r.DecodeInt(32))
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeStartupGracePeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1200 := &x.NodeStartupGracePeriod
+		yym1201 := z.DecBinary()
+		_ = yym1201
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1200) {
+		} else if !yym1201 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1200)
+		} else {
+			z.DecFallback(yyv1200, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.NodeMonitorPeriod = pkg1_unversioned.Duration{}
+	} else {
+		yyv1202 := &x.NodeMonitorPeriod
+		yym1203 := z.DecBinary()
+		_ = yym1203
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1202) {
+		} else if !yym1203 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1202)
+		} else {
+			z.DecFallback(yyv1202, false)
+		}
+	}
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
+	} else {
+		yyb1154 = r.CheckBreak()
+	}
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9966,13 +10130,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ServiceAccountKeyFile = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9982,13 +10146,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterSigningCertFile = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9998,13 +10162,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterSigningKeyFile = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10014,13 +10178,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ApproveAllKubeletCSRsForGroup = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10030,13 +10194,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.EnableProfiling = bool(r.DecodeBool())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10046,13 +10210,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterName = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10062,13 +10226,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ClusterCIDR = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10078,13 +10242,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ServiceCIDR = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10094,13 +10258,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.NodeCIDRMaskSize = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10110,13 +10274,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.AllocateNodeCIDRs = bool(r.DecodeBool())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10126,13 +10290,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConfigureCloudRoutes = bool(r.DecodeBool())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10142,13 +10306,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.RootCAFile = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10158,13 +10322,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ContentType = string(r.DecodeString())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10174,13 +10338,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.KubeAPIQPS = float32(r.DecodeFloat(true))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10190,13 +10354,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10204,16 +10368,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv1199 := &x.LeaderElection
-		yyv1199.CodecDecodeSelf(d)
+		yyv1219 := &x.LeaderElection
+		yyv1219.CodecDecodeSelf(d)
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10221,16 +10385,16 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.VolumeConfiguration = VolumeConfiguration{}
 	} else {
-		yyv1200 := &x.VolumeConfiguration
-		yyv1200.CodecDecodeSelf(d)
+		yyv1220 := &x.VolumeConfiguration
+		yyv1220.CodecDecodeSelf(d)
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10238,24 +10402,24 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	if r.TryDecodeAsNil() {
 		x.ControllerStartInterval = pkg1_unversioned.Duration{}
 	} else {
-		yyv1201 := &x.ControllerStartInterval
-		yym1202 := z.DecBinary()
-		_ = yym1202
+		yyv1221 := &x.ControllerStartInterval
+		yym1222 := z.DecBinary()
+		_ = yym1222
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1201) {
-		} else if !yym1202 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1201)
+		} else if z.HasExtensions() && z.DecExt(yyv1221) {
+		} else if !yym1222 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1221)
 		} else {
-			z.DecFallback(yyv1201, false)
+			z.DecFallback(yyv1221, false)
 		}
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10265,13 +10429,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.EnableGarbageCollector = bool(r.DecodeBool())
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10281,13 +10445,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.ConcurrentGCSyncs = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10297,13 +10461,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.NodeEvictionRate = float32(r.DecodeFloat(true))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10313,13 +10477,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.SecondaryNodeEvictionRate = float32(r.DecodeFloat(true))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10329,13 +10493,13 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 	} else {
 		x.LargeClusterSizeThreshold = int32(r.DecodeInt(32))
 	}
-	yyj1134++
-	if yyhl1134 {
-		yyb1134 = yyj1134 > l
+	yyj1154++
+	if yyhl1154 {
+		yyb1154 = yyj1154 > l
 	} else {
-		yyb1134 = r.CheckBreak()
+		yyb1154 = r.CheckBreak()
 	}
-	if yyb1134 {
+	if yyb1154 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10346,17 +10510,17 @@ func (x *KubeControllerManagerConfiguration) codecDecodeSelfFromArray(l int, d *
 		x.UnhealthyZoneThreshold = float32(r.DecodeFloat(true))
 	}
 	for {
-		yyj1134++
-		if yyhl1134 {
-			yyb1134 = yyj1134 > l
+		yyj1154++
+		if yyhl1154 {
+			yyb1154 = yyj1154 > l
 		} else {
-			yyb1134 = r.CheckBreak()
+			yyb1154 = r.CheckBreak()
 		}
-		if yyb1134 {
+		if yyb1154 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1134-1, "")
+		z.DecStructFieldNotFound(yyj1154-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10368,33 +10532,33 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1209 := z.EncBinary()
-		_ = yym1209
+		yym1229 := z.EncBinary()
+		_ = yym1229
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1210 := !z.EncBinary()
-			yy2arr1210 := z.EncBasicHandle().StructToArray
-			var yyq1210 [4]bool
-			_, _, _ = yysep1210, yyq1210, yy2arr1210
-			const yyr1210 bool = false
-			var yynn1210 int
-			if yyr1210 || yy2arr1210 {
+			yysep1230 := !z.EncBinary()
+			yy2arr1230 := z.EncBasicHandle().StructToArray
+			var yyq1230 [4]bool
+			_, _, _ = yysep1230, yyq1230, yy2arr1230
+			const yyr1230 bool = false
+			var yynn1230 int
+			if yyr1230 || yy2arr1230 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1210 = 4
-				for _, b := range yyq1210 {
+				yynn1230 = 4
+				for _, b := range yyq1230 {
 					if b {
-						yynn1210++
+						yynn1230++
 					}
 				}
-				r.EncodeMapStart(yynn1210)
-				yynn1210 = 0
+				r.EncodeMapStart(yynn1230)
+				yynn1230 = 0
 			}
-			if yyr1210 || yy2arr1210 {
+			if yyr1230 || yy2arr1230 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1212 := z.EncBinary()
-				_ = yym1212
+				yym1232 := z.EncBinary()
+				_ = yym1232
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableHostPathProvisioning))
@@ -10403,17 +10567,17 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableHostPathProvisioning"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1213 := z.EncBinary()
-				_ = yym1213
+				yym1233 := z.EncBinary()
+				_ = yym1233
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableHostPathProvisioning))
 				}
 			}
-			if yyr1210 || yy2arr1210 {
+			if yyr1230 || yy2arr1230 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1215 := z.EncBinary()
-				_ = yym1215
+				yym1235 := z.EncBinary()
+				_ = yym1235
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableDynamicProvisioning))
@@ -10422,28 +10586,28 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableDynamicProvisioning"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1216 := z.EncBinary()
-				_ = yym1216
+				yym1236 := z.EncBinary()
+				_ = yym1236
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableDynamicProvisioning))
 				}
 			}
-			if yyr1210 || yy2arr1210 {
+			if yyr1230 || yy2arr1230 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1218 := &x.PersistentVolumeRecyclerConfiguration
-				yy1218.CodecEncodeSelf(e)
+				yy1238 := &x.PersistentVolumeRecyclerConfiguration
+				yy1238.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("persitentVolumeRecyclerConfiguration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1219 := &x.PersistentVolumeRecyclerConfiguration
-				yy1219.CodecEncodeSelf(e)
+				yy1239 := &x.PersistentVolumeRecyclerConfiguration
+				yy1239.CodecEncodeSelf(e)
 			}
-			if yyr1210 || yy2arr1210 {
+			if yyr1230 || yy2arr1230 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1221 := z.EncBinary()
-				_ = yym1221
+				yym1241 := z.EncBinary()
+				_ = yym1241
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FlexVolumePluginDir))
@@ -10452,14 +10616,14 @@ func (x *VolumeConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("flexVolumePluginDir"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1222 := z.EncBinary()
-				_ = yym1222
+				yym1242 := z.EncBinary()
+				_ = yym1242
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FlexVolumePluginDir))
 				}
 			}
-			if yyr1210 || yy2arr1210 {
+			if yyr1230 || yy2arr1230 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10472,25 +10636,25 @@ func (x *VolumeConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1223 := z.DecBinary()
-	_ = yym1223
+	yym1243 := z.DecBinary()
+	_ = yym1243
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1224 := r.ContainerType()
-		if yyct1224 == codecSelferValueTypeMap1234 {
-			yyl1224 := r.ReadMapStart()
-			if yyl1224 == 0 {
+		yyct1244 := r.ContainerType()
+		if yyct1244 == codecSelferValueTypeMap1234 {
+			yyl1244 := r.ReadMapStart()
+			if yyl1244 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1224, d)
+				x.codecDecodeSelfFromMap(yyl1244, d)
 			}
-		} else if yyct1224 == codecSelferValueTypeArray1234 {
-			yyl1224 := r.ReadArrayStart()
-			if yyl1224 == 0 {
+		} else if yyct1244 == codecSelferValueTypeArray1234 {
+			yyl1244 := r.ReadArrayStart()
+			if yyl1244 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1224, d)
+				x.codecDecodeSelfFromArray(yyl1244, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10502,12 +10666,12 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1225Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1225Slc
-	var yyhl1225 bool = l >= 0
-	for yyj1225 := 0; ; yyj1225++ {
-		if yyhl1225 {
-			if yyj1225 >= l {
+	var yys1245Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1245Slc
+	var yyhl1245 bool = l >= 0
+	for yyj1245 := 0; ; yyj1245++ {
+		if yyhl1245 {
+			if yyj1245 >= l {
 				break
 			}
 		} else {
@@ -10516,10 +10680,10 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1225Slc = r.DecodeBytes(yys1225Slc, true, true)
-		yys1225 := string(yys1225Slc)
+		yys1245Slc = r.DecodeBytes(yys1245Slc, true, true)
+		yys1245 := string(yys1245Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1225 {
+		switch yys1245 {
 		case "enableHostPathProvisioning":
 			if r.TryDecodeAsNil() {
 				x.EnableHostPathProvisioning = false
@@ -10536,8 +10700,8 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.PersistentVolumeRecyclerConfiguration = PersistentVolumeRecyclerConfiguration{}
 			} else {
-				yyv1228 := &x.PersistentVolumeRecyclerConfiguration
-				yyv1228.CodecDecodeSelf(d)
+				yyv1248 := &x.PersistentVolumeRecyclerConfiguration
+				yyv1248.CodecDecodeSelf(d)
 			}
 		case "flexVolumePluginDir":
 			if r.TryDecodeAsNil() {
@@ -10546,9 +10710,9 @@ func (x *VolumeConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.FlexVolumePluginDir = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1225)
-		} // end switch yys1225
-	} // end for yyj1225
+			z.DecStructFieldNotFound(-1, yys1245)
+		} // end switch yys1245
+	} // end for yyj1245
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10556,16 +10720,16 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1230 int
-	var yyb1230 bool
-	var yyhl1230 bool = l >= 0
-	yyj1230++
-	if yyhl1230 {
-		yyb1230 = yyj1230 > l
+	var yyj1250 int
+	var yyb1250 bool
+	var yyhl1250 bool = l >= 0
+	yyj1250++
+	if yyhl1250 {
+		yyb1250 = yyj1250 > l
 	} else {
-		yyb1230 = r.CheckBreak()
+		yyb1250 = r.CheckBreak()
 	}
-	if yyb1230 {
+	if yyb1250 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10575,13 +10739,13 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.EnableHostPathProvisioning = bool(r.DecodeBool())
 	}
-	yyj1230++
-	if yyhl1230 {
-		yyb1230 = yyj1230 > l
+	yyj1250++
+	if yyhl1250 {
+		yyb1250 = yyj1250 > l
 	} else {
-		yyb1230 = r.CheckBreak()
+		yyb1250 = r.CheckBreak()
 	}
-	if yyb1230 {
+	if yyb1250 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10591,13 +10755,13 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.EnableDynamicProvisioning = bool(r.DecodeBool())
 	}
-	yyj1230++
-	if yyhl1230 {
-		yyb1230 = yyj1230 > l
+	yyj1250++
+	if yyhl1250 {
+		yyb1250 = yyj1250 > l
 	} else {
-		yyb1230 = r.CheckBreak()
+		yyb1250 = r.CheckBreak()
 	}
-	if yyb1230 {
+	if yyb1250 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10605,16 +10769,16 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	if r.TryDecodeAsNil() {
 		x.PersistentVolumeRecyclerConfiguration = PersistentVolumeRecyclerConfiguration{}
 	} else {
-		yyv1233 := &x.PersistentVolumeRecyclerConfiguration
-		yyv1233.CodecDecodeSelf(d)
+		yyv1253 := &x.PersistentVolumeRecyclerConfiguration
+		yyv1253.CodecDecodeSelf(d)
 	}
-	yyj1230++
-	if yyhl1230 {
-		yyb1230 = yyj1230 > l
+	yyj1250++
+	if yyhl1250 {
+		yyb1250 = yyj1250 > l
 	} else {
-		yyb1230 = r.CheckBreak()
+		yyb1250 = r.CheckBreak()
 	}
-	if yyb1230 {
+	if yyb1250 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10625,17 +10789,17 @@ func (x *VolumeConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.FlexVolumePluginDir = string(r.DecodeString())
 	}
 	for {
-		yyj1230++
-		if yyhl1230 {
-			yyb1230 = yyj1230 > l
+		yyj1250++
+		if yyhl1250 {
+			yyb1250 = yyj1250 > l
 		} else {
-			yyb1230 = r.CheckBreak()
+			yyb1250 = r.CheckBreak()
 		}
-		if yyb1230 {
+		if yyb1250 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1230-1, "")
+		z.DecStructFieldNotFound(yyj1250-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10647,33 +10811,33 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1235 := z.EncBinary()
-		_ = yym1235
+		yym1255 := z.EncBinary()
+		_ = yym1255
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1236 := !z.EncBinary()
-			yy2arr1236 := z.EncBasicHandle().StructToArray
-			var yyq1236 [7]bool
-			_, _, _ = yysep1236, yyq1236, yy2arr1236
-			const yyr1236 bool = false
-			var yynn1236 int
-			if yyr1236 || yy2arr1236 {
+			yysep1256 := !z.EncBinary()
+			yy2arr1256 := z.EncBasicHandle().StructToArray
+			var yyq1256 [7]bool
+			_, _, _ = yysep1256, yyq1256, yy2arr1256
+			const yyr1256 bool = false
+			var yynn1256 int
+			if yyr1256 || yy2arr1256 {
 				r.EncodeArrayStart(7)
 			} else {
-				yynn1236 = 7
-				for _, b := range yyq1236 {
+				yynn1256 = 7
+				for _, b := range yyq1256 {
 					if b {
-						yynn1236++
+						yynn1256++
 					}
 				}
-				r.EncodeMapStart(yynn1236)
-				yynn1236 = 0
+				r.EncodeMapStart(yynn1256)
+				yynn1256 = 0
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1238 := z.EncBinary()
-				_ = yym1238
+				yym1258 := z.EncBinary()
+				_ = yym1258
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaximumRetry))
@@ -10682,17 +10846,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maximumRetry"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1239 := z.EncBinary()
-				_ = yym1239
+				yym1259 := z.EncBinary()
+				_ = yym1259
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaximumRetry))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1241 := z.EncBinary()
-				_ = yym1241
+				yym1261 := z.EncBinary()
+				_ = yym1261
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutNFS))
@@ -10701,17 +10865,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minimumTimeoutNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1242 := z.EncBinary()
-				_ = yym1242
+				yym1262 := z.EncBinary()
+				_ = yym1262
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutNFS))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1244 := z.EncBinary()
-				_ = yym1244
+				yym1264 := z.EncBinary()
+				_ = yym1264
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathNFS))
@@ -10720,17 +10884,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podTemplateFilePathNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1245 := z.EncBinary()
-				_ = yym1245
+				yym1265 := z.EncBinary()
+				_ = yym1265
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathNFS))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1247 := z.EncBinary()
-				_ = yym1247
+				yym1267 := z.EncBinary()
+				_ = yym1267
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutNFS))
@@ -10739,17 +10903,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("incrementTimeoutNFS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1248 := z.EncBinary()
-				_ = yym1248
+				yym1268 := z.EncBinary()
+				_ = yym1268
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutNFS))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1250 := z.EncBinary()
-				_ = yym1250
+				yym1270 := z.EncBinary()
+				_ = yym1270
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathHostPath))
@@ -10758,17 +10922,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("podTemplateFilePathHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1251 := z.EncBinary()
-				_ = yym1251
+				yym1271 := z.EncBinary()
+				_ = yym1271
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PodTemplateFilePathHostPath))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1253 := z.EncBinary()
-				_ = yym1253
+				yym1273 := z.EncBinary()
+				_ = yym1273
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutHostPath))
@@ -10777,17 +10941,17 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minimumTimeoutHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1254 := z.EncBinary()
-				_ = yym1254
+				yym1274 := z.EncBinary()
+				_ = yym1274
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinimumTimeoutHostPath))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1256 := z.EncBinary()
-				_ = yym1256
+				yym1276 := z.EncBinary()
+				_ = yym1276
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutHostPath))
@@ -10796,14 +10960,14 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecEncodeSelf(e *codec1978.Enc
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("incrementTimeoutHostPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1257 := z.EncBinary()
-				_ = yym1257
+				yym1277 := z.EncBinary()
+				_ = yym1277
 				if false {
 				} else {
 					r.EncodeInt(int64(x.IncrementTimeoutHostPath))
 				}
 			}
-			if yyr1236 || yy2arr1236 {
+			if yyr1256 || yy2arr1256 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10816,25 +10980,25 @@ func (x *PersistentVolumeRecyclerConfiguration) CodecDecodeSelf(d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1258 := z.DecBinary()
-	_ = yym1258
+	yym1278 := z.DecBinary()
+	_ = yym1278
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1259 := r.ContainerType()
-		if yyct1259 == codecSelferValueTypeMap1234 {
-			yyl1259 := r.ReadMapStart()
-			if yyl1259 == 0 {
+		yyct1279 := r.ContainerType()
+		if yyct1279 == codecSelferValueTypeMap1234 {
+			yyl1279 := r.ReadMapStart()
+			if yyl1279 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1259, d)
+				x.codecDecodeSelfFromMap(yyl1279, d)
 			}
-		} else if yyct1259 == codecSelferValueTypeArray1234 {
-			yyl1259 := r.ReadArrayStart()
-			if yyl1259 == 0 {
+		} else if yyct1279 == codecSelferValueTypeArray1234 {
+			yyl1279 := r.ReadArrayStart()
+			if yyl1279 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1259, d)
+				x.codecDecodeSelfFromArray(yyl1279, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10846,12 +11010,12 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1260Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1260Slc
-	var yyhl1260 bool = l >= 0
-	for yyj1260 := 0; ; yyj1260++ {
-		if yyhl1260 {
-			if yyj1260 >= l {
+	var yys1280Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1280Slc
+	var yyhl1280 bool = l >= 0
+	for yyj1280 := 0; ; yyj1280++ {
+		if yyhl1280 {
+			if yyj1280 >= l {
 				break
 			}
 		} else {
@@ -10860,10 +11024,10 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1260Slc = r.DecodeBytes(yys1260Slc, true, true)
-		yys1260 := string(yys1260Slc)
+		yys1280Slc = r.DecodeBytes(yys1280Slc, true, true)
+		yys1280 := string(yys1280Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1260 {
+		switch yys1280 {
 		case "maximumRetry":
 			if r.TryDecodeAsNil() {
 				x.MaximumRetry = 0
@@ -10907,9 +11071,9 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromMap(l int, d 
 				x.IncrementTimeoutHostPath = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1260)
-		} // end switch yys1260
-	} // end for yyj1260
+			z.DecStructFieldNotFound(-1, yys1280)
+		} // end switch yys1280
+	} // end for yyj1280
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10917,16 +11081,16 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1268 int
-	var yyb1268 bool
-	var yyhl1268 bool = l >= 0
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	var yyj1288 int
+	var yyb1288 bool
+	var yyhl1288 bool = l >= 0
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10936,13 +11100,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MaximumRetry = int32(r.DecodeInt(32))
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10952,13 +11116,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MinimumTimeoutNFS = int32(r.DecodeInt(32))
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10968,13 +11132,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.PodTemplateFilePathNFS = string(r.DecodeString())
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10984,13 +11148,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.IncrementTimeoutNFS = int32(r.DecodeInt(32))
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11000,13 +11164,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.PodTemplateFilePathHostPath = string(r.DecodeString())
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11016,13 +11180,13 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 	} else {
 		x.MinimumTimeoutHostPath = int32(r.DecodeInt(32))
 	}
-	yyj1268++
-	if yyhl1268 {
-		yyb1268 = yyj1268 > l
+	yyj1288++
+	if yyhl1288 {
+		yyb1288 = yyj1288 > l
 	} else {
-		yyb1268 = r.CheckBreak()
+		yyb1288 = r.CheckBreak()
 	}
-	if yyb1268 {
+	if yyb1288 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11033,17 +11197,17 @@ func (x *PersistentVolumeRecyclerConfiguration) codecDecodeSelfFromArray(l int, 
 		x.IncrementTimeoutHostPath = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj1268++
-		if yyhl1268 {
-			yyb1268 = yyj1268 > l
+		yyj1288++
+		if yyhl1288 {
+			yyb1288 = yyj1288 > l
 		} else {
-			yyb1268 = r.CheckBreak()
+			yyb1288 = r.CheckBreak()
 		}
-		if yyb1268 {
+		if yyb1288 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1268-1, "")
+		z.DecStructFieldNotFound(yyj1288-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11053,20 +11217,20 @@ func (x codecSelfer1234) encconfig_ConfigurationMap(v pkg2_config.ConfigurationM
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk1276, yyv1276 := range v {
+	for yyk1296, yyv1296 := range v {
 		z.EncSendContainerState(codecSelfer_containerMapKey1234)
-		yym1277 := z.EncBinary()
-		_ = yym1277
+		yym1297 := z.EncBinary()
+		_ = yym1297
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk1276))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk1296))
 		}
 		z.EncSendContainerState(codecSelfer_containerMapValue1234)
-		yym1278 := z.EncBinary()
-		_ = yym1278
+		yym1298 := z.EncBinary()
+		_ = yym1298
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyv1276))
+			r.EncodeString(codecSelferC_UTF81234, string(yyv1296))
 		}
 	}
 	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11077,63 +11241,63 @@ func (x codecSelfer1234) decconfig_ConfigurationMap(v *pkg2_config.Configuration
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1279 := *v
-	yyl1279 := r.ReadMapStart()
-	yybh1279 := z.DecBasicHandle()
-	if yyv1279 == nil {
-		yyrl1279, _ := z.DecInferLen(yyl1279, yybh1279.MaxInitLen, 32)
-		yyv1279 = make(map[string]string, yyrl1279)
-		*v = yyv1279
+	yyv1299 := *v
+	yyl1299 := r.ReadMapStart()
+	yybh1299 := z.DecBasicHandle()
+	if yyv1299 == nil {
+		yyrl1299, _ := z.DecInferLen(yyl1299, yybh1299.MaxInitLen, 32)
+		yyv1299 = make(map[string]string, yyrl1299)
+		*v = yyv1299
 	}
-	var yymk1279 string
-	var yymv1279 string
-	var yymg1279 bool
-	if yybh1279.MapValueReset {
+	var yymk1299 string
+	var yymv1299 string
+	var yymg1299 bool
+	if yybh1299.MapValueReset {
 	}
-	if yyl1279 > 0 {
-		for yyj1279 := 0; yyj1279 < yyl1279; yyj1279++ {
+	if yyl1299 > 0 {
+		for yyj1299 := 0; yyj1299 < yyl1299; yyj1299++ {
 			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
-				yymk1279 = ""
+				yymk1299 = ""
 			} else {
-				yymk1279 = string(r.DecodeString())
+				yymk1299 = string(r.DecodeString())
 			}
 
-			if yymg1279 {
-				yymv1279 = yyv1279[yymk1279]
+			if yymg1299 {
+				yymv1299 = yyv1299[yymk1299]
 			}
 			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
-				yymv1279 = ""
+				yymv1299 = ""
 			} else {
-				yymv1279 = string(r.DecodeString())
+				yymv1299 = string(r.DecodeString())
 			}
 
-			if yyv1279 != nil {
-				yyv1279[yymk1279] = yymv1279
+			if yyv1299 != nil {
+				yyv1299[yymk1299] = yymv1299
 			}
 		}
-	} else if yyl1279 < 0 {
-		for yyj1279 := 0; !r.CheckBreak(); yyj1279++ {
+	} else if yyl1299 < 0 {
+		for yyj1299 := 0; !r.CheckBreak(); yyj1299++ {
 			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
-				yymk1279 = ""
+				yymk1299 = ""
 			} else {
-				yymk1279 = string(r.DecodeString())
+				yymk1299 = string(r.DecodeString())
 			}
 
-			if yymg1279 {
-				yymv1279 = yyv1279[yymk1279]
+			if yymg1299 {
+				yymv1299 = yyv1299[yymk1299]
 			}
 			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
-				yymv1279 = ""
+				yymv1299 = ""
 			} else {
-				yymv1279 = string(r.DecodeString())
+				yymv1299 = string(r.DecodeString())
 			}
 
-			if yyv1279 != nil {
-				yyv1279[yymk1279] = yymv1279
+			if yyv1299 != nil {
+				yyv1299[yymk1299] = yymv1299
 			}
 		}
 	} // else len==0: TODO: Should we clear map entries?

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -205,6 +205,21 @@ type KubeletConfiguration struct {
 	MaxContainerCount int32 `json:"maxContainerCount"`
 	// cAdvisorPort is the port of the localhost cAdvisor endpoint
 	CAdvisorPort int32 `json:"cAdvisorPort"`
+	// customMetricsCollectorClientCertFile is the file containing a x509 Certificate (CA cert, if any,
+	// concatenated after server cert). This is used by the custom metrics collectors when accessing
+	// a custom metric endpoint which require certificate based authentication.
+	// If CustomMetricsCollectorClientCertFile and CustomMetricsCollectorClientPrivateKeyFile are not provided,
+	// the default HTTP.client will be used.
+	CustomMetricsCollectorClientCertFile string `json:"customMetricsCollectorClientCertFile"`
+	// customMetricsCollectorClientPrivateKeyFile is the file containing x509 private key matching
+	// customMetricsCollectorClientCertFile.
+	CustomMetricsCollectorClientPrivateKeyFile string `json:"customMetricsCollectorClientPrivateKeyFile"`
+	// customMetricsInsecureSkipVerify enable connecting to insecure tls metric endpoints
+	CustomMetricsInsecureSkipVerify bool `json:"customMetricsInsecureSkipVerify"`
+	// customMetricsRootCAFile enables specifying the root certificate authority will be used to verify
+	// custom metric endpoints. This must be a valid PEM-encoded CA bundle. If not set, the system's default root
+	// CA bundle is used instead.
+	CustomMetricsRootCAFile string `json:"customMetricsRootCAFile"`
 	// healthzPort is the port of the localhost healthz endpoint
 	HealthzPort int32 `json:"healthzPort"`
 	// healthzBindAddress is the IP address for the healthz server to serve

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -259,6 +259,21 @@ type KubeletConfiguration struct {
 	MaxContainerCount *int32 `json:"maxContainerCount"`
 	// cAdvisorPort is the port of the localhost cAdvisor endpoint
 	CAdvisorPort int32 `json:"cAdvisorPort"`
+	// customMetricsCollectorClientCertFile is the file containing a x509 Certificate (CA cert, if any,
+	// concatenated after server cert). This is used by the custom metrics collectors when accessing
+	// a custom metric endpoint which require certificate based authentication.
+	// If CustomMetricsCollectorClientCertFile and CustomMetricsCollectorPrivateKeyFile are not provided,
+	// the default HTTP.client will be used.
+	CustomMetricsCollectorClientCertFile string `json:"customMetricsCollectorClientCertFile"`
+	// customMetricsCollectorClientPrivateKeyFile is the file containing x509 private key matching
+	// customMetricsCollectorClientCertFile.
+	CustomMetricsCollectorClientPrivateKeyFile string `json:"customMetricsCollectorClientPrivateKeyFile"`
+	// customMetricsInsecureSkipVerify enable connecting to insecure tls metric endpoints
+	CustomMetricsInsecureSkipVerify bool `json:"customMetricsInsecureSkipVerify"`
+	// customMetricsRootCAFile enables specifying the root certificate authority will be used to verify
+	// custom metric endpoints. This must be a valid PEM-encoded CA bundle. If not set, the system's default root
+	// CA bundle is used instead.
+	CustomMetricsRootCAFile string `json:"customMetricsRootCAFile"`
 	// healthzPort is the port of the localhost healthz endpoint
 	HealthzPort int32 `json:"healthzPort"`
 	// healthzBindAddress is the IP address for the healthz server to serve

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -209,6 +209,10 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 		return err
 	}
 	out.CAdvisorPort = in.CAdvisorPort
+	out.CustomMetricsCollectorClientCertFile = in.CustomMetricsCollectorClientCertFile
+	out.CustomMetricsCollectorClientPrivateKeyFile = in.CustomMetricsCollectorClientPrivateKeyFile
+	out.CustomMetricsInsecureSkipVerify = in.CustomMetricsInsecureSkipVerify
+	out.CustomMetricsRootCAFile = in.CustomMetricsRootCAFile
 	out.HealthzPort = in.HealthzPort
 	out.HealthzBindAddress = in.HealthzBindAddress
 	if err := api.Convert_Pointer_int32_To_int32(&in.OOMScoreAdj, &out.OOMScoreAdj, s); err != nil {
@@ -390,6 +394,10 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 		return err
 	}
 	out.CAdvisorPort = in.CAdvisorPort
+	out.CustomMetricsCollectorClientCertFile = in.CustomMetricsCollectorClientCertFile
+	out.CustomMetricsCollectorClientPrivateKeyFile = in.CustomMetricsCollectorClientPrivateKeyFile
+	out.CustomMetricsInsecureSkipVerify = in.CustomMetricsInsecureSkipVerify
+	out.CustomMetricsRootCAFile = in.CustomMetricsRootCAFile
 	out.HealthzPort = in.HealthzPort
 	out.HealthzBindAddress = in.HealthzBindAddress
 	if err := api.Convert_int32_To_Pointer_int32(&in.OOMScoreAdj, &out.OOMScoreAdj, s); err != nil {

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -199,6 +199,10 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 			out.MaxContainerCount = nil
 		}
 		out.CAdvisorPort = in.CAdvisorPort
+		out.CustomMetricsCollectorClientCertFile = in.CustomMetricsCollectorClientCertFile
+		out.CustomMetricsCollectorClientPrivateKeyFile = in.CustomMetricsCollectorClientPrivateKeyFile
+		out.CustomMetricsInsecureSkipVerify = in.CustomMetricsInsecureSkipVerify
+		out.CustomMetricsRootCAFile = in.CustomMetricsRootCAFile
 		out.HealthzPort = in.HealthzPort
 		out.HealthzBindAddress = in.HealthzBindAddress
 		if in.OOMScoreAdj != nil {

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -243,6 +243,10 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		out.MaxPerPodContainerCount = in.MaxPerPodContainerCount
 		out.MaxContainerCount = in.MaxContainerCount
 		out.CAdvisorPort = in.CAdvisorPort
+		out.CustomMetricsCollectorClientCertFile = in.CustomMetricsCollectorClientCertFile
+		out.CustomMetricsCollectorClientPrivateKeyFile = in.CustomMetricsCollectorClientPrivateKeyFile
+		out.CustomMetricsInsecureSkipVerify = in.CustomMetricsInsecureSkipVerify
+		out.CustomMetricsRootCAFile = in.CustomMetricsRootCAFile
 		out.HealthzPort = in.HealthzPort
 		out.HealthzBindAddress = in.HealthzBindAddress
 		out.OOMScoreAdj = in.OOMScoreAdj

--- a/test/e2e_node/environment/conformance.go
+++ b/test/e2e_node/environment/conformance.go
@@ -99,7 +99,7 @@ func containerRuntime() error {
 	}
 
 	// Setup cadvisor to check the container environment
-	c, err := cadvisor.New(0 /*don't start the http server*/, "docker")
+	c, err := cadvisor.New(0 /*don't start the http server*/, "docker", cadvisor.CAdvisorCustomMetricsConfig{})
 	if err != nil {
 		return printError("Container Runtime Check: %s Could not start cadvisor %v", failed, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest version of cAdvisor used in Kubernetes has the option to supply an http.client object to be used by the cAdvisor custom metric collectors. This allows the collectors to be able to expose a client certificate that a custom metric endpoint can use to verify that it is indeed cAdvisor who is requesting access (certificate based authentication).

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
Add option to pass certificates to cAdvisor custom metric collectors to allow metric endpoints to use certificate based authentication.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32491)

<!-- Reviewable:end -->
