### PR TITLE
Fix typo in scheduler doc

### DIFF
--- a/docs/devel/scheduler.md
+++ b/docs/devel/scheduler.md
@@ -81,7 +81,7 @@ that rank the nodes that weren't filtered out by the predicate check. For exampl
 The scheduler is extensible: the cluster administrator can choose which of the pre-defined
 scheduling policies to apply, and can add new ones.
 
-### Policies Prediates + Priorities
+### Policies (Predicates and Priorities)
 
 The built-in predicates and priorities are
 defined in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/algorithm/predicates/predicates.go) and


### PR DESCRIPTION
Also add parentheses

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32787)

<!-- Reviewable:end -->
