### PR TITLE
Put loopback authn/authz first in chain

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -279,10 +279,10 @@ func Run(s *options.APIServer) error {
 		}
 
 		tokenAuthenticator := authenticator.NewAuthenticatorFromTokens(tokens)
-		apiAuthenticator = authenticatorunion.New(apiAuthenticator, tokenAuthenticator)
+		apiAuthenticator = authenticatorunion.New(tokenAuthenticator, apiAuthenticator)
 
 		tokenAuthorizer := authorizer.NewPrivilegedGroups("system:masters")
-		apiAuthorizer = authorizerunion.New(apiAuthorizer, tokenAuthorizer)
+		apiAuthorizer = authorizerunion.New(tokenAuthorizer, apiAuthorizer)
 	}
 
 	sharedInformers := informers.NewSharedInformerFactory(client, 10*time.Minute)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -187,10 +187,10 @@ func Run(s *options.ServerRunOptions) error {
 		}
 
 		tokenAuthenticator := authenticator.NewAuthenticatorFromTokens(tokens)
-		apiAuthenticator = authenticatorunion.New(apiAuthenticator, tokenAuthenticator)
+		apiAuthenticator = authenticatorunion.New(tokenAuthenticator, apiAuthenticator)
 
 		tokenAuthorizer := authorizer.NewPrivilegedGroups("system:masters")
-		apiAuthorizer = authorizerunion.New(apiAuthorizer, tokenAuthorizer)
+		apiAuthorizer = authorizerunion.New(tokenAuthorizer, apiAuthorizer)
 	}
 
 	sharedInformers := informers.NewSharedInformerFactory(client, 10*time.Minute)


### PR DESCRIPTION
We want the loopback token auth to go first in the chain, for performance reasons, and so the loopback token isn't seen by any remote token authenticators configured.

The loopback authorizer should also go first in the chain for performance.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33297)

<!-- Reviewable:end -->
