### PR TITLE
Fix make rebuilds for openapi

### DIFF
--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -296,6 +296,7 @@ $(DEEPCOPY_GEN):
 # The result file, in each pkg, of open-api generation.
 OPENAPI_BASENAME := $(GENERATED_FILE_PREFIX)openapi
 OPENAPI_FILENAME := $(OPENAPI_BASENAME).go
+OPENAPI_OUTPUT_PKG := pkg/generated/openapi
 
 # The tool used to generate open apis.
 OPENAPI_GEN := $(BIN_DIR)/openapi-gen
@@ -321,6 +322,7 @@ gen_openapi: $(OPENAPI_FILES)
 	        --v $(KUBE_VERBOSE)                                         \
 	        --logtostderr                                               \
 	        -i $$(cat $(META_DIR)/$(OPENAPI_GEN).todo | paste -sd, -)   \
+	        -p $(PRJ_SRC_PATH)/$(OPENAPI_OUTPUT_PKG)                    \
 	        -O $(OPENAPI_BASENAME);                                     \
 	fi
 

--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -311,20 +311,11 @@ OPENAPI_DIRS := $(shell                                             \
         | sort -u                                                   \
 )
 
-OPENAPI_FILES := $(addsuffix /$(OPENAPI_FILENAME), $(OPENAPI_DIRS))
+OPENAPI_OUTFILE := $(OPENAPI_OUTPUT_PKG)/$(OPENAPI_FILENAME)
 
-# This rule aggregates the set of files to generate and then generates them all
-# in a single run of the tool.
+# This rule is the user-friendly entrypoint for openapi generation.
 .PHONY: gen_openapi
-gen_openapi: $(OPENAPI_FILES)
-	if [[ -f $(META_DIR)/$(OPENAPI_GEN).todo ]]; then                   \
-	    ./hack/run-in-gopath.sh $(OPENAPI_GEN)                          \
-	        --v $(KUBE_VERBOSE)                                         \
-	        --logtostderr                                               \
-	        -i $$(cat $(META_DIR)/$(OPENAPI_GEN).todo | paste -sd, -)   \
-	        -p $(PRJ_SRC_PATH)/$(OPENAPI_OUTPUT_PKG)                    \
-	        -O $(OPENAPI_BASENAME);                                     \
-	fi
+gen_openapi: $(OPENAPI_OUTFILE)
 
 # For each dir in OPENAPI_DIRS, this establishes a dependency between the
 # output file and the input files that should trigger a rebuild.
@@ -339,18 +330,18 @@ gen_openapi: $(OPENAPI_FILES)
 # We depend on the $(GOFILES_META).stamp to detect when the set of input files
 # has changed.  This allows us to detect deleted input files.
 $(foreach dir, $(OPENAPI_DIRS), $(eval                                     \
-    $(dir)/$(OPENAPI_FILENAME): $(META_DIR)/$(dir)/$(GOFILES_META).stamp   \
+    $(OPENAPI_OUTFILE): $(META_DIR)/$(dir)/$(GOFILES_META).stamp           \
                                  $(gofiles__$(dir))                        \
 ))
 
-# Unilaterally remove any leftovers from previous runs.
-$(shell rm -f $(META_DIR)/$(OPENAPI_GEN)*.todo)
-
-# How to regenerate open-api code.  We need to collect these up and trigger one
-# single run to generate definition for all types.
-$(OPENAPI_FILES): $(OPENAPI_GEN)
-	mkdir -p $$(dirname $(META_DIR)/$(OPENAPI_GEN))
-	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(OPENAPI_GEN).todo
+# How to regenerate open-api code.  This emits a single file for all results.
+$(OPENAPI_OUTFILE): $(OPENAPI_GEN)
+	./hack/run-in-gopath.sh $(OPENAPI_GEN)                                          \
+	    --v $(KUBE_VERBOSE)                                                         \
+	    --logtostderr                                                               \
+	    -i $$(echo $(addprefix $(PRJ_SRC_PATH)/, $(OPENAPI_DIRS)) | sed 's/ /,/g')  \
+	    -p $(PRJ_SRC_PATH)/$(OPENAPI_OUTPUT_PKG)                                    \
+	    -O $(OPENAPI_BASENAME)
 
 # This calculates the dependencies for the generator tool, so we only rebuild
 # it when needed.  It is PHONY so that it always runs, but it only updates the

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -112,7 +112,6 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			},
 		},
 	}
-	return generator.Packages{}
 }
 
 const (

--- a/pkg/generated/openapi/doc.go
+++ b/pkg/generated/openapi/doc.go
@@ -15,5 +15,4 @@ limitations under the License.
 */
 
 // openapi generated definitions.
-// +k8s:openapi-gen=target
 package openapi


### PR DESCRIPTION
openapi generates a single file, so its rules can be significantly simpler.

federation generates an empty file which we previously elided, but which triggers deps every build.

This fixes both.

@mbohlool something to think about.  Generating a single file means you generate everything every time any tagged package changes.  This is not awesome.  In practice, it's pretty fast, so maybe just for thinking about - would it be better to generate a file for every tagged package, and only regenerate when needed.  The file could self-register a callback or just add some structs to your mega-map.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33420)

<!-- Reviewable:end -->
