### PR TITLE
v1.2.0 Heapster

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -20,29 +20,29 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.2.0-beta.3
+  name: heapster-v1.2.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.2.0-beta.3
+    version: v1.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.2.0-beta.3
+      version: v1.2.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.2.0-beta.3
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -67,7 +67,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -110,7 +110,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -139,7 +139,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -20,29 +20,29 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.2.0-beta.3
+  name: heapster-v1.2.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.2.0-beta.3
+    version: v1.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.2.0-beta.3
+      version: v1.2.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.2.0-beta.3
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -68,7 +68,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -111,7 +111,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -140,7 +140,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -20,29 +20,29 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.2.0-beta.3
+  name: heapster-v1.2.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.2.0-beta.3
+    version: v1.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.2.0-beta.3
+      version: v1.2.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.2.0-beta.3
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -63,7 +63,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -102,7 +102,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -131,7 +131,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -16,29 +16,29 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.2.0-beta.3
+  name: heapster-v1.2.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.2.0-beta.3
+    version: v1.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.2.0-beta.3
+      version: v1.2.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.2.0-beta.3
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.3
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -83,7 +83,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.3
+            - --deployment=heapster-v1.2.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -2,23 +2,23 @@
 	"kind": "ReplicationController",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "heapster-v1.2.0-beta.3",
+		"name": "heapster-v1.2.0",
 		"labels": {
 			"k8s-app": "heapster",
-			"version": "v1.2.0-beta.3"
+			"version": "v1.2.0"
 		}
 	},
 	"spec": {
 		"replicas": 1,
 		"selector": {
 			"k8s-app": "heapster",
-			"version": "v1.2.0-beta.3"
+			"version": "v1.2.0"
 		},
 		"template": {
 			"metadata": {
 				"labels": {
 					"k8s-app": "heapster",
-					"version": "v1.2.0-beta.3"
+					"version": "v1.2.0"
 				}
 			},
 			"spec": {
@@ -33,7 +33,7 @@
 				"containers": [
 				{
 					"name": "heapster",
-					"image": "gcr.io/google_containers/heapster:v1.2.0-beta.3",
+					"image": "gcr.io/google_containers/heapster:v1.2.0",
 					"resources": {
 						"requests": {
 							"cpu": "100m",
@@ -55,7 +55,7 @@
 				},
 				{
 					"name": "eventer",
-					"image": "gcr.io/google_containers/heapster:v1.2.0-beta.3",
+					"image": "gcr.io/google_containers/heapster:v1.2.0",
 					"resources": {
 						"requests": {
 							"cpu": "100m",


### PR DESCRIPTION
``` release-note
Bumped Heapster to v1.2.0.
More details about the release https://github.com/kubernetes/heapster/releases/tag/v1.2.0
```

Version `v1.2.0` is a stable release of the previous release candidate `v1.2.0-beta.3`. The only difference is bumped Kubernetes deps to the lastest stable release `v1.4.0-beta.3` https://github.com/kubernetes/heapster/pull/1290.

It's low risk change. It may impact HPA and Monitoring e2e tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32649)

<!-- Reviewable:end -->
