### PR TITLE
Disabled monitoring e2e test for server in version 1.4+

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -386,6 +386,16 @@ func SkipUnlessServerVersionGTE(v semver.Version, c discovery.ServerVersionInter
 	}
 }
 
+func SkipUnlessServerVersionLT(v semver.Version, c discovery.ServerVersionInterface) {
+	gte, err := ServerVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		Skipf("Supported only for server versions before %q", v)
+	}
+}
+
 // Detects whether the federation namespace exists in the underlying cluster
 func SkipUnlessFederated(c *client.Client) {
 	federationNS := os.Getenv("FEDERATION_NAMESPACE")

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
@@ -36,6 +37,7 @@ var _ = framework.KubeDescribe("Monitoring", func() {
 
 	BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce")
+		framework.SkipUnlessServerVersionLT(version.MustParse("v1.4.0"), f.Client)
 	})
 
 	It("should verify monitoring pods and all cluster nodes are available on influxdb using heapster.", func() {


### PR DESCRIPTION
The text from release-1.3 doesn't work with release-1.4 due to incompatible change (influxdb was updated from 0.9 to 0.12).

ref #31626

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33181)

<!-- Reviewable:end -->
