### PR TITLE
Fix API Installer to generate unique Operation IDs

### DIFF
--- a/api/swagger-spec/apps_v1alpha1.json
+++ b/api/swagger-spec/apps_v1alpha1.json
@@ -643,7 +643,7 @@
       "type": "v1alpha1.PetSetList",
       "method": "GET",
       "summary": "list or watch objects of kind PetSet",
-      "nickname": "listNamespacedPetSet",
+      "nickname": "listPetSetForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -720,7 +720,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PetSet",
-      "nickname": "watchNamespacedPetSetList",
+      "nickname": "watchPetSetListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -643,7 +643,7 @@
       "type": "v1.HorizontalPodAutoscalerList",
       "method": "GET",
       "summary": "list or watch objects of kind HorizontalPodAutoscaler",
-      "nickname": "listNamespacedHorizontalPodAutoscaler",
+      "nickname": "listHorizontalPodAutoscalerForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -720,7 +720,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
-      "nickname": "watchNamespacedHorizontalPodAutoscalerList",
+      "nickname": "watchHorizontalPodAutoscalerListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -643,7 +643,7 @@
       "type": "v1.JobList",
       "method": "GET",
       "summary": "list or watch objects of kind Job",
-      "nickname": "listNamespacedJob",
+      "nickname": "listJobForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -720,7 +720,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Job",
-      "nickname": "watchNamespacedJobList",
+      "nickname": "watchJobListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -643,7 +643,7 @@
       "type": "v1beta1.DaemonSetList",
       "method": "GET",
       "summary": "list or watch objects of kind DaemonSet",
-      "nickname": "listNamespacedDaemonSet",
+      "nickname": "listDaemonSetForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -720,7 +720,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of DaemonSet",
-      "nickname": "watchNamespacedDaemonSetList",
+      "nickname": "watchDaemonSetListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1590,7 +1590,7 @@
       "type": "v1beta1.DeploymentList",
       "method": "GET",
       "summary": "list or watch objects of kind Deployment",
-      "nickname": "listNamespacedDeployment",
+      "nickname": "listDeploymentForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1667,7 +1667,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Deployment",
-      "nickname": "watchNamespacedDeploymentList",
+      "nickname": "watchDeploymentListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2763,7 +2763,7 @@
       "type": "v1beta1.HorizontalPodAutoscalerList",
       "method": "GET",
       "summary": "list or watch objects of kind HorizontalPodAutoscaler",
-      "nickname": "listNamespacedHorizontalPodAutoscaler",
+      "nickname": "listHorizontalPodAutoscalerForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2840,7 +2840,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
-      "nickname": "watchNamespacedHorizontalPodAutoscalerList",
+      "nickname": "watchHorizontalPodAutoscalerListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -3710,7 +3710,7 @@
       "type": "v1beta1.IngressList",
       "method": "GET",
       "summary": "list or watch objects of kind Ingress",
-      "nickname": "listNamespacedIngress",
+      "nickname": "listIngressForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -3787,7 +3787,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Ingress",
-      "nickname": "watchNamespacedIngressList",
+      "nickname": "watchIngressListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -4657,7 +4657,7 @@
       "type": "v1beta1.JobList",
       "method": "GET",
       "summary": "list or watch objects of kind Job",
-      "nickname": "listNamespacedJob",
+      "nickname": "listJobForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -4734,7 +4734,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Job",
-      "nickname": "watchNamespacedJobList",
+      "nickname": "watchJobListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -5604,7 +5604,7 @@
       "type": "v1beta1.NetworkPolicyList",
       "method": "GET",
       "summary": "list or watch objects of kind NetworkPolicy",
-      "nickname": "listNamespacedNetworkPolicy",
+      "nickname": "listNetworkPolicyForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -5681,7 +5681,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of NetworkPolicy",
-      "nickname": "watchNamespacedNetworkPolicyList",
+      "nickname": "watchNetworkPolicyListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -6386,7 +6386,7 @@
       "type": "v1beta1.ReplicaSetList",
       "method": "GET",
       "summary": "list or watch objects of kind ReplicaSet",
