### PR TITLE
salt: Don't stop trying to start kubelet

### DIFF
--- a/cluster/saltbase/salt/kubelet/kubelet.service
+++ b/cluster/saltbase/salt/kubelet/kubelet.service
@@ -6,6 +6,8 @@ Documentation=https://github.com/kubernetes/kubernetes
 EnvironmentFile=/etc/sysconfig/kubelet
 ExecStart=/usr/local/bin/kubelet "$DAEMON_ARGS"
 Restart=always
+RestartSec=2s
+StartLimitInterval=0
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Tell systemd to keep trying to restart kubelet without limit.  Without
this change at some stage systemd will stop trying to restart kubelet
and mark it failed.

These are the settings we're using elsewhere (e.g. Docker)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32808)

<!-- Reviewable:end -->
