### PR TITLE
hack: Allow running other etcd instances in containers

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -26,8 +26,8 @@ kube::etcd::start() {
     exit 1
   }
 
-  if pgrep etcd >/dev/null 2>&1; then
-    kube::log::usage "etcd appears to already be running on this machine (`pgrep -l etcd`) (or its a zombie and you need to kill its parent)."
+  if netstat -tnlp | grep $(pgrep etcd) >/dev/null 2>&1; then
+    kube::log::usage "etcd appears to already be running on this machine without network isolation (`pgrep -l etcd`, `netstat -tnlp | grep $(pgrep etcd)`) (or its a zombie and you need to kill its parent)."
     kube::log::usage "retry after you resolve this etcd error."
     exit 1
   fi


### PR DESCRIPTION
If some etcd instance is running in a container, without
using host networking mode or binding its ports to the host,
there is no conflict with etcd instance which k8s local
cluster is setting up.

Fixes #32647

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32648)

<!-- Reviewable:end -->
