### PR TITLE
oidc authenticator: allow string value as groups claim

### DIFF
--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -401,7 +401,7 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.OIDCGroupsClaim, "oidc-groups-claim", "", ""+
 		"If provided, the name of a custom OpenID Connect claim for specifying user groups. "+
-		"The claim value is expected to be an array of strings. This flag is experimental, "+
+		"The claim value is expected to be a string or array of strings. This flag is experimental, "+
 		"please see the authentication documentation for further details.")
 
 	fs.Var(&s.RuntimeConfig, "runtime-config", ""+


### PR DESCRIPTION
Allow the group claim to be a single string instead of an array of
strings. This means the following claim

```
{
  "role": "admin"
}
```

Will be mapped to the groups

```
["admin"]
```

cc @kubernetes/sig-auth @mlbiam

closes #33290

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33332)

<!-- Reviewable:end -->