-      "nickname": "listNamespacedReplicaSet",
+      "nickname": "listReplicaSetForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -6463,7 +6463,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ReplicaSet",
-      "nickname": "watchNamespacedReplicaSetList",
+      "nickname": "watchReplicaSetListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/policy_v1alpha1.json
+++ b/api/swagger-spec/policy_v1alpha1.json
@@ -643,7 +643,7 @@
       "type": "v1alpha1.PodDisruptionBudgetList",
       "method": "GET",
       "summary": "list or watch objects of kind PodDisruptionBudget",
-      "nickname": "listNamespacedPodDisruptionBudget",
+      "nickname": "listPodDisruptionBudgetForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -720,7 +720,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PodDisruptionBudget",
-      "nickname": "watchNamespacedPodDisruptionBudgetList",
+      "nickname": "watchPodDisruptionBudgetListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -1705,7 +1705,7 @@
       "type": "v1alpha1.RoleBindingList",
       "method": "GET",
       "summary": "list or watch objects of kind RoleBinding",
-      "nickname": "listNamespacedRoleBinding",
+      "nickname": "listRoleBindingForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1782,7 +1782,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of RoleBinding",
-      "nickname": "watchNamespacedRoleBindingList",
+      "nickname": "watchRoleBindingListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2471,7 +2471,7 @@
       "type": "v1alpha1.RoleList",
       "method": "GET",
       "summary": "list or watch objects of kind Role",
-      "nickname": "listNamespacedRole",
+      "nickname": "listRoleForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2548,7 +2548,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Role",
-      "nickname": "watchNamespacedRoleList",
+      "nickname": "watchRoleListForAllNamespaces",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -818,7 +818,7 @@
       "type": "v1.ConfigMapList",
       "method": "GET",
       "summary": "list or watch objects of kind ConfigMap",
-      "nickname": "listNamespacedConfigMap",
+      "nickname": "listConfigMapForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -895,7 +895,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ConfigMap",
-      "nickname": "watchNamespacedConfigMapList",
+      "nickname": "watchConfigMapListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1600,7 +1600,7 @@
       "type": "v1.EndpointsList",
       "method": "GET",
       "summary": "list or watch objects of kind Endpoints",
-      "nickname": "listNamespacedEndpoints",
+      "nickname": "listEndpointsForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1677,7 +1677,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Endpoints",
-      "nickname": "watchNamespacedEndpointsList",
+      "nickname": "watchEndpointsListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2382,7 +2382,7 @@
       "type": "v1.EventList",
       "method": "GET",
       "summary": "list or watch objects of kind Event",
-      "nickname": "listNamespacedEvent",
+      "nickname": "listEventForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2459,7 +2459,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Event",
-      "nickname": "watchNamespacedEventList",
+      "nickname": "watchEventListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -3164,7 +3164,7 @@
       "type": "v1.LimitRangeList",
       "method": "GET",
       "summary": "list or watch objects of kind LimitRange",
-      "nickname": "listNamespacedLimitRange",
+      "nickname": "listLimitRangeForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -3241,7 +3241,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of LimitRange",
-      "nickname": "watchNamespacedLimitRangeList",
+      "nickname": "watchLimitRangeListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -4623,7 +4623,7 @@
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Node",
-      "nickname": "proxyGETNode",
+      "nickname": "proxyGETNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -4653,7 +4653,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Node",
-      "nickname": "proxyPUTNode",
+      "nickname": "proxyPUTNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -4683,7 +4683,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Node",
-      "nickname": "proxyPOSTNode",
+      "nickname": "proxyPOSTNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -4713,7 +4713,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Node",
-      "nickname": "proxyDELETENode",
+      "nickname": "proxyDELETENodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -4743,7 +4743,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Node",
-      "nickname": "proxyHEADNode",
+      "nickname": "proxyHEADNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -4773,7 +4773,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Node",
-      "nickname": "proxyOPTIONSNode",
+      "nickname": "proxyOPTIONSNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5133,7 +5133,7 @@
       "type": "string",
       "method": "GET",
       "summary": "connect GET requests to proxy of Node",
-      "nickname": "connectGetNodeProxy",
+      "nickname": "connectGetNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5171,7 +5171,7 @@
       "type": "string",
       "method": "POST",
       "summary": "connect POST requests to proxy of Node",
