### PR TITLE
Apply default image tags for all runtimes

### DIFF
--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -65,7 +65,6 @@ func (ds *dockerService) ImageStatus(image *runtimeApi.ImageSpec) (*runtimeApi.I
 
 // PullImage pulls an image with authentication config.
 func (ds *dockerService) PullImage(image *runtimeApi.ImageSpec, auth *runtimeApi.AuthConfig) error {
-	// TODO: add default tags for images or should this be done by kubelet?
 	return ds.client.PullImage(image.GetImage(),
 		dockertypes.AuthConfig{
 			Username:      auth.GetUsername(),

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -315,34 +315,16 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 	}
 }
 
-func TestApplyDefaultImageTag(t *testing.T) {
-	for _, testCase := range []struct {
-		Input  string
-		Output string
-	}{
-		{Input: "root", Output: "root:latest"},
-		{Input: "root:tag", Output: "root:tag"},
-		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-	} {
-		image, err := applyDefaultImageTag(testCase.Input)
-		if err != nil {
-			t.Errorf("applyDefaultTag(%s) failed: %v", testCase.Input, err)
-		} else if image != testCase.Output {
-			t.Errorf("Expected image reference: %q, got %q", testCase.Output, image)
-		}
-	}
-}
-
 func TestPullWithNoSecrets(t *testing.T) {
 	tests := []struct {
 		imageName     string
 		expectedImage string
 	}{
-		{"ubuntu", "ubuntu:latest using {}"},
+		{"ubuntu", "ubuntu using {}"},
 		{"ubuntu:2342", "ubuntu:2342 using {}"},
 		{"ubuntu:latest", "ubuntu:latest using {}"},
 		{"foo/bar:445566", "foo/bar:445566 using {}"},
-		{"registry.example.com:5000/foobar", "registry.example.com:5000/foobar:latest using {}"},
+		{"registry.example.com:5000/foobar", "registry.example.com:5000/foobar using {}"},
 		{"registry.example.com:5000/foobar:5342", "registry.example.com:5000/foobar:5342 using {}"},
 		{"registry.example.com:5000/foobar:latest", "registry.example.com:5000/foobar:latest using {}"},
 	}
@@ -430,7 +412,7 @@ func TestPullWithSecrets(t *testing.T) {
 			"ubuntu",
 			[]api.Secret{},
 			credentialprovider.DockerConfig(map[string]credentialprovider.DockerConfigEntry{}),
-			[]string{"ubuntu:latest using {}"},
+			[]string{"ubuntu using {}"},
 		},
 		"default keyring secrets": {
 			"ubuntu",
@@ -438,7 +420,7 @@ func TestPullWithSecrets(t *testing.T) {
 			credentialprovider.DockerConfig(map[string]credentialprovider.DockerConfigEntry{
 				"index.docker.io/v1/": {Username: "built-in", Password: "password", Email: "email", Provider: nil},
 			}),
-			[]string{`ubuntu:latest using {"username":"built-in","password":"password","email":"email"}`},
+			[]string{`ubuntu using {"username":"built-in","password":"password","email":"email"}`},
 		},
 		"default keyring secrets unused": {
 			"ubuntu",
@@ -446,7 +428,7 @@ func TestPullWithSecrets(t *testing.T) {
 			credentialprovider.DockerConfig(map[string]credentialprovider.DockerConfigEntry{
 				"extraneous": {Username: "built-in", Password: "password", Email: "email", Provider: nil},
 			}),
-			[]string{`ubuntu:latest using {}`},
+			[]string{`ubuntu using {}`},
 		},
 		"builtin keyring secrets, but use passed": {
 			"ubuntu",
@@ -454,7 +436,7 @@ func TestPullWithSecrets(t *testing.T) {
 			credentialprovider.DockerConfig(map[string]credentialprovider.DockerConfigEntry{
 				"index.docker.io/v1/": {Username: "built-in", Password: "password", Email: "email", Provider: nil},
 			}),
-			[]string{`ubuntu:latest using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
+			[]string{`ubuntu using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
 		},
 		"builtin keyring secrets, but use passed with new docker config": {
 			"ubuntu",
@@ -462,7 +444,7 @@ func TestPullWithSecrets(t *testing.T) {
 			credentialprovider.DockerConfig(map[string]credentialprovider.DockerConfigEntry{
 				"index.docker.io/v1/": {Username: "built-in", Password: "password", Email: "email", Provider: nil},
 			}),
-			[]string{`ubuntu:latest using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
+			[]string{`ubuntu using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
 		},
 	}
 	for i, test := range tests {

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -211,3 +211,21 @@ func TestSerializedPuller(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyDefaultImageTag(t *testing.T) {
+	for _, testCase := range []struct {
+		Input  string
+		Output string
+	}{
+		{Input: "root", Output: "root:latest"},
+		{Input: "root:tag", Output: "root:tag"},
+		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	} {
+		image, err := applyDefaultImageTag(testCase.Input)
+		if err != nil {
+			t.Errorf("applyDefaultImageTag(%s) failed: %v", testCase.Input, err)
+		} else if image != testCase.Output {
+			t.Errorf("Expected image reference: %q, got %q", testCase.Output, image)
+		}
+	}
+}

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -37,6 +37,9 @@ var (
 
 	// Get http error when pulling image from registry
 	RegistryUnavailable = errors.New("RegistryUnavailable")
+
+	// Unable to parse the image name.
+	ErrInvalidImageName = errors.New("InvalidImageName")
 )
 
 // ImageManager provides an interface to manage the lifecycle of images.


### PR DESCRIPTION
Move the docker-specific logic up to the ImageManager to allow code sharing
among different implementations.

Part of #31459

/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33233)

<!-- Reviewable:end -->
