### PR TITLE
Enable end-user customization of Hyperkube container

### DIFF
--- a/cluster/images/hyperkube/copy-addons.sh
+++ b/cluster/images/hyperkube/copy-addons.sh
@@ -19,13 +19,12 @@
 # This way we're using the latest manifests from hyperkube without updating
 # kube-addon-manager which is used for other deployments too
 
-# Inside /etc/kubernetes/addons, there are two directories: singlenode and multinode
-# If "singlenode" is passed to this script; those manifests are copied to the addon-manager and vice versa with "multinode"
-SUBDIRECTORY=$1
+# Copy the manifests from hyperkube container to the addon-manager.
+# In case of "multinode" the manifests are copied from the host to allow customizations
 
 # While there is no data copied over to the emptyDir, try to copy it.
 while [[ -z $(ls /srv/kubernetes/addons) ]]; do
-	cp -r /etc/kubernetes/addons/${SUBDIRECTORY}/* /srv/kubernetes/addons/
+	cp -r /etc/kubernetes/addons/singlenode/* /srv/kubernetes/addons/
 done
 
 # Then sleep forever

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -22,21 +22,6 @@
           {
             "name": "addons",
             "mountPath": "/etc/kubernetes/addons",
-            "readOnly": true
-          }
-        ]
-      },
-      {
-        "name": "kube-addon-manager-data",
-        "image": "REGISTRY/hyperkube-ARCH:VERSION",
-        "command": [
-          "/copy-addons.sh",
-          "multinode"
-        ],
-        "volumeMounts": [
-          {
-            "name": "addons",
-            "mountPath": "/srv/kubernetes/addons",
             "readOnly": false
           }
         ]
@@ -45,7 +30,10 @@
     "volumes":[
       {
         "name": "addons",
-        "emptyDir": {}
+        "hostPath":
+          {
+            "path": "/etc/kubernetes/addons/multinode"
+          }
       }
     ]
   }

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -30,8 +30,7 @@
         "name": "kube-addon-manager-data",
         "image": "REGISTRY/hyperkube-ARCH:VERSION",
         "command": [
-          "/copy-addons.sh",
-          "singlenode"
+          "/copy-addons.sh"
         ],
         "volumeMounts": [
           {


### PR DESCRIPTION
**What this PR does / why we need it**:

Customization of Hyperkube container is very hard, because all the manifest files are kept inside the container. Therefore, in most cases the repository must be forked and hyperkube rebuild. 

**Which issue this PR fixes**

https://github.com/kubernetes/kube-deploy/issues/215

**Special notes for your reviewer**:

I tried to keep the code simple as possible. Unfortunately, this wasn't as easy as expected.

The addon-manager must mount the manifest files from the host. In this PR I avoided to use a config-map. 

In singlenode case, I assume that customization is not required. Therefore, I read the manifests from the container. 

In multinode case, the manifest files are always read from the host (/etc/kubernetes). The scripts are adapted accordingly in docker-mulitnode project. This is a separate PR.

IMHO, this switch based on singlenode / multinode is rather simple and fits to user requirements and expectations

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32578)

<!-- Reviewable:end -->
