### PR TITLE
Reset core_patern on GCI

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -25,6 +25,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function setup-os-params {
+  # Reset core_pattern. On GCI, the default core_pattern pipes the core dumps to
+  # /sbin/crash_reporter which is more restrictive in saving crash dumps. So for
+  # now, set a generic core_pattern that users can work with.
+  echo "core.%e.%p.%t" > /proc/sys/kernel/core_pattern
+}
+
 function config-ip-firewall {
   echo "Configuring IP firewall rules"
   # The GCI image has host firewall which drop most inbound/forwarded packets.
@@ -1176,6 +1183,7 @@ if [[ -n "${KUBE_USER:-}" ]]; then
   fi
 fi
 
+setup-os-params
 config-ip-firewall
 create-dirs
 ensure-local-ssds


### PR DESCRIPTION
The default core_pattern pipes the core dumps to /sbin/crash_reporter
which is more restrictive in saving crash dumps. So for
now, set a generic core_pattern that users can work with.

@dchen1107 @aulanov can you please review?

cc/ @kubernetes/goog-image

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33197)

<!-- Reviewable:end -->
