### PR TITLE
Minor Ingress tests cleanup, that includes service shard and GCE resource cleanups in underlying clusters.

### DIFF
--- a/test/e2e/federated-ingress.go
+++ b/test/e2e/federated-ingress.go
@@ -51,7 +51,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 
 	// Create/delete ingress api objects
 	// Validate federation apiserver, does not rely on underlying clusters or federation ingress controller.
-	Describe("Ingress objects", func() {
+	Describe("Federated Ingresses", func() {
 		AfterEach(func() {
 			nsName := f.FederationNamespace.Name
 			// Delete registered ingresses.
@@ -137,6 +137,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 				deleteBackendPodsOrFail(clusters, ns)
 				if service != nil {
 					deleteServiceOrFail(f.FederationClientset_1_4, ns, service.Name)
+					cleanupServiceShardsAndProviderResources(ns, service, clusters)
 					service = nil
 				} else {
 					By("No service to delete. Service is nil")
@@ -164,6 +165,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 				}
 				// TODO check dns record in global dns server
 			})
+
 			It("should be able to connect to a federated ingress via its load balancer", func() {
 				// check the traffic on federation ingress
 				jig.waitForFederatedIngress()


### PR DESCRIPTION
Follow up for #32810.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33161)

<!-- Reviewable:end -->
