### PR TITLE
Revert "Remove long sleep in provisioning e2e tests."

### DIFF
--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -78,6 +78,22 @@ func testDynamicProvisioning(client *client.Client, claim *api.PersistentVolumeC
 	By("checking the created volume is readable and retains data")
 	runInPodWithVolume(client, claim.Namespace, claim.Name, "grep 'hello world' /mnt/test/data")
 
+	// Ugly hack: if we delete the AWS/GCE/OpenStack volume here, it will
+	// probably collide with destruction of the pods above - the pods
+	// still have the volume attached (kubelet is slow...) and deletion
+	// of attached volume is not allowed by AWS/GCE/OpenStack.
+	// Kubernetes *will* retry deletion several times in
+	// pvclaimbinder-sync-period.
+	// So, technically, this sleep is not needed. On the other hand,
+	// the sync perion is 10 minutes and we really don't want to wait
+	// 10 minutes here. There is no way how to see if kubelet is
+	// finished with cleaning volumes. A small sleep here actually
+	// speeds up the test!
+	// Three minutes should be enough to clean up the pods properly.
+	// We've seen GCE PD detach to take more than 1 minute.
+	By("Sleeping to let kubelet destroy all pods")
+	time.Sleep(3 * time.Minute)
+
 	By("deleting the claim")
 	framework.ExpectNoError(client.PersistentVolumeClaims(claim.Namespace).Delete(claim.Name))
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#32279 to unblock the submit queue.

`[k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Alpha should create and delete alpha persistent volumes [Slow]` began to fail consistently in the `kubernetes-e2e-gke-slow` test suite after kubernetes/kubernetes#32279 was merged. See issue https://github.com/kubernetes/kubernetes/issues/32492.

CC @jsafrane

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32507)

<!-- Reviewable:end -->