-      "nickname": "connectPostNodeProxy",
+      "nickname": "connectPostNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5209,7 +5209,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "connect PUT requests to proxy of Node",
-      "nickname": "connectPutNodeProxy",
+      "nickname": "connectPutNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5247,7 +5247,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "connect DELETE requests to proxy of Node",
-      "nickname": "connectDeleteNodeProxy",
+      "nickname": "connectDeleteNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5285,7 +5285,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "connect HEAD requests to proxy of Node",
-      "nickname": "connectHeadNodeProxy",
+      "nickname": "connectHeadNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5323,7 +5323,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "connect OPTIONS requests to proxy of Node",
-      "nickname": "connectOptionsNodeProxy",
+      "nickname": "connectOptionsNodeProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6135,7 +6135,7 @@
       "type": "v1.PersistentVolumeClaimList",
       "method": "GET",
       "summary": "list or watch objects of kind PersistentVolumeClaim",
-      "nickname": "listNamespacedPersistentVolumeClaim",
+      "nickname": "listPersistentVolumeClaimForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -6212,7 +6212,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PersistentVolumeClaim",
-      "nickname": "watchNamespacedPersistentVolumeClaimList",
+      "nickname": "watchPersistentVolumeClaimListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -7778,7 +7778,7 @@
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Pod",
-      "nickname": "proxyGETNamespacedPod",
+      "nickname": "proxyGETNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -7816,7 +7816,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Pod",
-      "nickname": "proxyPUTNamespacedPod",
+      "nickname": "proxyPUTNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -7854,7 +7854,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Pod",
-      "nickname": "proxyPOSTNamespacedPod",
+      "nickname": "proxyPOSTNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -7892,7 +7892,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Pod",
-      "nickname": "proxyDELETENamespacedPod",
+      "nickname": "proxyDELETENamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -7930,7 +7930,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Pod",
-      "nickname": "proxyHEADNamespacedPod",
+      "nickname": "proxyHEADNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -7968,7 +7968,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Pod",
-      "nickname": "proxyOPTIONSNamespacedPod",
+      "nickname": "proxyOPTIONSNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -8198,7 +8198,7 @@
       "type": "v1.PodList",
       "method": "GET",
       "summary": "list or watch objects of kind Pod",
-      "nickname": "listNamespacedPod",
+      "nickname": "listPodForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -8275,7 +8275,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Pod",
-      "nickname": "watchNamespacedPodList",
+      "nickname": "watchPodListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -9201,7 +9201,7 @@
       "type": "string",
       "method": "GET",
       "summary": "connect GET requests to proxy of Pod",
-      "nickname": "connectGetNamespacedPodProxy",
+      "nickname": "connectGetNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -9247,7 +9247,7 @@
       "type": "string",
       "method": "POST",
       "summary": "connect POST requests to proxy of Pod",
-      "nickname": "connectPostNamespacedPodProxy",
+      "nickname": "connectPostNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -9293,7 +9293,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "connect PUT requests to proxy of Pod",
-      "nickname": "connectPutNamespacedPodProxy",
+      "nickname": "connectPutNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -9339,7 +9339,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "connect DELETE requests to proxy of Pod",
-      "nickname": "connectDeleteNamespacedPodProxy",
+      "nickname": "connectDeleteNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -9385,7 +9385,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "connect HEAD requests to proxy of Pod",
-      "nickname": "connectHeadNamespacedPodProxy",
+      "nickname": "connectHeadNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -9431,7 +9431,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "connect OPTIONS requests to proxy of Pod",
-      "nickname": "connectOptionsNamespacedPodProxy",
+      "nickname": "connectOptionsNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -10275,7 +10275,7 @@
       "type": "v1.PodTemplateList",
       "method": "GET",
       "summary": "list or watch objects of kind PodTemplate",
-      "nickname": "listNamespacedPodTemplate",
+      "nickname": "listPodTemplateForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -10352,7 +10352,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PodTemplate",
-      "nickname": "watchNamespacedPodTemplateList",
+      "nickname": "watchPodTemplateListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -11057,7 +11057,7 @@
       "type": "v1.ReplicationControllerList",
       "method": "GET",
       "summary": "list or watch objects of kind ReplicationController",
