### PR TITLE
Fix possible panic in PodAffinityChecker

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -968,7 +968,7 @@ func (c *PodAffinityChecker) getMatchingAntiAffinityTerms(pod *api.Pod, allPods 
 		if err != nil {
 			return nil, err
 		}
-		if affinity.PodAntiAffinity != nil {
+		if affinity != nil && affinity.PodAntiAffinity != nil {
 			existingPodNode, err := c.info.GetNodeInfo(existingPod.Spec.NodeName)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
In `PodAffinityChecker.getMatchingAntiAffinityTerms()` `affinity.PodAntiAffinity` can be `nil` in this place. This problem occurs e.g. when `nil` is passed as `meta` to `PodAffinityChecker.InterPodAffinityMatches()`.

Stumbled upon it while working on #31136 (someone PTAL at that PR too, I've submitted it a month ago and seemingly no one noticed it), kube-controller-manager was crashing there.

``` release-note
Fix possible panic in PodAffinityChecker
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33086)

<!-- Reviewable:end -->
