### PR TITLE
Use scale subresource

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -306,7 +306,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 			filename, oldName)
 	}
 
-	updater := kubectl.NewRollingUpdater(newRc.Namespace, coreClient, coreClient)
+	updater := kubectl.NewRollingUpdater(newRc.Namespace, coreClient, coreClient, clientset.Extensions())
 
 	// To successfully pull off a rolling update the new and old rc have to differ
 	// by at least one selector. Every new pod should have the selector and every

--- a/pkg/kubectl/scale.go
+++ b/pkg/kubectl/scale.go
@@ -53,15 +53,15 @@ type Scaler interface {
 func ScalerFor(kind schema.GroupKind, c internalclientset.Interface) (Scaler, error) {
 	switch kind {
 	case api.Kind("ReplicationController"):
-		return &ReplicationControllerScaler{c.Core()}, nil
+		return &ReplicationControllerScaler{c.Core(), c.Extensions()}, nil
 	case extensions.Kind("ReplicaSet"):
-		return &ReplicaSetScaler{c.Extensions()}, nil
+		return &ReplicaSetScaler{c.Extensions(), c.Extensions()}, nil
 	case extensions.Kind("Job"), batch.Kind("Job"):
 		return &JobScaler{c.Batch()}, nil // Either kind of job can be scaled with Batch interface.
 	case apps.Kind("StatefulSet"):
 		return &StatefulSetScaler{c.Apps()}, nil
 	case extensions.Kind("Deployment"):
-		return &DeploymentScaler{c.Extensions()}, nil
+		return &DeploymentScaler{c.Extensions(), c.Extensions()}, nil
 	}
 	return nil, fmt.Errorf("no scaler has been implemented for %q", kind)
 }
@@ -149,42 +149,44 @@ func (precondition *ScalePrecondition) ValidateStatefulSet(ps *apps.StatefulSet)
 	return nil
 }
 
-// ValidateReplicationController ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
-func (precondition *ScalePrecondition) ValidateReplicationController(controller *api.ReplicationController) error {
-	if precondition.Size != -1 && int(controller.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(controller.Spec.Replicas))}
+// ValidateScale ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
+func (precondition *ScalePrecondition) ValidateScale(scale *extensions.Scale) error {
+	if precondition.Size != -1 && int(scale.Spec.Replicas) != precondition.Size {
+		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(scale.Spec.Replicas))}
 	}
