### PR TITLE
Mount kubelet root directory as executable in GCI

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1120,6 +1120,13 @@ function start-rescheduler {
   fi
 }
 
+# Setup working directory for kubelet.
+function setup-kubelet-dir {
+    echo "Making /var/lib/kubelet executable for kubelet"
+    mount --bind /var/lib/kubelet /var/lib/kubelet/
+    mount -B -o remount,exec,suid,dev /var/lib/kubelet    
+}
+
 function reset-motd {
   # kubelet is installed both on the master and nodes, and the version is easy to parse (unlike kubectl)
   local -r version="$("${KUBE_HOME}"/bin/kubelet --version=true | cut -f2 -d " ")"
@@ -1177,6 +1184,7 @@ fi
 
 config-ip-firewall
 create-dirs
+setup-kubelet-dir
 ensure-local-ssds
 setup-logrotate
 if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then


### PR DESCRIPTION
Fixes #33315 and #33318

This PR is isolated to GCI distro. Without this rather simple patch,
PetSets won't work with GCI. Hence requesting a cherry-pick.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33345)

<!-- Reviewable:end -->
