### PR TITLE
Dereference the UID pointer for a readable error message.

### DIFF
--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -444,7 +444,7 @@ func checkPreconditions(key string, preconditions *storage.Preconditions, out ru
 		return storage.NewInternalErrorf("can't enforce preconditions %v on un-introspectable object %v, got error: %v", *preconditions, out, err)
 	}
 	if preconditions.UID != nil && *preconditions.UID != objMeta.UID {
-		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", preconditions.UID, objMeta.UID)
+		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *preconditions.UID, objMeta.UID)
 		return storage.NewInvalidObjError(key, errMsg)
 	}
 	return nil


### PR DESCRIPTION
cc @nikhiljindal @quinton-hoole @kubernetes/sig-cluster-federation

``` release-note
etcd3: dereference the UID pointer for a readable error message.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33349)

<!-- Reviewable:end -->
