### PR TITLE
Exit scheduler retry loop correctly

### DIFF
--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -532,10 +532,13 @@ func (factory *ConfigFactory) makeDefaultErrorFunc(backoff *podBackoff, podQueue
 				return
 			}
 			// Get the pod again; it may have changed/been scheduled already.
-			pod = &api.Pod{}
 			getBackoff := initialGetBackoff
 			for {
-				if err := factory.Client.Get().Namespace(podID.Namespace).Resource("pods").Name(podID.Name).Do().Into(pod); err == nil {
+				pod, err := factory.Client.Pods(podID.Namespace).Get(podID.Name)
+				if err == nil {
+					if len(pod.Spec.NodeName) == 0 {
+						podQueue.AddIfNotPresent(pod)
+					}
 					break
 				}
 				if errors.IsNotFound(err) {
@@ -547,9 +550,6 @@ func (factory *ConfigFactory) makeDefaultErrorFunc(backoff *podBackoff, podQueue
 					getBackoff = maximalGetBackoff
 				}
 				time.Sleep(getBackoff)
-			}
-			if pod.Spec.NodeName == "" {
-				podQueue.AddIfNotPresent(pod)
 			}
 		}()
 	}


### PR DESCRIPTION
The error was being eaten and shadowed, which means we would never exit
this loop. This might lead to a goroutine in the scheduler being used
forever without exiting at maximum backoff.

Switched to use the real client to make later refactors easier.

@wojtek-t this may lead to scheduler informer exhaustion - not that familiar with retries

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32643)

<!-- Reviewable:end -->
