### PR TITLE
Fixed #32366: wrong master pd name during kube-down.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1183,12 +1183,14 @@ function kube-down() {
   fi
 
   # Delete the master replica pd (possibly leaked by kube-up if master create failed).
-  if gcloud compute disks describe "${REPLICA_NAME}"-pd --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
+  # TODO(jszczepkowski): remove also possibly leaked replicas' pds
+  local -r replica-pd="${REPLICA_NAME:-${MASTER_NAME}}-pd"
+  if gcloud compute disks describe "${replica-pd}" --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
     gcloud compute disks delete \
       --project "${PROJECT}" \
       --quiet \
       --zone "${ZONE}" \
-      "${REPLICA_NAME}"-pd
+      "${replica-pd}"
   fi
 
   # Delete disk for cluster registry if enabled


### PR DESCRIPTION
Fixed #32366: wrong master pd name during kube-down.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32658)

<!-- Reviewable:end -->
