### PR TITLE
Wait until master IP is visible

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -411,7 +411,21 @@ function create-static-ip() {
     if gcloud compute addresses create "$1" \
       --project "${PROJECT}" \
       --region "${REGION}" -q > /dev/null; then
-      # successful operation
+      # successful operation - wait until it's visible
+      start="$(date +%s)"
+      while true; do
+        now="$(date +%s)"
+        # Timeout set to 15 minutes
+        if [ $((now - start)) -gt 900 ]; then
+          echo "Timeout while waiting for master IP visibility"
+          exit 2
+        fi
+        if gcloud compute addresses describe "$1" --project "${PROJECT}" --region "${REGION}" >/dev/null 2>&1; then
+          break
+        fi
+        echo "Master IP not visible yet. Waiting..."
+        sleep 5
+      done
       break
     fi
 


### PR DESCRIPTION
Hopefully fix #32789 (see: https://github.com/kubernetes/kubernetes/pull/33085#issuecomment-248322464)

It's a pretty far-fetched, but this might fix our GCE cluster startup problems. @mikedanese @fejta @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33097)

<!-- Reviewable:end -->