-      "nickname": "listNamespacedReplicationController",
+      "nickname": "listReplicationControllerForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -11134,7 +11134,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ReplicationController",
-      "nickname": "watchNamespacedReplicationControllerList",
+      "nickname": "watchReplicationControllerListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -12169,7 +12169,7 @@
       "type": "v1.ResourceQuotaList",
       "method": "GET",
       "summary": "list or watch objects of kind ResourceQuota",
-      "nickname": "listNamespacedResourceQuota",
+      "nickname": "listResourceQuotaForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -12246,7 +12246,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ResourceQuota",
-      "nickname": "watchNamespacedResourceQuotaList",
+      "nickname": "watchResourceQuotaListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -13116,7 +13116,7 @@
       "type": "v1.SecretList",
       "method": "GET",
       "summary": "list or watch objects of kind Secret",
-      "nickname": "listNamespacedSecret",
+      "nickname": "listSecretForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -13193,7 +13193,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Secret",
-      "nickname": "watchNamespacedSecretList",
+      "nickname": "watchSecretListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -13898,7 +13898,7 @@
       "type": "v1.ServiceAccountList",
       "method": "GET",
       "summary": "list or watch objects of kind ServiceAccount",
-      "nickname": "listNamespacedServiceAccount",
+      "nickname": "listServiceAccountForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -13975,7 +13975,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ServiceAccount",
-      "nickname": "watchNamespacedServiceAccountList",
+      "nickname": "watchServiceAccountListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -14593,7 +14593,7 @@
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Service",
-      "nickname": "proxyGETNamespacedService",
+      "nickname": "proxyGETNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -14631,7 +14631,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Service",
-      "nickname": "proxyPUTNamespacedService",
+      "nickname": "proxyPUTNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -14669,7 +14669,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Service",
-      "nickname": "proxyPOSTNamespacedService",
+      "nickname": "proxyPOSTNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -14707,7 +14707,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Service",
-      "nickname": "proxyDELETENamespacedService",
+      "nickname": "proxyDELETENamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -14745,7 +14745,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Service",
-      "nickname": "proxyHEADNamespacedService",
+      "nickname": "proxyHEADNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -14783,7 +14783,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Service",
-      "nickname": "proxyOPTIONSNamespacedService",
+      "nickname": "proxyOPTIONSNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15013,7 +15013,7 @@
       "type": "v1.ServiceList",
       "method": "GET",
       "summary": "list or watch objects of kind Service",
-      "nickname": "listNamespacedService",
+      "nickname": "listServiceForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -15090,7 +15090,7 @@
       "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Service",
-      "nickname": "watchNamespacedServiceList",
+      "nickname": "watchServiceListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -15402,7 +15402,7 @@
       "type": "string",
       "method": "GET",
       "summary": "connect GET requests to proxy of Service",
-      "nickname": "connectGetNamespacedServiceProxy",
+      "nickname": "connectGetNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15448,7 +15448,7 @@
       "type": "string",
       "method": "POST",
       "summary": "connect POST requests to proxy of Service",
-      "nickname": "connectPostNamespacedServiceProxy",
+      "nickname": "connectPostNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15494,7 +15494,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "connect PUT requests to proxy of Service",
-      "nickname": "connectPutNamespacedServiceProxy",
+      "nickname": "connectPutNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15540,7 +15540,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "connect DELETE requests to proxy of Service",
-      "nickname": "connectDeleteNamespacedServiceProxy",
+      "nickname": "connectDeleteNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15586,7 +15586,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "connect HEAD requests to proxy of Service",
-      "nickname": "connectHeadNamespacedServiceProxy",
+      "nickname": "connectHeadNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -15632,7 +15632,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "connect OPTIONS requests to proxy of Service",
-      "nickname": "connectOptionsNamespacedServiceProxy",
+      "nickname": "connectOptionsNamespacedServiceProxyWithPath",
       "parameters": [
        {
         "type": "string",

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -47,10 +47,11 @@ type APIInstaller struct {
 
 // Struct capturing information about an action ("GET", "POST", "WATCH", PROXY", etc).
 type action struct {
-	Verb   string               // Verb identifying the action ("GET", "POST", "WATCH", PROXY", etc).
-	Path   string               // The path of the action
-	Params []*restful.Parameter // List of parameters associated with the action.
-	Namer  ScopeNamer
+	Verb          string               // Verb identifying the action ("GET", "POST", "WATCH", PROXY", etc).
+	Path          string               // The path of the action
+	Params        []*restful.Parameter // List of parameters associated with the action.
+	Namer         ScopeNamer
+	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
 }
 
 // An interface to see if an object supports swagger documentation as a method
@@ -367,29 +368,29 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
 		// DEPRECATED
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer}, isDeleter)
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer}, isWatcher)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isDeleter)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
 		// We add "proxy" subresource to remove the need for the generic top level prefix proxy.
 		// The generic top level prefix proxy is deprecated in v1.2, and will be removed in 1.3, or 1.4 at the latest.
 		// TODO: DEPRECATED in v1.2.
