### PR TITLE
[POC][WIP] Add remote archive volume type

### DIFF
--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1363,6 +1363,10 @@
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
       "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
+     "remoteTar": {
+      "$ref": "v1.RemoteTarVolumeSource",
+      "description": "RemoteTar represents a remote tar archive."
+     },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
       "description": "GitRepo represents a git repository at a particular revision."
@@ -1509,6 +1513,24 @@
      "readOnly": {
       "type": "boolean",
       "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+     }
+    }
+   },
+   "v1.RemoteTarVolumeSource": {
+    "id": "v1.RemoteTarVolumeSource",
+    "description": "Represents a volume that is populated with the contents of a remote tar.",
+    "required": [
+     "source",
+     "directory"
+    ],
+    "properties": {
+     "source": {
+      "type": "string",
+      "description": "Remote Tar URL"
+     },
+     "directory": {
+      "type": "string",
+      "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the remote tar content."
      }
     }
    },

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -7972,6 +7972,10 @@
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
       "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
+     "remoteTar": {
+      "$ref": "v1.RemoteTarVolumeSource",
+      "description": "RemoteTar represents a remote tar archive."
+     },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
       "description": "GitRepo represents a git repository at a particular revision."
@@ -8118,6 +8122,24 @@
      "readOnly": {
       "type": "boolean",
       "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+     }
+    }
+   },
+   "v1.RemoteTarVolumeSource": {
+    "id": "v1.RemoteTarVolumeSource",
+    "description": "Represents a volume that is populated with the contents of a remote tar.",
+    "required": [
+     "source",
+     "directory"
+    ],
+    "properties": {
+     "source": {
+      "type": "string",
+      "description": "Remote Tar URL"
+     },
+     "directory": {
+      "type": "string",
+      "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the remote tar content."
      }
     }
    },

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -17957,6 +17957,10 @@
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
       "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
      },
+     "remoteTar": {
+      "$ref": "v1.RemoteTarVolumeSource",
+      "description": "RemoteTar represents a remote tar archive."
+     },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
       "description": "GitRepo represents a git repository at a particular revision."
@@ -18038,6 +18042,24 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"
+     }
+    }
+   },
+   "v1.RemoteTarVolumeSource": {
+    "id": "v1.RemoteTarVolumeSource",
+    "description": "Represents a volume that is populated with the contents of a remote tar.",
+    "required": [
+     "source",
+     "directory"
+    ],
+    "properties": {
+     "source": {
+      "type": "string",
+      "description": "Remote Tar URL"
+     },
+     "directory": {
+      "type": "string",
+      "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the remote tar content."
      }
     }
    },

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -199,6 +199,8 @@ type VolumeSource struct {
 	// AWSElasticBlockStore represents an AWS EBS disk that is attached to a
 	// kubelet's host machine and then exposed to the pod.
 	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty"`
+	// RemoteTar represents a remote tar archive.
+	RemoteTar *RemoteTarVolumeSource `json:"remoteTar,omitempty"`
 	// GitRepo represents a git repository at a particular revision.
 	GitRepo *GitRepoVolumeSource `json:"gitRepo,omitempty"`
 	// Secret represents a secret that should populate this volume.
@@ -587,6 +589,20 @@ type AWSElasticBlockStoreVolumeSource struct {
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	ReadOnly bool `json:"readOnly,omitempty"`
+}
+
+// Represents a volume that is populated with the contents of a git repository.
+// Git repo volumes do not support ownership management.
+// Git repo volumes support SELinux relabeling.
+type RemoteTarVolumeSource struct {
+	// Remote tar URL
+	Source string `json:"source"`
+	// Decompression target
+	// Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+	// git repository.  Otherwise, if specified, the volume will contain the git repository in
+	// the subdirectory with the given name.
+	Directory string `json:"directory"`
+	// TODO: Consider credentials here.
 }
 
 // Represents a volume that is populated with the contents of a git repository.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -517,6 +517,14 @@ func validateVolumeSource(source *api.VolumeSource, fldPath *field.Path) field.E
 			allErrs = append(allErrs, validateHostPathVolumeSource(source.HostPath, fldPath.Child("hostPath"))...)
 		}
 	}
