### PR TITLE
Only skip petset test if resource is missing

### DIFF
--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -59,7 +59,10 @@ const (
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
 var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
-	f := framework.NewDefaultFramework("petset")
+	options := framework.FrameworkOptions{
+		GroupVersion: &unversioned.GroupVersion{Group: apps.GroupName, Version: "v1alpha1"},
+	}
+	f := framework.NewFramework("petset", options, nil)
 	var ns string
 	var c *client.Client
 
@@ -67,7 +70,7 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 		// PetSet is in alpha, so it's disabled on all platforms except GCE.
 		// In theory, tests that restart pets should pass on any platform with a
 		// dynamic volume provisioner.
-		framework.SkipUnlessProviderIs("gce")
+		framework.SkipIfMissingResource(f.ClientPool, unversioned.GroupVersionResource{Group: apps.GroupName, Version: "v1alpha1", Resource: "petsets"}, f.Namespace.Name)
 
 		c = f.Client
 		ns = f.Namespace.Name
@@ -166,10 +169,6 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 	})
 
 	framework.KubeDescribe("Deploy clustered applications [Slow] [Feature:PetSet]", func() {
-		BeforeEach(func() {
-			framework.SkipUnlessProviderIs("gce")
-		})
-
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				dumpDebugInfo(c, ns)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -67,10 +67,13 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 	var c *client.Client
 
 	BeforeEach(func() {
-		// PetSet is in alpha, so it's disabled on all platforms except GCE.
+		// PetSet is in alpha, so it's disabled on some platforms. We skip this
+		// test if a resource get fails on non-GCE platforms.
 		// In theory, tests that restart pets should pass on any platform with a
 		// dynamic volume provisioner.
-		framework.SkipIfMissingResource(f.ClientPool, unversioned.GroupVersionResource{Group: apps.GroupName, Version: "v1alpha1", Resource: "petsets"}, f.Namespace.Name)
+		if !framework.ProviderIs("gce") {
+			framework.SkipIfMissingResource(f.ClientPool, unversioned.GroupVersionResource{Group: apps.GroupName, Version: "v1alpha1", Resource: "petsets"}, f.Namespace.Name)
+		}
 
 		c = f.Client
 		ns = f.Namespace.Name


### PR DESCRIPTION
**What this PR does / why we need it**:
Unblock testing petset on other providers.

cc @pwittrock. Would like to cherrypick onto 1.4 but this is test code only, so it can wait til after release cut.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32632)

<!-- Reviewable:end -->
