### PR TITLE
Tune down initialDelaySeconds for readinessProbe.

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -68,7 +68,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -69,7 +69,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -69,7 +69,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -50,7 +50,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -66,7 +66,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"


### PR DESCRIPTION
Fixed #33053.

Tuned down the `initialDelaySeconds`(original 30s) for readiness probe to 3 seconds and `periodSeconds`(default 10s) to 5 seconds to shorten the initial time before a dns server pod being exposed. This configuration passed DNS e2e tests and did not even hit any readiness failure(for kube-dns) with a GCE cluster with 4 nodes during the experiments.

For scaling out kube-dns servers, it took less than 10s for servers being exposed after they appeared as running, which is much faster than 30+s(the original cost).

`failureThreshold` is left as default(3) and it would not lead to restart because the status of readiness probe would only affect whether endpoints being exposed in service or not(in the dns service point of view). According to the implementation of [prober](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/prober/worker.go), the number of retries for readiness probe is unbounded. Hence there is no obvious effect if the readiness probe fail several times in the beginning. 

The state machine of prober could be illustrated with below figure:

![drawing](https://cloud.githubusercontent.com/assets/8681801/18693503/fb4466dc-7f56-11e6-8671-0a14c4835d24.jpeg)

I want to see the e2e result of this PR for further evaluation.

``` release-note
Tune down initialDelaySeconds for readinessProbe.
```

@thockin @bprashanth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33146)

<!-- Reviewable:end -->
