### PR TITLE
Make @k82cn assignee for contrib/mesos/OWNERS and remove everyone else

### DIFF
--- a/contrib/mesos/OWNERS
+++ b/contrib/mesos/OWNERS
@@ -1,3 +1,2 @@
 assignees:
-  - jdef
-  - karlkfi
+  - k82cn


### PR DESCRIPTION
@k82cn is going to be the maintainer for contrib/mesos going forward.

cc/ @eparis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33427)

<!-- Reviewable:end -->
