### PR TITLE
Validate pet set scale up/down order

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -150,7 +150,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			})
 
 			// What happens in this test:
-			// 	Network traffic from a node to master is cut off to simulate network partition
+			//	Network traffic from a node to master is cut off to simulate network partition
 			// Expect to observe:
 			// 1. Node is marked NotReady after timeout by nodecontroller (40seconds)
 			// 2. All pods on node are marked NotReady shortly after #1
@@ -398,7 +398,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			restartNodes(f, nodeNames)
 
 			By("waiting for pods to be running again")
-			pst.waitForRunning(ps.Spec.Replicas, ps)
+			pst.waitForRunningAndReady(ps.Spec.Replicas, ps)
 		})
 
 		It("should not reschedule pets if there is a network partition [Slow] [Disruptive] [Feature:PetSet]", func() {
@@ -407,7 +407,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			pst := statefulSetTester{c: c}
-			pst.waitForRunning(ps.Spec.Replicas, ps)
+			pst.waitForRunningAndReady(ps.Spec.Replicas, ps)
 
 			pod := pst.getPodList(ps).Items[0]
 			node, err := c.Core().Nodes().Get(pod.Spec.NodeName)
@@ -428,7 +428,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			}
 
 			By("waiting for pods to be running again")
-			pst.waitForRunning(ps.Spec.Replicas, ps)
+			pst.waitForRunningAndReady(ps.Spec.Replicas, ps)
 		})
 	})
 


### PR DESCRIPTION
This change implements test cases to validate that:
- scale up will be done in order
- scale down in reverse order
- if any of the pets will be unhealthy, scale up/down will halt

related: https://github.com/kubernetes/kubernetes/issues/30082

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32868)

<!-- Reviewable:end -->
