### PR TITLE
Add the uid in a delete event to the absentOwnerCache

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -411,6 +411,7 @@ func (p *Propagator) processEvent() {
 		// the node's owners list.
 		p.removeDependentFromOwners(existingNode, removed)
 	case event.eventType == deleteEvent:
+		p.gc.absentOwnerCache.Add(accessor.GetUID())
 		if !found {
 			glog.V(6).Infof("%v doesn't exist in the graph, this shouldn't happen", accessor.GetUID())
 			return

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -298,8 +298,9 @@ func TestProcessEvent(t *testing.T) {
 				uidToNode: make(map[types.UID]*node),
 			},
 			gc: &GarbageCollector{
-				dirtyQueue: workqueue.NewTimedWorkQueue(),
-				clock:      clock.RealClock{},
+				dirtyQueue:       workqueue.NewTimedWorkQueue(),
+				clock:            clock.RealClock{},
+				absentOwnerCache: NewUIDCache(2),
 			},
 		}
 		for i := 0; i < len(scenario.events); i++ {


### PR DESCRIPTION
This is a small optimization to further reduce the traffic sent by the GC.

In #31167, GC caches the non-existent owners when it processes the dirtyQueue. As discovered in #32571, there is still small inefficiency, because there are multiple goroutines processing the dirtyQueue, many of them might send a GET to the apiserver before the cache gets populated.

This PR populates the cache when GC observes an object gets deleted, which happens before the processing of the dirtyQueue, so it avoids the simultaneous GET sent by the GC workers.

cc @lavalamp 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32805)

<!-- Reviewable:end -->