-	if len(precondition.ResourceVersion) != 0 && controller.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, controller.ResourceVersion}
+	if len(precondition.ResourceVersion) != 0 && scale.ResourceVersion != precondition.ResourceVersion {
+		return PreconditionError{"resource version", precondition.ResourceVersion, scale.ResourceVersion}
 	}
 	return nil
 }
 
 type ReplicationControllerScaler struct {
 	c coreclient.ReplicationControllersGetter
+	s extensionsclient.ScalesGetter
 }
 
 // ScaleSimple does a simple one-shot attempt at scaling. It returns the
 // resourceVersion of the replication controller if the update is successful.
 func (scaler *ReplicationControllerScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	controller, err := scaler.c.ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
+	sc := scaler.s.Scales(namespace)
+	scale, err := sc.Get("ReplicationController", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateReplicationController(controller); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
-	controller.Spec.Replicas = int32(newSize)
-	updatedRC, err := scaler.c.ReplicationControllers(namespace).Update(controller)
+	scale.Spec.Replicas = int32(newSize)
+	updatedScale, err := sc.Update("ReplicationController", scale)
 	if err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, controller.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, controller.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedRC.ObjectMeta.ResourceVersion, nil
+	return updatedScale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a ReplicationController to a new size, with optional precondition check (if preconditions is not nil),
@@ -247,42 +249,33 @@ func (scaler *ReplicationControllerScaler) Scale(namespace, name string, newSize
 	return nil
 }
 
-// ValidateReplicaSet ensures that the preconditions match.  Returns nil if they are valid, an error otherwise
-func (precondition *ScalePrecondition) ValidateReplicaSet(replicaSet *extensions.ReplicaSet) error {
-	if precondition.Size != -1 && int(replicaSet.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(replicaSet.Spec.Replicas))}
-	}
-	if len(precondition.ResourceVersion) != 0 && replicaSet.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, replicaSet.ResourceVersion}
-	}
-	return nil
-}
-
 type ReplicaSetScaler struct {
 	c extensionsclient.ReplicaSetsGetter
+	s extensionsclient.ScalesGetter
 }
 
 // ScaleSimple does a simple one-shot attempt at scaling. It returns the
 // resourceVersion of the replicaset if the update is successful.
 func (scaler *ReplicaSetScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	rs, err := scaler.c.ReplicaSets(namespace).Get(name, metav1.GetOptions{})
+	sc := scaler.s.Scales(namespace)
+	scale, err := sc.Get("ReplicaSet", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateReplicaSet(rs); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
-	rs.Spec.Replicas = int32(newSize)
-	updatedRS, err := scaler.c.ReplicaSets(namespace).Update(rs)
+	scale.Spec.Replicas = int32(newSize)
+	updatedScale, err := sc.Update("ReplicaSet", scale)
 	if err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, rs.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, rs.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedRS.ObjectMeta.ResourceVersion, nil
+	return updatedScale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a ReplicaSet to a new size, with optional precondition check (if preconditions is
@@ -439,46 +432,35 @@ func (scaler *JobScaler) Scale(namespace, name string, newSize uint, preconditio
 	return nil
 }
 
-// ValidateDeployment ensures that the preconditions match.  Returns nil if they are valid, an error otherwise.
-func (precondition *ScalePrecondition) ValidateDeployment(deployment *extensions.Deployment) error {
-	if precondition.Size != -1 && int(deployment.Spec.Replicas) != precondition.Size {
-		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(deployment.Spec.Replicas))}
-	}
-	if len(precondition.ResourceVersion) != 0 && deployment.ResourceVersion != precondition.ResourceVersion {
-		return PreconditionError{"resource version", precondition.ResourceVersion, deployment.ResourceVersion}
-	}
-	return nil
-}
-
 type DeploymentScaler struct {
 	c extensionsclient.DeploymentsGetter
+	s extensionsclient.ScalesGetter
 }
 
 // ScaleSimple is responsible for updating a deployment's desired replicas
 // count. It returns the resourceVersion of the deployment if the update is
 // successful.
 func (scaler *DeploymentScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
-	deployment, err := scaler.c.Deployments(namespace).Get(name, metav1.GetOptions{})
+	sc := scaler.s.Scales(namespace)
+	scale, err := sc.Get("Deployment", name)
 	if err != nil {
 		return "", ScaleError{ScaleGetFailure, "Unknown", err}
 	}
 	if preconditions != nil {
-		if err := preconditions.ValidateDeployment(deployment); err != nil {
+		if err := preconditions.ValidateScale(scale); err != nil {
 			return "", err
 		}
 	}
 
-	// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-	// For now I'm falling back to regular Deployment update operation.
-	deployment.Spec.Replicas = int32(newSize)
-	updatedDeployment, err := scaler.c.Deployments(namespace).Update(deployment)
+	scale.Spec.Replicas = int32(newSize)
+	updatedScale, err := sc.Update("Deployment", scale)
 	if err != nil {
 		if errors.IsConflict(err) {
-			return "", ScaleError{ScaleUpdateConflictFailure, deployment.ResourceVersion, err}
+			return "", ScaleError{ScaleUpdateConflictFailure, scale.ResourceVersion, err}
 		}
-		return "", ScaleError{ScaleUpdateFailure, deployment.ResourceVersion, err}
+		return "", ScaleError{ScaleUpdateFailure, scale.ResourceVersion, err}
 	}
-	return updatedDeployment.ObjectMeta.ResourceVersion, nil
+	return updatedScale.ObjectMeta.ResourceVersion, nil
 }
 
 // Scale updates a deployment to a new size, with optional precondition check (if preconditions is not nil),

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -27,44 +27,63 @@ import (
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	batchclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion"
-	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	extensionsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion"
 	testcore "k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/runtime"
 )
 
-type ErrorReplicationControllers struct {
-	coreclient.ReplicationControllerInterface
+type ErrorScales struct {
+	extensionsclient.ScaleInterface
 	conflict bool
 	invalid  bool
 }
 
-func (c *ErrorReplicationControllers) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
+func (c *ErrorScales) Update(kind string, scale *extensions.Scale) (*extensions.Scale, error) {
 	switch {
 	case c.invalid:
-		return nil, kerrors.NewInvalid(api.Kind(controller.Kind), controller.Name, nil)
+		return nil, kerrors.NewInvalid(api.Kind(kind), scale.Name, nil)
 	case c.conflict:
-		return nil, kerrors.NewConflict(api.Resource(controller.Kind), controller.Name, nil)
+		return nil, kerrors.NewConflict(api.Resource(kind), scale.Name, nil)
 	}
-	return nil, errors.New("Replication controller update failure")
+	return nil, errors.New("Scale update failure")
 }
 
-type ErrorReplicationControllerClient struct {
+type ErrorExtensions struct {
 	*fake.Clientset
 	conflict bool
 	invalid  bool
 }
 
-func (c *ErrorReplicationControllerClient) ReplicationControllers(namespace string) coreclient.ReplicationControllerInterface {
-	return &ErrorReplicationControllers{
-		ReplicationControllerInterface: c.Clientset.Core().ReplicationControllers(namespace),
-		conflict:                       c.conflict,
-		invalid:                        c.invalid,
+func (c *ErrorExtensions) Scales(namespace string) extensionsclient.ScaleInterface {
+	return &ErrorScales{
+		ScaleInterface: c.Clientset.Extensions().Scales(namespace),
+		conflict:       c.conflict,
+		invalid:        c.invalid,
+	}
+}
+
+func scale() *extensions.Scale {
+	return &extensions.Scale{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: api.NamespaceDefault,
+			Name:      "foo-v1",
+		},
+		Spec: extensions.ScaleSpec{
+			Replicas: 0,
+		},
 	}
 }
 
 func TestReplicationControllerScaleRetry(t *testing.T) {
-	fake := &ErrorReplicationControllerClient{Clientset: fake.NewSimpleClientset(oldRc(0, 0)), conflict: true}
-	scaler := ReplicationControllerScaler{fake}
+	clientset := fake.NewSimpleClientset(oldRc(0, 0), scale())
+	clientset.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := ReplicationControllerScaler{clientset.Core(), &ErrorExtensions{Clientset: clientset, conflict: true}}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo-v1"
@@ -87,8 +106,15 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 }
 
 func TestReplicationControllerScaleInvalid(t *testing.T) {
-	fake := &ErrorReplicationControllerClient{Clientset: fake.NewSimpleClientset(oldRc(0, 0)), invalid: true}
-	scaler := ReplicationControllerScaler{fake}
+	clientset := fake.NewSimpleClientset(oldRc(0, 0), scale())
+	clientset.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := ReplicationControllerScaler{clientset.Core(), &ErrorExtensions{Clientset: clientset, invalid: true}}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo-v1"
@@ -106,8 +132,15 @@ func TestReplicationControllerScaleInvalid(t *testing.T) {
 }
 
 func TestReplicationControllerScale(t *testing.T) {
-	fake := fake.NewSimpleClientset(oldRc(0, 0))
-	scaler := ReplicationControllerScaler{fake.Core()}
+	fake := fake.NewSimpleClientset(oldRc(0, 0), scale())
+	fake.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := ReplicationControllerScaler{fake.Core(), fake.Extensions()}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo-v1"
@@ -117,22 +150,37 @@ func TestReplicationControllerScale(t *testing.T) {
 	if len(actions) != 2 {
 		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
-	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("replicationcontrollers") || action.GetName() != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
+	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("ReplicationController") || action.GetName() != name || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action: %v, expected get-ReplicationController %s", actions[0], name)
 	}
-	if action, ok := actions[1].(testcore.UpdateAction); !ok || action.GetResource().GroupResource() != api.Resource("replicationcontrollers") || action.GetObject().(*api.ReplicationController).Spec.Replicas != int32(count) {
-		t.Errorf("unexpected action %v, expected update-replicationController with replicas = %d", actions[1], count)
+	if action, ok := actions[1].(testcore.UpdateAction); !ok || action.GetResource().GroupResource() != api.Resource("ReplicationController") || action.GetObject().(*extensions.Scale).Spec.Replicas != int32(count) || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action %v, expected update-ReplicationController with replicas = %d", actions[1], count)
 	}
 }
 
 func TestReplicationControllerScaleFailsPreconditions(t *testing.T) {
-	fake := fake.NewSimpleClientset(&api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceDefault, Name: "foo"},
-		Spec: api.ReplicationControllerSpec{
-			Replicas: 10,
+	fake := fake.NewSimpleClientset(
+		&api.ReplicationController{
+			ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceDefault, Name: "foo"},
+			Spec: api.ReplicationControllerSpec{
+				Replicas: 10,
+			},
 		},
-	})
-	scaler := ReplicationControllerScaler{fake.Core()}
+		&extensions.Scale{
+			ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceDefault, Name: "foo"},
+			Spec: extensions.ScaleSpec{
+				Replicas: 10,
+			},
+		},
+	)
+	fake.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := ReplicationControllerScaler{fake.Core(), fake.Extensions()}
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"
@@ -142,15 +190,15 @@ func TestReplicationControllerScaleFailsPreconditions(t *testing.T) {
 	if len(actions) != 1 {
 		t.Errorf("unexpected actions: %v, expected 1 action (get)", actions)
 	}
-	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("replicationcontrollers") || action.GetName() != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
+	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("ReplicationController") || action.GetName() != name || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action: %v, expected get-ReplicationController %s", actions[0], name)
 	}
 }
 
-func TestValidateReplicationController(t *testing.T) {
+func TestValidateScale(t *testing.T) {
 	tests := []struct {
 		preconditions ScalePrecondition
-		controller    api.ReplicationController
+		scale         extensions.Scale
 		expectError   bool
 		test          string
 	}{
@@ -161,11 +209,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{-1, ""},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "foo",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 10,
 				},
 			},
@@ -174,11 +222,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{0, ""},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "foo",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 0,
 				},
 			},
@@ -187,11 +235,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{-1, "foo"},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "foo",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 10,
 				},
 			},
@@ -200,11 +248,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{10, "foo"},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "foo",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 10,
 				},
 			},
