### PR TITLE
Allow kubectl describe ns to pass if server does not support resource quotas and limit ranges

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -173,13 +173,24 @@ func (d *NamespaceDescriber) Describe(namespace, name string, describerSettings 
 	}
 	resourceQuotaList, err := d.Core().ResourceQuotas(name).List(api.ListOptions{})
 	if err != nil {
-		return "", err
+		if errors.IsNotFound(err) {
+			// Server does not support resource quotas.
+			// Not an error, will not show resource quotas information.
+			resourceQuotaList = nil
+		} else {
+			return "", err
+		}
 	}
 	limitRangeList, err := d.Core().LimitRanges(name).List(api.ListOptions{})
 	if err != nil {
-		return "", err
+		if errors.IsNotFound(err) {
+			// Server does not support limit ranges.
+			// Not an error, will not show limit ranges information.
+			limitRangeList = nil
+		} else {
+			return "", err
+		}
 	}
-
 	return describeNamespace(ns, resourceQuotaList, limitRangeList)
 }
 

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -86,6 +86,23 @@ func TestDescribePodTolerations(t *testing.T) {
 	}
 }
 
+func TestDescribeNamespace(t *testing.T) {
+	fake := fake.NewSimpleClientset(&api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: "myns",
+		},
+	})
+	c := &describeClient{T: t, Namespace: "", Interface: fake}
+	d := NamespaceDescriber{c}
+	out, err := d.Describe("", "myns", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "myns") {
+		t.Errorf("unexpected out: %s", out)
+	}
+}
+
 func TestDescribeService(t *testing.T) {
 	fake := fake.NewSimpleClientset(&api.Service{
 		ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/32629

Context: federation-apiserver does not support limit ranges and resource quotas. Hence `kubectl describe ns` fails right now.
Fixing it so that `kubectl describe ns` does not error out and atleast prints information about the namespace.

cc @kubernetes/sig-cluster-federation @kubernetes/kubectl

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32823)

<!-- Reviewable:end -->
