### PR TITLE
federation e2e: Initialising cluster var before using it

### DIFF
--- a/test/e2e/federation-replicaset.go
+++ b/test/e2e/federation-replicaset.go
@@ -83,6 +83,7 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 			if federationName = os.Getenv("FEDERATION_NAME"); federationName == "" {
 				federationName = DefaultFederationName
 			}
+			clusters = map[string]*cluster{}
 			registerClusters(clusters, UserAgentName, federationName, f)
 		})
 


### PR DESCRIPTION
Fixing https://github.com/kubernetes/kubernetes/pull/31904#discussion_r78433657

cc @jianhuiz @kubernetes/sig-cluster-federation

Risk assessment:

This is a one-line change to e2e test code.  The test only exercises federated replicasets (i.e. it is completely disjoint from Kubernetes itself).  The worst case scenario is that the e2e test in question, which is currently failing, continues to fail.

Risk surface of accepting this cherrypick: none

How easy it is to revert if needed: can be trivially reverted. 

Why it is worth the risk, burden to cherrypick and verify the tests stay green, and noise it creates

It allows us to verify that e2e tests for federated replicasets pass in CI.  Without it, they fail.

How urgent is this?  important

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32515)

<!-- Reviewable:end -->
