### PR TITLE
add anytoken authenticator

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -202,6 +202,7 @@ func Run(s *options.APIServer) error {
 
 	apiAuthenticator, err := authenticator.New(authenticator.AuthenticatorConfig{
 		Anonymous:                   s.AnonymousAuth,
+		AnyToken:                    s.EnableAnyToken,
 		BasicAuthFile:               s.BasicAuthFile,
 		ClientCAFile:                s.ClientCAFile,
 		TokenAuthFile:               s.TokenAuthFile,

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -116,6 +116,7 @@ func Run(s *options.ServerRunOptions) error {
 
 	apiAuthenticator, err := authenticator.New(authenticator.AuthenticatorConfig{
 		Anonymous:         s.AnonymousAuth,
+		AnyToken:          s.EnableAnyToken,
 		BasicAuthFile:     s.BasicAuthFile,
 		ClientCAFile:      s.ClientCAFile,
 		TokenAuthFile:     s.TokenAuthFile,

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -280,6 +280,10 @@ function start_apiserver {
     CERT_DIR=/var/run/kubernetes
     ROOT_CA_FILE=$CERT_DIR/apiserver.crt
 
+    anytoken_arg=""
+    if [[ -n "${ALLOW_ANY_TOKEN:-}" ]]; then
+      anytoken_arg="--insecure-allow-any-token "
+    fi
     priv_arg=""
     if [[ -n "${ALLOW_PRIVILEGED}" ]]; then
       priv_arg="--allow-privileged "
@@ -297,7 +301,7 @@ function start_apiserver {
     fi
 
     APISERVER_LOG=/tmp/kube-apiserver.log
-    sudo -E "${GO_OUT}/hyperkube" apiserver ${priv_arg} ${runtime_config}\
+    sudo -E "${GO_OUT}/hyperkube" apiserver ${anytoken_arg} ${priv_arg} ${runtime_config}\
       ${advertise_address} \
       --v=${LOG_LEVEL} \
       --cert-dir="${CERT_DIR}" \

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -250,8 +250,9 @@ included-types-overrides
 include-extended-apis
 input-base
 input-dirs
-insecure-experimental-approve-all-kubelet-csrs-for-group
+insecure-allow-any-token
 insecure-bind-address
+insecure-experimental-approve-all-kubelet-csrs-for-group
 insecure-port
 insecure-skip-tls-verify
 instance-metadata

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -9148,7 +9148,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 	"v1.Node": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Node is a worker node in Kubernetes, formerly known as minion. Each node will have a unique identifier in the cache (i.e. in etcd).",
+				Description: "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -258,7 +258,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 			options.TLSPrivateKeyFile = path.Join(options.CertDirectory, "apiserver.key")
 			// TODO (cjcullen): Is ClusterIP the right address to sign a cert with?
 			alternateIPs := []net.IP{s.ServiceReadWriteIP}
-			alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+			alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}
 			// It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
 			// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
 			if !certutil.CanReadCertOrKey(options.TLSCertFile, options.TLSPrivateKeyFile) {

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -120,6 +120,7 @@ type ServerRunOptions struct {
 	TLSCertFile            string
 	TLSPrivateKeyFile      string
 	TokenAuthFile          string
+	EnableAnyToken         bool
 	WatchCacheSizes        []string
 }
 
@@ -472,6 +473,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, ""+
 		"If set, the file that will be used to secure the secure port of the API server "+
 		"via token authentication.")
+
+	fs.BoolVar(&s.EnableAnyToken, "insecure-allow-any-token", s.EnableAnyToken, ""+
+		"If set, your server will be INSECURE.  Any token will be allowed and user information will be parsed "+
+		"from the token as `username/group1,group2`")
 
 	fs.StringSliceVar(&s.WatchCacheSizes, "watch-cache-sizes", s.WatchCacheSizes, ""+
 		"List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. "+

--- a/plugin/pkg/auth/authenticator/token/anytoken/anytoken.go
+++ b/plugin/pkg/auth/authenticator/token/anytoken/anytoken.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anytoken
+
+import (
+	"strings"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+type AnyTokenAuthenticator struct{}
+
+func (AnyTokenAuthenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+	lastSlash := strings.LastIndex(value, "/")
+	if lastSlash == -1 {
+		return &user.DefaultInfo{Name: value}, true, nil
+	}
+
+	ret := &user.DefaultInfo{Name: value[:lastSlash]}
+
+	groupString := value[lastSlash+1:]
+	if len(groupString) == 0 {
+		return ret, true, nil
+	}
+
+	ret.Groups = strings.Split(groupString, ",")
+	return ret, true, nil
+}

--- a/plugin/pkg/auth/authenticator/token/anytoken/anytoken_test.go
+++ b/plugin/pkg/auth/authenticator/token/anytoken/anytoken_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anytoken
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+func TestAnyTokenAuthenticator(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+
+		expectedUser user.Info
+	}{
+		{
+			name:         "user only",
+			token:        "joe",
+			expectedUser: &user.DefaultInfo{Name: "joe"},
+		},
+		{
+			name:         "user with slash",
+			token:        "scheme/joe/",
+			expectedUser: &user.DefaultInfo{Name: "scheme/joe"},
+		},
+		{
+			name:         "user with groups",
+			token:        "joe/group1,group2",
+			expectedUser: &user.DefaultInfo{Name: "joe", Groups: []string{"group1", "group2"}},
+		},
+		{
+			name:         "user with slash and groups",
+			token:        "scheme/joe/group1,group2",
+			expectedUser: &user.DefaultInfo{Name: "scheme/joe", Groups: []string{"group1", "group2"}},
+		},
+	}
+
+	for _, tc := range tests {
+		actualUser, _, _ := AnyTokenAuthenticator{}.AuthenticateToken(tc.token)
+
+		if len(actualUser.GetExtra()) != 0 {
+			t.Errorf("%q: got extra: %v", tc.name, actualUser.GetExtra())
+		}
+		if len(actualUser.GetUID()) != 0 {
+			t.Errorf("%q: got extra: %v", tc.name, actualUser.GetUID())
+		}
+		if e, a := tc.expectedUser.GetName(), actualUser.GetName(); e != a {
+			t.Errorf("%q: expected %v, got %v", tc.name, e, a)
+		}
+		if e, a := tc.expectedUser.GetGroups(), actualUser.GetGroups(); !reflect.DeepEqual(e, a) {
+			t.Errorf("%q: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Adds `--insecure-allow-any-token` as a flag to the API server to create an authenticator that will accept any bearer token and transform it into a user by parsing it out as `username/group1,group2,...`.

This gives an easy way to identify as a user and check permissions:

``` bash
ALLOW_ANY_TOKEN=true hack/local-up-cluster.sh 
kubectl config set-cluster local-kube --server=https://localhost:6443 --insecure-skip-tls-verify=true
kubectl config set-credentials david --token=david/group1
kubectl config set-context local --cluster=local-kube --user=david
kubectl config use-context local
```

@kubernetes/sig-auth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33378)

<!-- Reviewable:end -->
