### PR TITLE
make api version optional

### DIFF
--- a/plugin/pkg/scheduler/extender.go
+++ b/plugin/pkg/scheduler/extender.go
@@ -155,12 +155,18 @@ func (h *HTTPExtender) Prioritize(pod *api.Pod, nodes []*api.Node) (*schedulerap
 
 // Helper function to send messages to the extender
 func (h *HTTPExtender) send(action string, args interface{}, result interface{}) error {
+	var url string
+
 	out, err := json.Marshal(args)
 	if err != nil {
 		return err
 	}
 
-	url := h.extenderURL + "/" + h.apiVersion + "/" + action
+	if h.apiVersion != "" {
+		url = h.extenderURL + "/" + h.apiVersion + "/" + action
+	} else {
+		url = h.extenderURL + "/" + action
+	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewReader(out))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

make api version optional in scheduler extender config.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32652)

<!-- Reviewable:end -->
