### PR TITLE
Enable DynamicKubeletConfig in benchmark test properties

### DIFF
--- a/test/e2e_node/jenkins/benchmark/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/benchmark/jenkins-benchmark.properties
@@ -6,4 +6,5 @@ CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
 SETUP_NODE=false
 #TEST_ARGS=--cgroups-per-qos=false
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
 PARALLELISM=1


### PR DESCRIPTION
This PR fixes "change QPS limit" failure by adding "TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'" in jenkins-benchmark.properties

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32604)

<!-- Reviewable:end -->
