### PR TITLE
Skip "Secret consumable" for server newer than 1.3

### DIFF
--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -21,14 +21,24 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/version"
 
 	. "github.com/onsi/ginkgo"
+)
+
+var (
+	serverVersion13 = version.MustParse("v1.3.0")
 )
 
 var _ = Describe("Secrets", func() {
 	f := NewDefaultFramework("secrets")
 
 	It("should be consumable from pods in volume [Conformance]", func() {
+		// The expected behavior of secrets changed in v1.3.0. Since this test
+		// expects the old behavior it should not run against 1.3.0+.
+		// See  https://github.com/kubernetes/kubernetes/issues/32705
+		// See https://github.com/kubernetes/kubernetes/issues/26662
+		SkipUnlessServerVersionLT(serverVersion13, f.Client)
 		name := "secret-test-" + string(util.NewUUID())
 		volumeName := "secret-volume"
 		volumeMountPath := "/etc/secret-volume"

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -386,6 +386,16 @@ func SkipUnlessServerVersionLTE(v semver.Version, c discovery.ServerVersionInter
 	}
 }
 
+func SkipUnlessServerVersionLT(v semver.Version, c discovery.ServerVersionInterface) {
+	lt, err := serverVersionLT(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if !lt {
+		Skipf("Test not supported for server version %q", v)
+	}
+}
+
 // providersWithSSH are those providers where each node is accessible with SSH
 var providersWithSSH = []string{"gce", "gke", "aws"}
 
@@ -1305,6 +1315,19 @@ func serverVersionGTE(v semver.Version, c discovery.ServerVersionInterface) (boo
 		return false, fmt.Errorf("Unable to parse server version %q: %v", serverVersion.GitVersion, err)
 	}
 	return sv.GTE(v), nil
+}
+
+// serverVersionLT returns true if v is less than the server version.
+func serverVersionLT(v semver.Version, c discovery.ServerVersionInterface) (bool, error) {
+	serverVersion, err := c.ServerVersion()
+	if err != nil {
+		return false, fmt.Errorf("Unable to get server version: %v", err)
+	}
+	sv, err := version.Parse(serverVersion.GitVersion)
+	if err != nil {
+		return false, fmt.Errorf("Unable to parse server version %q: %v", serverVersion.GitVersion, err)
+	}
+	return sv.LT(v), nil
 }
 
 // kubectlVersionGTE returns true if the kubectl version is greater than or


### PR DESCRIPTION
The expected behavior of secrets changed in v1.3.0. This PR skips the "Secrets should be consumable from pods in volume [Conformance]" test if server version is greater than or equal to 1.3.0 in release-1.2, so that it does not fail if run against new versions of the server.

See issues #32705 and #26662.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32930)

<!-- Reviewable:end -->
