### PR TITLE
WIP: Remove all non-completed pods when number of replicas of RC is 0

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -701,6 +701,25 @@ func IsPodActive(p *api.Pod) bool {
 		p.DeletionTimestamp == nil
 }
 
+// FilterDeletablePods returns pods that can be deleted.
+func FilterDeletablePods(pods []*api.Pod) []*api.Pod {
+	var result []*api.Pod
+	for _, p := range pods {
+		if IsPodDeletable(p) {
+			result = append(result, p)
+		} else {
+			glog.V(4).Infof("Ignoring non-deletable pod %v/%v in state %v, deletion time %v",
+				p.Namespace, p.Name, p.Status.Phase, p.DeletionTimestamp)
+		}
+	}
+	return result
+}
+
+func IsPodDeletable(p *api.Pod) bool {
+	return api.PodSucceeded != p.Status.Phase &&
+		p.DeletionTimestamp == nil
+}
+
 // FilterActiveReplicaSets returns replica sets that have (or at least ought to have) pods.
 func FilterActiveReplicaSets(replicaSets []*extensions.ReplicaSet) []*extensions.ReplicaSet {
 	active := []*extensions.ReplicaSet{}


### PR DESCRIPTION
Currently, pods that are in Failed state due to NodeSelectorMismatching are not deleted if the number of replicas is set to 0. When the number of replicas is zero, all pods should be deleted no matter if they are in "Failed" state or not. Only "Completed" pods can be ignored as they fulfiled they purpose.

Based on RC code, all failed pods are ignored. Based on [pod lifecycle](http://kubernetes.io/docs/user-guide/pod-states/#pod-lifetime), all failed pods are deleted by the master eventually. So if it is expected that all failed pods (originally managed by RC) are not deleted right away if the number of replicas is set to 0, this PR can be closed.

Bugzilla issue: https://bugzilla.redhat.com/show_bug.cgi?id=1334550
### TODO:
- [ ] - add integration tests
- [ ] - add e2e test

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32858)

<!-- Reviewable:end -->
