### PR TITLE
Node E2E: Add image pull retry in image pulling test.

### DIFF
--- a/test/e2e_node/container.go
+++ b/test/e2e_node/container.go
@@ -104,13 +104,13 @@ func (cc *ConformanceContainer) Present() (bool, error) {
 	return false, err
 }
 
-type ContainerState int
+type ContainerState string
 
 const (
-	ContainerStateWaiting ContainerState = iota
-	ContainerStateRunning
-	ContainerStateTerminated
-	ContainerStateUnknown
+	ContainerStateWaiting    ContainerState = "Waiting"
+	ContainerStateRunning    ContainerState = "Running"
+	ContainerStateTerminated ContainerState = "Terminated"
+	ContainerStateUnknown    ContainerState = "Unknown"
 )
 
 func GetContainerState(state api.ContainerState) ContainerState {


### PR DESCRIPTION
Fixes #29259, #28047.

This test added image pull retry in image pulling node e2e test. It will retry for 3 times until test successes.

This should be able to make the image pulling test less flaky.

@yujuhong

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/32990)

<!-- Reviewable:end -->