@@ -213,11 +261,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{10, "foo"},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "foo",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 20,
 				},
 			},
@@ -226,11 +274,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{10, "foo"},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "bar",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 10,
 				},
 			},
@@ -239,11 +287,11 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 		{
 			preconditions: ScalePrecondition{10, "foo"},
-			controller: api.ReplicationController{
+			scale: extensions.Scale{
 				ObjectMeta: api.ObjectMeta{
 					ResourceVersion: "bar",
 				},
-				Spec: api.ReplicationControllerSpec{
+				Spec: extensions.ScaleSpec{
 					Replicas: 20,
 				},
 			},
@@ -252,7 +300,7 @@ func TestValidateReplicationController(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := test.preconditions.ValidateReplicationController(&test.controller)
+		err := test.preconditions.ValidateScale(&test.scale)
 		if err != nil && !test.expectError {
 			t.Errorf("unexpected error: %v (%s)", err, test.test)
 		}
@@ -347,7 +395,7 @@ func TestJobScale(t *testing.T) {
 		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
 	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != batch.Resource("jobs") || action.GetName() != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
+		t.Errorf("unexpected action: %v, expected get-job %s", actions[0], name)
 	}
 	if action, ok := actions[1].(testcore.UpdateAction); !ok || action.GetResource().GroupResource() != batch.Resource("jobs") || *action.GetObject().(*batch.Job).Spec.Parallelism != int32(count) {
 		t.Errorf("unexpected action %v, expected update-job with parallelism = %d", actions[1], count)
@@ -525,50 +573,29 @@ func TestValidateJob(t *testing.T) {
 	}
 }
 
-type ErrorDeployments struct {
-	extensionsclient.DeploymentInterface
-	conflict bool
-	invalid  bool
-}
-
-func (c *ErrorDeployments) Update(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	switch {
-	case c.invalid:
-		return nil, kerrors.NewInvalid(api.Kind(deployment.Kind), deployment.Name, nil)
-	case c.conflict:
-		return nil, kerrors.NewConflict(api.Resource(deployment.Kind), deployment.Name, nil)
-	}
-	return nil, errors.New("deployment update failure")
-}
-
-func (c *ErrorDeployments) Get(name string, options metav1.GetOptions) (*extensions.Deployment, error) {
+func deployment() *extensions.Deployment {
 	return &extensions.Deployment{
-		Spec: extensions.DeploymentSpec{
-			Replicas: 0,
+		ObjectMeta: api.ObjectMeta{
+			Namespace: api.NamespaceDefault,
+			Name:      "foo-v1",
 		},
-	}, nil
-}
-
-type ErrorDeploymentClient struct {
-	extensionsclient.DeploymentsGetter
-	conflict bool
-	invalid  bool
-}
-
-func (c *ErrorDeploymentClient) Deployments(namespace string) extensionsclient.DeploymentInterface {
-	return &ErrorDeployments{
-		DeploymentInterface: c.DeploymentsGetter.Deployments(namespace),
-		invalid:             c.invalid,
-		conflict:            c.conflict,
 	}
 }
 
 func TestDeploymentScaleRetry(t *testing.T) {
-	fake := &ErrorDeploymentClient{DeploymentsGetter: fake.NewSimpleClientset().Extensions(), conflict: true}
-	scaler := &DeploymentScaler{fake}
+	clientset := fake.NewSimpleClientset(deployment(), scale())
+	clientset.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	fake := &ErrorExtensions{Clientset: clientset, conflict: true}
+	scaler := &DeploymentScaler{clientset.Extensions(), fake}
 	preconditions := &ScalePrecondition{-1, ""}
 	count := uint(3)
-	name := "foo"
+	name := "foo-v1"
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count, nil)
@@ -587,41 +614,47 @@ func TestDeploymentScaleRetry(t *testing.T) {
 	}
 }
 
-func deployment() *extensions.Deployment {
-	return &extensions.Deployment{
-		ObjectMeta: api.ObjectMeta{
-			Namespace: api.NamespaceDefault,
-			Name:      "foo",
-		},
-	}
-}
-
 func TestDeploymentScale(t *testing.T) {
-	fake := fake.NewSimpleClientset(deployment())
-	scaler := DeploymentScaler{fake.Extensions()}
+	fake := fake.NewSimpleClientset(deployment(), scale())
+	fake.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := DeploymentScaler{fake.Extensions(), fake.Extensions()}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
-	name := "foo"
+	name := "foo-v1"
 	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
 	actions := fake.Actions()
 	if len(actions) != 2 {
 		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
-	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != extensions.Resource("deployments") || action.GetName() != name {
-		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
+	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("Deployment") || action.GetName() != name || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action: %v, expected get-Deployment %s", actions[0], name)
 	}
-	if action, ok := actions[1].(testcore.UpdateAction); !ok || action.GetResource().GroupResource() != extensions.Resource("deployments") || action.GetObject().(*extensions.Deployment).Spec.Replicas != int32(count) {
-		t.Errorf("unexpected action %v, expected update-deployment with replicas = %d", actions[1], count)
+	if action, ok := actions[1].(testcore.UpdateAction); !ok || action.GetResource().GroupResource() != api.Resource("Deployment") || action.GetObject().(*extensions.Scale).Spec.Replicas != int32(count) || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action %v, expected update-Deployment with replicas = %d", actions[1], count)
 	}
 }
 
 func TestDeploymentScaleInvalid(t *testing.T) {
-	fake := &ErrorDeploymentClient{DeploymentsGetter: fake.NewSimpleClientset().Extensions(), invalid: true}
-	scaler := DeploymentScaler{fake}
+	clientset := fake.NewSimpleClientset(deployment(), scale())
+	clientset.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	fake := &ErrorExtensions{Clientset: clientset, invalid: true}
+	scaler := DeploymentScaler{clientset.Extensions(), fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
-	name := "foo"
+	name := "foo-v1"
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count, nil)
@@ -637,151 +670,29 @@ func TestDeploymentScaleInvalid(t *testing.T) {
 
 func TestDeploymentScaleFailsPreconditions(t *testing.T) {
 	fake := fake.NewSimpleClientset(&extensions.Deployment{
-		ObjectMeta: api.ObjectMeta{
-			Namespace: api.NamespaceDefault,
-			Name:      "foo",
-		},
+		ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceDefault, Name: "foo-v1"},
 		Spec: extensions.DeploymentSpec{
 			Replicas: 10,
 		},
-	})
-	scaler := DeploymentScaler{fake.Extensions()}
+	}, scale())
+	fake.PrependReactor("*", "*",
+		func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() == "scale" {
+				return true, &extensions.Scale{}, nil
+			}
+			return false, nil, nil
+		})
+	scaler := DeploymentScaler{fake.Extensions(), fake.Extensions()}
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
-	name := "foo"
+	name := "foo-v1"
 	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
 	actions := fake.Actions()
 	if len(actions) != 1 {
 		t.Errorf("unexpected actions: %v, expected 1 actions (get)", actions)
 	}
-	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != extensions.Resource("deployments") || action.GetName() != name {
-		t.Errorf("unexpected action: %v, expected get-deployment %s", actions[0], name)
-	}
-}
-
-func TestValidateDeployment(t *testing.T) {
-	zero, ten, twenty := int32(0), int32(10), int32(20)
-	tests := []struct {
-		preconditions ScalePrecondition
-		deployment    extensions.Deployment
-		expectError   bool
-		test          string
-	}{
-		{
-			preconditions: ScalePrecondition{-1, ""},
-			expectError:   false,
-			test:          "defaults",
-		},
-		{
-			preconditions: ScalePrecondition{-1, ""},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: ten,
-				},
-			},
-			expectError: false,
-			test:        "defaults 2",
-		},
-		{
-			preconditions: ScalePrecondition{0, ""},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: zero,
-				},
-			},
-			expectError: false,
-			test:        "size matches",
-		},
-		{
-			preconditions: ScalePrecondition{-1, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: ten,
-				},
-			},
-			expectError: false,
-			test:        "resource version matches",
-		},
-		{
-			preconditions: ScalePrecondition{10, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: ten,
-				},
-			},
-			expectError: false,
-			test:        "both match",
-		},
-		{
-			preconditions: ScalePrecondition{10, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: twenty,
-				},
-			},
-			expectError: true,
-			test:        "size different",
-		},
-		{
-			preconditions: ScalePrecondition{10, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "foo",
-				},
-			},
-			expectError: true,
-			test:        "no replicas",
-		},
-		{
-			preconditions: ScalePrecondition{10, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "bar",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: ten,
-				},
-			},
-			expectError: true,
-			test:        "version different",
-		},
-		{
-			preconditions: ScalePrecondition{10, "foo"},
-			deployment: extensions.Deployment{
-				ObjectMeta: api.ObjectMeta{
-					ResourceVersion: "bar",
-				},
-				Spec: extensions.DeploymentSpec{
-					Replicas: twenty,
-				},
-			},
-			expectError: true,
-			test:        "both different",
-		},
-	}
-	for _, test := range tests {
-		err := test.preconditions.ValidateDeployment(&test.deployment)
-		if err != nil && !test.expectError {
-			t.Errorf("unexpected error: %v (%s)", err, test.test)
-		}
-		if err == nil && test.expectError {
-			t.Errorf("unexpected non-error: %v (%s)", err, test.test)
-		}
+	if action, ok := actions[0].(testcore.GetAction); !ok || action.GetResource().GroupResource() != api.Resource("Deployment") || action.GetName() != name || action.GetSubresource() != "scale" {
+		t.Errorf("unexpected action: %v, expected get-Deployment %s", actions[0], name)
 	}
 }

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -71,10 +71,10 @@ func IsNoSuchReaperError(err error) bool {
 func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, error) {
 	switch kind {
 	case api.Kind("ReplicationController"):
-		return &ReplicationControllerReaper{c.Core(), Interval, Timeout}, nil
+		return &ReplicationControllerReaper{c.Core(), c.Extensions(), Interval, Timeout}, nil
 
 	case extensions.Kind("ReplicaSet"):
-		return &ReplicaSetReaper{c.Extensions(), Interval, Timeout}, nil
+		return &ReplicaSetReaper{c.Extensions(), c.Extensions(), Interval, Timeout}, nil
 
 	case extensions.Kind("DaemonSet"):
 		return &DaemonSetReaper{c.Extensions(), Interval, Timeout}, nil
@@ -92,22 +92,24 @@ func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, er
 		return &StatefulSetReaper{c.Apps(), c.Core(), Interval, Timeout}, nil
 
 	case extensions.Kind("Deployment"):
-		return &DeploymentReaper{c.Extensions(), c.Extensions(), Interval, Timeout}, nil
+		return &DeploymentReaper{c.Extensions(), c.Extensions(), c.Extensions(), Interval, Timeout}, nil
 
 	}
 	return nil, &NoSuchReaperError{kind}
 }
 
