### PR TITLE
examples/javaee: fix resource type abbreviation for service

### DIFF
--- a/examples/javaee/README.md
+++ b/examples/javaee/README.md
@@ -88,7 +88,7 @@ kubectl create -f examples/javaee/mysql-service.yaml
 Get status of the service:
 
 ```sh
-kubectl get -w se
+kubectl get -w svc
 NAME            LABELS                                    SELECTOR                                IP(S)          PORT(S)
 kubernetes      component=apiserver,provider=kubernetes   <none>                                  10.247.0.1     443/TCP
 mysql-service   context=docker-k8s-lab,name=mysql-pod     context=docker-k8s-lab,name=mysql-pod   10.247.63.43   3306/TCP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This corrects an incorrect command in the documentations for the javaee example application. On newer versions of Kubernetes you get the following error when you run `kubectl get -w se`

```
the server doesn't have a resource type "se"
```

The correct command should be `kubectl get -w svc`.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
examples/javaee: fix resource type abbreviation for service
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32859)

<!-- Reviewable:end -->
