### PR TITLE
Add glusterfs-client in hyperkube image.

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -29,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     socat \
     git \
     nfs-common \
+    glusterfs-client \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
When we run kubernete in a docker container, the glusterfs volume doesn't work.
This PR add glusterfs-client package in hyperkube image to fix the bug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32686)

<!-- Reviewable:end -->
