### PR TITLE
Skip test "MetricsGrabber should grab all metrics from API server." w…

### DIFF
--- a/test/e2e/metrics_grabber_test.go
+++ b/test/e2e/metrics_grabber_test.go
@@ -90,6 +90,10 @@ var _ = Describe("MetricsGrabber", func() {
 	})
 
 	It("should grab all metrics from API server.", func() {
+		// From @gmarek 9/19/2016 - this test can safely be ignored for upgrade testing
+		// TODO(gmarek): Add details about why this can be safely ignored
+		// See issue https://github.com/kubernetes/kubernetes/issues/32704
+		SkipUnlessServerVersionLT(serverVersion13, c)
 		By("Connecting to /metrics endpoint")
 		unknownMetrics := sets.NewString()
 		response, err := grabber.GrabFromApiServer(unknownMetrics)

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -21,13 +21,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/version"
 
 	. "github.com/onsi/ginkgo"
-)
-
-var (
-	serverVersion13 = version.MustParse("v1.3.0")
 )
 
 var _ = Describe("Secrets", func() {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -144,6 +144,7 @@ var gitVersionRegexp = regexp.MustCompile("GitVersion:\"(v.+?)\"")
 // in v1.3).
 var subResourcePodProxyVersion = version.MustParse("v1.1.0")
 var subResourceServiceAndNodeProxyVersion = version.MustParse("v1.2.0")
+var serverVersion13 = version.MustParse("v1.3.0")
 
 func getServicesProxyRequest(c *client.Client, request *restclient.Request) (*restclient.Request, error) {
 	subResourceProxyAvailable, err := serverVersionGTE(subResourceServiceAndNodeProxyVersion, c)


### PR DESCRIPTION
…hen running upgrade tests.

See #32704.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33045)

<!-- Reviewable:end -->
