### PR TITLE
kubectl: use the merged config when it's invalid but empty

### DIFF
--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -115,10 +115,10 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 		// TODO: this shouldn't be a global - the client config rules should be
 		//   handling this.
 		defaultConfig, defErr := DefaultClientConfig.ClientConfig()
-		if IsConfigurationInvalid(defErr) && !IsEmptyConfig(defErr) {
+		if defErr != nil && !IsConfigurationInvalid(defErr) {
 			return mergedConfig, nil
 		}
-		if defErr == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
+		if defaultConfig != nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {
 			return mergedConfig, nil
 		}
 	}

--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -115,7 +115,7 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 		// TODO: this shouldn't be a global - the client config rules should be
 		//   handling this.
 		defaultConfig, defErr := DefaultClientConfig.ClientConfig()
-		if IsConfigurationInvalid(defErr) && !IsEmptyConfig(err) {
+		if IsConfigurationInvalid(defErr) && !IsEmptyConfig(defErr) {
 			return mergedConfig, nil
 		}
 		if defErr == nil && !reflect.DeepEqual(mergedConfig, defaultConfig) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
It fixes the broken case with kubectl unable to derive configuration when invoked with no cluster configuration in in-cluster context.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #33019 

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33032)

<!-- Reviewable:end -->
