### PR TITLE
Pass Pod structure to network plugins and JSON to CNI plugins

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -2119,7 +2119,7 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, _ api.PodStatus, podStatus *kubec
 		result.AddSyncResult(setupNetworkResult)
 		if !kubecontainer.IsHostNetworkPod(pod) {
 			glog.V(3).Infof("Calling network plugin %s to setup pod for %s", dm.networkPlugin.Name(), format.Pod(pod))
-			err = dm.networkPlugin.SetUpPod(pod.Namespace, pod.Name, podInfraContainerID.ContainerID())
+			err = dm.networkPlugin.SetUpPod(pod, podInfraContainerID.ContainerID())
 			if err != nil {
 				// TODO: (random-liu) There shouldn't be "Skipping pod" in sync result message
 				message := fmt.Sprintf("Failed to setup network for pod %q using network plugins %q: %v; Skipping pod", format.Pod(pod), dm.networkPlugin.Name(), err)

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2526,7 +2526,7 @@ func TestSyncPodGetsPodIPFromNetworkPlugin(t *testing.T) {
 	// Can be called multiple times due to GetPodStatus
 	fnp.EXPECT().Name().Return("someNetworkPlugin").AnyTimes()
 	fnp.EXPECT().GetPodNetworkStatus("new", "foo", gomock.Any()).Return(&network.PodNetworkStatus{IP: net.ParseIP(fakePodIP)}, nil).AnyTimes()
-	fnp.EXPECT().SetUpPod("new", "foo", gomock.Any()).Return(nil)
+	fnp.EXPECT().SetUpPod(pod, gomock.Any()).Return(nil)
 
 	runSyncPod(t, dm, fakeDocker, pod, nil, false)
 	verifyCalls(t, fakeDocker, []string{

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -26,6 +26,8 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
@@ -189,7 +191,7 @@ func (plugin *cniNetworkPlugin) Name() string {
 	return CNIPluginName
 }
 
-func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *cniNetworkPlugin) SetUpPod(pod *api.Pod, id kubecontainer.ContainerID) error {
 	if err := plugin.checkInitialized(); err != nil {
 		return err
 	}
@@ -198,13 +200,13 @@ func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubec
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
-	_, err = plugin.loNetwork.addToNetwork(name, namespace, id, netnsPath)
+	_, err = plugin.loNetwork.addToNetwork(pod.Name, pod.Namespace, id, netnsPath)
 	if err != nil {
 		glog.Errorf("Error while adding to cni lo network: %s", err)
 		return err
 	}
 
-	_, err = plugin.getDefaultNetwork().addToNetwork(name, namespace, id, netnsPath)
+	_, err = plugin.getDefaultNetwork().addToNetwork(pod.Name, pod.Namespace, id, netnsPath)
 	if err != nil {
 		glog.Errorf("Error while adding to cni network: %s", err)
 		return err

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cni
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -200,13 +201,13 @@ func (plugin *cniNetworkPlugin) SetUpPod(pod *api.Pod, id kubecontainer.Containe
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
-	_, err = plugin.loNetwork.addToNetwork(pod.Name, pod.Namespace, id, netnsPath)
+	_, err = plugin.loNetwork.addToNetwork(pod, id, netnsPath)
 	if err != nil {
 		glog.Errorf("Error while adding to cni lo network: %s", err)
 		return err
 	}
 
-	_, err = plugin.getDefaultNetwork().addToNetwork(pod.Name, pod.Namespace, id, netnsPath)
+	_, err = plugin.getDefaultNetwork().addToNetwork(pod, id, netnsPath)
 	if err != nil {
 		glog.Errorf("Error while adding to cni network: %s", err)
 		return err
@@ -243,14 +244,54 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	return &network.PodNetworkStatus{IP: ip}, nil
 }
 
-func (network *cniNetwork) addToNetwork(podName string, podNamespace string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*cnitypes.Result, error) {
-	rt, err := buildCNIRuntimeConf(podName, podNamespace, podInfraContainerID, podNetnsPath)
+func updateNetConfigWithPod(original *libcni.NetworkConfig, pod *api.Pod) (*libcni.NetworkConfig, error) {
+	type cniNetConf struct {
+		Name string                 `json:"name,omitempty"`
+		Type string                 `json:"type,omitempty"`
+		Args map[string]interface{} `json:"args,omitempty"`
+	}
+
+	// We don't want PodStatus, just the TypeMeta, ObjectMeta, and PodSpec
+	pod = &api.Pod{
+		TypeMeta:   pod.TypeMeta,
+		ObjectMeta: pod.ObjectMeta,
+	}
+
+	config := cniNetConf{}
+	err := json.Unmarshal(original.Bytes, &config)
+	if err != nil {
+		return nil, err
+	}
+	if config.Args == nil {
+		config.Args = make(map[string]interface{})
+	}
+
+	podBytes, err := json.Marshal(pod)
+	if err != nil {
+		return nil, err
+	}
+	config.Args["kubernetes.io/pod"] = string(podBytes)
+
+	return libcni.InjectConf(original, "args", config.Args)
+}
+
+func (network *cniNetwork) addToNetwork(pod *api.Pod, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*cnitypes.Result, error) {
+	rt, err := buildCNIRuntimeConf(pod.Name, pod.Namespace, podInfraContainerID, podNetnsPath)
 	if err != nil {
 		glog.Errorf("Error adding network: %v", err)
 		return nil, err
 	}
 
 	netconf, cninet := network.NetworkConfig, network.CNIConfig
+
+	// Merge the PodSpec into the network config's 'args' field
+	netconf, err = updateNetConfigWithPod(netconf, pod)
+	if err != nil {
+		glog.Errorf("Error updating network config with PodSpec: %v", err)
+		return nil, err
+	}
+	glog.Warningf("netconf %v", netconf.Bytes)
+
 	glog.V(4).Infof("About to run with conf.Network.Type=%v", netconf.Network.Type)
 	res, err := cninet.AddNetwork(netconf, rt)
 	if err != nil {

--- a/pkg/kubelet/network/exec/exec.go
+++ b/pkg/kubelet/network/exec/exec.go
@@ -65,6 +65,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -140,8 +141,8 @@ func (plugin *execNetworkPlugin) validate() error {
 	return nil
 }
 
-func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
-	out, err := utilexec.New().Command(plugin.getExecutable(), setUpCmd, namespace, name, id.ID).CombinedOutput()
+func (plugin *execNetworkPlugin) SetUpPod(pod *api.Pod, id kubecontainer.ContainerID) error {
+	out, err := utilexec.New().Command(plugin.getExecutable(), setUpCmd, pod.Namespace, pod.Name, id.ID).CombinedOutput()
 	glog.V(5).Infof("SetUpPod 'exec' network plugin output: %s, %v", string(out), err)
 	return err
 }

--- a/pkg/kubelet/network/exec/exec_test.go
+++ b/pkg/kubelet/network/exec/exec_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"text/template"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
@@ -226,7 +227,15 @@ func TestPluginSetupHook(t *testing.T) {
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
-	err = plug.SetUpPod("podNamespace", "podName", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "12345678",
+			Name:      "podName",
+			Namespace: "podNamespace",
+		},
+	}
+
+	err = plug.SetUpPod(pod, kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
 	if err != nil {
 		t.Errorf("Expected nil: %v", err)
 	}

--- a/pkg/kubelet/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/network/kubenet/kubenet_unsupported.go
@@ -21,6 +21,7 @@ package kubenet
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
@@ -42,7 +43,7 @@ func (plugin *kubenetNetworkPlugin) Name() string {
 	return "kubenet"
 }
 
-func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *kubenetNetworkPlugin) SetUpPod(pod *api.Pod, id kubecontainer.ContainerID) error {
 	return fmt.Errorf("Kubenet is not supported in this build")
 }
 

--- a/pkg/kubelet/network/mock_network/network_plugins.go
+++ b/pkg/kubelet/network/mock_network/network_plugins.go
@@ -22,6 +22,7 @@ package mock_network
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	api "k8s.io/kubernetes/pkg/api"
 	componentconfig "k8s.io/kubernetes/pkg/apis/componentconfig"
 	container "k8s.io/kubernetes/pkg/kubelet/container"
 	network "k8s.io/kubernetes/pkg/kubelet/network"
@@ -98,14 +99,14 @@ func (_mr *_MockNetworkPluginRecorder) Name() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Name")
 }
 
-func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID) error {
-	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1, _param2)
+func (_m *MockNetworkPlugin) SetUpPod(_param0 *api.Pod, _param1 container.ContainerID) error {
+	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) SetUpPod(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUpPod", arg0, arg1, arg2)
+func (_mr *_MockNetworkPluginRecorder) SetUpPod(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUpPod", arg0, arg1)
 }
 
 func (_m *MockNetworkPlugin) Status() error {

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -69,7 +69,7 @@ type NetworkPlugin interface {
 	// the pod has been created but before the other containers of the
 	// pod are launched.
 	// TODO: rename podInfraContainerID to sandboxID
-	SetUpPod(namespace string, name string, podInfraContainerID kubecontainer.ContainerID) error
+	SetUpPod(pod *api.Pod, podInfraContainerID kubecontainer.ContainerID) error
 
 	// TearDownPod is the method called before a pod's infra container will be deleted
 	// TODO: rename podInfraContainerID to sandboxID
@@ -187,7 +187,7 @@ func (plugin *NoopNetworkPlugin) Capabilities() utilsets.Int {
 	return utilsets.NewInt()
 }
 
-func (plugin *NoopNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *NoopNetworkPlugin) SetUpPod(pod *api.Pod, id kubecontainer.ContainerID) error {
 	return nil
 }
 

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1272,7 +1272,7 @@ func (r *Runtime) setupPodNetwork(pod *api.Pod) (string, string, error) {
 	// Set up networking with the network plugin
 	glog.V(3).Infof("Calling network plugin %s to setup pod for %s", r.networkPlugin.Name(), format.Pod(pod))
 	containerID := kubecontainer.ContainerID{ID: string(pod.UID)}
-	err = r.networkPlugin.SetUpPod(pod.Namespace, pod.Name, containerID)
+	err = r.networkPlugin.SetUpPod(pod, containerID)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to set up pod network: %v", err)
 	}


### PR DESCRIPTION
Many external CNI plugins seem to want pod labels and annotations, so lets pass them to the plugin by marshaling the Pod TypeMeta, ObjectMeta, and PodSpec down to CNI plugins in the 'args' parameter of CNI config.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32681)

<!-- Reviewable:end -->
