### PR TITLE
Remove closing audit log file and add error check when writing to audit

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -377,6 +377,7 @@ func (c Config) New() (*GenericAPIServer, error) {
 
 	attributeGetter := apiserver.NewRequestAttributeGetter(c.RequestContextMapper, s.NewRequestInfoResolver())
 	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, c.Authorizer)
+	handler = apiserver.WithImpersonation(handler, c.RequestContextMapper, c.Authorizer)
 	if len(c.AuditLogPath) != 0 {
 		// audit handler must comes before the impersonationFilter to read the original user
 		writer := &lumberjack.Logger{
@@ -386,9 +387,7 @@ func (c Config) New() (*GenericAPIServer, error) {
 			MaxSize:    c.AuditLogMaxSize,
 		}
 		handler = audit.WithAudit(handler, attributeGetter, writer)
-		defer writer.Close()
 	}
-	handler = apiserver.WithImpersonation(handler, c.RequestContextMapper, c.Authorizer)
 
 	// Install Authenticator
 	if c.Authenticator != nil {


### PR DESCRIPTION
This picks the order fix from #33164. Additionally I've removed entirely closing the log file, since it didn't make sense where it was. I've also added error checks when actually writing to audit logs.

@sttts ptal

**1.4 justification:**

Risk: the code only runs if auditing is enabled with an apiserver flag. So the risk is low.
Rollback: nothing should depend on this
Cost: the auditing feature is broken because the impersonation filter is applied before and you might not see the proper user when using `--as` flag. Additionally no errors are logged if writing to audit fails. 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33170)

<!-- Reviewable:end -->
