### PR TITLE
Revert "Enabled Rescheduler e2e for gke"

### DIFF
--- a/test/e2e/rescheduler.go
+++ b/test/e2e/rescheduler.go
@@ -35,7 +35,7 @@ var _ = framework.KubeDescribe("Rescheduler [Serial]", func() {
 	var totalMillicores int
 
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce")
 		ns = f.Namespace.Name
 		nodes := framework.GetReadySchedulableNodesOrDie(f.Client)
 		nodeCount := len(nodes.Items)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#32196

This broke gke-serial.

fix #31710

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32500)

<!-- Reviewable:end -->
