### PR TITLE
kuberuntime: include container hash in backoff keys

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -18,6 +18,7 @@ package kuberuntime
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
@@ -159,4 +160,12 @@ func milliCPUToQuota(milliCPU int64) (quota int64, period int64) {
 	}
 
 	return
+}
+
+// getStableKey generates a key (string) to uniquely identify a
+// (pod, container) tuple. The key should include the content of the
+// container, so that any change to the container generates a new key.
+func getStableKey(pod *api.Pod, container *api.Container) string {
+	hash := strconv.FormatUint(kubecontainer.HashContainer(container), 16)
+	return fmt.Sprintf("%s_%s_%s_%s_%s", pod.Name, pod.Namespace, string(pod.UID), container.Name, hash)
 }

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestStableKey(t *testing.T) {
+	container := &api.Container{
+		Name:  "test_container",
+		Image: "foo/image:v1",
+	}
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "test_pod",
+			Namespace: "test_pod_namespace",
+			UID:       "test_pod_uid",
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{*container},
+		},
+	}
+	oldKey := getStableKey(pod, container)
+
+	// Updating the container image should change the key.
+	container.Image = "foo/image:v2"
+	newKey := getStableKey(pod, container)
+	assert.NotEqual(t, oldKey, newKey)
+}


### PR DESCRIPTION
We should reset the backoff if the content of the container has been updated.

Part of #33189

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33395)

<!-- Reviewable:end -->
