### PR TITLE
prevent printing of stack trace when proxying 304 requests in api gateway

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -152,6 +152,7 @@ func RecoverPanics(handler http.Handler) http.Handler {
 				http.StatusNotFound,
 				http.StatusUnauthorized,
 				http.StatusForbidden,
+				http.StatusNotModified,
 				errors.StatusUnprocessableEntity,
 				http.StatusSwitchingProtocols,
 			),


### PR DESCRIPTION
partially addresses #32747.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32786)

<!-- Reviewable:end -->
