### PR TITLE
Release 1.4 Batch Cherrypick

### DIFF
--- a/pkg/genericapiserver/default_storage_factory_builder.go
+++ b/pkg/genericapiserver/default_storage_factory_builder.go
@@ -70,12 +70,12 @@ func mergeAPIResourceConfigs(defaultAPIResourceConfig *ResourceConfig, resourceC
 
 	// "api/all=false" allows users to selectively enable specific api versions.
 	allAPIFlagValue, ok := overrides["api/all"]
-	if ok && allAPIFlagValue == "false" {
-		// Disable all group versions.
-		for _, groupVersion := range registered.RegisteredGroupVersions() {
-			if resourceConfig.AnyResourcesForVersionEnabled(groupVersion) {
-				resourceConfig.DisableVersions(groupVersion)
-			}
+	if ok {
+		if allAPIFlagValue == "false" {
+			// Disable all group versions.
+			resourceConfig.DisableVersions(registered.RegisteredGroupVersions()...)
+		} else if allAPIFlagValue == "true" {
+			resourceConfig.EnableVersions(registered.RegisteredGroupVersions()...)
 		}
 	}
 

--- a/pkg/genericapiserver/default_storage_factory_builder_test.go
+++ b/pkg/genericapiserver/default_storage_factory_builder_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	extensionsapiv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -159,6 +160,36 @@ func TestParseRuntimeConfig(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			// enable all
+			runtimeConfig: map[string]string{
+				"api/all": "true",
+			},
+			defaultResourceConfig: func() *ResourceConfig {
+				return NewResourceConfig()
+			},
+			expectedAPIConfig: func() *ResourceConfig {
+				config := NewResourceConfig()
+				config.EnableVersions(registered.RegisteredGroupVersions()...)
+				return config
+			},
+			err: false,
+		},
+		{
+			// disable all
+			runtimeConfig: map[string]string{
+				"api/all": "false",
+			},
+			defaultResourceConfig: func() *ResourceConfig {
+				return NewResourceConfig()
+			},
+			expectedAPIConfig: func() *ResourceConfig {
+				config := NewResourceConfig()
+				config.DisableVersions(registered.RegisteredGroupVersions()...)
+				return config
+			},
+			err: false,
+		},
 	}
 	for _, test := range testCases {
 		actualDisablers, err := mergeAPIResourceConfigs(test.defaultResourceConfig(), test.runtimeConfig)
@@ -173,5 +204,4 @@ func TestParseRuntimeConfig(t *testing.T) {
 			t.Fatalf("%v: unexpected apiResourceDisablers. Actual: %v\n expected: %v", test.runtimeConfig, actualDisablers, expectedConfig)
 		}
 	}
-
 }

--- a/test/e2e/rescheduler.go
+++ b/test/e2e/rescheduler.go
@@ -35,7 +35,7 @@ var _ = framework.KubeDescribe("Rescheduler [Serial]", func() {
 	var totalMillicores int
 
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce")
+		framework.SkipUnlessProviderIs("gce", "gke")
 		ns = f.Namespace.Name
 		nodes := framework.GetReadySchedulableNodesOrDie(f.Client)
 		nodeCount := len(nodes.Items)


### PR DESCRIPTION
#32568: Enabled Rescheduler e2e for GKE
#32582: make --runtime-config=api/all=true|false work

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32674)

<!-- Reviewable:end -->
