### PR TITLE
Add additional delay to the es logging e2e test to make it stable

### DIFF
--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -219,6 +219,11 @@ func ClusterLevelLoggingWithElasticsearch(f *framework.Framework) {
 	}
 	framework.Logf("Found %d healthy nodes.", len(nodes.Items))
 
+	// TODO: Figure out why initialization time influences
+	// results of the test and remove this step
+	By("Wait some more time to ensure ES and fluentd are ready")
+	time.Sleep(2 * time.Minute)
+
 	// Wait for the Fluentd pods to enter the running state.
 	By("Checking to make sure the Fluentd pod are running on each healthy node")
 	label = labels.SelectorFromSet(labels.Set(map[string]string{k8sAppKey: fluentdValue}))


### PR DESCRIPTION
Fix #32804

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33098)

<!-- Reviewable:end -->
