### PR TITLE
Update storage API group in docs

### DIFF
--- a/docs/proposals/volume-provisioning.md
+++ b/docs/proposals/volume-provisioning.md
@@ -77,7 +77,7 @@ We propose that:
 
 1.  For the base impelementation storage class and volume selectors are mutually exclusive.
 
-2.  An api object will be incubated in extensions/v1beta1 named `storage` to hold the a `StorageClass`
+2.  An api object will be incubated in storage.k8s.io/v1beta1 to hold the a `StorageClass`
     API resource. Each StorageClass object contains parameters required by the provisioner to provision volumes of that class.  These parameters are opaque to the user.
 
 3.  `PersistentVolume.Spec.Class` attribute is added to volumes. This attribute
@@ -155,7 +155,7 @@ Existing behavior is un-changed for claims that do not specify `claim.Spec.Class
 
 A new API group should hold the API for storage classes, following the pattern
 of autoscaling, metrics, etc.  To allow for future storage-related APIs, we
-should call this new API group `storage` and incubate in extensions/v1beta1.
+should call this new API group `storage.k8s.io` and incubate in storage.k8s.io/v1beta1.
 
 Storage classes will be represented by an API object called `StorageClass`:
 


### PR DESCRIPTION
It reflects actual state of implementation (i.e. the API group was already changed in 1.4).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33371)

<!-- Reviewable:end -->
