### PR TITLE
kubectl: move events sorting interface to the api for general use

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -56,6 +56,7 @@ hack/cmd/teststale
 pkg/api
 pkg/api/annotations
 pkg/api/errors
+pkg/api/events
 pkg/api/install
 pkg/api/meta
 pkg/api/resource

--- a/pkg/api/events/sorted_event_list.go
+++ b/pkg/api/events/sorted_event_list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package events
 
 import (
 	"k8s.io/kubernetes/pkg/api"

--- a/pkg/api/events/sorted_event_list_test.go
+++ b/pkg/api/events/sorted_event_list_test.go
@@ -14,42 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package events
 
 import (
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
-
-// VerifyDatesInOrder checks the start of each line for a RFC1123Z date
-// and posts error if all subsequent dates are not equal or increasing
-func VerifyDatesInOrder(
-	resultToTest, rowDelimiter, columnDelimiter string, t *testing.T) {
-	lines := strings.Split(resultToTest, rowDelimiter)
-	var previousTime time.Time
-	for _, str := range lines {
-		columns := strings.Split(str, columnDelimiter)
-		if len(columns) > 0 {
-			currentTime, err := time.Parse(time.RFC1123Z, columns[0])
-			if err == nil {
-				if previousTime.After(currentTime) {
-					t.Errorf(
-						"Output is not sorted by time. %s should be listed after %s. Complete output: %s",
-						previousTime.Format(time.RFC1123Z),
-						currentTime.Format(time.RFC1123Z),
-						resultToTest)
-				}
-				previousTime = currentTime
-			}
-		}
-	}
-
-}
 
 func TestSortableEvents(t *testing.T) {
 	// Arrange

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -32,6 +32,7 @@ import (
 	fed_clientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/events"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -2166,8 +2167,8 @@ func DescribeEvents(el *api.EventList, w io.Writer) {
 		fmt.Fprint(w, "No events.\n")
 		return
 	}
-	sort.Sort(SortableEvents(el.Items))
-	fmt.Fprint(w, "Events:\n  FirstSeen\tLastSeen\tCount\tFrom\tSubobjectPath\tType\tReason\tMessage\n")
+	sort.Sort(events.SortableEvents(el.Items))
+	fmt.Fprint(w, "Events:\n  FirstSeen\tLastSeen\tCount\tFrom\tSubObjectPath\tType\tReason\tMessage\n")
 	fmt.Fprint(w, "  ---------\t--------\t-----\t----\t-------------\t--------\t------\t-------\n")
 	for _, e := range el.Items {
 		fmt.Fprintf(w, "  %s\t%s\t%d\t%v\t%v\t%v\t%v\t%v\n",

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -170,6 +170,30 @@ func TestPodDescribeResultsSorted(t *testing.T) {
 	VerifyDatesInOrder(out, "\n" /* rowDelimiter */, "\t" /* columnDelimiter */, t)
 }
 
+// VerifyDatesInOrder checks the start of each line for a RFC1123Z date
+// and posts error if all subsequent dates are not equal or increasing
+func VerifyDatesInOrder(
+	resultToTest, rowDelimiter, columnDelimiter string, t *testing.T) {
+	lines := strings.Split(resultToTest, rowDelimiter)
+	var previousTime time.Time
+	for _, str := range lines {
+		columns := strings.Split(str, columnDelimiter)
+		if len(columns) > 0 {
+			currentTime, err := time.Parse(time.RFC1123Z, columns[0])
+			if err == nil {
+				if previousTime.After(currentTime) {
+					t.Errorf(
+						"Output is not sorted by time. %s should be listed after %s. Complete output: %s",
+						previousTime.Format(time.RFC1123Z),
+						currentTime.Format(time.RFC1123Z),
+						resultToTest)
+				}
+				previousTime = currentTime
+			}
+		}
+	}
+}
+
 func TestDescribeContainers(t *testing.T) {
 	testCases := []struct {
 		container        api.Container

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/events"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -1629,7 +1630,7 @@ func printEvent(event *api.Event, w io.Writer, options PrintOptions) error {
 
 // Sorts and prints the EventList in a human-friendly format.
 func printEventList(list *api.EventList, w io.Writer, options PrintOptions) error {
-	sort.Sort(SortableEvents(list.Items))
+	sort.Sort(events.SortableEvents(list.Items))
 	for i := range list.Items {
 		if err := printEvent(&list.Items[i], w, options); err != nil {
 			return err


### PR DESCRIPTION
Split from https://github.com/kubernetes/kubernetes/pull/19343

@kubernetes/kubectl

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32867)

<!-- Reviewable:end -->
