### PR TITLE
Make node E2E tests more transparent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ test-e2e: ginkgo generated_files
 #  INSTANCE_METADATA: For REMOTE=true and running on GCE only.
 #  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
 #	 Defaults to false.
+#  PARALLELISM: The number of gingko nodes to run.  Defaults to 8.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -141,8 +141,9 @@ if [ $remote = true ] ; then
   exit $?
 
 else
-  # Refresh sudo credentials if not running on GCE.
+  # Refresh sudo credentials for local run
   if ! ping -c 1 -q metadata.google.internal &> /dev/null; then
+    echo "Updating sudo credentials"
     sudo -v || exit 1
   fi
 

--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -47,6 +47,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Failed to get build output directory: %v", err)
 	}
+	glog.Infof("Got build output dir: %v", outputDir)
 	ginkgo := filepath.Join(outputDir, "ginkgo")
 	test := filepath.Join(outputDir, "e2e_node.test")
 	runCommand(ginkgo, *ginkgoFlags, test, "--", *testFlags)
@@ -54,6 +55,7 @@ func main() {
 }
 
 func runCommand(name string, args ...string) error {
+	glog.Infof("Running command: %v %v", name, strings.Join(args, " "))
 	cmd := exec.Command("sh", "-c", strings.Join(append([]string{name}, args...), " "))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -57,7 +57,7 @@ func (a *APIServer) Start() error {
 		}
 	}()
 
-	err = readinessCheck([]string{apiserverHealthCheckURL}, errCh)
+	err = readinessCheck("apiserver", []string{apiserverHealthCheckURL}, errCh)
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/services/etcd.go
+++ b/test/e2e_node/services/etcd.go
@@ -118,7 +118,7 @@ func (e *EtcdServer) Start() error {
 		errCh <- srv.Serve(l)
 	}(e.clientListen)
 
-	err = readinessCheck([]string{etcdHealthCheckURL}, errCh)
+	err = readinessCheck("etcd", []string{etcdHealthCheckURL}, errCh)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add some logging and minor code reorg to make the node E2E tests a little more transparent and understandable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33063)

<!-- Reviewable:end -->
