### PR TITLE
Revert "e2e: only tear down existing cluster if it exists"

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -94,9 +94,7 @@ func main() {
 		}
 	}
 
-	// TODO: remove the IsUp() check after we stop testing 1.2 and earlier
-	// (or if we figure out a better way to handle TearDown failing on nonexisting clusters on old releases).
-	if *up && IsUp() {
+	if *up {
 		if err := TearDown(); err != nil {
 			log.Fatalf("error tearing down previous cluster: %v", err)
 		}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#32420

This broke more things. We're going to backport the `|| true` fix to 1.2 -- doing just enough maintenance on old branches to keep upgrades working with new infra changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32521)

<!-- Reviewable:end -->
