### PR TITLE
Support for storage class for vSphere volume plugin. Custom disk format for dynamic provisioning.

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -83,6 +83,21 @@ parameters:
 * `type`: `pd-standard` or `pd-ssd`. Default: `pd-ssd`
 * `zone`: GCE zone. If not specified, a random zone in the same region as controller-manager will be chosen.
 
+#### vSphere
+
+```yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  diskformat: thin
+```
+
+* `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick`. See vSphere docs for details. Default: `"thin"`.
+
+
 #### GLUSTERFS
 
 ```yaml

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -222,12 +222,13 @@ func TestVolumes(t *testing.T) {
 		t.Fatalf("Instances.List() returned zero servers")
 	}
 
-	tags := map[string]string{
-		"adapterType": "lsiLogic",
-		"diskType":    "thin",
-	}
+	volumeOptions := &VolumeOptions{
+		CapacityKB: 1 * 1024 * 1024,
+		Tags:       nil,
+		Name:       "kubernetes-test-volume-" + rand.String(10),
+		DiskFormat: "thin"}
 
-	volPath, err := vs.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1*1024*1024, &tags)
+	volPath, err := vs.CreateVolume(volumeOptions)
 	if err != nil {
 		t.Fatalf("Cannot create a new VMDK volume: %v", err)
 	}

--- a/pkg/volume/vsphere_volume/attacher_test.go
+++ b/pkg/volume/vsphere_volume/attacher_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 
@@ -305,7 +306,7 @@ func (testcase *testcase) DiskIsAttached(diskName, hostName string) (bool, error
 	return expected.isAttached, expected.ret
 }
 
-func (testcase *testcase) CreateVolume(name string, size int, tags *map[string]string) (volumePath string, err error) {
+func (testcase *testcase) CreateVolume(volumeOptions *vsphere.VolumeOptions) (volumePath string, err error) {
 	return "", errors.New("Not implemented")
 }
 


### PR DESCRIPTION
This PR does following,
1.  Add support for storage class for vSphere volume plugin.
2. Add option for user to provision disk with different disk formats. Format choices are
   "thin" (default), "zeroedthick", "eagerzeroedthick".

Sample storageclass (yaml):

```
kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
  name: slow
provisioner: kubernetes.io/vsphere-volume
parameters:
  diskformat: thin
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32745)

<!-- Reviewable:end -->
