### PR TITLE
Add metrics provider to nfs volume plugin

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -158,6 +158,7 @@ pkg/kubelet/volume/reconciler
 pkg/kubelet/volumemanager
 pkg/kubelet/volumemanager/cache
 pkg/kubelet/volumemanager/populator
+pkg/kubelet/volumemanager/provider
 pkg/kubelet/volumemanager/reconciler
 pkg/proxy/config
 pkg/proxy/healthcheck

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -50,6 +50,15 @@ func (kl *Kubelet) ListVolumesForPod(podUID types.UID) (map[string]volume.Volume
 	return volumesToReturn, len(volumesToReturn) > 0
 }
 
+// GetVolumesMetricsForPod returns a map of the mounted volumes metrics for the
+// given pod.
+// The key in the map is the OuterVolumeSpecName (i.e. pod.Spec.Volumes[x].Name)
+func (kl *Kubelet) GetVolumesMetricsForPod(podUID types.UID) (map[string]*volume.Metrics, bool) {
+	metricsToReturn := kl.volumeManager.GetMountedVolumesMetricsForPod(volumetypes.UniquePodName(podUID))
+
+	return metricsToReturn, len(metricsToReturn) > 0
+}
+
 // podVolumesExist checks with the volume manager and returns true any of the
 // pods for the specified volume are mounted.
 func (kl *Kubelet) podVolumesExist(podUID types.UID) bool {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -181,6 +181,7 @@ type HostInterface interface {
 	ImagesFsInfo() (cadvisorapiv2.FsInfo, error)
 	RootFsInfo() (cadvisorapiv2.FsInfo, error)
 	ListVolumesForPod(podUID types.UID) (map[string]volume.Volume, bool)
+	GetVolumesMetricsForPod(podUID types.UID) (map[string]*volume.Metrics, bool)
 	PLEGHealthCheck() (bool, error)
 	GetExec(podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommand.Options) (*url.URL, error)
 	GetAttach(podFullName string, podUID types.UID, containerName string, streamOpts remotecommand.Options) (*url.URL, error)

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -181,6 +181,10 @@ func (fk *fakeKubelet) ListVolumesForPod(podUID types.UID) (map[string]volume.Vo
 	return map[string]volume.Volume{}, true
 }
 
+func (fk *fakeKubelet) GetVolumesMetricsForPod(podUID types.UID) (map[string]*volume.Metrics, bool) {
+	return map[string]*volume.Metrics{}, true
+}
+
 type fakeAuth struct {
 	authenticateFunc func(*http.Request) (user.Info, bool, error)
 	attributesFunc   func(user.Info, *http.Request) authorizer.Attributes

--- a/pkg/kubelet/server/stats/BUILD
+++ b/pkg/kubelet/server/stats/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//pkg/kubelet/leaky:go_default_library",
         "//pkg/kubelet/network:go_default_library",
         "//pkg/kubelet/types:go_default_library",
-        "//pkg/kubelet/util/format:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/util/wait:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -47,6 +47,7 @@ type StatsProvider interface {
 	ImagesFsInfo() (cadvisorapiv2.FsInfo, error)
 	RootFsInfo() (cadvisorapiv2.FsInfo, error)
 	ListVolumesForPod(podUID types.UID) (map[string]volume.Volume, bool)
+	GetVolumesMetricsForPod(podUID types.UID) (map[string]*volume.Metrics, bool)
 	GetPods() []*v1.Pod
 }
 

--- a/pkg/kubelet/server/stats/mocks_test.go
+++ b/pkg/kubelet/server/stats/mocks_test.go
@@ -227,6 +227,29 @@ func (_m *MockStatsProvider) ListVolumesForPod(podUID types.UID) (map[string]vol
 	return r0, r1
 }
 
+// GetVolumesMetricsForPod provides a mock function with given fields: podUID
+func (_m *MockStatsProvider) GetVolumesMetricsForPod(podUID types.UID) (map[string]*volume.Metrics, bool) {
+	ret := _m.Called(podUID)
+
+	var r0 map[string]*volume.Metrics
+	if rf, ok := ret.Get(0).(func(types.UID) map[string]*volume.Metrics); ok {
+		r0 = rf(podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*volume.Metrics)
+		}
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func(types.UID) bool); ok {
+		r1 = rf(podUID)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
 // GetPods provides a mock function with given fields:
 func (_m *MockStatsProvider) GetPods() []*v1.Pod {
 	ret := _m.Called()

--- a/pkg/kubelet/volumemanager/BUILD
+++ b/pkg/kubelet/volumemanager/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/kubelet/volumemanager/cache:go_default_library",
         "//pkg/kubelet/volumemanager/populator:go_default_library",
+        "//pkg/kubelet/volumemanager/provider:go_default_library",
         "//pkg/kubelet/volumemanager/reconciler:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/util/mount:go_default_library",

--- a/pkg/kubelet/volumemanager/cache/BUILD
+++ b/pkg/kubelet/volumemanager/cache/BUILD
@@ -15,6 +15,7 @@ go_library(
     srcs = [
         "actual_state_of_world.go",
         "desired_state_of_world.go",
+        "volume_metric_of_world.go",
     ],
     tags = ["automanaged"],
     deps = [

--- a/pkg/kubelet/volumemanager/cache/volume_metric_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/volume_metric_of_world.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package cache implements data structures used by the kubelet volume manager to
+keep track of attached volumes and the pods that mounted them.
+*/
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+// VolumesMetricsOfWorld defines a set of thread-safe operations for the kubelet
+// volume manager's volumes metrics of the world cache.
+// This cache contains volumes->metrics data.
+type VolumesMetricsOfWorld interface {
+	// MarkVolumeIsMeasuring marks the volume as being measured or not.
+	// The volume may be mounted on multiple paths for multiple pods.
+	// It is neccery to avoid excute 'du' on all paths that mountes the same volume.
+	// When mark it as true indicates the volume is being measuring.
+	// if the volume does not exist in the cache , an error is returned.
+	MarkVolumeIsMeasuring(volumeName v1.UniqueVolumeName)
+
+	// SetVolumeMetricsData sets the volume metrics data value for the given volume.
+	// volumeMetrics is the metrics of the volume.
+	// cacheDuration is the amount of time the metrics is available in the cache.
+	// dataTimestamp is the time of last measure of the metrics.
+	UpdateVolumeMetricsData(volumeName v1.UniqueVolumeName, volumeMetrics *volume.Metrics, outerVolumeSpecName string, cacheDuration time.Duration, dataTimestamp time.Time)
+
+	// UpdateVolumeMetricsStatus update cache time and timestap
+	// when fail to provide volume metrics.
+	UpdateVolumeMetricsStatus(volumeName v1.UniqueVolumeName, cacheDuration time.Duration, dataTimestamp time.Time)
+
+	// HousekeepVolumeMetricsWorld removes the volume metrics from the
+	// cache when the volume has not been in the actual world.
+	HousekeepVolumeMetricsWorld(volumeNamesInActualWorld []v1.UniqueVolumeName)
+
+	// GetVolumeMetricsCacheDuration return whether volume requires measure or not
+	// and volume metrics cache duration.
+	// If return 'measureRequired' as false, return 'cacheDuration' as nil.
+	GetVolumeMetricsStatus(volumeName v1.UniqueVolumeName) (measureRequired bool, cacheDuration *time.Duration)
+
+	// GetVolumeMetrics return the volume metrics and volume outerVolumeSpecName.
+	GetVolumeMetrics(volumeName v1.UniqueVolumeName) (*volume.Metrics, string)
+}
+
+// NewVolumeMetricsOfWorld returns a new instance of VolumesMetricsOfWorld.
+func NewVolumeMetricsOfWorld() VolumesMetricsOfWorld {
+	return &volumeMetricsOfWorld{
+		mountedVolumesMetricsCache: make(map[v1.UniqueVolumeName]volumeMetricsData),
+	}
+}
+
+type volumeMetricsData struct {
+	metrics             *volume.Metrics
+	outerVolumeSpecName string
+	isMeasuring         bool
+	cacheDuration       *time.Duration
+	metricsTimestamp    *time.Time
+}
+
+type volumeMetricsOfWorld struct {
+	mountedVolumesMetricsCache map[v1.UniqueVolumeName]volumeMetricsData
+	sync.RWMutex
+}
+
+func (vmw *volumeMetricsOfWorld) MarkVolumeIsMeasuring(volumeName v1.UniqueVolumeName) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+	metricsData, exist := vmw.mountedVolumesMetricsCache[volumeName]
+	if exist {
+		metricsData.isMeasuring = true
+	} else {
+		metricsData = volumeMetricsData{isMeasuring: true}
+	}
+
+	vmw.mountedVolumesMetricsCache[volumeName] = metricsData
+}
+
+func (vmw *volumeMetricsOfWorld) UpdateVolumeMetricsData(volumeName v1.UniqueVolumeName,
+	volumeMetrics *volume.Metrics,
+	outerVolumeSpecName string,
+	cacheDuration time.Duration,
+	dataTimestamp time.Time) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+	metricsData := volumeMetricsData{
+		metrics:             volumeMetrics,
+		outerVolumeSpecName: outerVolumeSpecName,
+		isMeasuring:         false,
+		cacheDuration:       &cacheDuration,
+		metricsTimestamp:    &dataTimestamp}
+	vmw.mountedVolumesMetricsCache[volumeName] = metricsData
+}
+
+func (vmw *volumeMetricsOfWorld) UpdateVolumeMetricsStatus(volumeName v1.UniqueVolumeName,
+	cacheDuration time.Duration,
+	dataTimestamp time.Time) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+	metricsData, exist := vmw.mountedVolumesMetricsCache[volumeName]
+	if exist {
+		metricsData.isMeasuring = false
+		metricsData.cacheDuration = &cacheDuration
+		metricsData.metricsTimestamp = &dataTimestamp
+	} else {
+		metricsData = volumeMetricsData{
+			isMeasuring:      false,
+			cacheDuration:    &cacheDuration,
+			metricsTimestamp: &dataTimestamp}
+	}
+
+	vmw.mountedVolumesMetricsCache[volumeName] = metricsData
+}
+
+func (vmw *volumeMetricsOfWorld) HousekeepVolumeMetricsWorld(volumeNamesInActualWorld []v1.UniqueVolumeName) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+	for volumeName := range vmw.mountedVolumesMetricsCache {
+		dataRequireDeleted := true
+		for index := range volumeNamesInActualWorld {
+			if volumeName == volumeNamesInActualWorld[index] {
+				dataRequireDeleted = false
+				break
+			}
+		}
+		if dataRequireDeleted {
+			delete(vmw.mountedVolumesMetricsCache, volumeName)
+		}
+	}
+}
+
+func (vmw *volumeMetricsOfWorld) GetVolumeMetricsStatus(volumeName v1.UniqueVolumeName) (bool, *time.Duration) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+
+	metricsData, exist := vmw.mountedVolumesMetricsCache[volumeName]
+	// The volume appear first time in actual world and requires measure.
+	if !exist {
+		return true, nil
+	}
+
+	// The volume is being measured by 'du' .
+	if !metricsData.isMeasuring {
+		return false, nil
+	}
+
+	if metricsData.metricsTimestamp != nil && metricsData.cacheDuration != nil {
+		isExpired := metricsData.metricsTimestamp.Add(*metricsData.cacheDuration).Before(time.Now())
+		// The volume metrics is expired and requires measure.
+		if isExpired {
+			return true, metricsData.cacheDuration
+		}
+	}
+
+	return false, nil
+}
+
+func (vmw *volumeMetricsOfWorld) GetVolumeMetrics(volumeName v1.UniqueVolumeName) (*volume.Metrics, string) {
+	vmw.RLock()
+	defer vmw.RUnlock()
+
+	metricsData, exist := vmw.mountedVolumesMetricsCache[volumeName]
+	if !exist || metricsData.metrics == nil {
+		return nil, ""
+	}
+
+	return metricsData.metrics, metricsData.outerVolumeSpecName
+}

--- a/pkg/kubelet/volumemanager/provider/BUILD
+++ b/pkg/kubelet/volumemanager/provider/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+    "cgo_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["volume_metric_of_world_provider.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/kubelet/volumemanager/cache:go_default_library",
+        "//vendor:github.com/golang/glog",
+    ],
+)

