### PR TITLE
32702 fix upgrade test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -459,6 +459,8 @@ var _ = Describe("Kubectl client", func() {
 
 		It("should support inline execution and attach", func() {
 			SkipUnlessServerVersionGTE(jobsVersion, c)
+			// if the version is >= 1.3.0 the job with --restart=Never is a pod, see: https://github.com/kubernetes/kubernetes/commit/d76fa8a1197a6329da3125c8bfb2202dfead1273
+			SkipUnlessServerVersionLTE(version.MustParse("v1.3.0-alpha.5"), c)
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -376,6 +376,16 @@ func SkipUnlessServerVersionGTE(v semver.Version, c discovery.ServerVersionInter
 	}
 }
 
+func SkipUnlessServerVersionLTE(v semver.Version, c discovery.ServerVersionInterface) {
+	gte, err := serverVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		Skipf("Not supported for server versions after %q", v)
+	}
+}
+
 // providersWithSSH are those providers where each node is accessible with SSH
 var providersWithSSH = []string{"gce", "gke", "aws"}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Fixes the upgrade test #32702 , had the same problem as https://github.com/kubernetes/kubernetes/pull/32895 

if the version is <= 1.3.0 the job with --restart=Never is a pod, see: https://github.com/kubernetes/kubernetes/commit/d76fa8a1197a6329da3125c8bfb2202dfead1273

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
NONE
```

closes #32702

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32898)

<!-- Reviewable:end -->
