### PR TITLE
Dumping federation events if federation e2e test failed

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -98,6 +98,10 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	if err != nil {
 		glog.Fatal("Error loading client: ", err)
 	}
+	clientset, err := framework.LoadClientset()
+	if err != nil {
+		glog.Fatal("Error loading clientset: ", err)
+	}
 
 	// Delete any namespaces except default and kube-system. This ensures no
 	// lingering resources are left over from a previous test run.
@@ -118,7 +122,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// ready will fail).
 	podStartupTimeout := framework.TestContext.SystemPodsStartupTimeout
 	if err := framework.WaitForPodsRunningReady(c, api.NamespaceSystem, int32(framework.TestContext.MinStartupPods), podStartupTimeout, framework.ImagePullerLabels); err != nil {
-		framework.DumpAllNamespaceInfo(c, api.NamespaceSystem)
+		framework.DumpAllNamespaceInfo(c, clientset, api.NamespaceSystem)
 		framework.LogFailedContainers(c, api.NamespaceSystem)
 		framework.RunKubernetesServiceTestContainer(c, api.NamespaceDefault)
 		framework.Failf("Error waiting for all pods to be running and ready: %v", err)

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -199,7 +199,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		pods, err := clusterState().WaitFor(atLeast, framework.PodStartTimeout)
 		if err != nil || len(pods) < atLeast {
 			// TODO: Generalize integrating debug info into these tests so we always get debug info when we need it
-			framework.DumpAllNamespaceInfo(c, ns)
+			framework.DumpAllNamespaceInfo(c, f.Clientset_1_5, ns)
 			framework.Failf("Verified %v of %v pods , error : %v", len(pods), atLeast, err)
 		}
 	}


### PR DESCRIPTION
Updating the e2e framework to dump events in federation control plane if a federation e2e test failed.

This should help in debugging https://github.com/kubernetes/kubernetes/issues/32733

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33159)

<!-- Reviewable:end -->
