### PR TITLE
Fix error message around gcloud calls in node e2e and gubernator

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -89,14 +89,14 @@ if [ $remote = true ] ; then
   # Get the compute zone
   zone=$(gcloud info --format='value(config.properties.compute.zone)')
   if [[ $zone == "" ]]; then
-    echo "Could not find gcloud compute/zone when running:\ngcloud info --format='value(config.properties.compute.zone)'"
+    echo "Could not find gcloud compute/zone when running: \`gcloud info --format='value(config.properties.compute.zone)'\`"
     exit 1
   fi
 
   # Get the compute project
   project=$(gcloud info --format='value(config.project)')
   if [[ $project == "" ]]; then
-    echo "Could not find gcloud project when running:\ngcloud info --format='value(config.project)'"
+    echo "Could not find gcloud project when running: \`gcloud info --format='value(config.project)'\`"
     exit 1
   fi
 

--- a/test/e2e_node/gubernator.sh
+++ b/test/e2e_node/gubernator.sh
@@ -35,19 +35,19 @@ fi
 
 # Check that user has gsutil
 if [[ $(which gsutil) == "" ]]; then
-  echo "Could not find gsutil when running:\which gsutil"
+  echo "Could not find gsutil when running \`which gsutil\`"
   exit 1
 fi
 
 # Check that user has gcloud
 if [[ $(which gcloud) == "" ]]; then
-  echo "Could not find gcloud when running:\which gcloud"
+  echo "Could not find gcloud when running: \`which gcloud\`"
   exit 1
 fi
 
 # Check that user has Credentialed Active account
 if ! gcloud auth list | grep -q "ACTIVE"; then
-  echo "Could not find active account when running:\gcloud auth list"
+  echo "Could not find active account when running: \`gcloud auth list\`"
   exit 1
 fi
 


### PR DESCRIPTION
Fixes some janky error messages around gcloud calls.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32938)

<!-- Reviewable:end -->
