### PR TITLE
Fix backward compatibility issue caused by promoting initcontainers f…

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1749,8 +1749,13 @@ const (
 	PodInitContainersAnnotationKey = "pod.alpha.kubernetes.io/init-containers"
 	// This annotation key will be used to contain an array of v1 JSON encoded
 	// ContainerStatuses for init containers. The annotation will be placed into the internal
-	// type and cleared.
-	PodInitContainerStatusesAnnotationKey = "pod.beta.kubernetes.io/init-container-statuses"
+	// type and cleared. This key is only recognized by version >= 1.4.
+	PodInitContainerStatusesBetaAnnotationKey = "pod.beta.kubernetes.io/init-container-statuses"
+	// This annotation key will be used to contain an array of v1 JSON encoded
+	// ContainerStatuses for init containers. The annotation will be placed into the internal
+	// type and cleared. This key is recognized by version >= 1.3. For version 1.4 code,
+	// this key will have its value copied to the beta key.
+	PodInitContainerStatusesAnnotationKey = "pod.alpha.kubernetes.io/init-container-statuses"
 )
 
 // PodSpec is a description of a pod.


### PR DESCRIPTION
#31026 moves init-container feature from alpha to beta, but only took care the backward compatibility for pod specification, not deal with status. For status, it simply moved from `pods.beta.kubernetes.io/init-container-statuses` to

`pods.beta.kubernetes.io/init-container-statuses` instead of introducing one more pods.beta.kubernetes.io/init-container-statuses. This breaks when the cluster is running with 1.4, but the user is still running with kubectl 1.3.x. 

Fixed #32711

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33055)

<!-- Reviewable:end -->
