### PR TITLE
Apiserver don't log stacktrace when proxying

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -134,30 +134,33 @@ func tooManyRequests(req *http.Request, w http.ResponseWriter) {
 }
 
 // RecoverPanics wraps an http Handler to recover and log panics.
-func RecoverPanics(handler http.Handler) http.Handler {
+func RecoverPanics(handler http.Handler, resolver *RequestInfoResolver) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer runtime.HandleCrash(func(err interface{}) {
 			http.Error(w, "This request caused apisever to panic. Look in log for details.", http.StatusInternalServerError)
 			glog.Errorf("APIServer panic'd on %v %v: %v\n%s\n", req.Method, req.RequestURI, err, debug.Stack())
 		})
-		defer httplog.NewLogged(req, &w).StacktraceWhen(
-			httplog.StatusIsNot(
-				http.StatusOK,
-				http.StatusCreated,
-				http.StatusAccepted,
-				http.StatusBadRequest,
-				http.StatusMovedPermanently,
-				http.StatusTemporaryRedirect,
-				http.StatusConflict,
-				http.StatusNotFound,
-				http.StatusUnauthorized,
-				http.StatusForbidden,
-				http.StatusNotModified,
-				errors.StatusUnprocessableEntity,
-				http.StatusSwitchingProtocols,
-			),
-		).Log()
 
+		requestInfo, err := resolver.GetRequestInfo(req)
+		if err != nil || requestInfo.Verb != "proxy" {
+			defer httplog.NewLogged(req, &w).StacktraceWhen(
+				httplog.StatusIsNot(
+					http.StatusOK,
+					http.StatusCreated,
+					http.StatusAccepted,
+					http.StatusBadRequest,
+					http.StatusMovedPermanently,
+					http.StatusTemporaryRedirect,
+					http.StatusConflict,
+					http.StatusNotFound,
+					http.StatusUnauthorized,
+					http.StatusForbidden,
+					http.StatusNotModified,
+					errors.StatusUnprocessableEntity,
+					http.StatusSwitchingProtocols,
+				),
+			).Log()
+		}
 		// Dispatch to the internal handler
 		handler.ServeHTTP(w, req)
 	})

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -288,7 +288,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 
 	secureStartedCh := make(chan struct{})
 	if secureLocation != "" {
-		handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.Handler), longRunningTimeout)
+		handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.Handler, s.NewRequestInfoResolver()), longRunningTimeout)
 		secureServer := &http.Server{
 			Addr:           secureLocation,
 			Handler:        apiserver.MaxInFlightLimit(sem, longRunningRequestCheck, handler),
@@ -358,7 +358,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 		close(secureStartedCh)
 	}
 
-	handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.InsecureHandler), longRunningTimeout)
+	handler := apiserver.TimeoutHandler(apiserver.RecoverPanics(s.InsecureHandler, s.NewRequestInfoResolver()), longRunningTimeout)
 	http := &http.Server{
 		Addr:           insecureLocation,
 		Handler:        handler,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

When we are proxying unexpected status from a service or a pod, we print the stack traces (which is not the wanted behaviour). This is an attempt at fixing the issue #32747,

With the `RequestInfoResolver` struct, it's possible to inspect the request and get the `Verb`. In this case, the `proxy` value is what I was looking for to avoid logging stack traces.

I'm wrapping the `.Log()` call with an `if` statement to remove all stack traces logging when the call is a proxy from a service or a pod

Another approach would have been to add another kind of `StacktracePred` in the `httplog` package. I found this path to be trickier to code as it's currently only accepting int values.

**Which issue this PR fixes** : fixes #32747

**Special notes for your reviewer**: N/A

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33286)

<!-- Reviewable:end -->
