### PR TITLE
Node Upgrade: Change the upgrade script to keep os distro during upgrade.

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -33,11 +33,12 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 function usage() {
   echo "!!! EXPERIMENTAL !!!"
   echo ""
-  echo "${0} [-M|-N|-P] -l | <version number or publication>"
+  echo "${0} [-M|-N|-P] -l -o | <version number or publication>"
   echo "  Upgrades master and nodes by default"
   echo "  -M:  Upgrade master only"
   echo "  -N:  Upgrade nodes only"
   echo "  -P:  Node upgrade prerequisites only (create a new instance template)"
+  echo "  -o:  Use os distro sepcified in KUBE_NODE_OS_DISTRIBUTION for new nodes"
   echo "  -l:  Use local(dev) binaries"
   echo ""
   echo '  Version number or publication is either a proper version number'
@@ -134,6 +135,20 @@ function get-node-env() {
       'http://metadata/computeMetadata/v1/instance/attributes/kube-env'" 2>/dev/null
 }
 
+# Read os distro information from /os/release on node.
+# $1: The name of node
+#
+# Assumed vars:
+#   PROJECT
+#   ZONE
+function get-node-os() {
+  gcloud compute ssh "$1" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --command \
+    "cat /etc/os-release | grep \"^ID=.*\" | cut -c 4-"
+}
+
 # Assumed vars:
 #   KUBE_VERSION
 #   NODE_SCOPES
@@ -198,6 +213,13 @@ function prepare-node-upgrade() {
   # TODO(zmerlynn): How do we ensure kube-env is written in a ${version}-
   #                 compatible way?
   write-node-env
+
+  if [[ "${env_os_distro}" == "false" ]]; then
+    NODE_OS_DISTRIBUTION=$(get-node-os "${NODE_NAMES[0]}")
+    source "${KUBE_ROOT}/cluster/gce/${NODE_OS_DISTRIBUTION}/node-helper.sh"
+    # Reset the node image based on current os distro
+    set-node-image
+  fi
 
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
   #                 through all create-node-instance-template implementations).
@@ -271,6 +293,7 @@ master_upgrade=true
 node_upgrade=true
 node_prereqs=false
 local_binaries=false
+env_os_distro=false
 
 while getopts ":MNPlh" opt; do
   case ${opt} in
@@ -285,6 +308,9 @@ while getopts ":MNPlh" opt; do
       ;;
     l)
       local_binaries=true
+      ;;
+    o)
+      env_os_distro=true
       ;;
     h)
       usage

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -47,15 +47,21 @@ elif [[ "${MASTER_OS_DISTRIBUTION}" == "debian" ]]; then
   MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 fi
 
-if [[ "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
-  # If the node image is not set, we use the latest GCI image.
-  # Otherwise, we respect whatever is set by the user.
-  NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}
-  NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
-elif [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
-  NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}
-  NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
-fi
+# Sets node image based on the specified os distro. Currently this function only
+# supports gci and debian.
+function set-node-image() {
+  if [[ "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
+    # If the node image is not set, we use the latest GCI image.
+    # Otherwise, we respect whatever is set by the user.
+    NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}
+    NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
+  elif [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
+    NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}
+    NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
+  fi
+}
+
+set-node-image
 
 # Verfiy cluster autoscaler configuration.
 if [[ "${ENABLE_CLUSTER_AUTOSCALER}" == "true" ]]; then


### PR DESCRIPTION
This PR fixes https://github.com/kubernetes/kubernetes/issues/32812#issuecomment-247473584.

This PR will fix flakiness in upgrade tests for v1.4.0

Basically, our script didn't detect the image currently being used, it just use the [default image hard coded in the script](https://github.com/kubernetes/kubernetes/blob/d9ea0887653b62597a332d02453db53a4df2d494/cluster/gce/config-default.sh#L39) during upgrade.

This PR changes the script to detect the os distro currently being used and keep it unchanged during the upgrade.

@vishh @dchen1107
/cc @kubernetes/sig-cluster-lifecycle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32840)

<!-- Reviewable:end -->
