### PR TITLE
Fix FakeNodeHandler Update behaviour

### DIFF
--- a/pkg/controller/node/test_utils.go
+++ b/pkg/controller/node/test_utils.go
@@ -107,6 +107,12 @@ func (m *FakeNodeHandler) Get(name string) (*api.Node, error) {
 		m.RequestCount++
 		m.lock.Unlock()
 	}()
+	for i := range m.UpdatedNodes {
+		if m.UpdatedNodes[i].Name == name {
+			nodeCopy := *m.UpdatedNodes[i]
+			return &nodeCopy, nil
+		}
+	}
 	for i := range m.Existing {
 		if m.Existing[i].Name == name {
 			nodeCopy := *m.Existing[i]
@@ -169,6 +175,12 @@ func (m *FakeNodeHandler) Update(node *api.Node) (*api.Node, error) {
 		m.lock.Unlock()
 	}()
 	nodeCopy := *node
+	for i, updateNode := range m.UpdatedNodes {
+		if updateNode.Name == nodeCopy.Name {
+			m.UpdatedNodes[i] = &nodeCopy
+			return node, nil
+		}
+	}
 	m.UpdatedNodes = append(m.UpdatedNodes, &nodeCopy)
 	return node, nil
 }


### PR DESCRIPTION
Two problems:
1. Get is always using Existing nodes slice, and you will for sure miss any updated data
2. Each Update adds a duplicate node entry to UpdatedNodes slice

For the 1st, we will try to find a node in UpdatedNodes slice (same as for the List).
2nd - append only if there is no node with same name as updated, if there is we will replace object in UpdatedNodes slice.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32655)

<!-- Reviewable:end -->
