### PR TITLE
Fix clientcmd for a non-host cluster client running in a pod. 

### DIFF
--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -112,11 +112,11 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 		//   "empty due to defaults"
 		// TODO: this shouldn't be a global - the client config rules should be
 		//   handling this.
-		defaultConfig, err := DefaultClientConfig.ClientConfig()
-		if IsConfigurationInvalid(err) {
+		defaultConfig, defErr := DefaultClientConfig.ClientConfig()
+		if IsConfigurationInvalid(defErr) && !IsEmptyConfig(err) {
 			return mergedConfig, nil
 		}
-		if err == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
+		if defErr == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
 			return mergedConfig, nil
 		}
 	}

--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -113,6 +113,9 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 		// TODO: this shouldn't be a global - the client config rules should be
 		//   handling this.
 		defaultConfig, err := DefaultClientConfig.ClientConfig()
+		if IsConfigurationInvalid(err) {
+			return mergedConfig, nil
+		}
 		if err == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
 			return mergedConfig, nil
 		}

--- a/pkg/client/unversioned/clientcmd/merged_client_builder_test.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder_test.go
@@ -172,6 +172,16 @@ func TestInClusterConfig(t *testing.T) {
 			result:     config2,
 			err:        nil,
 		},
+
+		"in-cluster not checked when default is invalid": {
+			defaultConfig: &DefaultClientConfig,
+			clientConfig:  &testClientConfig{config: config2},
+			icc:           &testICC{},
+
+			checkedICC: false,
+			result:     config2,
+			err:        nil,
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
This is based on @errordeveloper's PR #32438. It fixes a case where default config is invalid and original config, i.e. `mergedConfig` is empty. It also adds a test for the case where default config is invalid and original config is neither invalid nor empty.

cc @errordeveloper @kubernetes/sig-cluster-federation @pwittrock @colhom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32613)

<!-- Reviewable:end -->
