### PR TITLE
kubectl: Add --curl option to "kubectl proxy"

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -130,25 +130,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 			return err
 		}
 
-		stream, err := restClient.Get().RequestURI(options.Raw).Stream()
-		if err != nil {
-			return err
-		}
-		defer stream.Close()
-
-		for {
-			buffer := make([]byte, 1024, 1024)
-			bytesRead, err := stream.Read(buffer)
-			if bytesRead > 0 {
-				fmt.Printf("%s", string(buffer[:bytesRead]))
-			}
-			if err == io.EOF {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-		}
+		return cmdutil.PrintRESTClientStream(restClient, options.Raw)
 	}
 
 	selector := cmdutil.GetFlagString(cmd, "selector")

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -83,13 +83,29 @@ func NewCmdProxy(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringP("address", "", "127.0.0.1", "The IP address on which to serve on.")
 	cmd.Flags().Bool("disable-filter", false, "If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.")
 	cmd.Flags().StringP("unix-socket", "u", "", "Unix socket on which to run the proxy.")
+	cmd.Flags().StringP("curl", "", "", "Raw URI to request from the proxy server.")
 	return cmd
+}
+
+func curl(f *cmdutil.Factory, uri, address string, port int) error {
+	restClient, err := f.RESTClientProxy(address, port)
+	if err != nil {
+		return err
+	}
+
+	return cmdutil.PrintRESTClientStream(restClient, uri)
 }
 
 func RunProxy(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	path := cmdutil.GetFlagString(cmd, "unix-socket")
 	port := cmdutil.GetFlagInt(cmd, "port")
 	address := cmdutil.GetFlagString(cmd, "address")
+
+	uri := cmdutil.GetFlagString(cmd, "curl")
+
+	if uri != "" && path != "" {
+		return errors.New("Don't specify both --curl and --unix-socket, --curl doesn't work with unix sockets.")
+	}
 
 	if port != default_port && path != "" {
 		return errors.New("Don't specify both --unix-socket and --port")
@@ -134,7 +150,14 @@ func RunProxy(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	fmt.Fprintf(out, "Starting to serve on %s", l.Addr().String())
-	glog.Fatal(server.ServeOnListener(l))
+
+	if uri == "" {
+		fmt.Fprintf(out, "Starting to serve on %s", l.Addr().String())
+		glog.Fatal(server.ServeOnListener(l))
+	} else {
+		go server.ServeOnListener(l)
+		return curl(f, uri, address, port)
+	}
+
 	return nil
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -98,6 +98,8 @@ type Factory struct {
 	ClientSet func() (*internalclientset.Clientset, error)
 	// Returns a RESTClient for accessing Kubernetes resources or an error.
 	RESTClient func() (*restclient.RESTClient, error)
+	// Returns a RESTClient for accessing Kubernetes proxy (with given address and port) or an error.
+	RESTClientProxy func(address string, port int) (*restclient.RESTClient, error)
 	// Returns a client.Config for accessing the Kubernetes server.
 	ClientConfig func() (*restclient.Config, error)
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
@@ -370,6 +372,17 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			if err != nil {
 				return nil, err
 			}
+			return restclient.RESTClientFor(clientConfig)
+		},
+		RESTClientProxy: func(address string, port int) (*restclient.RESTClient, error) {
+			clientConfig, err := clients.ClientConfigForVersion(nil)
+			if err != nil {
+				return nil, err
+			}
+
+			host := fmt.Sprintf("%s:%d", address, port)
+			clientConfig.Host = host
+
 			return restclient.RESTClientFor(clientConfig)
 		},
 		ClientSet: func() (*internalclientset.Clientset, error) {

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/flag"
+	nettesting "k8s.io/kubernetes/pkg/util/net/testing"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -244,12 +245,6 @@ func loadSchemaForTest() (validation.Schema, error) {
 	return validation.NewSwaggerSchemaFromBytes(data, nil)
 }
 
-func header() http.Header {
-	header := http.Header{}
-	header.Set("Content-Type", runtime.ContentTypeJSON)
-	return header
-}
-
 func TestRefetchSchemaWhenValidationFails(t *testing.T) {
 	schema, err := loadSchemaForTest()
 	if err != nil {
@@ -269,7 +264,7 @@ func TestRefetchSchemaWhenValidationFails(t *testing.T) {
 			switch p, m := req.URL.Path, req.Method; {
 			case strings.HasPrefix(p, "/swaggerapi") && m == "GET":
 				requests[p] = requests[p] + 1
-				return &http.Response{StatusCode: 200, Header: header(), Body: ioutil.NopCloser(bytes.NewBuffer(output))}, nil
+				return &http.Response{StatusCode: 200, Header: nettesting.Header(), Body: ioutil.NopCloser(bytes.NewBuffer(output))}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -326,7 +321,7 @@ func TestValidateCachesSchema(t *testing.T) {
 			switch p, m := req.URL.Path, req.Method; {
 			case strings.HasPrefix(p, "/swaggerapi") && m == "GET":
 				requests[p] = requests[p] + 1
-				return &http.Response{StatusCode: 200, Header: header(), Body: ioutil.NopCloser(bytes.NewBuffer(output))}, nil
+				return &http.Response{StatusCode: 200, Header: nettesting.Header(), Body: ioutil.NopCloser(bytes.NewBuffer(output))}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -632,3 +632,26 @@ func MaybeConvertObject(obj runtime.Object, gv unversioned.GroupVersion, convert
 		return converter.ConvertToVersion(obj, gv)
 	}
 }
+
+// PrintRESTClientStream makes a request for the given URI and prints the whole raw content.
+func PrintRESTClientStream(restClient kubectl.RESTClient, uri string) error {
+	stream, err := restClient.Get().RequestURI(uri).Stream()
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	for {
+		buffer := make([]byte, 1024, 1024)
+		bytesRead, err := stream.Read(buffer)
+		if bytesRead > 0 {
+			fmt.Printf("%s", string(buffer[:bytesRead]))
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package resource
 
 import (
-	"bytes"
 	"errors"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -33,17 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
+	nettesting "k8s.io/kubernetes/pkg/util/net/testing"
 )
-
-func objBody(obj runtime.Object) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), obj))))
-}
-
-func header() http.Header {
-	header := http.Header{}
-	header.Set("Content-Type", runtime.ContentTypeJSON)
-	return header
-}
 
 // splitPath returns the segments for a URL path.
 func splitPath(path string) []string {
@@ -68,16 +57,16 @@ func TestHelperDelete(t *testing.T) {
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusFailure}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusFailure}),
 			},
 			Err: true,
 		},
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
 			},
 			Req: func(req *http.Request) bool {
 				if req.Method != "DELETE" {
@@ -155,16 +144,16 @@ func TestHelperCreate(t *testing.T) {
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusFailure}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusFailure}),
 			},
 			Err: true,
 		},
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
 			},
 			Object:       &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
 			ExpectObject: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
