### PR TITLE
fix upgrade test for 1.2->1.4

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1107,6 +1107,8 @@ var _ = Describe("Kubectl client", func() {
 
 		It("should create a job from an image when restart is Never [Conformance]", func() {
 			SkipUnlessServerVersionGTE(jobsVersion, c)
+			// if the version is >= 1.3.0 the job with --restart=Never is a pod, see: https://github.com/kubernetes/kubernetes/commit/d76fa8a1197a6329da3125c8bfb2202dfead1273
+			SkipUnlessServerVersionLTE(version.MustParse("v1.3.0-alpha.5"), c)
 
 			By("running the image " + nginxImage)
 			runKubectlOrDie("run", jobName, "--restart=Never", "--image="+nginxImage, nsFlag)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -376,6 +376,16 @@ func SkipUnlessServerVersionGTE(v semver.Version, c discovery.ServerVersionInter
 	}
 }
 
+func SkipUnlessServerVersionLTE(v semver.Version, c discovery.ServerVersionInterface) {
+	gte, err := serverVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		Skipf("Not supported for server versions after %q", v)
+	}
+}
+
 // providersWithSSH are those providers where each node is accessible with SSH
 var providersWithSSH = []string{"gce", "gke", "aws"}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: fixes #32700 upgrade test since jobs started with --restart=Never after v1.3.0 are considered pods.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
None
```

fix #32700

Signed-off-by: Jess Frazelle me@jessfraz.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32895)

<!-- Reviewable:end -->
