### PR TITLE
Skip kubectl rolling-update test for client older than 1.4

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1571,6 +1571,16 @@ func ServerVersionGTE(v semver.Version, c discovery.ServerVersionInterface) (boo
 	return sv.GTE(v), nil
 }
 
+func SkipUnlessKubectlVersionGTE(v semver.Version) {
+	gte, err := KubectlVersionGTE(v)
+	if err != nil {
+		Failf("Failed to get kubectl version: %v", err)
+	}
+	if !gte {
+		Skipf("Not supported for kubectl versions before %q", v)
+	}
+}
+
 // KubectlVersionGTE returns true if the kubectl version is greater than or
 // equal to v.
 func KubectlVersionGTE(v semver.Version) (bool, error) {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -121,6 +121,11 @@ var (
 	//
 	// TODO(ihmccreery): remove once we don't care about v1.1 anymore, (tentatively in v1.4).
 	podProbeParametersVersion = version.MustParse("v1.2.0-alpha.4")
+
+	// Garbage collector was introduced in v1.4.0 and breaks kubectl rolling-update older than
+	// v1.4.0. We don't expect older kubectl to work on v1.4 cluster. See
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#kubectl-rolling-update
+	kubectlRollingUpdateVersion = version.MustParse("v1.4.0")
 )
 
 // Stops everything from filePath from namespace ns and checks if everything matching selectors from the given namespace is correctly stopped.
@@ -934,6 +939,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		})
 
 		It("should support rolling-update to same image [Conformance]", func() {
+			framework.SkipUnlessKubectlVersionGTE(kubectlRollingUpdateVersion)
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", rcName, "--image="+nginxImage, "--generator=run/v1", nsFlag)
 			By("verifying the rc " + rcName + " was created")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Fixing upgrade test kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew 

Supersedes #32890; garbage collector was introduced in 1.4 which breaks kubectl rolling-update with kubectl <1.4; skip this in 1.3 test to make it passing kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew 

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #32706 

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Garbage collector was introduced in v1.4, which caused kubectl rolling-update
with kubectl version < 1.4 to fail. This is cherrypicked into 1.3 merely for
fixing test failures on kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32919)

<!-- Reviewable:end -->
