### PR TITLE
Use soft link to binary files when building release

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -826,7 +826,7 @@ function kube::release::create_docker_images_for_server() {
 
         rm -rf ${docker_build_path}
         mkdir -p ${docker_build_path}
-        ln ${binary_dir}/${binary_name} ${docker_build_path}/${binary_name}
+        ln -s ${binary_dir}/${binary_name} ${docker_build_path}/${binary_name}
         printf " FROM ${base_image} \n ADD ${binary_name} /usr/local/bin/${binary_name}\n" > ${docker_file_path}
 
         if [[ ${arch} == "amd64" ]]; then


### PR DESCRIPTION
It seems we don't have to use hard link here (correct me if I'm wrong), let's change it to soft link, since hard link doesn't work in vboxsf (share folder is a common case in local dev env)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33082)

<!-- Reviewable:end -->
