### PR TITLE
Behave gracefully in kubectl if /version returns 404

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -747,10 +747,11 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				dir := cacheDir
 				if len(dir) > 0 {
 					version, err := clientset.Discovery().ServerVersion()
-					if err != nil {
-						return nil, err
+					if err == nil {
+						dir = path.Join(cacheDir, version.String())
+					} else {
+						dir = "" // disable caching as a fallback
 					}
-					dir = path.Join(cacheDir, version.String())
 				}
 				fedClient, err := clients.FederationClientForVersion(nil)
 				if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/32679. 

It's only about caching the swagger spec here. So it's safe to fall back to non-caching mode and continue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32680)

<!-- Reviewable:end -->
