### PR TITLE
start creating controller SA roles.  start with just one

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbac
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -93,4 +94,71 @@ func NonResourceURLMatches(rule PolicyRule, requestedURL string) bool {
 	}
 
 	return false
+}
+
+// +k8s:deepcopy-gen=false
+// PolicyRuleBuilder let's us attach methods.  A no-no for API types.
+// We use it to construct rules in code.  It's more compact than trying to write them
+// out in a literal and allows us to perform some basic checking during construction
+type PolicyRuleBuilder struct {
+	PolicyRule PolicyRule
+}
+
+func NewRule(verbs ...string) *PolicyRuleBuilder {
+	return &PolicyRuleBuilder{
+		PolicyRule: PolicyRule{Verbs: verbs},
+	}
+}
+
+func (r *PolicyRuleBuilder) Groups(groups ...string) *PolicyRuleBuilder {
+	r.PolicyRule.APIGroups = append(r.PolicyRule.APIGroups, groups...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) Resources(resources ...string) *PolicyRuleBuilder {
+	r.PolicyRule.Resources = append(r.PolicyRule.Resources, resources...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) Names(names ...string) *PolicyRuleBuilder {
+	r.PolicyRule.ResourceNames = append(r.PolicyRule.ResourceNames, names...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) URLs(urls ...string) *PolicyRuleBuilder {
+	r.PolicyRule.NonResourceURLs = append(r.PolicyRule.NonResourceURLs, urls...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) RuleOrDie() PolicyRule {
+	ret, err := r.Rule()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (r *PolicyRuleBuilder) Rule() (PolicyRule, error) {
+	if len(r.PolicyRule.Verbs) == 0 {
+		return PolicyRule{}, fmt.Errorf("verbs are required: %#v", r.PolicyRule)
+	}
+
+	switch {
+	case len(r.PolicyRule.NonResourceURLs) > 0:
+		if len(r.PolicyRule.APIGroups) != 0 || len(r.PolicyRule.Resources) != 0 || len(r.PolicyRule.ResourceNames) != 0 {
+			return PolicyRule{}, fmt.Errorf("non-resource rule may not have apiGroups, resources, or resourceNames: %#v", r.PolicyRule)
+		}
+	case len(r.PolicyRule.Resources) > 0:
+		if len(r.PolicyRule.NonResourceURLs) != 0 {
+			return PolicyRule{}, fmt.Errorf("resource rule may not have nonResourceURLs: %#v", r.PolicyRule)
+		}
+		if len(r.PolicyRule.APIGroups) == 0 {
+			// this a common bug
+			return PolicyRule{}, fmt.Errorf("resource rule must have apiGroups: %#v", r.PolicyRule)
+		}
+	default:
+		return PolicyRule{}, fmt.Errorf("a rule must have either nonResourceURLs or resources: %#v", r.PolicyRule)
+	}
+
+	return r.PolicyRule, nil
 }

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -122,7 +122,7 @@ func newPostStartHook(directClusterRoleAccess *clusterroleetcd.REST) genericapis
 			return nil
 		}
 
-		for _, clusterRole := range bootstrappolicy.ClusterRoles() {
+		for _, clusterRole := range append(bootstrappolicy.ClusterRoles(), bootstrappolicy.ControllerRoles()...) {
 			if _, err := directClusterRoleAccess.Create(ctx, &clusterRole); err != nil {
 				// don't fail on failures, try to create as many as you can
 				utilruntime.HandleError(fmt.Errorf("unable to initialize clusterroles: %v", err))

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrappolicy
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+var (
+	// controllerRoles is a slice of roles used for controllers
+	controllerRoles = []rbac.ClusterRole{}
+)
+
+func addControllerRole(role rbac.ClusterRole) {
+	if !strings.HasPrefix(role.Name, "system:controller:") {
+		glog.Fatalf(`role %q must start with "system:controller:"`, role.Name)
+	}
+
+	for _, existingRole := range controllerRoles {
+		if role.Name == existingRole.Name {
+			glog.Fatalf("role %q was already registered", role.Name)
+		}
+	}
+
+	controllerRoles = append(controllerRoles, role)
+}
+
+func eventsRule() rbac.PolicyRule {
+	return rbac.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie()
+}
+
+func init() {
+	addControllerRole(rbac.ClusterRole{
+		ObjectMeta: api.ObjectMeta{Name: "system:controller:replication-controller"},
+		Rules: []rbac.PolicyRule{
+			rbac.NewRule("get", "list", "watch", "update").Groups(legacyGroup).Resources("replicationcontrollers").RuleOrDie(),
+			rbac.NewRule("update").Groups(legacyGroup).Resources("replicationcontrollers/status").RuleOrDie(),
+			rbac.NewRule("list", "watch", "create", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+			eventsRule(),
+		},
+	})
+}
+
+// ControllerRoles returns the cluster roles used by controllers
+func ControllerRoles() []rbac.ClusterRole {
+	return controllerRoles
+}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -18,18 +18,24 @@ package bootstrappolicy
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
+	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+var (
+	readWrite = []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+	read      = []string{"get", "list", "watch"}
+
+	legacyGroup = ""
 )
 
 // ClusterRoles returns the cluster roles to bootstrap an API server with
-func ClusterRoles() []rbacapi.ClusterRole {
-	return []rbacapi.ClusterRole{
-		// TODO update the expression of these rules to match openshift for ease of inspection
+func ClusterRoles() []rbac.ClusterRole {
+	return []rbac.ClusterRole{
 		{
 			ObjectMeta: api.ObjectMeta{Name: "cluster-admin"},
-			Rules: []rbacapi.PolicyRule{
-				{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
-				{Verbs: []string{"*"}, NonResourceURLs: []string{"*"}},
+			Rules: []rbac.PolicyRule{
+				rbac.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
+				rbac.NewRule("*").URLs("*").RuleOrDie(),
 			},
 		},
 	}


### PR DESCRIPTION
This creates a clusterrole for the replicationcontroller controller.  It also streamlines the rule creation code and I'll use this role as practice for wiring up RBAC rules.

@kubernetes/sig-auth 
@ericchiang Jordan is ooto, mind taking a look?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33294)

<!-- Reviewable:end -->
