### PR TITLE
Fix typo in redis example

### DIFF
--- a/examples/storage/redis/README.md
+++ b/examples/storage/redis/README.md
@@ -48,7 +48,7 @@ This is a somewhat long tutorial.  If you want to jump straight to the "do it no
 
 A [_Pod_](../../../docs/user-guide/pods.md) is one or more containers that _must_ be scheduled onto the same host.  All containers in a pod share a network namespace, and may optionally share mounted volumes.
 
-We will used the shared network namespace to bootstrap our Redis cluster.  In particular, the very first sentinel needs to know how to find the master (subsequent sentinels just ask the first sentinel).  Because all containers in a Pod share a network namespace, the sentinel can simply look at ```$(hostname -i):6379```.
+We will use the shared network namespace to bootstrap our Redis cluster.  In particular, the very first sentinel needs to know how to find the master (subsequent sentinels just ask the first sentinel).  Because all containers in a Pod share a network namespace, the sentinel can simply look at ```$(hostname -i):6379```.
 
 Here is the config for the initial master and sentinel pod: [redis-master.yaml](redis-master.yaml)
 


### PR DESCRIPTION
This fixes a small typo in the redis example documentation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33465)

<!-- Reviewable:end -->
