### PR TITLE
Add ResolveImage function to CLI factory

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -293,6 +293,10 @@ func (f *FakeFactory) Resumer(info *resource.Info) (bool, error) {
 	return false, nil
 }
 
+func (f *FakeFactory) ResolveImage(name string) (string, error) {
+	return name, nil
+}
+
 func (f *FakeFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
 	return f.tf.Validator, f.tf.Err
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -135,6 +135,10 @@ type Factory interface {
 	Pauser(info *resource.Info) (bool, error)
 	// Resumer resumes a paused object inside the info ie. it will be reconciled by its controller.
 	Resumer(info *resource.Info) (bool, error)
+	// ResolveImage resolves the image names. For kubernetes this function is just
+	// passthrough but it allows to perform more sophisticated image name resolving for
+	// third-party vendors.
+	ResolveImage(imageName string) (string, error)
 	// Returns a schema that can validate objects stored on disk.
 	Validator(validate bool, cacheDir string) (validation.Schema, error)
 	// SwaggerSchema returns the schema declaration for the provided group version kind.
@@ -652,6 +656,10 @@ func (f *factory) Pauser(info *resource.Info) (bool, error) {
 	default:
 		return false, fmt.Errorf("pausing is not supported")
 	}
+}
+
+func (f *factory) ResolveImage(name string) (string, error) {
+	return name, nil
 }
 
 func (f *factory) Resumer(info *resource.Info) (bool, error) {


### PR DESCRIPTION
This functions helps to integrate third-party mechanism for resolving the image names. For example, this function can be used in OpenShift to add support for resolving the ImageStreamTag and ImageStreamImage.

See: https://github.com/openshift/origin/pull/10995

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33083)

<!-- Reviewable:end -->
