### PR TITLE
Node E2E: Add image white list

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package common
 
+import (
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
 type Suite string
 
 const (
@@ -24,3 +28,20 @@ const (
 )
 
 var CurrentSuite Suite
+
+// CommonImageWhiteList is the list of images used in common test. These images should be prepulled
+// before a tests starts, so that the tests won't fail due image pulling flakes. Currently, this is
+// only used by node e2e test.
+// TODO(random-liu): Change the image puller pod to use similar mechanism.
+var CommonImageWhiteList = sets.NewString(
+	"gcr.io/google_containers/busybox:1.24",
+	"gcr.io/google_containers/eptest:0.1",
+	"gcr.io/google_containers/liveness:e2e",
+	"gcr.io/google_containers/mounttest:0.7",
+	"gcr.io/google_containers/mounttest-user:0.3",
+	"gcr.io/google_containers/netexec:1.4",
+	"gcr.io/google_containers/nginx-slim:0.7",
+	"gcr.io/google_containers/serve_hostname:v1.4",
+	"gcr.io/google_containers/test-webserver:e2e",
+	"gcr.io/google_containers/hostexec:1.2",
+)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -92,6 +92,8 @@ type NodeTestContextType struct {
 	EvictionHard string
 	// ManifestPath is the static pod manifest path.
 	ManifestPath string
+	// PrepullImages indicates whether node e2e framework should prepull images.
+	PrepullImages bool
 }
 
 type CloudConfig struct {
@@ -183,6 +185,7 @@ func RegisterNodeFlags() {
 	//flag.BoolVar(&TestContext.CgroupsPerQOS, "cgroups-per-qos", false, "Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created.")
 	flag.StringVar(&TestContext.EvictionHard, "eviction-hard", "memory.available<250Mi,imagefs.available<10%", "The hard eviction thresholds. If set, pods get evicted when the specified resources drop below the thresholds.")
 	flag.StringVar(&TestContext.ManifestPath, "manifest-path", "", "The path to the static pod manifest file.")
+	flag.BoolVar(&TestContext.PrepullImages, "prepull-images", true, "If true, prepull images so image pull failures do not cause test failures.")
 }
 
 // Enable viper configuration management of flags.

--- a/test/e2e_node/apparmor_test.go
+++ b/test/e2e_node/apparmor_test.go
@@ -165,7 +165,7 @@ func createPodWithAppArmor(f *framework.Framework, profile string) *api.Pod {
 		Spec: api.PodSpec{
 			Containers: []api.Container{{
 				Name:    "test",
-				Image:   ImageRegistry[busyBoxImage],
+				Image:   "gcr.io/google_containers/busybox:1.24",
 				Command: []string{"touch", "foo"},
 			}},
 			RestartPolicy: api.RestartPolicyNever,

--- a/test/e2e_node/cgroup_manager_test.go
+++ b/test/e2e_node/cgroup_manager_test.go
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("Kubelet Cgroup Manager [Skip]", func() {
 						RestartPolicy: api.RestartPolicyNever,
 						Containers: []api.Container{
 							{
-								Image:   ImageRegistry[busyBoxImage],
+								Image:   "gcr.io/google_containers/busybox:1.24",
 								Name:    contName,
 								Command: []string{"sh", "-c", "if [ -d /tmp/memory/Burstable ] && [ -d /tmp/memory/BestEffort ]; then exit 0; else exit 1; fi"},
 								VolumeMounts: []api.VolumeMount{

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -104,7 +104,7 @@ var _ = framework.KubeDescribe("Kubelet Container Manager [Serial]", func() {
 					Spec: api.PodSpec{
 						Containers: []api.Container{
 							{
-								Image: ImageRegistry[serveHostnameImage],
+								Image: "gcr.io/google_containers/serve_hostname:v1.4",
 								Name:  podName,
 							},
 						},
@@ -148,7 +148,7 @@ var _ = framework.KubeDescribe("Kubelet Container Manager [Serial]", func() {
 					Spec: api.PodSpec{
 						Containers: []api.Container{
 							{
-								Image: ImageRegistry[nginxImage],
+								Image: "gcr.io/google_containers/nginx-slim:0.7",
 								Name:  podName,
 								Resources: api.ResourceRequirements{
 									Limits: api.ResourceList{
@@ -189,7 +189,7 @@ var _ = framework.KubeDescribe("Kubelet Container Manager [Serial]", func() {
 					Spec: api.PodSpec{
 						Containers: []api.Container{
 							{
-								Image: ImageRegistry[testWebServer],
+								Image: "gcr.io/google_containers/test-webserver:e2e",
 								Name:  podName,
 								Resources: api.ResourceRequirements{
 									Requests: api.ResourceList{

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -324,7 +324,7 @@ func runDensityBatchTest(f *framework.Framework, rc *ResourceCollector, testArg 
 	)
 
 	// create test pod data structure
-	pods := newTestPods(testArg.podsNr, ImageRegistry[pauseImage], podType)
+	pods := newTestPods(testArg.podsNr, framework.GetPauseImageNameForHostArch(), podType)
 
 	// the controller watches the change of pod status
 	controller := newInformerWatchPod(f, mutex, watchTimes, podType)
@@ -403,8 +403,8 @@ func runDensitySeqTest(f *framework.Framework, rc *ResourceCollector, testArg de
 		podType               = "density_test_pod"
 		sleepBeforeCreatePods = 30 * time.Second
 	)
-	bgPods := newTestPods(testArg.bgPodsNr, ImageRegistry[pauseImage], "background_pod")
-	testPods := newTestPods(testArg.podsNr, ImageRegistry[pauseImage], podType)
+	bgPods := newTestPods(testArg.bgPodsNr, framework.GetPauseImageNameForHostArch(), "background_pod")
+	testPods := newTestPods(testArg.podsNr, framework.GetPauseImageNameForHostArch(), podType)
 
 	By("Creating a batch of background pods")
 

--- a/test/e2e_node/disk_eviction_test.go
+++ b/test/e2e_node/disk_eviction_test.go
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("Kubelet Eviction Manager [Serial] [Disruptive]",
 						RestartPolicy: api.RestartPolicyNever,
 						Containers: []api.Container{
 							{
-								Image: ImageRegistry[busyBoxImage],
+								Image: "gcr.io/google_containers/busybox:1.24",
 								Name:  busyPodName,
 								// Filling the disk
 								Command: []string{"sh", "-c",
@@ -190,7 +190,7 @@ func createIdlePod(podName string, podClient *framework.PodClient) {
 			RestartPolicy: api.RestartPolicyNever,
 			Containers: []api.Container{
 				{
-					Image: ImageRegistry[pauseImage],
+					Image: framework.GetPauseImageNameForHostArch(),
 					Name:  podName,
 				},
 			},

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -47,7 +47,6 @@ import (
 
 var e2es *services.E2EServices
 
-var prePullImages = flag.Bool("prepull-images", true, "If true, prepull images so image pull failures do not cause test failures.")
 var runServicesMode = flag.Bool("run-services-mode", false, "If true, only run services (etcd, apiserver) in current process, and not run test.")
 
 func init() {
@@ -94,7 +93,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}
 	// Pre-pull the images tests depend on so we can fail immediately if there is an image pull issue
 	// This helps with debugging test flakes since it is hard to tell when a test failure is due to image pulling.
-	if *prePullImages {
+	if framework.TestContext.PrepullImages {
 		glog.Infof("Pre-pulling images so that they are cached for the tests.")
 		err := PrePullAllImages()
 		Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e_node/image_conformance_test.go
+++ b/test/e2e_node/image_conformance_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Image Container Conformance Test", func() {
 			var conformImages []ConformanceImage
 			BeforeEach(func() {
 				existImageTags := []string{
-					NoPullImageRegistry[pullTestExecHealthz],
-					NoPullImageRegistry[pullTestAlpineWithBash],
+					"gcr.io/google_containers/exechealthz:1.0",
+					"gcr.io/google_containers/alpine-with-bash:1.0",
 				}
 				for _, existImageTag := range existImageTags {
 					conformImage, _ := NewConformanceImage("docker", existImageTag)

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -55,7 +55,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 					RestartPolicy: api.RestartPolicyNever,
 					Containers: []api.Container{
 						{
-							Image:   ImageRegistry[busyBoxImage],
+							Image:   "gcr.io/google_containers/busybox:1.24",
 							Name:    podName,
 							Command: []string{"sh", "-c", "echo 'Hello World' ; sleep 240"},
 						},
@@ -89,7 +89,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 					RestartPolicy: api.RestartPolicyNever,
 					Containers: []api.Container{
 						{
-							Image:   ImageRegistry[busyBoxImage],
+							Image:   "gcr.io/google_containers/busybox:1.24",
 							Name:    podName,
 							Command: []string{"/bin/false"},
 						},
@@ -136,7 +136,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 					RestartPolicy: api.RestartPolicyNever,
 					Containers: []api.Container{
 						{
-							Image:   ImageRegistry[busyBoxImage],
+							Image:   "gcr.io/google_containers/busybox:1.24",
 							Name:    podName,
 							Command: []string{"sh", "-c", "echo test > /file; sleep 240"},
 							SecurityContext: &api.SecurityContext{
@@ -221,7 +221,7 @@ func createSummaryTestPods(podClient *framework.PodClient, podNamePrefix string,
 				RestartPolicy: api.RestartPolicyNever,
 				Containers: []api.Container{
 					{
-						Image:   ImageRegistry[busyBoxImage],
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "while true; do echo 'hello world' | tee /test-empty-dir-mnt/file ; sleep 1; done"},
 						Name:    podName + containerSuffix,
 						VolumeMounts: []api.VolumeMount{

--- a/test/e2e_node/memory_eviction_test.go
+++ b/test/e2e_node/memory_eviction_test.go
@@ -116,7 +116,7 @@ var _ = framework.KubeDescribe("MemoryEviction [Slow] [Serial] [Disruptive]", fu
 						RestartPolicy: api.RestartPolicyNever,
 						Containers: []api.Container{
 							{
-								Image: ImageRegistry[pauseImage],
+								Image: framework.GetPauseImageNameForHostArch(),
 								Name:  podName,
 							},
 						},

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -44,7 +44,8 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
 			By("create the static pod")
-			err := createStaticPod(framework.TestContext.ManifestPath, staticPodName, ns, ImageRegistry[nginxImage], api.RestartPolicyAlways)
+			err := createStaticPod(framework.TestContext.ManifestPath, staticPodName, ns,
+				"gcr.io/google_containers/nginx-slim:0.7", api.RestartPolicyAlways)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("wait for the mirror pod to be running")
@@ -59,7 +60,7 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 			uid := pod.UID
 
 			By("update the static pod container image")
-			image := ImageRegistry[pauseImage]
+			image := framework.GetPauseImageNameForHostArch()
 			err = createStaticPod(framework.TestContext.ManifestPath, staticPodName, ns, image, api.RestartPolicyAlways)
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -139,7 +139,7 @@ func runResourceUsageTest(f *framework.Framework, rc *ResourceCollector, testArg
 		// sleep for an interval here to measure steady data
 		sleepAfterCreatePods = 10 * time.Second
 	)
-	pods := newTestPods(testArg.podsNr, ImageRegistry[pauseImage], "test_pod")
+	pods := newTestPods(testArg.podsNr, framework.GetPauseImageNameForHostArch(), "test_pod")
 
 	rc.Start()
 	// Explicitly delete pods to prevent namespace controller cleanning up timeout

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 				restartCountVolumeName := "restart-count"
 				restartCountVolumePath := "/restart-count"
 				testContainer := api.Container{
-					Image: ImageRegistry[busyBoxImage],
+					Image: "gcr.io/google_containers/busybox:1.24",
 					VolumeMounts: []api.VolumeMount{
 						{
 							MountPath: restartCountVolumePath,
@@ -136,7 +136,7 @@ while true; do sleep 1; done
 				c := ConformanceContainer{
 					PodClient: f.PodClient(),
 					Container: api.Container{
-						Image:   ImageRegistry[busyBoxImage],
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Name:    name,
 						Command: []string{"/bin/sh", "-c"},
 						Args:    []string{fmt.Sprintf("/bin/echo -n %s > %s", terminationMessage, terminationMessagePath)},
@@ -185,6 +185,9 @@ while true; do sleep 1; done
 				Data: map[string][]byte{api.DockerConfigJsonKey: []byte(auth)},
 				Type: api.SecretTypeDockerConfigJson,
 			}
+			// The following images are not added into NodeImageWhiteList, because this test is
+			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
+			// is api.PullAlways, so it won't be blocked by framework image white list check.
 			for _, testCase := range []struct {
 				description string
 				image       string
@@ -206,25 +209,25 @@ while true; do sleep 1; done
 				},
 				{
 					description: "should be able to pull image from gcr.io",
-					image:       NoPullImageRegistry[pullTestAlpineWithBash],
+					image:       "gcr.io/google_containers/alpine-with-bash:1.0",
 					phase:       api.PodRunning,
 					waiting:     false,
 				},
 				{
 					description: "should be able to pull image from docker hub",
-					image:       NoPullImageRegistry[pullTestAlpine],
+					image:       "alpine:3.1",
 					phase:       api.PodRunning,
 					waiting:     false,
 				},
 				{
 					description: "should not be able to pull from private registry without secret",
-					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.1",
 					phase:       api.PodPending,
 					waiting:     true,
 				},
 				{
 					description: "should be able to pull from private registry with secret",
-					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.1",
 					secret:      true,
 					phase:       api.PodRunning,
 					waiting:     false,


### PR DESCRIPTION
This is part of #29081. Fixes #29155.

As is discussed with @yujuhong in #29155, it is difficult to maintain the prepull image list if it is not enforced. 

This PR added an image white list in the test framework, only images in the white list could be used in the test. If the image is not in the white list, the test will fail with reason:

```
Image "XXX" is not in the white list, consider adding it to CommonImageWhiteList in test/e2e/common/util.go or NodeImageWhiteList in test/e2e_node/image_list.go
```

Notice that if image pull policy is `PullAlways`, the image is not necessary to be in the white list or prepulled, because the test expects the image to be pulled during the test.

Currently, the image white list is only enabled in node e2e, because the image puller in e2e test is not integrated with the image white list yet.

/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32986)

<!-- Reviewable:end -->
