### PR TITLE
Make container exec failures in e2e easier to debug

### DIFF
--- a/test/e2e/framework/exec_util.go
+++ b/test/e2e/framework/exec_util.go
@@ -55,8 +55,8 @@ func (f *Framework) ExecCommandInContainer(podName, containerName string, cmd ..
 	}, api.ParameterCodec)
 
 	err = execute("POST", req.URL(), config, stdin, &stdout, &stderr, tty)
-	Expect(err).NotTo(HaveOccurred(), "post request failed")
 	Logf("Exec stderr: %q", stderr.String())
+	Expect(err).NotTo(HaveOccurred(), "post request failed")
 	return strings.TrimSpace(stdout.String())
 }
 


### PR DESCRIPTION
Makes container exec failures in e2e tests easier to debug.  Found while chasing some SELinux bugs :)

@pwittrock I'm adding this to the 1.4 milestone because it makes e2e failures easier to debug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32933)

<!-- Reviewable:end -->
