### PR TITLE
Update bin directory for Calico CNI plugin

### DIFF
--- a/cluster/saltbase/salt/calico/node.sls
+++ b/cluster/saltbase/salt/calico/node.sls
@@ -18,7 +18,7 @@ calico-node:
 
 calico-cni:
   file.managed:
-    - name: /opt/cni/bin/calico
+    - name: /home/kubernetes/bin
     - source: https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico
     - source_hash: sha256=ac05cb9254b5aaa5822cf10325983431bd25489147f2edf9dec7e43d99c43e77
     - makedirs: True


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/32151 fixes CNI in the GCE provider by configuring the correct cni binary directory.

This is the corresponding PR necessary to fix NetworkPolicy in the GCE provider by installing the Calico CNI binary in the new CNI bin directory for GCI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32598)

<!-- Reviewable:end -->
