### PR TITLE
Fix SSH Authentication errors caused by Vagrant 1.8.5 and VSphere

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,12 +123,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.proxy.no_proxy = $no_proxy
   end
 
-  # this corrects a bug in 1.8.5 where an invalid SSH key is inserted.
-  if Vagrant::VERSION == "1.8.5"
-    config.ssh.insert_key = false
-  end
-
   def setvmboxandurl(config, provider)
+    
+    # this corrects a bug in 1.8.5 where an invalid SSH key is inserted.
+    if Vagrant::VERSION == "1.8.5"
+      config.ssh.insert_key = false
+    end
+    
     if ENV['KUBERNETES_BOX_NAME'] then
       config.vm.box = ENV['KUBERNETES_BOX_NAME']
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes Vagrant 1.8.5 K8S installation when VSphere is setup

**Which issue this PR fixes**: fixes #33452

**Special notes for your reviewer**: Previous code by @erikh 

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33453)

<!-- Reviewable:end -->
