### PR TITLE
remove storage related fields from genericapiserver

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -295,7 +295,6 @@ func Run(s *options.APIServer) error {
 
 	genericConfig := genericapiserver.NewConfig(s.ServerRunOptions)
 	// TODO: Move the following to generic api server as well.
-	genericConfig.StorageFactory = storageFactory
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0
 	genericConfig.Authorizer = apiAuthorizer
@@ -311,7 +310,10 @@ func Run(s *options.APIServer) error {
 	genericConfig.EnableOpenAPISupport = true
 
 	config := &master.Config{
-		Config:                  genericConfig,
+		Config: genericConfig,
+
+		StorageFactory:          storageFactory,
+		EnableWatchCache:        s.EnableWatchCache,
 		EnableCoreControllers:   true,
 		DeleteCollectionWorkers: s.DeleteCollectionWorkers,
 		EventTTL:                s.EventTTL,

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/genericapiserver/authorizer"
 	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	genericvalidation "k8s.io/kubernetes/pkg/genericapiserver/validation"
+	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 
 	// Install the testgroup API
@@ -87,7 +88,7 @@ func Run(serverOptions *genericoptions.ServerRunOptions) error {
 	}
 
 	restStorageMap := map[string]rest.Storage{
-		"testtypes": testgroupetcd.NewREST(storageConfig, s.StorageDecorator()),
+		"testtypes": testgroupetcd.NewREST(storageConfig, generic.UndecoratedStorage),
 	}
 	apiGroupInfo := genericapiserver.APIGroupInfo{
 		GroupMeta: *groupMeta,

--- a/federation/cmd/federation-apiserver/app/core.go
+++ b/federation/cmd/federation-apiserver/app/core.go
@@ -40,11 +40,11 @@ import (
 	serviceetcd "k8s.io/kubernetes/pkg/registry/core/service/etcd"
 )
 
-func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
-	serviceStore, serviceStatusStore := serviceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("service")))
-	namespaceStore, namespaceStatusStore, namespaceFinalizeStore := namespaceetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("namespaces")))
-	secretStore := secretetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("secrets")))
-	eventStore := eventetcd.NewREST(createRESTOptionsOrDie(s, g, f, api.Resource("events")), uint64(s.EventTTL.Seconds()))
+func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, restOptionsFactory restOptionsFactory) {
+	serviceStore, serviceStatusStore := serviceetcd.NewREST(restOptionsFactory.NewFor(api.Resource("service")))
+	namespaceStore, namespaceStatusStore, namespaceFinalizeStore := namespaceetcd.NewREST(restOptionsFactory.NewFor(api.Resource("namespaces")))
+	secretStore := secretetcd.NewREST(restOptionsFactory.NewFor(api.Resource("secrets")))
+	eventStore := eventetcd.NewREST(restOptionsFactory.NewFor(api.Resource("events")), uint64(s.EventTTL.Seconds()))
 	coreResources := map[string]rest.Storage{
 		"secrets":             secretStore,
 		"services":            serviceStore,

--- a/federation/cmd/federation-apiserver/app/extensions.go
+++ b/federation/cmd/federation-apiserver/app/extensions.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -29,9 +28,9 @@ import (
 	replicasetetcd "k8s.io/kubernetes/pkg/registry/extensions/replicaset/etcd"
 )
 
-func installExtensionsAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
-	replicaSetStorage := replicasetetcd.NewStorage(createRESTOptionsOrDie(s, g, f, extensions.Resource("replicasets")))
-	ingressStorage, ingressStatusStorage := ingressetcd.NewREST(createRESTOptionsOrDie(s, g, f, extensions.Resource("ingresses")))
+func installExtensionsAPIs(g *genericapiserver.GenericAPIServer, restOptionsFactory restOptionsFactory) {
+	replicaSetStorage := replicasetetcd.NewStorage(restOptionsFactory.NewFor(extensions.Resource("replicasets")))
+	ingressStorage, ingressStatusStorage := ingressetcd.NewREST(restOptionsFactory.NewFor(extensions.Resource("ingresses")))
 	extensionsResources := map[string]rest.Storage{
 		"replicasets":        replicaSetStorage.ReplicaSet,
 		"replicasets/status": replicaSetStorage.Status,

--- a/federation/cmd/federation-apiserver/app/federation.go
+++ b/federation/cmd/federation-apiserver/app/federation.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/federation/apis/federation"
-	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -30,8 +29,8 @@ import (
 	clusteretcd "k8s.io/kubernetes/federation/registry/cluster/etcd"
 )
 
-func installFederationAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
-	clusterStorage, clusterStatusStorage := clusteretcd.NewREST(createRESTOptionsOrDie(s, g, f, federation.Resource("clusters")))
+func installFederationAPIs(g *genericapiserver.GenericAPIServer, restOptionsFactory restOptionsFactory) {
+	clusterStorage, clusterStatusStorage := clusteretcd.NewREST(restOptionsFactory.NewFor(federation.Resource("clusters")))
 	federationResources := map[string]rest.Storage{
 		"clusters":        clusterStorage,
 		"clusters/status": clusterStatusStorage,

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -46,8 +46,6 @@ import (
 	"k8s.io/kubernetes/pkg/genericapiserver/routes"
 	genericvalidation "k8s.io/kubernetes/pkg/genericapiserver/validation"
 	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
-	"k8s.io/kubernetes/pkg/registry/generic"
-	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
@@ -55,8 +53,6 @@ import (
 
 // Config is a structure used to configure a GenericAPIServer.
 type Config struct {
-	// The storage factory for other objects
-	StorageFactory     StorageFactory
 	AuditLogPath       string
 	AuditLogMaxAge     int
 	AuditLogMaxBackups int
@@ -73,7 +69,6 @@ type Config struct {
 	EnableIndex             bool
 	EnableProfiling         bool
 	EnableVersion           bool
-	EnableWatchCache        bool
 	EnableGarbageCollection bool
 	APIPrefix               string
 	APIGroupPrefix          string
@@ -179,7 +174,6 @@ func NewConfig(options *options.ServerRunOptions) *Config {
 		EnableSwaggerSupport:      true,
 		EnableSwaggerUI:           options.EnableSwaggerUI,
 		EnableVersion:             true,
-		EnableWatchCache:          options.EnableWatchCache,
 		ExternalHost:              options.ExternalHost,
 		KubernetesServiceNodePort: options.KubernetesServiceNodePort,
 		MasterCount:               options.MasterCount,
@@ -313,12 +307,6 @@ func (c Config) New() (*GenericAPIServer, error) {
 		openAPIInfo:            c.OpenAPIInfo,
 		openAPIDefaultResponse: c.OpenAPIDefaultResponse,
 		openAPIDefinitions:     c.OpenAPIDefinitions,
-	}
-
-	if c.EnableWatchCache {
-		s.storageDecorator = registry.StorageWithCacher
-	} else {
-		s.storageDecorator = generic.UndecoratedStorage
 	}
 
 	if c.RestfulContainer != nil {

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver/options"
-	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
@@ -120,11 +119,6 @@ type GenericAPIServer struct {
 	// requestContextMapper provides a way to get the context for a request.  It may be nil.
 	requestContextMapper api.RequestContextMapper
 
-	// storageDecorator provides a decoration function for storage.  It will never be nil.
-	// TODO: this may be an abstraction at the wrong layer.  It doesn't seem like a genericAPIServer
-	// should be determining the backing storage for the RESTStorage interfaces
-	storageDecorator generic.StorageDecorator
-
 	Mux              *apiserver.PathRecorderMux
 	HandlerContainer *restful.Container
 	MasterCount      int
@@ -173,10 +167,6 @@ type GenericAPIServer struct {
 	postStartHookLock    sync.Mutex
 	postStartHooksCalled bool
 	openAPIDefinitions   *common.OpenAPIDefinitions
-}
-
-func (s *GenericAPIServer) StorageDecorator() generic.StorageDecorator {
-	return s.storageDecorator
 }
 
 // RequestContextMapper is exposed so that third party resource storage can be build in a different location.
@@ -551,7 +541,6 @@ func (s *GenericAPIServer) getSwaggerConfig() *swagger.Config {
 // register their own web services into the Kubernetes mux prior to initialization
 // of swagger, so that other resource types show up in the documentation.
 func (s *GenericAPIServer) InstallSwaggerAPI() {
-
 	// Enable swagger UI and discovery API
 	swagger.RegisterSwaggerService(*s.getSwaggerConfig(), s.HandlerContainer)
 }

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -224,14 +224,12 @@ func NewMasterConfig() *master.Config {
 
 	return &master.Config{
 		Config: &genericapiserver.Config{
-			StorageFactory:          storageFactory,
 			APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
 			APIPrefix:               "/api",
 			APIGroupPrefix:          "/apis",
 			Authorizer:              authorizer.NewAlwaysAllowAuthorizer(),
 			AdmissionControl:        admit.NewAlwaysAdmit(),
 			Serializer:              api.Codecs,
-			EnableWatchCache:        true,
 			// Set those values to avoid annoying warnings in logs.
 			ServiceClusterIPRange: parseCIDROrDie("10.0.0.0/24"),
 			ServiceNodePortRange:  utilnet.PortRange{Base: 30000, Size: 2768},
@@ -239,7 +237,9 @@ func NewMasterConfig() *master.Config {
 			OpenAPIDefinitions:    openapi.OpenAPIDefinitions,
 			EnableOpenAPISupport:  true,
 		},
-		KubeletClient: kubeletclient.FakeKubeletClient{},
+		StorageFactory:   storageFactory,
+		EnableWatchCache: true,
+		KubeletClient:    kubeletclient.FakeKubeletClient{},
 	}
 }
 


### PR DESCRIPTION
Removes `StorageFactory` and `StorageDecorator` from from `genericapiserver` since both constructs are related to building a `RESTStorage`, which should be provided fully formed (or via factory func) to a truly generic API server.

I found this while trying to move the creation API routes earlier.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33038)

<!-- Reviewable:end -->
