### PR TITLE
Towards custom handler chains in genericapiserver

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -337,11 +336,6 @@ func (c Config) New() (*GenericAPIServer, error) {
 			TLSClientConfig: c.ProxyTLSClientConfig,
 		})
 	}
-
-	// Send correct mime type for .svg files.
-	// TODO: remove when https://github.com/golang/go/commit/21e47d831bafb59f22b1ea8098f709677ec8ce33
-	// makes it into all of our supported go versions (only in v1.7.1 now).
-	mime.AddExtensionType(".svg", "image/svg+xml")
 
 	apiserver.InstallServiceErrorHandler(s.Serializer, s.HandlerContainer)
 

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -329,6 +329,7 @@ func (c Config) New() (*GenericAPIServer, error) {
 	// Use CurlyRouter to be able to use regular expressions in paths. Regular expressions are required in paths for example for proxy (where the path is proxy/{kind}/{name}/{*})
 	s.HandlerContainer.Router(restful.CurlyRouter{})
 	s.Mux = apiserver.NewPathRecorderMux(s.HandlerContainer.ServeMux)
+	apiserver.InstallServiceErrorHandler(s.Serializer, s.HandlerContainer)
 
 	if c.ProxyDialer != nil || c.ProxyTLSClientConfig != nil {
 		s.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{
@@ -336,8 +337,6 @@ func (c Config) New() (*GenericAPIServer, error) {
 			TLSClientConfig: c.ProxyTLSClientConfig,
 		})
 	}
-
-	apiserver.InstallServiceErrorHandler(s.Serializer, s.HandlerContainer)
 
 	s.installAPI(&c)
 	s.Handler, s.InsecureHandler = s.buildHandlerChains(&c, http.Handler(s.Mux.BaseMux().(*http.ServeMux)))

--- a/pkg/genericapiserver/filters/timeout.go
+++ b/pkg/genericapiserver/filters/timeout.go
@@ -35,6 +35,9 @@ var errConnKilled = fmt.Errorf("kill connection/stream")
 
 // WithTimeoutForNonLongRunningRequests times out non-long-running requests after the time given by globalTimeout.
 func WithTimeoutForNonLongRunningRequests(handler http.Handler, longRunning LongRunningRequestCheck) http.Handler {
+	if longRunning == nil {
+		return handler
+	}
 	timeoutFunc := func(req *http.Request) (<-chan time.Time, string) {
 		// TODO unify this with apiserver.MaxInFlightLimit
 		if longRunning(req) {

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -19,6 +19,7 @@ package genericapiserver
 import (
 	"crypto/tls"
 	"fmt"
+	"mime"
 	"net"
 	"net/http"
 	"path"
@@ -165,6 +166,13 @@ type GenericAPIServer struct {
 	postStartHooks       map[string]PostStartHookFunc
 	postStartHookLock    sync.Mutex
 	postStartHooksCalled bool
+}
+
+func init() {
+	// Send correct mime type for .svg files.
+	// TODO: remove when https://github.com/golang/go/commit/21e47d831bafb59f22b1ea8098f709677ec8ce33
+	// makes it into all of our supported go versions (only in v1.7.1 now).
+	mime.AddExtensionType(".svg", "image/svg+xml")
 }
 
 // RequestContextMapper is exposed so that third party resource storage can be build in a different location.

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -19,7 +19,6 @@ package genericapiserver
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"path"
@@ -166,9 +165,6 @@ type GenericAPIServer struct {
 	postStartHooks       map[string]PostStartHookFunc
 	postStartHookLock    sync.Mutex
 	postStartHooksCalled bool
-
-	// Writer to write the audit log to.
-	auditWriter io.Writer
 }
 
 // RequestContextMapper is exposed so that third party resource storage can be build in a different location.


### PR DESCRIPTION
**Based on https://github.com/kubernetes/kubernetes/pull/33478**

This PR makes the handler chain construction independent from the genericapiserver instance (with the exception of the `RequestInfoFilter` which will be fixed in https://github.com/kubernetes/kubernetes/pull/33490), i.e. the `Config` is enough to create a custom handler chain.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33365)

<!-- Reviewable:end -->
