### PR TITLE
Move TimeoutHandler+MaxInFlightLimit to Config.New()

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -162,6 +163,11 @@ type Config struct {
 	// OpenAPIDefinitions is a map of type to OpenAPI spec for all types used in this API server. Failure to provide
 	// this map or any of the models used by the server APIs will result in spec generation failure.
 	OpenAPIDefinitions *common.OpenAPIDefinitions
+
+	// MaxRequestsInFlight is the maximum number of parallel non-long-running requests. Every further
+	// request has to wait.
+	MaxRequestsInFlight  int
+	LongRunningRequestRE string
 }
 
 func NewConfig(options *options.ServerRunOptions) *Config {
@@ -197,6 +203,8 @@ func NewConfig(options *options.ServerRunOptions) *Config {
 				Version: "unversioned",
 			},
 		},
+		MaxRequestsInFlight:  options.MaxRequestsInFlight,
+		LongRunningRequestRE: options.LongRunningRequestRE,
 	}
 }
 
@@ -399,21 +407,34 @@ func (c Config) New() (*GenericAPIServer, error) {
 		handler = authenticatedHandler
 	}
 
-	// TODO: Make this optional?  Consumers of GenericAPIServer depend on this currently.
-	s.Handler = handler
-
-	// After all wrapping is done, put a context filter around both handlers
-	var err error
-	handler, err = api.NewRequestContextFilter(c.RequestContextMapper, s.Handler)
+	handler, err := api.NewRequestContextFilter(c.RequestContextMapper, handler)
 	if err != nil {
 		glog.Fatalf("Could not initialize request context filter for s.Handler: %v", err)
 	}
+
+	longRunningRE := regexp.MustCompile(c.LongRunningRequestRE)
+	longRunningRequestCheck := apiserver.BasicLongRunningRequestCheck(longRunningRE, map[string]string{"watch": "true"})
+	longRunningTimeout := func(req *http.Request) (<-chan time.Time, string) {
+		// TODO unify this with apiserver.MaxInFlightLimit
+		if longRunningRequestCheck(req) {
+			return nil, ""
+		}
+		return time.After(globalTimeout), ""
+	}
+	handler = apiserver.TimeoutHandler(apiserver.RecoverPanics(handler), longRunningTimeout)
+
+	var inFlightTokens chan bool
+	if c.MaxRequestsInFlight > 0 {
+		inFlightTokens = make(chan bool, c.MaxRequestsInFlight)
+	}
+	handler = apiserver.MaxInFlightLimit(inFlightTokens, longRunningRequestCheck, handler)
 	s.Handler = handler
 
 	handler, err = api.NewRequestContextFilter(c.RequestContextMapper, s.InsecureHandler)
 	if err != nil {
 		glog.Fatalf("Could not initialize request context filter for s.InsecureHandler: %v", err)
 	}
+	handler = apiserver.TimeoutHandler(apiserver.RecoverPanics(handler), longRunningTimeout)
 	s.InsecureHandler = handler
 
 	s.installGroupsDiscoveryHandler()

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -264,34 +263,16 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 	if s.enableOpenAPISupport {
 		s.InstallOpenAPI()
 	}
-	// We serve on 2 ports. See docs/admin/accessing-the-api.md
+
 	secureLocation := ""
 	if options.SecurePort != 0 {
 		secureLocation = net.JoinHostPort(options.BindAddress.String(), strconv.Itoa(options.SecurePort))
 	}
