### PR TITLE
Add docker client version.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -126,7 +126,7 @@ func UnsecuredKubeletDeps(s *options.KubeletServer) (*kubelet.KubeletDeps, error
 
 	var dockerClient dockertools.DockerInterface
 	if s.ContainerRuntime == "docker" {
-		dockerClient = dockertools.CreateDockerClientOrDie(s.DockerEndpoint, s.RuntimeRequestTimeout.Duration)
+		dockerClient = dockertools.ConnectToDockerOrDie(s.DockerEndpoint, s.RuntimeRequestTimeout.Duration)
 	} else {
 		dockerClient = nil
 	}

--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -184,7 +184,7 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 		mockDriver = &MockExecutorDriver{}
 		registry   = newFakeRegistry()
 		executor   = New(Config{
-			Docker:    dockertools.CreateDockerClientOrDie("fake://", 0),
+			Docker:    dockertools.ConnectToDockerOrDie("fake://", 0),
 			NodeInfos: make(chan NodeInfo, 1),
 			Registry:  registry,
 		})
@@ -388,7 +388,7 @@ func TestExecutorFrameworkMessage(t *testing.T) {
 		kubeletFinished = make(chan struct{})
 		registry        = newFakeRegistry()
 		executor        = New(Config{
-			Docker:    dockertools.CreateDockerClientOrDie("fake://", 0),
+			Docker:    dockertools.ConnectToDockerOrDie("fake://", 0),
 			NodeInfos: make(chan NodeInfo, 1),
 			ShutdownAlert: func() {
 				close(kubeletFinished)
@@ -585,7 +585,7 @@ func TestExecutorShutdown(t *testing.T) {
 		kubeletFinished = make(chan struct{})
 		exitCalled      = int32(0)
 		executor        = New(Config{
-			Docker:    dockertools.CreateDockerClientOrDie("fake://", 0),
+			Docker:    dockertools.ConnectToDockerOrDie("fake://", 0),
 			NodeInfos: make(chan NodeInfo, 1),
 			ShutdownAlert: func() {
 				close(kubeletFinished)

--- a/contrib/mesos/pkg/executor/mock_test.go
+++ b/contrib/mesos/pkg/executor/mock_test.go
@@ -75,7 +75,7 @@ func (m *MockExecutorDriver) SendFrameworkMessage(msg string) (mesosproto.Status
 
 func NewTestKubernetesExecutor() *Executor {
 	return New(Config{
-		Docker:   dockertools.CreateDockerClientOrDie("fake://", 0),
+		Docker:   dockertools.ConnectToDockerOrDie("fake://", 0),
 		Registry: newFakeRegistry(),
 	})
 }

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -108,7 +108,7 @@ func (s *KubeletExecutorServer) runExecutor(
 	exec := executor.New(executor.Config{
 		Registry:        registry,
 		APIClient:       apiclient,
-		Docker:          dockertools.CreateDockerClientOrDie(s.DockerEndpoint, 0),
+		Docker:          dockertools.ConnectToDockerOrDie(s.DockerEndpoint, 0),
 		SuicideTimeout:  s.SuicideTimeout,
 		KubeletFinished: kubeletFinished,
 		ExitFunc:        os.Exit,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -378,13 +378,13 @@ func getDockerClient(dockerEndpoint string) (*dockerapi.Client, error) {
 	return dockerapi.NewEnvClient()
 }
 
-// CreateDockerClientOrDie creates a docker client for connecting to the docker daemon.
-// It does not actually try to connect to the docker daemon!
-// requestTimeout is the timeout for docker requests.
-// If requestTimeout=0, a default value is used instead.
-// Pass dockerEndpoint="fake://" to create a fake docker client.
-// Errors during client creation will cause program termination.
-func CreateDockerClientOrDie(dockerEndpoint string, requestTimeout time.Duration) DockerInterface {
+// ConnectToDockerOrDie creates docker client connecting to docker daemon.
+// If the endpoint passed in is "fake://", a fake docker client
+// will be returned. The program exits if error occurs. The requestTimeout
+// is the timeout for docker requests. If timeout is exceeded, the request
+// will be cancelled and throw out an error. If requestTimeout is 0, a default
+// value will be applied.
+func ConnectToDockerOrDie(dockerEndpoint string, requestTimeout time.Duration) DockerInterface {
 	if dockerEndpoint == "fake://" {
 		return NewFakeDockerClient()
 	}

--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -87,10 +87,21 @@ func newKubeDockerClient(dockerClient *dockerapi.Client, requestTimeout time.Dur
 	if requestTimeout == 0 {
 		requestTimeout = defaultTimeout
 	}
-	return &kubeDockerClient{
+
+	k := &kubeDockerClient{
 		client:  dockerClient,
 		timeout: requestTimeout,
 	}
+	// Notice that this assumes that docker is running before kubelet is started.
+	v, err := k.Version()
+	if err != nil {
+		glog.Errorf("failed to retrieve docker version: %v", err)
+		glog.Warningf("Using empty version for docker client, this may sometimes cause compatibility issue.")
+	} else {
+		// Update client version with real api version.
+		dockerClient.UpdateClientVersion(v.APIVersion)
+	}
+	return k
 }
 
 func (d *kubeDockerClient) ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error) {

--- a/test/e2e_node/image.go
+++ b/test/e2e_node/image.go
@@ -40,7 +40,7 @@ func NewConformanceImage(containerRuntime string, image string) (ci ConformanceI
 
 //TODO: do not expose kubelet implementation details after we refactor the runtime API.
 func dockerRuntime() kubecontainer.Runtime {
-	dockerClient := dockertools.CreateDockerClientOrDie("", 0)
+	dockerClient := dockertools.ConnectToDockerOrDie("", 0)
 	pm := kubepod.NewBasicPodManager(nil)
 	dm := dockertools.NewDockerManager(
 		dockerClient,


### PR DESCRIPTION
Addressed https://github.com/kubernetes/kubernetes/issues/29478#issuecomment-248197665.

This partially reverted #31540, because currently we are really trying to connect to docker daemon when creating the client.

This PR updated docker client with real docker apiversion with `UpdateClientVersion`, so that the version related logic of engine-api can work properly, such as https://github.com/docker/engine-api/pull/174/files.

@yujuhong @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33066)

<!-- Reviewable:end -->
