### PR TITLE
Bump glbc version to 0.8.0

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.7.1
+  name: l7-lb-controller-v0.8.0
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.7.1
+    version: v0.8.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.7.1
+  - image: gcr.io/google_containers/glbc:0.8.0
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Picks up k8s.io godeps for v1.4 thereby fixing an int overflow bug in the upstream delayed-workqueue pkg. Without this the controller spams logs with retries in the "soft error" case, which is easy to come by when users eg: create ingresses that point to non-exist services. 

Should go into 1.4.1, because 1.4.0 is pretty much out at this point. 
https://github.com/kubernetes/kubernetes/issues/33279

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33280)

<!-- Reviewable:end -->
