### PR TITLE
disconnect contrib/mesos

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -32,6 +32,7 @@ kube::test::find_dirs() {
           -o -path './_output/*' \
           -o -path './_gopath/*' \
           -o -path './contrib/podex/*' \
+          -o -path './contrib/mesos/*' \
           -o -path './output/*' \
           -o -path './release/*' \
           -o -path './target/*' \


### PR DESCRIPTION
Partially addresses to https://github.com/kubernetes/kubernetes/issues/33283.

This just disconnects `contrib/mesos` from the rest of the `kubernetes/kubernetes` repo.  This leaves the code in place so that it can be used to prime a new repo once there's a champion and owner.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33487)

<!-- Reviewable:end -->