-	insecureLocation := net.JoinHostPort(options.InsecureBindAddress.String(), strconv.Itoa(options.InsecurePort))
-
-	var sem chan bool
-	if options.MaxRequestsInFlight > 0 {
-		sem = make(chan bool, options.MaxRequestsInFlight)
-	}
-
-	longRunningRE := regexp.MustCompile(options.LongRunningRequestRE)
-	longRunningRequestCheck := apiserver.BasicLongRunningRequestCheck(longRunningRE, map[string]string{"watch": "true"})
-	longRunningTimeout := func(req *http.Request) (<-chan time.Time, string) {
-		// TODO unify this with apiserver.MaxInFlightLimit
-		if longRunningRequestCheck(req) {
-			return nil, ""
-		}
-		return time.After(globalTimeout), ""
-	}
-
 	secureStartedCh := make(chan struct{})
 	if secureLocation != "" {
-		handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.Handler), longRunningTimeout)
 		secureServer := &http.Server{
 			Addr:           secureLocation,
-			Handler:        apiserver.MaxInFlightLimit(sem, longRunningRequestCheck, handler),
+			Handler:        s.Handler,
 			MaxHeaderBytes: 1 << 20,
 			TLSConfig: &tls.Config{
 				// Can't use SSLv3 because of POODLE and BEAST
@@ -358,10 +339,10 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 		close(secureStartedCh)
 	}
 
-	handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.InsecureHandler), longRunningTimeout)
+	insecureLocation := net.JoinHostPort(options.InsecureBindAddress.String(), strconv.Itoa(options.InsecurePort))
 	http := &http.Server{
 		Addr:           insecureLocation,
-		Handler:        handler,
+		Handler:        s.InsecureHandler,
 		MaxHeaderBytes: 1 << 20,
 	}
 

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -264,12 +264,9 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 		s.InstallOpenAPI()
 	}
 
-	secureLocation := ""
-	if options.SecurePort != 0 {
-		secureLocation = net.JoinHostPort(options.BindAddress.String(), strconv.Itoa(options.SecurePort))
-	}
 	secureStartedCh := make(chan struct{})
-	if secureLocation != "" {
+	if options.SecurePort != 0 {
+		secureLocation := net.JoinHostPort(options.BindAddress.String(), strconv.Itoa(options.SecurePort))
 		secureServer := &http.Server{
 			Addr:           secureLocation,
 			Handler:        s.Handler,
@@ -317,10 +314,6 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 
 			notifyStarted := sync.Once{}
 			for {
-				// err == systemd.SdNotifyNoSocket when not running on a systemd system
-				if err := systemd.SdNotify("READY=1\n"); err != nil && err != systemd.SdNotifyNoSocket {
-					glog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
-				}
 				if err := secureServer.ListenAndServeTLS(options.TLSCertFile, options.TLSPrivateKeyFile); err != nil {
 					glog.Errorf("Unable to listen for secure (%v); will try again.", err)
 				} else {
@@ -332,20 +325,15 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 			}
 		}()
 	} else {
-		// err == systemd.SdNotifyNoSocket when not running on a systemd system
-		if err := systemd.SdNotify("READY=1\n"); err != nil && err != systemd.SdNotifyNoSocket {
-			glog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
-		}
 		close(secureStartedCh)
 	}
 
 	insecureLocation := net.JoinHostPort(options.InsecureBindAddress.String(), strconv.Itoa(options.InsecurePort))
-	http := &http.Server{
+	insecureServer := &http.Server{
 		Addr:           insecureLocation,
 		Handler:        s.InsecureHandler,
 		MaxHeaderBytes: 1 << 20,
 	}
-
 	insecureStartedCh := make(chan struct{})
 	glog.Infof("Serving insecurely on %s", insecureLocation)
 	go func() {
@@ -353,7 +341,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 
 		notifyStarted := sync.Once{}
 		for {
-			if err := http.ListenAndServe(); err != nil {
+			if err := insecureServer.ListenAndServe(); err != nil {
 				glog.Errorf("Unable to listen for insecure (%v); will try again.", err)
 			} else {
 				notifyStarted.Do(func() {
@@ -367,6 +355,11 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 	<-secureStartedCh
 	<-insecureStartedCh
 	s.RunPostStartHooks(PostStartHookContext{})
+
+	// err == systemd.SdNotifyNoSocket when not running on a systemd system
+	if err := systemd.SdNotify("READY=1\n"); err != nil && err != systemd.SdNotifyNoSocket {
+		glog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
+	}
 
 	select {}
 }


### PR DESCRIPTION
On the way to make `genericapiserver.Run()` to be actually not much more than `.Serve()`. Post-`New()` initializations should be minimal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33095)

<!-- Reviewable:end -->
