### PR TITLE
Revert "Revert "Allow webhook authenticator to use TokenReviewsInterface""

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -410,6 +410,11 @@ func IsServerTimeout(err error) bool {
 	return reasonForError(err) == unversioned.StatusReasonServerTimeout
 }
 
+// IsInternalError determines if err is an error which indicates an internal server error.
+func IsInternalError(err error) bool {
+	return reasonForError(err) == unversioned.StatusReasonInternalError
+}
+
 // IsUnexpectedServerError returns true if the server response was not in the expected API format,
 // and may be the result of another HTTP actor.
 func IsUnexpectedServerError(err error) bool {


### PR DESCRIPTION
Reverts https://github.com/kubernetes/kubernetes/pull/32591 (commit 0a02c8275dd368b69575e1d1f5276b880aa277ec)
Readds https://github.com/kubernetes/kubernetes/pull/32547

Holding until GKE webhook authenticator is updated by @cjcullen 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32597)

<!-- Reviewable:end -->
