### PR TITLE
Make genericapiserver.PostStartHooks private

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -169,7 +169,7 @@ type GenericAPIServer struct {
 	// PostStartHooks are each called after the server has started listening, in a separate go func for each
 	// with no guaranteee of ordering between them.  The map key is a name used for error reporting.
 	// It may kill the process with a panic if it wishes to by returning an error
-	PostStartHooks       map[string]PostStartHookFunc
+	postStartHooks       map[string]PostStartHookFunc
 	postStartHookLock    sync.Mutex
 	postStartHooksCalled bool
 	openAPIDefinitions   *common.OpenAPIDefinitions

--- a/pkg/genericapiserver/hooks.go
+++ b/pkg/genericapiserver/hooks.go
@@ -61,14 +61,14 @@ func (s *GenericAPIServer) AddPostStartHook(name string, hook PostStartHookFunc)
 	if s.postStartHooksCalled {
 		return fmt.Errorf("unable to add %q because PostStartHooks have already been called", name)
 	}
-	if s.PostStartHooks == nil {
-		s.PostStartHooks = map[string]PostStartHookFunc{}
+	if s.postStartHooks == nil {
+		s.postStartHooks = map[string]PostStartHookFunc{}
 	}
-	if _, exists := s.PostStartHooks[name]; exists {
+	if _, exists := s.postStartHooks[name]; exists {
 		return fmt.Errorf("unable to add %q because it is already registered", name)
 	}
 
-	s.PostStartHooks[name] = hook
+	s.postStartHooks[name] = hook
 
 	return nil
 }
@@ -79,7 +79,7 @@ func (s *GenericAPIServer) RunPostStartHooks(context PostStartHookContext) {
 	defer s.postStartHookLock.Unlock()
 	s.postStartHooksCalled = true
 
-	for hookName, hook := range s.PostStartHooks {
+	for hookName, hook := range s.postStartHooks {
 		go runPostStartHook(hookName, hook, context)
 	}
 }


### PR DESCRIPTION
Better do not leak members to downstream if not necessary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33264)

<!-- Reviewable:end -->
