### PR TITLE
Make sh2ju not print 'error: 0' lines.

### DIFF
--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -113,7 +113,7 @@ function juLog() {
       H=`echo "$out" | egrep $icase "$ereg"`
       [ -n "$H" ] && err=1
   fi
-  echo "+++ error: $err"         | tee -a $outf
+  [ $err != 0 ] && echo "+++ error: $err"         | tee -a $outf
   rm -f $outf
 
   errMsg=`cat $errf`


### PR DESCRIPTION
They cause false positives on Gubernator when it's looking for error
reasons.

<!-- Reviewable:start -->

Note this script is packaged into e2e-image, so this won't actually be tested at all by CI.

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32892)

<!-- Reviewable:end -->