+	if source.RemoteTar != nil {
+		if numVolumes > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("remoteTar"), "may not specify more than 1 volume type"))
+		} else {
+			numVolumes++
+			allErrs = append(allErrs, validateRemoteTarVolumeSource(source.RemoteTar, fldPath.Child("remoteTar"))...)
+		}
+	}
 	if source.GitRepo != nil {
 		if numVolumes > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("gitRepo"), "may not specify more than 1 volume type"))
@@ -682,6 +690,17 @@ func validateHostPathVolumeSource(hostPath *api.HostPathVolumeSource, fldPath *f
 	if len(hostPath.Path) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("path"), ""))
 	}
+	return allErrs
+}
+
+func validateRemoteTarVolumeSource(remoteTar *api.RemoteTarVolumeSource, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(remoteTar.Source) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("source"), ""))
+	}
+
+	pathErrs := validateLocalDescendingPath(remoteTar.Directory, fldPath.Child("directory"))
+	allErrs = append(allErrs, pathErrs...)
 	return allErrs
 }
 

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -711,6 +711,7 @@ var (
 	EmptyDir              FSType = "emptyDir"
 	GCEPersistentDisk     FSType = "gcePersistentDisk"
 	AWSElasticBlockStore  FSType = "awsElasticBlockStore"
+	RemoteTar             FSType = "remoteTar"
 	GitRepo               FSType = "gitRepo"
 	Secret                FSType = "secret"
 	NFS                   FSType = "nfs"

--- a/pkg/security/podsecuritypolicy/util/util.go
+++ b/pkg/security/podsecuritypolicy/util/util.go
@@ -46,6 +46,7 @@ func GetAllFSTypesAsSet() sets.String {
 		string(extensions.EmptyDir),
 		string(extensions.GCEPersistentDisk),
 		string(extensions.AWSElasticBlockStore),
+		string(extensions.RemoteTar),
 		string(extensions.GitRepo),
 		string(extensions.Secret),
 		string(extensions.NFS),
@@ -75,6 +76,8 @@ func GetVolumeFSType(v api.Volume) (extensions.FSType, error) {
 		return extensions.GCEPersistentDisk, nil
 	case v.AWSElasticBlockStore != nil:
 		return extensions.AWSElasticBlockStore, nil
+	case v.RemoteTar != nil:
+		return extensions.RemoteTar, nil
 	case v.GitRepo != nil:
 		return extensions.GitRepo, nil
 	case v.Secret != nil:

--- a/pkg/volume/remote_tar/doc.go
+++ b/pkg/volume/remote_tar/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package remote_tar contains the internal representation of tar volumes.
+package remote_tar // import "k8s.io/kubernetes/pkg/volume/remote_tar"

--- a/pkg/volume/remote_tar/remote_tar.go
+++ b/pkg/volume/remote_tar/remote_tar.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote_tar
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/exec"
+	utilstrings "k8s.io/kubernetes/pkg/util/strings"
+	"k8s.io/kubernetes/pkg/volume"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+// This is the primary entrypoint for volume plugins.
+func ProbeVolumePlugins() []volume.VolumePlugin {
+	return []volume.VolumePlugin{&remoteTarPlugin{nil}}
+}
+
+type remoteTarPlugin struct {
+	host volume.VolumeHost
+}
+
+var _ volume.VolumePlugin = &remoteTarPlugin{}
+
+func wrappedVolumeSpec() volume.Spec {
+	return volume.Spec{
+		Volume: &api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},
+	}
+}
+
+const (
+	remoteTarPluginName = "kubernetes.io/remote-tar"
+)
+
+func (plugin *remoteTarPlugin) Init(host volume.VolumeHost) error {
+	plugin.host = host
+	return nil
+}
+
+func (plugin *remoteTarPlugin) GetPluginName() string {
+	return remoteTarPluginName
+}
+
+func (plugin *remoteTarPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
+	volumeSource, _ := getVolumeSource(spec)
+	if volumeSource == nil {
+		return "", fmt.Errorf("Spec does not reference a Remote tar volume type")
+	}
+
+	return fmt.Sprintf(
+		"%v:%v",
+		volumeSource.Source,
+		volumeSource.Directory), nil
+}
+
+func (plugin *remoteTarPlugin) CanSupport(spec *volume.Spec) bool {
+	return spec.Volume != nil && spec.Volume.RemoteTar != nil
+}
+
+func (plugin *remoteTarPlugin) RequiresRemount() bool {
+	return false
+}
+
+func (plugin *remoteTarPlugin) NewMounter(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions) (volume.Mounter, error) {
+	return &remoteTarVolumeMounter{
+		remoteTarVolume: &remoteTarVolume{
+			volName: spec.Name(),
+			podUID:  pod.UID,
+			plugin:  plugin,
+		},
+		pod:    *pod,
+		source: spec.Volume.RemoteTar.Source,
+		target: spec.Volume.RemoteTar.Directory,
+		exec:   exec.New(),
+		opts:   opts,
+	}, nil
+}
+
+func (plugin *remoteTarPlugin) NewUnmounter(volName string, podUID types.UID) (volume.Unmounter, error) {
+	return &remoteTarVolumeUnmounter{
+		&remoteTarVolume{
+			volName: volName,
+			podUID:  podUID,
+			plugin:  plugin,
+		},
+	}, nil
+}
+
+func (plugin *remoteTarPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
+	remoteTarVolume := &api.Volume{
+		Name: volumeName,
+		VolumeSource: api.VolumeSource{
+			RemoteTar: &api.RemoteTarVolumeSource{},
+		},
+	}
+	return volume.NewSpecFromVolume(remoteTarVolume), nil
+}
+
+// remoteTar volumes are directories which are pre-filled from a tar archive.
+// These do not persist beyond the lifetime of a pod.
+type remoteTarVolume struct {
+	volName string
+	podUID  types.UID
+	plugin  *remoteTarPlugin
+	volume.MetricsNil
+}
+
+var _ volume.Volume = &remoteTarVolume{}
+
+func (gr *remoteTarVolume) GetPath() string {
+	name := remoteTarPluginName
+	return gr.plugin.host.GetPodVolumeDir(gr.podUID, utilstrings.EscapeQualifiedNameForDisk(name), gr.volName)
+}
+
+// remoteTarVolumeMounter builds remote tar repo volumes.
+type remoteTarVolumeMounter struct {
+	*remoteTarVolume
+
+	pod    api.Pod
+	source string
+	target string
+	exec   exec.Interface
+	opts   volume.VolumeOptions
+}
+
+var _ volume.Mounter = &remoteTarVolumeMounter{}
+
+func (b *remoteTarVolumeMounter) GetAttributes() volume.Attributes {
+	return volume.Attributes{
+		ReadOnly:        false,
+		Managed:         true,
+		SupportsSELinux: true, // xattr change should be okay, TODO: double check
+	}
+}
+
+// SetUp creates new directory, download the tar then uncompress it.
+func (b *remoteTarVolumeMounter) SetUp(fsGroup *int64) error {
+	return b.SetUpAt(b.GetPath(), fsGroup)
+}
+
+// SetUp creates new directory, download the tar then uncompress it.
+func (b *remoteTarVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
+	if volumeutil.IsReady(b.getMetaDir()) {
+		return nil
+	}
+
+	// Wrap EmptyDir, let it do the setup.
+	wrapped, err := b.plugin.host.NewWrapperMounter(b.volName, wrappedVolumeSpec(), &b.pod, b.opts)
+	if err != nil {
+		return err
+	}
+	if err := wrapped.SetUpAt(dir, fsGroup); err != nil {
+		return err
+	}
+
+	args := []string{"-O-", b.source, "|", "tar", "-xzC", b.target}
+
+	if output, err := b.execCommand("wget", args, dir); err != nil {
+		return fmt.Errorf("failed to exec '%s': %s : %v",
+			strings.Join(args, " "), output, err)
+	}
+
+	volume.SetVolumeOwnership(b, fsGroup)
+
+	volumeutil.SetReady(b.getMetaDir())
+	return nil
+}
+
+func (b *remoteTarVolumeMounter) getMetaDir() string {
+	return path.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedNameForDisk(remoteTarPluginName)), b.volName)
+}
+
+func (b *remoteTarVolumeMounter) execCommand(command string, args []string, dir string) ([]byte, error) {
+	cmd := b.exec.Command(command, args...)
+	cmd.SetDir(dir)
+	return cmd.CombinedOutput()
+}
+
+// remoteTarVolumeUnmounter cleans tar volumes.
+type remoteTarVolumeUnmounter struct {
+	*remoteTarVolume
+}
+
+var _ volume.Unmounter = &remoteTarVolumeUnmounter{}
+
+// TearDown simply deletes everything in the directory.
+func (c *remoteTarVolumeUnmounter) TearDown() error {
+	return c.TearDownAt(c.GetPath())
+}
+
+// TearDownAt simply deletes everything in the directory.
+func (c *remoteTarVolumeUnmounter) TearDownAt(dir string) error {
+
+	// Wrap EmptyDir, let it do the teardown.
+	wrapped, err := c.plugin.host.NewWrapperUnmounter(c.volName, wrappedVolumeSpec(), c.podUID)
+	if err != nil {
+		return err
+	}
+	return wrapped.TearDownAt(dir)
+}
+
+func getVolumeSource(spec *volume.Spec) (*api.RemoteTarVolumeSource, bool) {
+	var readOnly bool
+	var volumeSource *api.RemoteTarVolumeSource
+
+	if spec.Volume != nil && spec.Volume.RemoteTar != nil {
+		volumeSource = spec.Volume.RemoteTar
+		readOnly = spec.ReadOnly
+	}
+
+	return volumeSource, readOnly
+}

