### PR TITLE
DNS Federation: Add ID to Zone interface

### DIFF
--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -43,6 +43,8 @@ type Zones interface {
 type Zone interface {
 	// Name returns the name of the zone, e.g. "example.com"
 	Name() string
+	// ID returns the unique provider identifier for the zone
+	ID() string
 	// ResourceRecordsets returns the provider's ResourceRecordSets interface, or false if not supported.
 	ResourceRecordSets() (ResourceRecordSets, bool)
 }

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -141,9 +141,20 @@ func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset d
 	}
 }
 
-/* TestResourceRecordSetsList verifies that listing of zones succeeds */
+/* TestZonesList verifies that listing of zones succeeds */
 func TestZonesList(t *testing.T) {
 	firstZone(t)
+}
+
+/* TestZonesID verifies that the id of the zone is returned with the prefix removed */
+func TestZonesID(t *testing.T) {
+	zone := firstZone(t)
+
+	// Check /hostedzone/ prefix is removed
+	zoneID := zone.ID()
+	if zoneID != zone.Name() {
+		t.Fatalf("Unexpected zone id: %q", zoneID)
+	}
 }
 
 /* TestZoneAddSuccess verifies that addition of a valid managed DNS zone succeeds */

--- a/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
@@ -20,6 +20,7 @@ package stubs
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -108,14 +109,16 @@ func (r *Route53APIStub) ListHostedZonesPages(input *route53.ListHostedZonesInpu
 }
 
 func (r *Route53APIStub) CreateHostedZone(input *route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error) {
-	if _, ok := r.zones[*input.Name]; ok {
-		return nil, fmt.Errorf("Error creating hosted DNS zone: %s already exists", *input.Name)
+	name := aws.StringValue(input.Name)
+	id := "/hostedzone/" + name
+	if _, ok := r.zones[id]; ok {
+		return nil, fmt.Errorf("Error creating hosted DNS zone: %s already exists", id)
 	}
-	r.zones[*input.Name] = &route53.HostedZone{
-		Id:   input.Name,
-		Name: input.Name,
+	r.zones[id] = &route53.HostedZone{
+		Id:   aws.String(id),
+		Name: aws.String(name),
 	}
-	return &route53.CreateHostedZoneOutput{HostedZone: r.zones[*input.Name]}, nil
+	return &route53.CreateHostedZoneOutput{HostedZone: r.zones[id]}, nil
 }
 
 func (r *Route53APIStub) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {

--- a/federation/pkg/dnsprovider/providers/aws/route53/zone.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/zone.go
@@ -17,8 +17,10 @@ limitations under the License.
 package route53
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"strings"
 )
 
 // Compile time check for interface adeherence
@@ -30,7 +32,13 @@ type Zone struct {
 }
 
 func (zone *Zone) Name() string {
-	return *zone.impl.Name
+	return aws.StringValue(zone.impl.Name)
+}
+
+func (zone *Zone) ID() string {
+	id := aws.StringValue(zone.impl.Id)
+	id = strings.TrimPrefix(id, "/hostedzone/")
+	return id
 }
 
 func (zone *Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
@@ -107,7 +107,7 @@ func NewFakeInterface() (dnsprovider.Interface, error) {
 	interface_ := newInterfaceWithStub("", service)
 	zones := service.ManagedZones_
 	// Add a fake zone to test against.
-	zone := &stubs.ManagedZone{Service: zones, Name_: "example.com", Rrsets: []stubs.ResourceRecordSet{}}
+	zone := &stubs.ManagedZone{Service: zones, Name_: "example.com", Rrsets: []stubs.ResourceRecordSet{}, Id_: 1}
 	call := zones.Create(interface_.project(), zone)
 	if _, err := call.Do(); err != nil {
 		return nil, err

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -118,9 +118,19 @@ func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset d
 	}
 }
 
-/* TestResourceRecordSetsList verifies that listing of zones succeeds */
+/* TestZonesList verifies that listing of zones succeeds */
 func TestZonesList(t *testing.T) {
 	firstZone(t)
+}
+
+/* TestZonesID verifies that the id of the zone is returned with the prefix removed */
+func TestZonesID(t *testing.T) {
+	zone := firstZone(t)
+
+	zoneID := zone.ID()
+	if zoneID != "1" {
+		t.Fatalf("Unexpected zone id: %q", zoneID)
+	}
 }
 
 /* TestZoneAddSuccess verifies that addition of a valid managed DNS zone succeeds */

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
@@ -83,7 +83,7 @@ type (
 		// CreationTime() string // TODO: Add as needed
 		// Description() string // TODO: Add as needed
 		DnsName() string
-		// Id()  uint64 // TODO: Add as needed
+		Id() uint64
 		// Kind() string // TODO: Add as needed
 		Name() string
 		// NameServerSet() string // TODO: Add as needed

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone.go
@@ -30,6 +30,10 @@ func (m ManagedZone) Name() string {
 	return m.impl.Name
 }
 
+func (m ManagedZone) Id() uint64 {
+	return m.impl.Id
+}
+
 func (m ManagedZone) DnsName() string {
 	return m.impl.DnsName
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
@@ -24,11 +24,16 @@ var _ interfaces.ManagedZone = ManagedZone{}
 type ManagedZone struct {
 	Service *ManagedZonesService
 	Name_   string
+	Id_     uint64
 	Rrsets  []ResourceRecordSet
 }
 
 func (m ManagedZone) Name() string {
 	return m.Name_
+}
+
+func (m ManagedZone) Id() uint64 {
+	return m.Id_
 }
 
 func (m ManagedZone) DnsName() string {

--- a/federation/pkg/dnsprovider/providers/google/clouddns/zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/zone.go
@@ -19,6 +19,7 @@ package clouddns
 import (
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"strconv"
 )
 
 // Compile time check for interface adeherence
@@ -31,6 +32,10 @@ type Zone struct {
 
 func (zone *Zone) Name() string {
 	return zone.impl.DnsName()
+}
+
+func (zone *Zone) ID() string {
+	return strconv.FormatUint(zone.impl.Id(), 10)
 }
 
 func (zone *Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {


### PR DESCRIPTION
This allows us to differentiate when we have two HostedZones with the
same DNS name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32581)

<!-- Reviewable:end -->
