### PR TITLE
Fix printing container usage in kubectl top

### DIFF
--- a/pkg/kubectl/metricsutil/metrics_printer.go
+++ b/pkg/kubectl/metricsutil/metrics_printer.go
@@ -110,8 +110,9 @@ func printSinglePodMetrics(out io.Writer, m *metrics_api.PodMetrics, printContai
 	for _, res := range MeasuredResources {
 		podMetrics[res], _ = resource.ParseQuantity("0")
 	}
-	var usage api.ResourceList
+
 	for _, c := range m.Containers {
+		var usage api.ResourceList
 		err := api.Scheme.Convert(&c.Usage, &usage, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in kubectl top, which showed the same value of usage for all containers in a pod.

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32660)

<!-- Reviewable:end -->
