### PR TITLE
[WIP] added guide url to the commands in kubectl

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -40,7 +40,9 @@ var (
 		kubectl create -f ./pod.json
 
 		# Create a pod based on the JSON passed into stdin.
-		cat pod.json | kubectl create -f -`)
+		cat pod.json | kubectl create -f -
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_create/`)
 )
 
 func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -63,7 +63,10 @@ var (
 		kubectl delete pod 1234-56-7890-234234-456456
 
 		# Delete all pods
-		kubectl delete pods --all`)
+		kubectl delete pods --all
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_delete/
+		`)
 )
 
 func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -75,7 +75,10 @@ var (
 		  KUBE_EDITOR="nano" kubectl edit svc/docker-registry
 
 		  # Edit the service 'docker-registry' in JSON using the v1 API format:
-		  kubectl edit svc/docker-registry --output-version=v1 -o json`)
+		  kubectl edit svc/docker-registry --output-version=v1 -o json
+
+		  For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/
+		  `)
 )
 
 var errExit = fmt.Errorf("exit directly")

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -77,8 +77,8 @@ var (
 		  # Edit the service 'docker-registry' in JSON using the v1 API format:
 		  kubectl edit svc/docker-registry --output-version=v1 -o json
 
-			For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/
-			`)
+		  For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/
+		  `)
 )
 
 var errExit = fmt.Errorf("exit directly")

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,7 +75,10 @@ var (
 		  KUBE_EDITOR="nano" kubectl edit svc/docker-registry
 
 		  # Edit the service 'docker-registry' in JSON using the v1 API format:
-		  kubectl edit svc/docker-registry --output-version=v1 -o json`)
+		  kubectl edit svc/docker-registry --output-version=v1 -o json
+
+			For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/
+			`)
 )
 
 var errExit = fmt.Errorf("exit directly")

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -63,7 +63,11 @@ func NewCmdExplain(f *cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f *cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to explain. ", valid_resources)
+		message := dedent.Dedent(`
+			You must specify the type of resource to explain.
+			For more info please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/
+		`)
+		fmt.Fprint(cmdErr, message, valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -37,7 +37,8 @@ var (
 		# Get the documentation of a specific field of a resource
 		kubectl explain pods.spec.containers
 
-		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/`)
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/
+		`)
 
 	explainLong = dedent.Dedent(`
 		Documentation of resources.

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,7 +35,9 @@ var (
 		kubectl explain pods
 
 		# Get the documentation of a specific field of a resource
-		kubectl explain pods.spec.containers`)
+		kubectl explain pods.spec.containers
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/`)
 
 	explainLong = dedent.Dedent(`
 		Documentation of resources.
@@ -63,11 +65,7 @@ func NewCmdExplain(f *cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f *cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		message := dedent.Dedent(`
-			You must specify the type of resource to explain.
-			For more info please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/
-		`)
-		fmt.Fprint(cmdErr, message, valid_resources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to explain", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -35,7 +35,10 @@ var (
 		kubectl explain pods
 
 		# Get the documentation of a specific field of a resource
-		kubectl explain pods.spec.containers`)
+		kubectl explain pods.spec.containers
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_explain/
+		`)
 
 	explainLong = dedent.Dedent(`
 		Documentation of resources.
@@ -63,7 +66,7 @@ func NewCmdExplain(f *cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f *cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to explain. ", valid_resources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to explain", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -70,7 +70,9 @@ var (
 		kubectl expose rs nginx --port=80 --target-port=8000
 
 		# Create a service for an nginx deployment, which serves on port 80 and connects to the containers on port 8000.
-		kubectl expose deployment nginx --port=80 --target-port=8000`)
+		kubectl expose deployment nginx --port=80 --target-port=8000
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_expose/`)
 )
 
 func NewCmdExposeService(f *cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -75,7 +75,10 @@ var (
 		kubectl get rc,services
 
 		# List one or more resources by their type and names.
-		kubectl get rc/web service/frontend pods/web-pod-13je7`)
+		kubectl get rc/web service/frontend pods/web-pod-13je7
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
+		`)
 )
 
 // NewCmdGet creates a command object for the generic "get" action, which

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -174,7 +174,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 
 	if len(args) == 0 && cmdutil.IsFilenameEmpty(options.Filenames) {
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
-		return cmdutil.UsageError(cmd, "Required resource not specified")
+		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 
 	// determine if args contains "all"

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -171,7 +171,11 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 
 	if len(args) == 0 && cmdutil.IsFilenameEmpty(options.Filenames) {
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
-		return cmdutil.UsageError(cmd, "Required resource not specified.")
+		message := dedent.Dedent(`
+			Required resource not specified.
+			For more info on 'get' please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
+		`)
+		return cmdutil.UsageError(cmd, message)
 	}
 
 	// determine if args contains "all"

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,7 +75,10 @@ var (
 		kubectl get rc,services
 
 		# List one or more resources by their type and names.
-		kubectl get rc/web service/frontend pods/web-pod-13je7`)
+		kubectl get rc/web service/frontend pods/web-pod-13je7
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
+		`)
 )
 
 // NewCmdGet creates a command object for the generic "get" action, which
@@ -171,11 +174,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 
 	if len(args) == 0 && cmdutil.IsFilenameEmpty(options.Filenames) {
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
-		message := dedent.Dedent(`
-			Required resource not specified.
-			For more info please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
-		`)
-		return cmdutil.UsageError(cmd, message)
+		return cmdutil.UsageError(cmd, "Required resource not specified")
 	}
 
 	// determine if args contains "all"

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -173,7 +173,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
 		message := dedent.Dedent(`
 			Required resource not specified.
-			For more info on 'get' please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
+			For more info please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/
 		`)
 		return cmdutil.UsageError(cmd, message)
 	}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -77,7 +77,9 @@ var (
 		kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
 
 		# Start the scheduled job to compute π to 2000 places and print it out every 5 minutes.
-		kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'`)
+		kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+
+		For more info, please visit: http://kubernetes.io/docs/user-guide/kubectl/kubectl_run/`)
 )
 
 func NewCmdRun(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {


### PR DESCRIPTION
Do not merge. Work in progress. It will partially fix: https://github.com/kubernetes/kubernetes/issues/31267. Please @AdoHe have a look to this. Totes simple and I will keep adding code to fix other commands.

In order to show the changes, execute: `kubectl get` and along all the valid options will link you to the guide in the docs.

This is a point in the roadmap for kubectl. Once I get the green on format and procedure I will add the same for all the other commands (like annotate, expose...)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33435)

<!-- Reviewable:end -->
