### PR TITLE
Remove cpu limits for dns pod to avoid CPU starvation

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # __MACHINE_GENERATED_WARNING__
@@ -51,7 +49,6 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            cpu: 100m
             memory: 170Mi
           requests:
             cpu: 100m
@@ -103,9 +100,7 @@ spec:
       - name: healthz
         image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
             memory: 50Mi
           requests:
             cpu: 10m

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
@@ -51,7 +49,6 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            cpu: 100m
             memory: 170Mi
           requests:
             cpu: 100m
@@ -103,9 +100,7 @@ spec:
       - name: healthz
         image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
             memory: 50Mi
           requests:
             cpu: 10m

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
@@ -51,7 +49,6 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            cpu: 100m
             memory: 170Mi
           requests:
             cpu: 100m
@@ -102,9 +99,7 @@ spec:
       - name: healthz
         image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
             memory: 50Mi
           requests:
             cpu: 10m

--- a/cluster/addons/dns/skydns-svc.yaml.base
+++ b/cluster/addons/dns/skydns-svc.yaml.base
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-svc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # __MACHINE_GENERATED_WARNING__

--- a/cluster/addons/dns/skydns-svc.yaml.in
+++ b/cluster/addons/dns/skydns-svc.yaml.in
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-svc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-svc.yaml.base

--- a/cluster/addons/dns/skydns-svc.yaml.sed
+++ b/cluster/addons/dns/skydns-svc.yaml.sed
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-svc.yaml
-
 # TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 
 # Warning: This is a file generated from the base underscore template file: skydns-svc.yaml.base


### PR DESCRIPTION
The current limits are not based on usage profiles
Fixes #33222

``` release-note
Remove cpu limits for dns pod to avoid CPU starvation
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33227)

<!-- Reviewable:end -->
