### PR TITLE
Setting the default image for GKE tests to Container_VM.

### DIFF
--- a/cluster/gke/config-test.sh
+++ b/cluster/gke/config-test.sh
@@ -18,7 +18,7 @@
 CLUSTER_NAME="${CLUSTER_NAME:-${USER}-gke-e2e}"
 NETWORK=${KUBE_GKE_NETWORK:-e2e}
 NODE_TAG="k8s-${CLUSTER_NAME}-node"
-IMAGE_TYPE="${KUBE_GKE_IMAGE_TYPE:-}"
+IMAGE_TYPE="${KUBE_GKE_IMAGE_TYPE:-container_vm}"
 
 
 # For ease of maintenance, extract any pieces that do not vary between default


### PR DESCRIPTION
@vishh @spxtr @pwittrock

The purpose is to keep the current state of tests as is even if GKE changes the base image.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33125)

<!-- Reviewable:end -->
