### PR TITLE
Fix elasticsearch cluster logging e2e test on GCI

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -23,9 +23,9 @@ spec:
       - image: gcr.io/google_containers/elasticsearch:1.9
         name: elasticsearch-logging         
         resources:
-          # keep request = limit to keep this container in guaranteed class
+          # need more cpu upon initialization, therefore burstable class
           limits:
-            cpu: 100m
+            cpu: 1000m
           requests:
             cpu: 100m
         ports:

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -219,11 +219,6 @@ func ClusterLevelLoggingWithElasticsearch(f *framework.Framework) {
 	}
 	framework.Logf("Found %d healthy nodes.", len(nodes.Items))
 
-	// TODO: Figure out why initialization time influences
-	// results of the test and remove this step
-	By("Wait some more time to ensure ES and fluentd are ready")
-	time.Sleep(2 * time.Minute)
-
 	// Wait for the Fluentd pods to enter the running state.
 	By("Checking to make sure the Fluentd pod are running on each healthy node")
 	label = labels.SelectorFromSet(labels.Set(map[string]string{k8sAppKey: fluentdValue}))
@@ -305,9 +300,6 @@ func ClusterLevelLoggingWithElasticsearch(f *framework.Framework) {
 		err = framework.WaitForPodSuccessInNamespace(f.Client, pod, "synth-logger", ns)
 		Expect(err).NotTo(HaveOccurred())
 	}
-
-	// Wait a bit for the log information to make it into Elasticsearch.
-	time.Sleep(30 * time.Second)
 
 	// Make several attempts to observe the logs ingested into Elasticsearch.
 	By("Checking all the log lines were ingested into Elasticsearch")


### PR DESCRIPTION
Fix #33126
Fix #32804

Additional timeouts are proven unnecessary, the problem lies with the cpu limits

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33168)

<!-- Reviewable:end -->
