### PR TITLE
kubectl get events should by default sort by lasttimestamp

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
-
-	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -374,6 +374,14 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	sorting, err := cmd.Flags().GetString("sort-by")
 	if err != nil {
 		return err
+	}
+	if sorting == "" {
+		if len(objs) > 0 {
+			_, ok := objs[0].(*api.Event)
+			if ok {
+				sorting = "{.lastTimestamp}"
+			}
+		}
 	}
 	var sorter *kubectl.RuntimeSort
 	if len(sorting) > 0 && len(objs) > 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubectl get events` by default gives events which are for multiple resources. Since they are for multiple resources, they are sorted by lasttimestamp for each resource and not across resources. This doesn't help the user. since if someone is doing get events, he is quickly interested in seeing the latest events that happened irrespective of the resources.  This PR sorts events across resources by lastTimeStamp so that we are shown only the latest events.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes https://github.com/kubernetes/kubernetes/issues/29838

**Special notes for your reviewer**:
Since this is first PR, i am still not sure if this is the right way to fix it, but sending this out to see if experts agree with this fix or there is a better way to fix this. But it seems like the printEventList function is never called in any circumstances or for that matter my understanding is none of the xxList functions are ever called.. See my analysis in the issue. THe apiserver returns api.EventList, but the kubectl still breaks it into Event for each resource , before passing it to printEvent function. I fixed it by processing the api.EventList as a object and passing it to printEventList directly.
**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33010)

<!-- Reviewable:end -->
