### PR TITLE
Move HighWaterMark to the top of the struct in order to fix arm

### DIFF
--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -61,6 +61,12 @@ func exceptKey(except string) includeFunc {
 
 // etcdWatcher converts a native etcd watch to a watch.Interface.
 type etcdWatcher struct {
+	// HighWaterMarks for performance debugging.
+	// Important: Since HighWaterMark is using sync/atomic, it has to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
+	incomingHWM storage.HighWaterMark
+	outgoingHWM storage.HighWaterMark
+
 	encoding runtime.Codec
 	// Note that versioner is required for etcdWatcher to work correctly.
 	// There is no public constructor of it, so be careful when manipulating
@@ -89,10 +95,6 @@ type etcdWatcher struct {
 
 	// Injectable for testing. Send the event down the outgoing channel.
 	emit func(watch.Event)
-
-	// HighWaterMarks for performance debugging.
-	incomingHWM storage.HighWaterMark
-	outgoingHWM storage.HighWaterMark
 
 	cache etcdCache
 }


### PR DESCRIPTION
I haven't tested this yet, but let's see how e2e tests react.
It should be no difference at all except for that it will fix arm.

etcd has had to do this some times (and I think there are some fixes like this that are needed for etcd as well)

For reference see: https://golang.org/pkg/sync/atomic/

This should be a cherrypick-candidate for v1.4.1 (as I understand it, v1.4.0 has clearly left the cherrypickable state)

@lavalamp @pwittrock @xiang90 @smarterclayton

``` release-note
Move HighWaterMark to the top of the struct in order to fix arm
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33117)

<!-- Reviewable:end -->
