### PR TITLE
update .gitignore to ignore the symlink dir _output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # This is where the result of the go build goes
 /output*/
 /_output*/
+/_output
 
 # Emacs save files
 *~


### PR DESCRIPTION
Just update the .gitignore to ignore the symlinked _output.
the size of _output is too big for me, PC: 8G ssd + 1T HDD

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33089)

<!-- Reviewable:end -->
