### PR TITLE
docs: devel: tell people how to find flake tests

### DIFF
--- a/docs/devel/flaky-tests.md
+++ b/docs/devel/flaky-tests.md
@@ -69,6 +69,15 @@ discoverable from the issue.
    link is nice but strictly optional: not only does it expire more quickly,
    it's not accessible to non-Googlers.
 
+## Finding filed flaky test cases
+
+Find flaky tests issues on GitHub under the [kind/flake issue label][flake].
+There are significant numbers of flaky tests reported on a regular basis and P2
+flakes are under-investigated. Fixing flakes is a quick way to gain expertise
+and community goodwill.
+
+[flake]: https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fflake
+
 ## Expectations when a flaky test is assigned to you
 
 Note that we won't randomly assign these issues to you unless you've opted in or


### PR DESCRIPTION
This doc talks about flake tests but never links to all of them. Fix
this so people can dive in.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32788)

<!-- Reviewable:end -->