@@ -174,7 +163,7 @@ func TestHelperCreate(t *testing.T) {
 			Modify:       false,
 			Object:       &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
 			ExpectObject: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
-			Resp:         &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
+			Resp:         &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
 			Req:          expectPost,
 		},
 		{
@@ -187,7 +176,7 @@ func TestHelperCreate(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
 				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
-			Resp: &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
+			Resp: &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
 			Req:  expectPost,
 		},
 	}
@@ -242,16 +231,16 @@ func TestHelperGet(t *testing.T) {
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusFailure}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusFailure}),
 			},
 			Err: true,
 		},
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     header(),
-				Body:       objBody(&api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}),
 			},
 			Req: func(req *http.Request) bool {
 				if req.Method != "GET" {
@@ -311,16 +300,16 @@ func TestHelperList(t *testing.T) {
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusFailure}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusFailure}),
 			},
 			Err: true,
 		},
 		{
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     header(),
-				Body: objBody(&api.PodList{
+				Header:     nettesting.Header(),
+				Body: nettesting.ObjBody(&api.PodList{
 					Items: []api.Pod{{
 						ObjectMeta: api.ObjectMeta{Name: "foo"},
 					},
@@ -409,8 +398,8 @@ func TestHelperReplace(t *testing.T) {
 			Object:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
 			Resp: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusFailure}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusFailure}),
 			},
 			Err: true,
 		},
@@ -422,8 +411,8 @@ func TestHelperReplace(t *testing.T) {
 			ExpectObject:    &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     header(),
-				Body:       objBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
+				Header:     nettesting.Header(),
+				Body:       nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess}),
 			},
 			Req: expectPut,
 		},
@@ -443,9 +432,9 @@ func TestHelperReplace(t *testing.T) {
 			Overwrite: true,
 			HTTPClient: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				if req.Method == "PUT" {
-					return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&unversioned.Status{Status: unversioned.StatusSuccess})}, nil
+					return &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess})}, nil
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
 			}),
 			Req: expectPut,
 		},
@@ -461,9 +450,9 @@ func TestHelperReplace(t *testing.T) {
 			ExpectPath: "/foo",
 			HTTPClient: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				if req.Method == "PUT" {
-					return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&unversioned.Status{Status: unversioned.StatusSuccess})}, nil
+					return &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess})}, nil
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&api.Node{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&api.Node{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
 			}),
 			Req: expectPut,
 		},
@@ -473,7 +462,7 @@ func TestHelperReplace(t *testing.T) {
 			Object:          &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
 			ExpectPath:      "/namespaces/bar/foo",
 			ExpectObject:    &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
-			Resp:            &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
+			Resp:            &http.Response{StatusCode: http.StatusOK, Header: nettesting.Header(), Body: nettesting.ObjBody(&unversioned.Status{Status: unversioned.StatusSuccess})},
 			Req:             expectPut,
 		},
 	}

--- a/pkg/util/net/testing/response.go
+++ b/pkg/util/net/testing/response.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func ObjBody(obj runtime.Object) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), obj))))
+}
+
+func Header() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}


### PR DESCRIPTION
Provide a --curl option which allows to make raw HTTP
requests to the proxy server. It works simillary
to the --raw option in "kubectl get".

Fixes #31178

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33077)

<!-- Reviewable:end -->
