### PR TITLE
Fix audit_test regex for iso8601 timestamps

### DIFF
--- a/pkg/apiserver/audit/audit_test.go
+++ b/pkg/apiserver/audit/audit_test.go
@@ -95,14 +95,14 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}
 	if !match {
 		t.Errorf("Unexpected first line of audit: %s", line[0])
 	}
-	match, err = regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	match, err = regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" response="200"`, line[1])
 	if err != nil {
 		t.Errorf("Unexpected error matching second line: %v", err)
 	}

--- a/pkg/apiserver/audit/audit_test.go
+++ b/pkg/apiserver/audit/audit_test.go
@@ -95,14 +95,14 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}
 	if !match {
 		t.Errorf("Unexpected first line of audit: %s", line[0])
 	}
-	match, err = regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	match, err = regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" response="200"`, line[1])
 	if err != nil {
 		t.Errorf("Unexpected error matching second line: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:  The audit_test unit test fails as some iso8601 timestamps are of the form 2016-09-13T10:32:50.823081217Z and the current regex doesn't allow T's or Z's.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:NONE

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
Fix audit_test regex for iso8601 timestamps
```

Signed-off-by: Johnny Bieren jbieren@redhat.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32593)

<!-- Reviewable:end -->
