### PR TITLE
kube-dns: Add --dns-bind-address flag

### DIFF
--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -34,6 +34,7 @@ type KubeDNSConfig struct {
 	KubeConfigFile string
 	KubeMasterURL  string
 	HealthzPort    int
+	DNSBindAddress string
 	DNSPort        int
 	// Federations maps federation names to their registered domain names.
 	Federations map[string]string
@@ -45,6 +46,7 @@ func NewKubeDNSConfig() *KubeDNSConfig {
 		KubeConfigFile: "",
 		KubeMasterURL:  "",
 		HealthzPort:    8081,
+		DNSBindAddress: "0.0.0.0",
 		DNSPort:        53,
 		Federations:    make(map[string]string),
 	}
@@ -143,6 +145,7 @@ func (s *KubeDNSConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeConfigFile, "kubecfg-file", s.KubeConfigFile, "Location of kubecfg file for access to kubernetes master service; --kube-master-url overrides the URL part of this; if neither this nor --kube-master-url are provided, defaults to service account tokens")
 	fs.Var(kubeMasterURLVar{&s.KubeMasterURL}, "kube-master-url", "URL to reach kubernetes master. Env variables in this flag will be expanded.")
 	fs.IntVar(&s.HealthzPort, "healthz-port", s.HealthzPort, "port on which to serve a kube-dns HTTP readiness probe.")
+	fs.StringVar(&s.DNSBindAddress, "dns-bind-address", s.DNSBindAddress, "address on which to serve DNS requests.")
 	fs.IntVar(&s.DNSPort, "dns-port", s.DNSPort, "port on which to serve DNS requests.")
 	fs.Var(federationsVar{s.Federations}, "federations", "a comma separated list of the federation names and their corresponding domain names to which this cluster belongs. Example: \"myfederation1=example.com,myfederation2=example2.com,myfederation3=example.com\"")
 }

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -118,6 +118,7 @@ deserialization-cache-size
 dest-file
 disable-filter
 disable-kubenet
+dns-bind-address
 dns-port
 dns-provider
 dns-provider-config


### PR DESCRIPTION
Currently, `kube-dns` always binds to `0.0.0.0` when starting the SkyDNS server. Sometimes it's useful to have it bind to a different address for testing. So add a new `--dns-bind-address` flag that can be used to configure this (default is `0.0.0.0`).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33379)

<!-- Reviewable:end -->
