### PR TITLE
1.4 Cherrypick Batch Update

### DIFF
--- a/pkg/util/cache/lruexpirecache.go
+++ b/pkg/util/cache/lruexpirecache.go
@@ -25,7 +25,7 @@ import (
 
 type LRUExpireCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
+	lock  sync.Mutex
 }
 
 func NewLRUExpireCache(maxSize int) *LRUExpireCache {
@@ -46,8 +46,8 @@ func (c *LRUExpireCache) Add(key lru.Key, value interface{}, ttl time.Duration) 
 }
 
 func (c *LRUExpireCache) Get(key lru.Key) (interface{}, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	e, ok := c.cache.Get(key)
 	if !ok {
 		return nil, false


### PR DESCRIPTION
#32524: Namespace Controller handles items with finalizers gracefully
#32330: e2e/log-dump: Collect kernel log with journald
#32244: LRUExpireCache#Get requires write lock

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32602)

<!-- Reviewable:end -->