--- a/pkg/kubelet/volumemanager/provider/volume_metric_of_world_provider.go
+++ b/pkg/kubelet/volumemanager/provider/volume_metric_of_world_provider.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package provider implements interfaces that provide the metrics of volumes
+// which exist in the actual state of the world.
+package provider
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
+)
+
+const (
+	longDu             = 1 * time.Second
+	longCacheDuration  = 24 * time.Hour
+	maxDuBackoffFactor = 20
+	// The maximum number of routine that is running `du` tasks at once.
+	maxConsecutiveRoutinesRunningDu = 20
+)
+
+// A pool for restricting the number of consecutive routines running `du` tasks.
+var routinePoolForRunningDu = make(chan struct{}, maxConsecutiveRoutinesRunningDu)
+
+func claimRoutineTokenForRunningDu() {
+	<-routinePoolForRunningDu
+}
+
+func releaseRoutineTokenForRunningDu() {
+	routinePoolForRunningDu <- struct{}{}
+}
+
+func initRoutineToken() {
+	for i := 0; i < maxConsecutiveRoutinesRunningDu; i++ {
+		routinePoolForRunningDu <- struct{}{}
+	}
+}
+
+// VolumesMetricsOfWorldProvider periodically loops through the map containing
+// metrics providers which generated from actual world cache and update each
+// volume using provider on the path to which the volume should be mounted for
+// a pod.
+type VolumesMetricsOfWorldProvider interface {
+	// Starts running the provider loop which executes periodically,
+	// checks if volume metrics that should be updated will be measured
+	// using provider.
+	Run(stopCh <-chan struct{})
+}
+
+// NewVolumesMetricsOfWorldProvider returns a new instance of
+// NewVolumesMetricsOfWorldProvider.
+//
+// metricsCacheDuration - the amount of time the metrics data is effective
+// 	in the cache
+// loopSleepDuration - the amount of time the provider loop sleeps between
+//     successive executions
+// actualStateOfWorld - the cache of actual world
+// volumesMetricsOfWorld - the cache to keep volume metrics data
+func NewVolumesMetricsOfWorldProvider(
+	metricsCacheDuration time.Duration,
+	loopSleepDuration time.Duration,
+	housekeepingDuration time.Duration,
+	actualStateOfWorld cache.ActualStateOfWorld,
+	volumesMetricsOfWorld cache.VolumesMetricsOfWorld) VolumesMetricsOfWorldProvider {
+	return &volumesMetricsOfWorldProvider{
+		metricsCacheDuration:  metricsCacheDuration,
+		loopSleepDuration:     loopSleepDuration,
+		housekeepingDuration:  housekeepingDuration,
+		actualStateOfWorld:    actualStateOfWorld,
+		volumesMetricsOfWorld: volumesMetricsOfWorld,
+	}
+}
+
+type volumesMetricsOfWorldProvider struct {
+	metricsCacheDuration  time.Duration
+	loopSleepDuration     time.Duration
+	housekeepingDuration  time.Duration
+	actualStateOfWorld    cache.ActualStateOfWorld
+	volumesMetricsOfWorld cache.VolumesMetricsOfWorld
+}
+
+// provideVolumeMetrics use the proper provider for the various volumes.
+func (vmwp *volumesMetricsOfWorldProvider) provideVolumeMetrics(providerWrapper cache.MetricsProviderWrapper, cacheDuration time.Duration) {
+	// TODO: Use Constant as case values.
+	switch providerWrapper.PluginName {
+	case "kubernetes.io/nfs", "kubernetes.io/empty-dir":
+		// It should mark the volume being measured before starting a routine.
+		// It would attempt to avoid running 'du' on paths simultaneously to which the same volume is mounted.
+		// Ignore side effect of 'HousekeepVolumeMetricsWorld' that remove the metrics data while 'du' is running.
+		vmwp.volumesMetricsOfWorld.MarkVolumeIsMeasuring(providerWrapper.VolumeName)
+		go vmwp.provideVolumeMetricsByDu(providerWrapper, cacheDuration)
+
+	case "kubernetes.io/aws-ebs", "kubernetes.io/azure-file", "kubernetes.io/gce-pd":
+		vmwp.provideVolumeMetricsByStatFS(providerWrapper, cacheDuration)
+
+	case "kubernetes.io/secret":
+		// Excute the next updating after 'longCacheDuration' hours.
+		vmwp.provideVolumeMetricsByDu(providerWrapper, longCacheDuration)
+	// TODO:Provide other volume plugins.
+	default:
+	}
+}
+
+// provideVolumeMetricsByDu get metrics by 'StatFS' and update volume
+// metrics in cahce.
+func (vmwp *volumesMetricsOfWorldProvider) provideVolumeMetricsByStatFS(providerWrapper cache.MetricsProviderWrapper, cacheDuration time.Duration) {
+	metrics, err := providerWrapper.Provider.GetMetrics()
+	if err != nil {
+		glog.Errorf("Failed to get FsInfo of volume with name %s due to error %v.", providerWrapper.VolumeName, err)
+		return
+	}
+	vmwp.volumesMetricsOfWorld.UpdateVolumeMetricsData(providerWrapper.VolumeName,
+		metrics,
+		providerWrapper.OuterVolumeSpecName,
+		vmwp.metricsCacheDuration,
+		time.Now())
+}
+
+// provideVolumeMetricsByDu get metrics by 'Du' and update volume
+// metrics in cahce.
+func (vmwp *volumesMetricsOfWorldProvider) provideVolumeMetricsByDu(providerWrapper cache.MetricsProviderWrapper, cacheDuration time.Duration) {
+	// startMeasureVolume Call will block here until the number of 'du' task
+	// running at once is less than maxConsecutiveRoutinesRunningDu.
+	claimRoutineTokenForRunningDu()
+	defer releaseRoutineTokenForRunningDu()
+
+	start := time.Now()
+	// GetMetrics Call maybe block here for some time.
+	metrics, err := providerWrapper.Provider.GetMetrics()
+	// If fail to get the volume metrics, double the cache time.
+	// The cache time of volume metrics determine how frequently to provide the metrics.
+	// The cache time is not greater than maxDuBackoffFactor*vmwp.metricsCacheDuration.
+	// Just as cadvisor does.
+	if err != nil {
+		glog.Errorf("failed to excute 'du' on volume with name %s - %v", providerWrapper.VolumeName, err)
+		cacheDuration = cacheDuration * 2
+		if cacheDuration > maxDuBackoffFactor*vmwp.metricsCacheDuration {
+			cacheDuration = maxDuBackoffFactor * vmwp.metricsCacheDuration
+		}
+
+		vmwp.volumesMetricsOfWorld.UpdateVolumeMetricsStatus(providerWrapper.VolumeName,
+			cacheDuration,
+			time.Now())
+
+		return
+	}
+
+	duration := time.Since(start)
+	if duration > longDu {
+		glog.V(2).Infof("`du` on volume with name %s took %v", providerWrapper.VolumeName, duration)
+	}
+
+	vmwp.volumesMetricsOfWorld.UpdateVolumeMetricsData(providerWrapper.VolumeName,
+		metrics,
+		providerWrapper.OuterVolumeSpecName,
+		vmwp.metricsCacheDuration,
+		time.Now())
+}
+
+func (vmwp *volumesMetricsOfWorldProvider) Run(stopCh <-chan struct{}) {
+	initRoutineToken()
+	for {
+		select {
+		case <-stopCh:
+			return
+
+		case <-time.After(vmwp.housekeepingDuration):
+			// Clear the dirty volume metrics.
+			volumeNamesInActualWorld := vmwp.actualStateOfWorld.GetMountedVolumeNames()
+			vmwp.volumesMetricsOfWorld.HousekeepVolumeMetricsWorld(volumeNamesInActualWorld)
+
+		case <-time.After(vmwp.loopSleepDuration):
+			metricsProviderWrappers := vmwp.actualStateOfWorld.GetMountedMetricsProviderWrappers()
+			for path := range metricsProviderWrappers {
+				metricsProviderWrapper := metricsProviderWrappers[path]
+				// A volume mabye mounted to multiple paths.
+				// Running 'du' on only one of the paths.
+				measureRequired, cacheDuration := vmwp.volumesMetricsOfWorld.GetVolumeMetricsStatus(metricsProviderWrapper.VolumeName)
+				if measureRequired {
+					// Set cache duration of new volume metrics as
+					// the default value 'vmwp.metricsCacheDuration'.
+					if cacheDuration == nil {
+						cacheDuration = &vmwp.metricsCacheDuration
+					}
+					vmwp.provideVolumeMetrics(metricsProviderWrapper, *cacheDuration)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add metrics provider in order to effectively manage persistent volume provided by nfs. Refer to [https://trello.com/c/6gpwW6uJ/253-pv-monitoring]

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33468)

<!-- Reviewable:end -->
