### PR TITLE
Move HighWaterMark to the top of the struct in order to fix arm, second time

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -219,6 +219,8 @@ type Expectations interface {
 
 // ControlleeExpectations track controllee creates/deletes.
 type ControlleeExpectations struct {
+	// Important: Since these two int64 fields are using sync/atomic, they have to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
 	add       int64
 	del       int64
 	key       string

--- a/pkg/genericapiserver/tunneler.go
+++ b/pkg/genericapiserver/tunneler.go
@@ -46,14 +46,17 @@ type Tunneler interface {
 }
 
 type SSHTunneler struct {
+	// Important: Since these two int64 fields are using sync/atomic, they have to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
+	lastSync       int64 // Seconds since Epoch
+	lastSSHKeySync int64 // Seconds since Epoch
+
 	SSHUser        string
 	SSHKeyfile     string
 	InstallSSHKey  InstallSSHKey
 	HealthCheckURL *url.URL
 
 	tunnels        *ssh.SSHTunnelList
-	lastSync       int64 // Seconds since Epoch
-	lastSSHKeySync int64 // Seconds since Epoch
 	lastSyncMetric prometheus.GaugeFunc
 	clock          clock.Clock
 

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -130,6 +130,13 @@ func (i *indexedWatchers) terminateAll(objectType reflect.Type) {
 // Cacher implements storage.Interface (although most of the calls are just
 // delegated to the underlying storage).
 type Cacher struct {
+	// HighWaterMarks for performance debugging.
+	// Important: Since HighWaterMark is using sync/atomic, it has to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
+	incomingHWM HighWaterMark
+	// Incoming events that should be dispatched to watchers.
+	incoming chan watchCacheEvent
+
 	sync.RWMutex
 
 	// Before accessing the cacher's cache, wait for the ready to be ok.
@@ -163,10 +170,6 @@ type Cacher struct {
 	// watcher is interested into the watchers
 	watcherIdx int
 	watchers   indexedWatchers
-
-	// Incoming events that should be dispatched to watchers.
-	incoming    chan watchCacheEvent
-	incomingHWM HighWaterMark
 
 	// Handling graceful termination.
 	stopLock sync.RWMutex


### PR DESCRIPTION
ref: #33117

Sorry for not fixing everyone at once, but I seriously wasn't prepared for that quick LGTM :smile:, so here's the other half.

@lavalamp 

> lgtm, but seriously, this is terrible, we probably have this bug all over. And what if someone embeds the etcdWatcher struct in something else not at the top? We need the compiler to enforce things like this, it just can't be done manually. Can you file or link a golang issue for this?

I totally agree! There isn't currently a way of programmatically detecting this unfortunately.
I guess @davecheney or @minux can explain better to you why it's so hard.

This is noted in https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/multi-platform.md as a corner case indeed.

@pwittrock This should be cherrypicked toghether with #33117

``` release-note
Move HighWaterMark to the top of the struct in order to fix arm, second time
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33376)

<!-- Reviewable:end -->
