### PR TITLE
kubelet: eviction: add timestamp to FsStats

### DIFF
--- a/pkg/kubelet/api/v1alpha1/stats/types.go
+++ b/pkg/kubelet/api/v1alpha1/stats/types.go
@@ -165,6 +165,8 @@ type VolumeStats struct {
 
 // FsStats contains data about filesystem usage.
 type FsStats struct {
+	// The time at which these stats were updated.
+	Time unversioned.Time `json:"time"`
 	// AvailableBytes represents the storage space available (bytes) for the filesystem.
 	AvailableBytes *uint64 `json:"availableBytes,omitempty"`
 	// CapacityBytes represents the total capacity (bytes) of the filesystems underlying storage.

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -629,14 +629,14 @@ func makeSignalObservations(summaryProvider stats.SummaryProvider) (signalObserv
 			result[SignalNodeFsAvailable] = signalObservation{
 				available: resource.NewQuantity(int64(*nodeFs.AvailableBytes), resource.BinarySI),
 				capacity:  resource.NewQuantity(int64(*nodeFs.CapacityBytes), resource.BinarySI),
-				// TODO: add timestamp to stat (see memory stat)
+				time:      nodeFs.Time,
 			}
 		}
 		if nodeFs.InodesFree != nil && nodeFs.Inodes != nil {
 			result[SignalNodeFsInodesFree] = signalObservation{
 				available: resource.NewQuantity(int64(*nodeFs.InodesFree), resource.BinarySI),
 				capacity:  resource.NewQuantity(int64(*nodeFs.Inodes), resource.BinarySI),
-				// TODO: add timestamp to stat (see memory stat)
+				time:      nodeFs.Time,
 			}
 		}
 	}
@@ -646,13 +646,13 @@ func makeSignalObservations(summaryProvider stats.SummaryProvider) (signalObserv
 				result[SignalImageFsAvailable] = signalObservation{
 					available: resource.NewQuantity(int64(*imageFs.AvailableBytes), resource.BinarySI),
 					capacity:  resource.NewQuantity(int64(*imageFs.CapacityBytes), resource.BinarySI),
-					// TODO: add timestamp to stat (see memory stat)
+					time:      imageFs.Time,
 				}
 				if imageFs.InodesFree != nil && imageFs.Inodes != nil {
 					result[SignalImageFsInodesFree] = signalObservation{
 						available: resource.NewQuantity(int64(*imageFs.InodesFree), resource.BinarySI),
 						capacity:  resource.NewQuantity(int64(*imageFs.Inodes), resource.BinarySI),
-						// TODO: add timestamp to stat (see memory stat)
+						time:      imageFs.Time,
 					}
 				}
 			}

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -116,12 +116,14 @@ func (sb *summaryBuilder) build() (*stats.Summary, error) {
 	}
 
 	rootStats := sb.containerInfoV2ToStats("", &rootInfo)
+	cStats, _ := sb.latestContainerStats(&rootInfo)
 	nodeStats := stats.NodeStats{
 		NodeName: sb.node.Name,
 		CPU:      rootStats.CPU,
 		Memory:   rootStats.Memory,
 		Network:  sb.containerInfoV2ToNetworkStats("node:"+sb.node.Name, &rootInfo),
 		Fs: &stats.FsStats{
+			Time:           unversioned.NewTime(cStats.Timestamp),
 			AvailableBytes: &sb.rootFsInfo.Available,
 			CapacityBytes:  &sb.rootFsInfo.Capacity,
 			UsedBytes:      &sb.rootFsInfo.Usage,
@@ -130,6 +132,7 @@ func (sb *summaryBuilder) build() (*stats.Summary, error) {
 		StartTime: rootStats.StartTime,
 		Runtime: &stats.RuntimeStats{
 			ImageFs: &stats.FsStats{
+				Time:           unversioned.NewTime(cStats.Timestamp),
 				AvailableBytes: &sb.imageFsInfo.Available,
 				CapacityBytes:  &sb.imageFsInfo.Capacity,
 				UsedBytes:      &sb.imageStats.TotalStorageBytes,
@@ -162,8 +165,14 @@ func (sb *summaryBuilder) containerInfoV2FsStats(
 	info *cadvisorapiv2.ContainerInfo,
 	cs *stats.ContainerStats) {
 
+	lcs, found := sb.latestContainerStats(info)
+	if !found {
+		return
+	}
+
 	// The container logs live on the node rootfs device
 	cs.Logs = &stats.FsStats{
+		Time:           unversioned.NewTime(lcs.Timestamp),
 		AvailableBytes: &sb.rootFsInfo.Available,
 		CapacityBytes:  &sb.rootFsInfo.Capacity,
 		InodesFree:     sb.rootFsInfo.InodesFree,
@@ -172,14 +181,11 @@ func (sb *summaryBuilder) containerInfoV2FsStats(
 
 	// The container rootFs lives on the imageFs devices (which may not be the node root fs)
 	cs.Rootfs = &stats.FsStats{
+		Time:           unversioned.NewTime(lcs.Timestamp),
 		AvailableBytes: &sb.imageFsInfo.Available,
 		CapacityBytes:  &sb.imageFsInfo.Capacity,
 		InodesFree:     sb.imageFsInfo.InodesFree,
 		Inodes:         sb.imageFsInfo.Inodes,
-	}
-	lcs, found := sb.latestContainerStats(info)
-	if !found {
-		return
 	}
 	cfs := lcs.Filesystem
 	if cfs != nil && cfs.BaseUsageBytes != nil {


### PR DESCRIPTION
Fixes #33049 

Needs #32724 to actually do anything.  Best if it merged before this.

Allows for eviction manager to not act on stale filesystem stats just like #32724 does for memory stats.  This is achieved by comparing the timestamp on the cadvisor stat to the last stat we saw in the last `synchronize()`.  If it hasn't been updated, we do not need to take additional action.

@derekwaynecarr @vishh

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33121)

<!-- Reviewable:end -->