-func ReaperForReplicationController(rcClient coreclient.ReplicationControllersGetter, timeout time.Duration) (Reaper, error) {
-	return &ReplicationControllerReaper{rcClient, Interval, timeout}, nil
+func ReaperForReplicationController(rcClient coreclient.ReplicationControllersGetter, scaleClient extensionsclient.ScalesGetter, timeout time.Duration) (Reaper, error) {
+	return &ReplicationControllerReaper{rcClient, scaleClient, Interval, timeout}, nil
 }
 
 type ReplicationControllerReaper struct {
 	client                coreclient.ReplicationControllersGetter
+	scaleClient           extensionsclient.ScalesGetter
 	pollInterval, timeout time.Duration
 }
 type ReplicaSetReaper struct {
 	client                extensionsclient.ReplicaSetsGetter
+	scaleClient           extensionsclient.ScalesGetter
 	pollInterval, timeout time.Duration
 }
 type DaemonSetReaper struct {
@@ -122,6 +124,7 @@ type JobReaper struct {
 type DeploymentReaper struct {
 	dClient               extensionsclient.DeploymentsGetter
 	rsClient              extensionsclient.ReplicaSetsGetter
+	scaleClient           extensionsclient.ScalesGetter
 	pollInterval, timeout time.Duration
 }
 type PodReaper struct {
@@ -160,7 +163,7 @@ func getOverlappingControllers(rcClient coreclient.ReplicationControllerInterfac
 
 func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *api.DeleteOptions) error {
 	rc := reaper.client.ReplicationControllers(namespace)
-	scaler := &ReplicationControllerScaler{reaper.client}
+	scaler := &ReplicationControllerScaler{reaper.client, reaper.scaleClient}
 	ctrl, err := rc.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -229,7 +232,7 @@ func getOverlappingReplicaSets(c extensionsclient.ReplicaSetInterface, rs *exten
 
 func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *api.DeleteOptions) error {
 	rsc := reaper.client.ReplicaSets(namespace)
-	scaler := &ReplicaSetScaler{reaper.client}
+	scaler := &ReplicaSetScaler{reaper.client, reaper.scaleClient}
 	rs, err := rsc.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -416,7 +419,7 @@ func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gra
 func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *api.DeleteOptions) error {
 	deployments := reaper.dClient.Deployments(namespace)
 	replicaSets := reaper.rsClient.ReplicaSets(namespace)
-	rsReaper := &ReplicaSetReaper{reaper.rsClient, reaper.pollInterval, reaper.timeout}
+	rsReaper := &ReplicaSetReaper{reaper.rsClient, reaper.scaleClient, reaper.pollInterval, reaper.timeout}
 
 	deployment, err := reaper.updateDeploymentWithRetries(namespace, name, func(d *extensions.Deployment) {
 		// set deployment's history and scale to 0


### PR DESCRIPTION
fixes #29698

This has one additional fix from the previous change which is to return the new version after the scale.
Since I cannot see the actual error from the failure it is hard to say what went wrong.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32523)

<!-- Reviewable:end -->