--- a/pkg/volume/remote_tar/remote_tar_test.go
+++ b/pkg/volume/remote_tar/remote_tar_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote_tar
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/empty_dir"
+	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+)
+
+func newTestHost(t *testing.T) (string, volume.VolumeHost) {
+	tempDir, err := ioutil.TempDir("/tmp", "remote_tar_test.")
+	if err != nil {
+		t.Fatalf("can't make a temp rootdir: %v", err)
+	}
+	return tempDir, volumetest.NewFakeVolumeHost(tempDir, nil, empty_dir.ProbeVolumePlugins(), "" /* rootContext */)
+}
+
+func TestCanSupport(t *testing.T) {
+	plugMgr := volume.VolumePluginMgr{}
+	_, host := newTestHost(t)
+	plugMgr.InitPlugins(ProbeVolumePlugins(), host)
+
+	plug, err := plugMgr.FindPluginByName("kubernetes.io/remote-tar")
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	if plug.GetPluginName() != "kubernetes.io/remote-tar" {
+		t.Errorf("Wrong name: %s", plug.GetPluginName())
+	}
+	if !plug.CanSupport(&volume.Spec{Volume: &api.Volume{VolumeSource: api.VolumeSource{RemoteTar: &api.RemoteTarVolumeSource{}}}}) {
+		t.Errorf("Expected true")
+	}
+}
+
+// Expected command
+type expectedCommand struct {
+	// The tar command
+	cmd []string
+	// The dir of tar command is executed
+	dir string
+}
+
+func TestPlugin(t *testing.T) {
+	remoteTarUrl := "https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz"
+
+	scenarios := []struct {
+		name              string
+		vol               *api.Volume
+		expecteds         []expectedCommand
+		isExpectedFailure bool
+	}{
+		{
+			name: "target-dir",
+			vol: &api.Volume{
+				Name: "vol1",
+				VolumeSource: api.VolumeSource{
+					RemoteTar: &api.RemoteTarVolumeSource{
+						Source:    remoteTarUrl,
+						Directory: "target_dir",
+					},
+				},
+			},
+			expecteds: []expectedCommand{
+				{
+					cmd: []string{"wget", "-O-", remoteTarUrl, "|", "tar", "-xzC", "target_dir"},
+					dir: "",
+				},
+			},
+			isExpectedFailure: false,
+		},
+		{
+			name: "current-dir",
+			vol: &api.Volume{
+				Name: "vol1",
+				VolumeSource: api.VolumeSource{
+					RemoteTar: &api.RemoteTarVolumeSource{
+						Source:    remoteTarUrl,
+						Directory: ".",
+					},
+				},
+			},
+			expecteds: []expectedCommand{
+				{
+					cmd: []string{"wget", "-O-", remoteTarUrl, "|", "tar", "-xzC", "."},
+					dir: "",
+				},
+			},
+			isExpectedFailure: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		allErrs := doTestPlugin(scenario, t)
+		if len(allErrs) == 0 && scenario.isExpectedFailure {
+			t.Errorf("Unexpected success for scenario: %s", scenario.name)
+		}
+		if len(allErrs) > 0 && !scenario.isExpectedFailure {
+			t.Errorf("Unexpected failure for scenario: %s - %+v", scenario.name, allErrs)
+		}
+	}
+
+}
+
+func doTestPlugin(scenario struct {
+	name              string
+	vol               *api.Volume
+	expecteds         []expectedCommand
+	isExpectedFailure bool
+}, t *testing.T) []error {
+	allErrs := []error{}
+
+	plugMgr := volume.VolumePluginMgr{}
+	rootDir, host := newTestHost(t)
+	plugMgr.InitPlugins(ProbeVolumePlugins(), host)
+
+	plug, err := plugMgr.FindPluginByName("kubernetes.io/remote-tar")
+	if err != nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Can't find the plugin by name"))
+		return allErrs
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}
+	mounter, err := plug.NewMounter(volume.NewSpecFromVolume(scenario.vol), pod, volume.VolumeOptions{})
+
+	if err != nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Failed to make a new Mounter: %v", err))
+		return allErrs
+	}
+	if mounter == nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Got a nil Mounter"))
+		return allErrs
+	}
+
+	path := mounter.GetPath()
+	suffix := fmt.Sprintf("pods/poduid/volumes/kubernetes.io~remote-tar/%v", scenario.vol.Name)
+	if !strings.HasSuffix(path, suffix) {
+		allErrs = append(allErrs,
+			fmt.Errorf("Got unexpected path: %s", path))
+		return allErrs
+	}
+
+	// Test setUp()
+	setUpErrs := doTestSetUp(scenario, mounter)
+	allErrs = append(allErrs, setUpErrs...)
+
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			allErrs = append(allErrs,
+				fmt.Errorf("SetUp() failed, volume path not created: %s", path))
+			return allErrs
+		} else {
+			allErrs = append(allErrs,
+				fmt.Errorf("SetUp() failed: %v", err))
+			return allErrs
+		}
+	}
+
+	// remoteTar volume should create its own empty wrapper path
+	podWrapperMetadataDir := fmt.Sprintf("%v/pods/poduid/plugins/kubernetes.io~empty-dir/wrapped_%v", rootDir, scenario.vol.Name)
+
+	if _, err := os.Stat(podWrapperMetadataDir); err != nil {
+		if os.IsNotExist(err) {
+			allErrs = append(allErrs,
+				fmt.Errorf("SetUp() failed, empty-dir wrapper path is not created: %s", podWrapperMetadataDir))
+		} else {
+			allErrs = append(allErrs,
+				fmt.Errorf("SetUp() failed: %v", err))
+		}
+	}
+
+	unmounter, err := plug.NewUnmounter("vol1", types.UID("poduid"))
+	if err != nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Failed to make a new Unmounter: %v", err))
+		return allErrs
+	}
+	if unmounter == nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Got a nil Unmounter"))
+		return allErrs
+	}
+
+	if err := unmounter.TearDown(); err != nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("Expected success, got: %v", err))
+		return allErrs
+	}
+	if _, err := os.Stat(path); err == nil {
+		allErrs = append(allErrs,
+			fmt.Errorf("TearDown() failed, volume path still exists: %s", path))
+	} else if !os.IsNotExist(err) {
+		allErrs = append(allErrs,
+			fmt.Errorf("SetUp() failed: %v", err))
+	}
+	return allErrs
+}
+
+func doTestSetUp(scenario struct {
+	name              string
+	vol               *api.Volume
+	expecteds         []expectedCommand
+	isExpectedFailure bool
+}, mounter volume.Mounter) []error {
+	expecteds := scenario.expecteds
+	allErrs := []error{}
+
+	// Construct combined outputs from expected commands
+	var fakeOutputs []exec.FakeCombinedOutputAction
+	var fcmd exec.FakeCmd
+	for _, expected := range expecteds {
+		fakeOutputs = append(fakeOutputs, func() ([]byte, error) {
+			// it creates new dir/files
+			os.MkdirAll(path.Join(fcmd.Dirs[0], expected.dir), 0750)
+			return []byte{}, nil
+		})
+	}
+	fcmd = exec.FakeCmd{
+		CombinedOutputScript: fakeOutputs,
+	}
+
+	// Construct fake exec outputs from fcmd
+	var fakeAction []exec.FakeCommandAction
+	for i := 0; i < len(expecteds); i++ {
+		fakeAction = append(fakeAction, func(cmd string, args ...string) exec.Cmd {
+			return exec.InitFakeCmd(&fcmd, cmd, args...)
+		})
+
+	}
+	fake := exec.FakeExec{
+		CommandScript: fakeAction,
+	}
+
+	g := mounter.(*remoteTarVolumeMounter)
+	g.exec = &fake
+
+	g.SetUp(nil)
+
+	if fake.CommandCalls != len(expecteds) {
+		allErrs = append(allErrs,
+			fmt.Errorf("unexpected command calls in scenario: expected %d, saw: %d", len(expecteds), fake.CommandCalls))
+	}
+	var expectedCmds [][]string
+	for _, expected := range expecteds {
+		expectedCmds = append(expectedCmds, expected.cmd)
+	}
+	if !reflect.DeepEqual(expectedCmds, fcmd.CombinedOutputLog) {
+		allErrs = append(allErrs,
+			fmt.Errorf("unexpected commands: %v, expected: %v", fcmd.CombinedOutputLog, expectedCmds))
+	}
+
+	var expectedPaths []string
+	for _, expected := range expecteds {
+		expectedPaths = append(expectedPaths, g.GetPath()+expected.dir)
+	}
+	if len(fcmd.Dirs) != len(expectedPaths) || !reflect.DeepEqual(expectedPaths, fcmd.Dirs) {
+		allErrs = append(allErrs,
+			fmt.Errorf("unexpected directories: %v, expected: %v", fcmd.Dirs, expectedPaths))
+	}
+
+	return allErrs
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**Which issue this PR fixes**:
None, should we open an issue?

**Special notes for your reviewer**:

I'm currently trying to add a volume that take the code from a remote tar archive.

**What this PR does / why we need it**:

Currently, there is many scenarii for deploying code into containers, in those we find:
- Having code inside the container
- Using gitRepo volume to build the code when the container goes up

The first scenario has this problem that we don't use anymore the same container everywhere (but the container + the built code at time T) and make the container usage different from local dev to CI to production.

The second scenario has this problem that it takes time for the container to start and the build process could eventually fail.

We currently explore a third scenario:
- Having the same container everywhere with no code inside
- The code is prebuild from github
  - by scripts (so it works directly for our dev in local),
  - in CI jenkins do the same then runs the test with the same container then creates a tarball of the code and push it to a remote http server

=> So to be able to deploy in production we should be able to get a volume from this tarball with kubernetes

Here is this PR, we did it mostly quickly and we hope to have some feedback about the idea and to what direction we should go :).

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

```
- Add a remote tar volume
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32572)

<!-- Reviewable:end -->
