### PR TITLE
Handle situation in which init fails but the exit code is 0

### DIFF
--- a/pkg/volume/flexvolume/flexvolume_test.go
+++ b/pkg/volume/flexvolume/flexvolume_test.go
@@ -134,6 +134,15 @@ exit 1
 echo -n $@ &> {{.OutputFile}}
 `
 
+const execScriptTempl3 = `#!/bin/bash
+if [ "$1" == "init" -a $# -eq 1 ]; then
+  echo -n '{
+    "status": "Failure"
+  }'
+  exit 0
+fi
+`
+
 func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, execScriptTempl string, execTemplateData *map[string]interface{}) {
 	vendoredName := plugName
 	if vendorName != "" {
@@ -171,6 +180,21 @@ func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, e
 		t.Errorf("Failed to write plugin exec")
 	}
 	f.Close()
+}
+
+func TestInitFailExitCode0(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("flexvolume_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	plugMgr := volume.VolumePluginMgr{}
+	installPluginUnderTest(t, "kubernetes.io", "fakeAttacher", tmpDir, execScriptTempl3, nil)
+	err = plugMgr.InitPlugins(ProbeVolumePlugins(tmpDir), volumetest.NewFakeVolumeHost("fake", nil, nil, "" /* rootContext */))
+	if err == nil {
+		t.Error("Expect init failure")
+	}
 }
 
 func TestCanSupport(t *testing.T) {

--- a/pkg/volume/flexvolume/flexvolume_util.go
+++ b/pkg/volume/flexvolume/flexvolume_util.go
@@ -100,6 +100,11 @@ func (u *flexVolumeUtil) init(plugin *flexVolumePlugin) error {
 		return err
 	}
 
+	_, err = handleCmdResponse(unmountCmd, output)
+	if err != nil {
+		return err
+	}
+
 	glog.V(5).Infof("Successfully initialized driver %s", plugin.driverName)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Fixes corner case issue in flexvol init.  It is possible for a plugin to return {"Status":"Failure"} but actually exit 0.  Because the spec is not clear on the behaviour of exit codes this odd case should be handled.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

No issue created

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

NONE

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32979)

<!-- Reviewable:end -->
