### PR TITLE
update list of vailable resources

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -175,25 +175,28 @@ __custom_func() {
     * configmaps (aka 'cm')
     * daemonsets (aka 'ds')
     * deployments (aka 'deploy')
-    * events (aka 'ev')
     * endpoints (aka 'ep')
+    * events (aka 'ev')
     * horizontalpodautoscalers (aka 'hpa')
-    * ingress (aka 'ing')
+    * ingresses (aka 'ing')
     * jobs
     * limitranges (aka 'limits')
-    * nodes (aka 'no')
     * namespaces (aka 'ns')
-    * statefulsets (alpha feature, may be unstable)
-    * pods (aka 'po')
-    * persistentvolumes (aka 'pv')
+    * networkpolicies
+    * nodes (aka 'no')
     * persistentvolumeclaims (aka 'pvc')
-    * quota
-    * resourcequotas (aka 'quota')
+    * persistentvolumes (aka 'pv')
+    * pods (aka 'po')
+    * podsecuritypolicies (aka 'psp')
+    * podtemplates
     * replicasets (aka 'rs')
     * replicationcontrollers (aka 'rc')
+    * resourcequotas (aka 'quota')
     * secrets
     * serviceaccounts (aka 'sa')
     * services (aka 'svc')
+    * storageclasses
+    * thirdpartyresources
     `
 )
 


### PR DESCRIPTION
Hi,

kubectl get --help produce a list of resource types and aliases :

```
Valid resource types include:
   * clusters (valid only for federation apiservers)
   * componentstatuses (aka 'cs')
   ...
```

``` release-note
Update the list of resources in kubectl get --help
```

The list is currently outdated (for exemple missing networkpolicy).

http://kubernetes.io/docs/user-guide/kubectl-overview/#resource-types has the same data and is also outdated.

The patch updates these 2 lists.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32687)

<!-- Reviewable:end -->
