### PR TITLE
Fixed downloading of flannel 0.6.x releases in ubuntu installer, 0.5.x works as well

### DIFF
--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -22,22 +22,27 @@ set -e
 
 function cleanup {
   # cleanup work
-  rm -rf flannel* kubernetes* etcd* binaries
+  rm -rf flannel* kubernetes* etcd* binaries out
 }
 trap cleanup SIGHUP SIGINT SIGTERM
 
 pushd $(dirname $0)
 mkdir -p binaries/master
 mkdir -p binaries/minion
+mkdir -p out
 
 # flannel
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 echo "Prepare flannel ${FLANNEL_VERSION} release ..."
 grep -q "^${FLANNEL_VERSION}\$" binaries/.flannel 2>/dev/null || {
-  curl -L  https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz
-  tar xzf flannel.tar.gz
-  cp flannel-${FLANNEL_VERSION}/flanneld binaries/master
-  cp flannel-${FLANNEL_VERSION}/flanneld binaries/minion
+  ( curl --fail -L https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz &&
+    tar xzf flannel.tar.gz flannel-${FLANNEL_VERSION}/flanneld -O > out/flanneld
+  ) ||
+  ( curl --fail -L https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-v${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz &&
+    tar xzf flannel.tar.gz flanneld -O > out/flanneld
+  )
+  cp out/flanneld binaries/master
+  cp out/flanneld binaries/minion
   echo ${FLANNEL_VERSION} > binaries/.flannel
 }
 
@@ -85,7 +90,7 @@ grep -q "^${KUBE_VERSION}\$" binaries/.kubernetes 2>/dev/null || {
   echo ${KUBE_VERSION} > binaries/.kubernetes
 }
 
-rm -rf flannel* kubernetes* etcd*
+rm -rf flannel* kubernetes* etcd* out
 
 echo "Done! All your binaries locate in kubernetes/cluster/ubuntu/binaries directory"
 popd

--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -41,6 +41,7 @@ grep -q "^${FLANNEL_VERSION}\$" binaries/.flannel 2>/dev/null || {
   ( curl --fail -L https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-v${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz &&
     tar xzf flannel.tar.gz flanneld -O > out/flanneld
   )
+  chmod 0755 out/flanneld
   cp out/flanneld binaries/master
   cp out/flanneld binaries/minion
   echo ${FLANNEL_VERSION} > binaries/.flannel


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes compatibility of ubuntu installer with flannel release 0.6.0 and 0.6.1 where download url was changed.

**Release note**:

``` NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32667)

<!-- Reviewable:end -->
