### PR TITLE
Remove -f from calls to 'docker tag' due to recent deprecation in latest version

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -848,7 +848,7 @@ function kube::release::create_docker_images_for_server() {
         if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
           local release_docker_image_tag="${KUBE_DOCKER_REGISTRY}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
           kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
-          "${DOCKER[@]}" tag -f "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
+          "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
         fi
 
         kube::log::status "Deleting docker image ${docker_image_tag}"

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -76,7 +76,7 @@ container: .container-$(ARCH)
 .container-$(ARCH): bin/$(BIN)-$(ARCH)
 	docker build -t $(IMAGE):$(TAG) --build-arg ARCH=$(ARCH) .
 ifeq ($(ARCH),amd64)
-	docker tag -f $(IMAGE):$(TAG) $(LEGACY_AMD64_IMAGE):$(TAG)
+	docker tag $(IMAGE):$(TAG) $(LEGACY_AMD64_IMAGE):$(TAG)
 endif
 	touch $@
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -66,7 +66,7 @@ push: build
 	gcloud docker push $(IMAGE)-$(ARCH):$(VERSION)
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag
-	docker tag -f $(IMAGE)-$(ARCH):$(VERSION) $(IMAGE):$(VERSION)
+	docker tag $(IMAGE)-$(ARCH):$(VERSION) $(IMAGE):$(VERSION)
 	gcloud docker push $(IMAGE):$(VERSION)
 endif
 

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -496,7 +496,7 @@ function stage-images() {
     local docker_tag="$(cat ${temp_dir}/kubernetes/server/bin/${binary}.docker_tag)"
     (
       "${docker_cmd[@]}" load -i "${temp_dir}/kubernetes/server/bin/${binary}.tar"
-      "${docker_cmd[@]}" tag -f "gcr.io/google_containers/${binary}:${docker_tag}" "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
+      "${docker_cmd[@]}" tag "gcr.io/google_containers/${binary}:${docker_tag}" "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
       "${docker_push_cmd[@]}" push "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
     ) &> "${temp_dir}/${binary}-push.log" &
   done

--- a/cluster/images/flannel/Makefile
+++ b/cluster/images/flannel/Makefile
@@ -40,7 +40,7 @@ ifeq ($(ARCH),amd64)
 	# If we should build an amd64 flannel image, go with the official one
 	docker pull quay.io/coreos/flannel:$(TAG)
 
-	docker tag -f quay.io/coreos/flannel:$(TAG) $(REGISTRY)/flannel-$(ARCH):$(TAG)
+	docker tag quay.io/coreos/flannel:$(TAG) $(REGISTRY)/flannel-$(ARCH):$(TAG)
 else
 	# Copy the content in this dir to the temp dir
 	cp ./* $(TEMP_DIR)

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -107,7 +107,7 @@ endif
 push: build
 	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
-	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
+	docker tag ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
 	gcloud docker push ${REGISTRY}/hyperkube:${VERSION}
 endif
 


### PR DESCRIPTION
Allows the newest docker version (which deprecates 'tag -f') to run 'docker tag' commands during the build.

cc @kubernetes/test-infra-maintainers

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33229)

<!-- Reviewable:end -->
