### PR TITLE
Corrected timeout on Downward API volume

### DIFF
--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -31,7 +31,7 @@ import (
 
 var _ = framework.KubeDescribe("Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
-	const podLogTimeout = 45 * time.Second
+	const podLogTimeout = 65 * time.Second
 	f := framework.NewDefaultFramework("downward-api")
 	var podClient *framework.PodClient
 	BeforeEach(func() {
@@ -81,9 +81,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	// Mark the following 2 tests as [Flaky] because of https://github.com/kubernetes/kubernetes/issues/29633,
-	// we should re-enable these tests when the issue is fixed.
-	It("should update labels on modification [Conformance] [Flaky]", func() {
+	It("should update labels on modification [Conformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -114,7 +112,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 	})
 
-	It("should update annotations on modification [Conformance] [Flaky]", func() {
+	It("should update annotations on modification [Conformance]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())


### PR DESCRIPTION
The tests for Downward API volume were apparently created before the
default sync-frequency was set to 1 minute. As the current
implementation of Pod gives us no guarantee that the changes will be
seen in Downward API before `sync-frequency` we need the tests to
reflect this.

Fixes: #29633

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33165)

<!-- Reviewable:end -->
