### PR TITLE
WIP: Fix federation ingress test helper

### DIFF
--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -93,6 +93,7 @@ func TestIngressController(t *testing.T) {
 	stop := make(chan struct{})
 	t.Log("Running Ingress Controller")
 	ingressController.Run(stop)
+	defer close(stop)
 
 	ing1 := extensions_v1beta1.Ingress{
 		ObjectMeta: api_v1.ObjectMeta{
@@ -169,7 +170,6 @@ func TestIngressController(t *testing.T) {
 			fmt.Sprintf("UID's in configmaps in cluster's 1 and 2 are not equal (%q != %q)", cfg1.Data["uid"], updatedConfigMap2.Data["uid"]))
 	}
 
-	close(stop)
 }
 
 func GetIngressFromChan(t *testing.T, c chan runtime.Object) *extensions_v1beta1.Ingress {


### PR DESCRIPTION
This is not a full fix!! If someone wants and have a time to pick it up - feel free.

I was debugging unit-test failures for federation ingress (hence the sleep in this PR). My current theory for this problem is that all throughout the test infrastructure we pass pointers to objects, which is OK as long as there's only one watcher. Having multiple "watchers" for the same object, and actually calling handlers on the same object doesn't seem like a good idea.

cc @wojtek-t @mwielgus @quinton-hoole

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32882)

<!-- Reviewable:end -->