-		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath + "/{path:*}", proxyParams, namer}, isRedirector)
+		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath + "/{path:*}", proxyParams, namer, false}, isRedirector)
 		// TODO: DEPRECATED in v1.2.
-		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath, nameParams, namer}, isRedirector)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath, nameParams, namer, false}, isRedirector)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
 		break
 	case meta.RESTScopeNameNamespace:
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -420,36 +421,36 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		}
 		namer := scopeNaming{scope, a.group.Linker, itemPathFn, false}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
 		// DEPRECATED
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer}, isDeleter)
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer}, isWatcher)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isDeleter)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
 		// We add "proxy" subresource to remove the need for the generic top level prefix proxy.
 		// The generic top level prefix proxy is deprecated in v1.2, and will be removed in 1.3, or 1.4 at the latest.
 		// TODO: DEPRECATED in v1.2.
-		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath + "/{path:*}", proxyParams, namer}, isRedirector)
+		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath + "/{path:*}", proxyParams, namer, false}, isRedirector)
 		// TODO: DEPRECATED in v1.2.
-		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath, nameParams, namer}, isRedirector)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"PROXY", "proxy/" + itemPath, nameParams, namer, false}, isRedirector)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !hasSubresource {
 			namer = scopeNaming{scope, a.group.Linker, itemPathFn, true}
-			actions = appendIf(actions, action{"LIST", resource, params, namer}, isLister)
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer}, allowWatchList)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true}, isLister)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true}, allowWatchList)
 		}
 		break
 	default:
@@ -492,6 +493,15 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		if apiResource.Namespaced {
 			namespaced = "Namespaced"
 		}
