### PR TITLE
AWS: Make AttachVolume & DetachVolume more idempotent

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1468,22 +1468,28 @@ func (c *Cloud) AttachDisk(diskName string, instanceName string, readOnly bool) 
 	// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
 	ec2Device := "/dev/xvd" + string(mountDevice)
 
-	if !alreadyAttached {
-		request := &ec2.AttachVolumeInput{
-			Device:     aws.String(ec2Device),
-			InstanceId: aws.String(awsInstance.awsID),
-			VolumeId:   aws.String(disk.awsID),
+	request := &ec2.AttachVolumeInput{
+		Device:     aws.String(ec2Device),
+		InstanceId: aws.String(awsInstance.awsID),
+		VolumeId:   aws.String(disk.awsID),
+	}
+
+	attachResponse, err := c.ec2.AttachVolume(request)
+	if err != nil {
+		// Only remove the entry from the attachment map if we added it
+		if !alreadyAttached {
+			attachEnded = true
 		}
 
-		attachResponse, err := c.ec2.AttachVolume(request)
-		if err != nil {
-			attachEnded = true
-			// TODO: Check if the volume was concurrently attached?
+		if AWSErrorCode(err) == "VolumeInUse" {
+			// This is the error we get if we call Attach on an attached volume
+			glog.Warningf("Got VolumeInUse error attaching volume %q - will check if volume is attached correctly: %v", disk.awsID, err)
+		} else {
 			return "", fmt.Errorf("Error attaching EBS volume: %v", err)
 		}
-
-		glog.V(2).Infof("AttachVolume request returned %v", attachResponse)
 	}
+
+	glog.V(2).Infof("AttachVolume request returned %v", attachResponse)
 
 	attachment, err := disk.waitForAttachmentStatus("attached")
 	if err != nil {
@@ -1548,7 +1554,12 @@ func (c *Cloud) DetachDisk(diskName string, instanceName string) (string, error)
 
 	response, err := c.ec2.DetachVolume(&request)
 	if err != nil {
-		return "", fmt.Errorf("error detaching EBS volume: %v", err)
+		if AWSErrorCode(err) == "IncorrectState" {
+			// This is the error we get if the volume was already detached
+			glog.Warningf("Got IncorrectState error detaching volume %q; will ignore and check state: %v", disk.awsID, err)
+		} else {
+			return "", fmt.Errorf("error detaching EBS volume: %v", err)
+		}
 	}
 	if response == nil {
 		return "", errors.New("no response from DetachVolume")
@@ -3207,4 +3218,12 @@ func (c *Cloud) addFilters(filters []*ec2.Filter) []*ec2.Filter {
 // Returns the cluster name or an empty string
 func (c *Cloud) getClusterName() string {
 	return c.filterTags[TagNameKubernetesCluster]
+}
+
+// AWSErrorCode returns the aws error code, if err is an awserr.Error, otherwise ""
+func AWSErrorCode(err error) string {
+	if awsError, ok := err.(awserr.Error); ok {
+		return awsError.Code()
+	}
+	return ""
 }


### PR DESCRIPTION
We try to recognize errors from when the volume is already in the state
we want, and continue to validate their state.

Issue #32630

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32635)

<!-- Reviewable:end -->
