### PR TITLE
kubelet: api: improve some comments in api.proto

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -362,7 +362,7 @@ func (m *PortMapping) GetHostIp() string {
 	return ""
 }
 
-// Mount specifies the volume mount for the sandbox
+// Mount specifies a volume mount for a container.
 type Mount struct {
 	// The name of the volume mount.
 	Name *string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -3,7 +3,7 @@ syntax = 'proto2';
 
 package runtime;
 
-// Runtime service defines the public APIs for remote container runtimes
+// RuntimeService defines the public APIs for remote container runtimes
 service RuntimeService {
     // Version returns the runtime name, runtime version and runtime API version
     rpc Version(VersionRequest) returns (VersionResponse) {}
@@ -42,7 +42,7 @@ service RuntimeService {
     rpc Exec(stream ExecRequest) returns (stream ExecResponse) {}
 }
 
-// Image service defines the public APIs for managing images
+// ImageService defines the public APIs for managing images
 service ImageService {
     // ListImages lists existing images.
     rpc ListImages(ListImagesRequest) returns (ListImagesResponse) {}
@@ -98,7 +98,7 @@ message PortMapping {
     optional string host_ip = 5;
 }
 
-// Mount specifies the volume mount for the sandbox
+// Mount specifies a volume mount for a container.
 message Mount {
     // The name of the volume mount.
     optional string name = 1;


### PR DESCRIPTION
- Match the service comments to be consistent with the type comments
- Mounts appear in containers not sandboxes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32783)

<!-- Reviewable:end -->
