### PR TITLE
Adding the option for the system to use the HOME env for windows.

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -58,7 +58,13 @@ func currentMigrationRules() map[string]string {
 	migrationRules := map[string]string{}
 	migrationRules[RecommendedHomeFile] = oldRecommendedHomeFile
 	if goruntime.GOOS == "windows" {
-		migrationRules[RecommendedHomeFile] = oldRecommendedWindowsHomeFile
+		if home := os.Getenv("HOME"); len(home) > 0 {
+			if _, err := os.Stat(home); err = nill {
+				migrationRules[oldRecommendedWindowsHomeFile] = RecommendedHomeFile
+			}
+		} else {
+			migrationRules[RecommendedHomeFile] = oldRecommendedWindowsHomeFile
+		}
 	}
 	return migrationRules
 }

--- a/pkg/util/homedir/homedir.go
+++ b/pkg/util/homedir/homedir.go
@@ -23,7 +23,13 @@ import (
 
 // HomeDir returns the home directory for the current user
 func HomeDir() string {
-	if runtime.GOOS == "windows"; len(os.Getenv("HOME")) <= 0) {
+	if runtime.GOOS == "windows" {
+		if home := os.Getenv("HOME"); len(home) > 0 {
+			if _, err := os.Stat(home); err == nill {
+				return home
+			}
+
+		}
 		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
 			homeDir := homeDrive + homePath
 			if _, err := os.Stat(homeDir); err == nil {

--- a/pkg/util/homedir/homedir.go
+++ b/pkg/util/homedir/homedir.go
@@ -23,7 +23,7 @@ import (
 
 // HomeDir returns the home directory for the current user
 func HomeDir() string {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows"; len(os.Getenv("HOME")) <= 0) {
 		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
 			homeDir := homeDrive + homePath
 			if _, err := os.Stat(homeDir); err == nil {


### PR DESCRIPTION
Adding the option of checking for the HOME environment on windows. As on a work network, HOMEDRIVE is setup from the Group Policy on a work network.

Initial change was made https://github.com/kubernetes/kubernetes/pull/17590

This change would fix this issue: 
https://github.com/kubernetes/minikube/issues/459

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32790)

<!-- Reviewable:end -->
