### PR TITLE
Support Access-Control-Expose-Headers in CORS Handler

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -353,7 +353,7 @@ func (c Config) New() (*GenericAPIServer, error) {
 
 func (s *GenericAPIServer) buildHandlerChains(c *Config, handler http.Handler) (secure http.Handler, insecure http.Handler) {
 	// filters which insecure and secure have in common
-	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, "true")
+	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 
 	// insecure filters
 	insecure = handler

--- a/pkg/genericapiserver/filters/cors.go
+++ b/pkg/genericapiserver/filters/cors.go
@@ -35,7 +35,7 @@ import (
 // WithCORS is a simple CORS implementation that wraps an http Handler.
 // Pass nil for allowedMethods and allowedHeaders to use the defaults. If allowedOriginPatterns
 // is empty or nil, no CORS support is installed.
-func WithCORS(handler http.Handler, allowedOriginPatterns []string, allowedMethods []string, allowedHeaders []string, allowCredentials string) http.Handler {
+func WithCORS(handler http.Handler, allowedOriginPatterns []string, allowedMethods []string, allowedHeaders []string, exposedHeaders []string, allowCredentials string) http.Handler {
 	if len(allowedOriginPatterns) == 0 {
 		return handler
 	}
@@ -58,8 +58,12 @@ func WithCORS(handler http.Handler, allowedOriginPatterns []string, allowedMetho
 				if allowedHeaders == nil {
 					allowedHeaders = []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "X-Requested-With", "If-Modified-Since"}
 				}
+				if exposedHeaders == nil {
+					exposedHeaders = []string{"Date"}
+				}
 				w.Header().Set("Access-Control-Allow-Methods", strings.Join(allowedMethods, ", "))
 				w.Header().Set("Access-Control-Allow-Headers", strings.Join(allowedHeaders, ", "))
+				w.Header().Set("Access-Control-Expose-Headers", strings.Join(exposedHeaders, ", "))
 				w.Header().Set("Access-Control-Allow-Credentials", allowCredentials)
 
 				// Stop here if its a preflight OPTIONS request

--- a/pkg/genericapiserver/filters/cors_test.go
+++ b/pkg/genericapiserver/filters/cors_test.go
@@ -39,7 +39,7 @@ func TestCORSAllowedOrigins(t *testing.T) {
 	for _, item := range table {
 		handler := WithCORS(
 			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-			item.allowedOrigins, nil, nil, "true",
+			item.allowedOrigins, nil, nil, nil, "true",
 		)
 		server := httptest.NewServer(handler)
 		defer server.Close()
@@ -72,6 +72,9 @@ func TestCORSAllowedOrigins(t *testing.T) {
 			if response.Header.Get("Access-Control-Allow-Methods") == "" {
 				t.Errorf("Expected Access-Control-Allow-Methods header to be set")
 			}
+			if response.Header.Get("Access-Control-Expose-Headers") != "Date" {
+				t.Errorf("Expected Date in Access-Control-Expose-Headers header")
+			}
 		} else {
 			if response.Header.Get("Access-Control-Allow-Origin") != "" {
 				t.Errorf("Expected Access-Control-Allow-Origin header to not be set")
@@ -87,6 +90,9 @@ func TestCORSAllowedOrigins(t *testing.T) {
 
 			if response.Header.Get("Access-Control-Allow-Methods") != "" {
 				t.Errorf("Expected Access-Control-Allow-Methods header to not be set")
+			}
+			if response.Header.Get("Access-Control-Expose-Headers") == "Date" {
+				t.Errorf("Expected Date in Access-Control-Expose-Headers header")
 			}
 		}
 	}


### PR DESCRIPTION
Our typical HTTP Response has a "Date" Header, if we don't add an
additional http header "Access-Control-Expose-Headers: Date" then
the browser based clients cannot use the Date HTTP Header.

Fixes #33231

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
When CORS Handler is enabled, we now add a new HTTP header named "Access-Control-Expose-Headers" with a value of "Date". This allows the "Date" HTTP header to be accessed from XHR/JavaScript.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33242)

<!-- Reviewable:end -->