+		operationSuffix := ""
+		if strings.HasSuffix(action.Path, "/{path:*}") {
+			operationSuffix = operationSuffix + "WithPath"
+		}
+		if action.AllNamespaces {
+			operationSuffix = operationSuffix + "ForAllNamespaces"
+			namespaced = ""
+		}
+
 		switch action.Verb {
 		case "GET": // Get a resource.
 			var handler restful.RouteFunction
@@ -508,7 +518,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("read"+namespaced+kind+strings.Title(subresource)).
+				Operation("read"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Returns(http.StatusOK, "OK", versionedObject).
 				Writes(versionedObject)
@@ -533,7 +543,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("list"+namespaced+kind+strings.Title(subresource)).
+				Operation("list"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Returns(http.StatusOK, "OK", versionedList).
 				Writes(versionedList)
@@ -565,7 +575,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.PUT(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("replace"+namespaced+kind+strings.Title(subresource)).
+				Operation("replace"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Returns(http.StatusOK, "OK", versionedObject).
 				Reads(versionedObject).
@@ -582,7 +592,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Consumes(string(api.JSONPatchType), string(api.MergePatchType), string(api.StrategicMergePatchType)).
-				Operation("patch"+namespaced+kind+strings.Title(subresource)).
+				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Returns(http.StatusOK, "OK", versionedObject).
 				Reads(unversioned.Patch{}).
@@ -604,7 +614,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.POST(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("create"+namespaced+kind+strings.Title(subresource)).
+				Operation("create"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Returns(http.StatusOK, "OK", versionedObject).
 				Reads(versionedObject).
@@ -620,7 +630,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.DELETE(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("delete"+namespaced+kind+strings.Title(subresource)).
+				Operation("delete"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Writes(versionedStatus).
 				Returns(http.StatusOK, "OK", versionedStatus)
@@ -638,7 +648,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.DELETE(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)).
+				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), a.group.Serializer.SupportedMediaTypes()...)...).
 				Writes(versionedStatus).
 				Returns(http.StatusOK, "OK", versionedStatus)
@@ -657,7 +667,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("watch"+namespaced+kind+strings.Title(subresource)).
+				Operation("watch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(a.group.Serializer.SupportedStreamingMediaTypes()...).
 				Returns(http.StatusOK, "OK", versionedWatchEvent).
 				Writes(versionedWatchEvent)
@@ -676,7 +686,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-				Operation("watch"+namespaced+kind+strings.Title(subresource)+"List").
+				Operation("watch"+namespaced+kind+strings.Title(subresource)+"List"+operationSuffix).
 				Produces(a.group.Serializer.SupportedStreamingMediaTypes()...).
 				Returns(http.StatusOK, "OK", versionedWatchEvent).
 				Writes(versionedWatchEvent)
@@ -690,12 +700,12 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// TODO: DEPRECATED in v1.2.
 		case "PROXY": // Proxy requests to a resource.
 			// Accept all methods as per http://issue.k8s.io/3996
-			addProxyRoute(ws, "GET", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
-			addProxyRoute(ws, "PUT", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
-			addProxyRoute(ws, "POST", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
-			addProxyRoute(ws, "DELETE", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
-			addProxyRoute(ws, "HEAD", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
-			addProxyRoute(ws, "OPTIONS", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params)
+			addProxyRoute(ws, "GET", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
+			addProxyRoute(ws, "PUT", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
+			addProxyRoute(ws, "POST", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
+			addProxyRoute(ws, "DELETE", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
+			addProxyRoute(ws, "HEAD", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
+			addProxyRoute(ws, "OPTIONS", a.prefix, action.Path, proxyHandler, namespaced, kind, resource, subresource, hasSubresource, action.Params, operationSuffix)
 		case "CONNECT":
 			for _, method := range connecter.ConnectMethods() {
 				doc := "connect " + method + " requests to " + kind
@@ -706,7 +716,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				route := ws.Method(method).Path(action.Path).
 					To(handler).
 					Doc(doc).
-					Operation("connect" + strings.Title(strings.ToLower(method)) + namespaced + kind + strings.Title(subresource)).
+					Operation("connect" + strings.Title(strings.ToLower(method)) + namespaced + kind + strings.Title(subresource) + operationSuffix).
 					Produces("*/*").
 					Consumes("*/*").
 					Writes("string")
@@ -884,7 +894,7 @@ func routeFunction(handler http.Handler) restful.RouteFunction {
 	}
 }
 
-func addProxyRoute(ws *restful.WebService, method string, prefix string, path string, proxyHandler http.Handler, namespaced, kind, resource, subresource string, hasSubresource bool, params []*restful.Parameter) {
+func addProxyRoute(ws *restful.WebService, method string, prefix string, path string, proxyHandler http.Handler, namespaced, kind, resource, subresource string, hasSubresource bool, params []*restful.Parameter, operationSuffix string) {
 	doc := "proxy " + method + " requests to " + kind
 	if hasSubresource {
 		doc = "proxy " + method + " requests to " + subresource + " of " + kind
@@ -892,7 +902,7 @@ func addProxyRoute(ws *restful.WebService, method string, prefix string, path st
 	handler := metrics.InstrumentRouteFunc("PROXY", resource, routeFunction(proxyHandler))
 	proxyRoute := ws.Method(method).Path(path).To(handler).
 		Doc(doc).
-		Operation("proxy" + strings.Title(method) + namespaced + kind + strings.Title(subresource)).
+		Operation("proxy" + strings.Title(method) + namespaced + kind + strings.Title(subresource) + operationSuffix).
 		Produces("*/*").
 		Consumes("*/*").
 		Writes("string")


### PR DESCRIPTION
OperationIDs generated by api_installer.go may not be unique and that causes long auto-generated function names in swagger generated clients. This is a step toward making those IDs unique.

Reference Issue kubernetes/features#53 and #13414

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33337)

<!-- Reviewable:end -->
