### PR TITLE
Store RequestInfo in Context instead of RequestInfoResolver dependency injection

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -40,7 +40,6 @@ import (
 
 type APIInstaller struct {
 	group             *APIGroupVersion
-	info              *RequestInfoResolver
 	prefix            string // Path prefix where API resources are to be registered.
 	minRequestTimeout time.Duration
 }
@@ -67,11 +66,10 @@ func (a *APIInstaller) Install(ws *restful.WebService) (apiResources []unversion
 	errors = make([]error, 0)
 
 	proxyHandler := (&ProxyHandler{
-		prefix:              a.prefix + "/proxy/",
-		storage:             a.group.Storage,
-		serializer:          a.group.Serializer,
-		context:             a.group.Context,
-		requestInfoResolver: a.info,
+		prefix:     a.prefix + "/proxy/",
+		storage:    a.group.Storage,
+		serializer: a.group.Serializer,
+		mapper:     a.group.Context,
 	})
 
 	// Register the paths in a deterministic (sorted) order to get a deterministic swagger spec.

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -67,10 +67,6 @@ type APIGroupVersion struct {
 	// GroupVersion is the external group version
 	GroupVersion unversioned.GroupVersion
 
-	// RequestInfoResolver is used to parse URLs for the legacy proxy handler.  Don't use this for anything else
-	// TODO: refactor proxy handler to use sub resources
-	RequestInfoResolver *RequestInfoResolver
-
 	// OptionsExternalVersion controls the Kubernetes APIVersion used for common objects in the apiserver
 	// schema like api.Status, api.DeleteOptions, and api.ListOptions. Other implementors may
 	// define a version "v1beta1" but want to use the Kubernetes "v1" internal objects. If
@@ -175,7 +171,6 @@ func (g *APIGroupVersion) newInstaller() *APIInstaller {
 	prefix := path.Join(g.Root, g.GroupVersion.Group, g.GroupVersion.Version)
 	installer := &APIInstaller{
 		group:             g,
-		info:              g.RequestInfoResolver,
 		prefix:            prefix,
 		minRequestTimeout: g.MinRequestTimeout,
 	}

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -39,11 +39,14 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apiserver/filters"
+	"k8s.io/kubernetes/pkg/apiserver/request"
 	apiservertesting "k8s.io/kubernetes/pkg/apiserver/testing"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/diff"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 	"k8s.io/kubernetes/pkg/watch/versioned"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
@@ -258,8 +261,6 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 
 	template := APIGroupVersion{
 		Storage: storage,
-
-		RequestInfoResolver: newTestRequestInfoResolver(),
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
@@ -2386,14 +2387,13 @@ func TestCreateChecksDecode(t *testing.T) {
 func TestUpdateREST(t *testing.T) {
 	makeGroup := func(storage map[string]rest.Storage) *APIGroupVersion {
 		return &APIGroupVersion{
-			Storage:             storage,
-			Root:                "/" + prefix,
-			RequestInfoResolver: newTestRequestInfoResolver(),
-			Creater:             api.Scheme,
-			Convertor:           api.Scheme,
-			Copier:              api.Scheme,
-			Typer:               api.Scheme,
-			Linker:              selfLinker,
+			Storage:   storage,
+			Root:      "/" + prefix,
+			Creater:   api.Scheme,
+			Convertor: api.Scheme,
+			Copier:    api.Scheme,
+			Typer:     api.Scheme,
+			Linker:    selfLinker,
 
 			Admit:   admissionControl,
 			Context: requestContextMapper,
@@ -2472,13 +2472,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Storage: map[string]rest.Storage{
 			"simple/sub": storage,
 		},
-		Root:                "/" + prefix,
-		RequestInfoResolver: newTestRequestInfoResolver(),
-		Creater:             api.Scheme,
-		Convertor:           api.Scheme,
-		Copier:              api.Scheme,
-		Typer:               api.Scheme,
-		Linker:              selfLinker,
+		Root:      "/" + prefix,
+		Creater:   api.Scheme,
+		Convertor: api.Scheme,
+		Copier:    api.Scheme,
+		Typer:     api.Scheme,
+		Linker:    selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,
@@ -2504,13 +2503,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 			"simple":     &SimpleRESTStorage{},
 			"simple/sub": storage,
 		},
-		Root:                "/" + prefix,
-		RequestInfoResolver: newTestRequestInfoResolver(),
-		Creater:             api.Scheme,
-		Convertor:           api.Scheme,
-		Copier:              api.Scheme,
-		Typer:               api.Scheme,
-		Linker:              selfLinker,
+		Root:      "/" + prefix,
+		Creater:   api.Scheme,
+		Convertor: api.Scheme,
+		Copier:    api.Scheme,
+		Typer:     api.Scheme,
+		Linker:    selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,
@@ -3131,8 +3129,6 @@ func TestXGSubresource(t *testing.T) {
 	group := APIGroupVersion{
 		Storage: storage,
 
-		RequestInfoResolver: newTestRequestInfoResolver(),
-
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
 		Copier:    api.Scheme,
@@ -3159,8 +3155,7 @@ func TestXGSubresource(t *testing.T) {
 		panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
 	}
 
-	handler := defaultAPIServer{mux, container}
-	server := httptest.NewServer(handler)
+	server := newTestServer(defaultAPIServer{mux, container})
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/subsimple")
@@ -3248,4 +3243,17 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 		response.Body.Close()
 	}
 	b.StopTimer()
+}
+
+func newTestServer(handler http.Handler) *httptest.Server {
+	handler = filters.WithRequestInfo(handler, newTestRequestInfoResolver(), requestContextMapper)
+	handler = api.WithRequestContext(handler, requestContextMapper)
+	return httptest.NewServer(handler)
+}
+
+func newTestRequestInfoResolver() *request.RequestInfoResolver {
+	return &request.RequestInfoResolver{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
 }

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -76,6 +76,13 @@ func notFound(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "Not Found: %#v", req.RequestURI)
 }
 
+// internalError renders a simple internal error
+func internalError(w http.ResponseWriter, req *http.Request, err error) {
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintf(w, "Internal Server Error: %#v", req.RequestURI)
+	runtime.HandleError(err)
+}
+
 // errAPIPrefixNotFound indicates that a RequestInfo resolution failed because the request isn't under
 // any known API prefixes
 type errAPIPrefixNotFound struct {

--- a/pkg/apiserver/filters/audit.go
+++ b/pkg/apiserver/filters/audit.go
@@ -89,7 +89,11 @@ func WithAudit(handler http.Handler, attributeGetter RequestAttributeGetter, out
 		return handler
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		attribs := attributeGetter.GetAttribs(req)
+		attribs, err := attributeGetter.GetAttribs(req)
+		if err != nil {
+			internalError(w, req, err)
+			return
+		}
 		asuser := req.Header.Get("Impersonate-User")
 		if len(asuser) == 0 {
 			asuser = "<self>"

--- a/pkg/apiserver/filters/requestinfo.go
+++ b/pkg/apiserver/filters/requestinfo.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apiserver/request"
+)
+
+// WithRequestInfo attaches a RequestInfo to the context.
+func WithRequestInfo(handler http.Handler, resolver *request.RequestInfoResolver, requestContextMapper api.RequestContextMapper) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, ok := requestContextMapper.Get(req)
+		if !ok {
+			internalError(w, req, errors.New("no context found for request"))
+			return
+		}
+
+		info, err := resolver.GetRequestInfo(req)
+		if err != nil {
+			internalError(w, req, fmt.Errorf("failed to create RequestInfo: %v", err))
+		}
+
+		requestContextMapper.Update(req, request.WithRequestInfo(ctx, info))
+
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/pkg/apiserver/filters/requestinfo.go
+++ b/pkg/apiserver/filters/requestinfo.go
@@ -37,6 +37,7 @@ func WithRequestInfo(handler http.Handler, resolver *request.RequestInfoResolver
 		info, err := resolver.GetRequestInfo(req)
 		if err != nil {
 			internalError(w, req, fmt.Errorf("failed to create RequestInfo: %v", err))
+			return
 		}
 
 		requestContextMapper.Update(req, request.WithRequestInfo(ctx, info))

--- a/pkg/apiserver/filters/requestinfo_test.go
+++ b/pkg/apiserver/filters/requestinfo_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"k8s.io/kubernetes/pkg/apiserver/request"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func newTestRequestInfoResolver() *request.RequestInfoResolver {
+	return &request.RequestInfoResolver{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
+}

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"errors"
 	"io"
 	"math/rand"
 	"net/http"
@@ -27,7 +28,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/errors"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apiserver/metrics"
@@ -38,16 +39,16 @@ import (
 	proxyutil "k8s.io/kubernetes/pkg/util/proxy"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/apiserver/request"
 )
 
 // ProxyHandler provides a http.Handler which will proxy traffic to locations
 // specified by items implementing Redirector.
 type ProxyHandler struct {
-	prefix              string
-	storage             map[string]rest.Storage
-	serializer          runtime.NegotiatedSerializer
-	context             api.RequestContextMapper
-	requestInfoResolver *RequestInfoResolver
+	prefix     string
+	storage    map[string]rest.Storage
+	serializer runtime.NegotiatedSerializer
+	mapper     api.RequestContextMapper
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -59,8 +60,19 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	reqStart := time.Now()
 	defer metrics.Monitor(&verb, &apiResource, net.GetHTTPClient(req), w.Header().Get("Content-Type"), httpCode, reqStart)
 
-	requestInfo, err := r.requestInfoResolver.GetRequestInfo(req)
-	if err != nil || !requestInfo.IsResourceRequest {
+	ctx, ok := r.mapper.Get(req)
+	if !ok {
+		internalError(w, req, errors.New("Error getting request context"))
+		return
+	}
+
+	requestInfo, ok := request.RequestInfoFrom(ctx)
+	if !ok {
+		internalError(w, req, errors.New("Error getting RequestInfo from context"))
+		httpCode = http.StatusInternalServerError
+		return
+	}
+	if !requestInfo.IsResourceRequest {
 		notFound(w, req)
 		httpCode = http.StatusNotFound
 		return
@@ -68,10 +80,6 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	verb = requestInfo.Verb
 	namespace, resource, parts := requestInfo.Namespace, requestInfo.Resource, requestInfo.Parts
 
-	ctx, ok := r.context.Get(req)
-	if !ok {
-		ctx = api.NewContext()
-	}
 	ctx = api.WithNamespace(ctx, namespace)
 	if len(parts) < 2 {
 		notFound(w, req)
@@ -104,7 +112,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	redirector, ok := storage.(rest.Redirector)
 	if !ok {
 		httplog.LogOf(req, w).Addf("'%v' is not a redirector", resource)
-		httpCode = errorNegotiated(errors.NewMethodNotSupported(api.Resource(resource), "proxy"), r.serializer, gv, w, req)
+		httpCode = errorNegotiated(apierrors.NewMethodNotSupported(api.Resource(resource), "proxy"), r.serializer, gv, w, req)
 		return
 	}
 

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -63,6 +63,7 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx, ok := r.mapper.Get(req)
 	if !ok {
 		internalError(w, req, errors.New("Error getting request context"))
+		httpCode = http.StatusInternalServerError
 		return
 	}
 

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -204,7 +204,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			expectedResourceNamespace: "default",
 		}
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
-		server := httptest.NewServer(namespaceHandler)
+		server := newTestServer(namespaceHandler)
 		defer server.Close()
 
 		// Dial the proxy server
@@ -310,7 +310,7 @@ func TestProxy(t *testing.T) {
 		}
 
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
-		namespaceServer := httptest.NewServer(namespaceHandler)
+		namespaceServer := newTestServer(namespaceHandler)
 		defer namespaceServer.Close()
 
 		// test each supported URL pattern for finding the redirection resource in the proxy in a particular namespace
@@ -432,7 +432,7 @@ func TestProxyUpgrade(t *testing.T) {
 
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
 
-		server := httptest.NewServer(namespaceHandler)
+		server := newTestServer(namespaceHandler)
 		defer server.Close()
 
 		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/"+prefix+"/"+newGroupVersion.Group+"/"+newGroupVersion.Version+"/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
@@ -496,7 +496,7 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		}
 
 		handler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
-		server := httptest.NewServer(handler)
+		server := newTestServer(handler)
 		defer server.Close()
 
 		proxyTestPattern := "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/ns/foo/id" + item.path

--- a/pkg/apiserver/request/doc.go
+++ b/pkg/apiserver/request/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package request contains everything around extracting info from
+// a http request object.
+// TODO: this package is temporary. Handlers must move into pkg/apiserver/handlers to avoid dependency cycle
+package request // import "k8s.io/kubernetes/pkg/apiserver/request"

--- a/pkg/apiserver/request/requestinfo_test.go
+++ b/pkg/apiserver/request/requestinfo_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apiserver
+package request
 
 import (
 	"net/http"
@@ -194,5 +194,8 @@ func TestGetNonAPIRequestInfo(t *testing.T) {
 }
 
 func newTestRequestInfoResolver() *RequestInfoResolver {
-	return &RequestInfoResolver{sets.NewString("api", "apis"), sets.NewString("api")}
+	return &RequestInfoResolver{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
 }

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/emicklei/go-restful"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apiserver"
 	apiserverfilters "k8s.io/kubernetes/pkg/apiserver/filters"
+	"k8s.io/kubernetes/pkg/apiserver/request"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	authhandlers "k8s.io/kubernetes/pkg/auth/handlers"
@@ -49,6 +51,7 @@ import (
 	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/runtime"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Config is a structure used to configure a GenericAPIServer.
@@ -355,7 +358,7 @@ func (s *GenericAPIServer) buildHandlerChains(c *Config, handler http.Handler) (
 	// insecure filters
 	insecure = handler
 	insecure = genericfilters.WithPanicRecovery(insecure, c.RequestContextMapper)
-	insecure = apiserverfilters.WithRequestInfo(insecure, s.NewRequestInfoResolver(), c.RequestContextMapper)
+	insecure = apiserverfilters.WithRequestInfo(insecure, NewRequestInfoResolver(c), c.RequestContextMapper)
 	insecure = api.WithRequestContext(insecure, c.RequestContextMapper)
 	insecure = genericfilters.WithTimeoutForNonLongRunningRequests(insecure, c.LongRunningFunc)
 
@@ -367,7 +370,7 @@ func (s *GenericAPIServer) buildHandlerChains(c *Config, handler http.Handler) (
 	secure = apiserverfilters.WithAudit(secure, attributeGetter, c.AuditWriter) // before impersonation to read original user
 	secure = authhandlers.WithAuthentication(secure, c.RequestContextMapper, c.Authenticator, authhandlers.Unauthorized(c.SupportsBasicAuth))
 	secure = genericfilters.WithPanicRecovery(secure, c.RequestContextMapper)
-	secure = apiserverfilters.WithRequestInfo(secure, s.NewRequestInfoResolver(), c.RequestContextMapper)
+	secure = apiserverfilters.WithRequestInfo(secure, NewRequestInfoResolver(c), c.RequestContextMapper)
 	secure = api.WithRequestContext(secure, c.RequestContextMapper)
 	secure = genericfilters.WithTimeoutForNonLongRunningRequests(secure, c.LongRunningFunc)
 	secure = genericfilters.WithMaxInFlightLimit(secure, c.MaxRequestsInFlight, c.LongRunningFunc)
@@ -438,5 +441,12 @@ func DefaultAndValidateRunOptions(options *options.ServerRunOptions) {
 				}
 			}
 		}
+	}
+}
+
+func NewRequestInfoResolver(c *Config) *request.RequestInfoResolver {
+	return &request.RequestInfoResolver{
+		APIPrefixes:          sets.NewString(strings.Trim(c.APIPrefix, "/"), strings.Trim(c.APIGroupPrefix, "/")), // all possible API prefixes
+		GrouplessAPIPrefixes: sets.NewString(strings.Trim(c.APIPrefix, "/")),                                      // APIPrefixes that won't have groups (legacy)
 	}
 }

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/apiserver/request"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
 	"k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -187,8 +188,8 @@ func (s *GenericAPIServer) MinRequestTimeout() time.Duration {
 	return s.minRequestTimeout
 }
 
-func (s *GenericAPIServer) NewRequestInfoResolver() *apiserver.RequestInfoResolver {
-	return &apiserver.RequestInfoResolver{
+func (s *GenericAPIServer) NewRequestInfoResolver() *request.RequestInfoResolver {
+	return &request.RequestInfoResolver{
 		APIPrefixes:          sets.NewString(strings.Trim(s.legacyAPIPrefix, "/"), strings.Trim(s.apiPrefix, "/")), // all possible API prefixes
 		GrouplessAPIPrefixes: sets.NewString(strings.Trim(s.legacyAPIPrefix, "/")),                                 // APIPrefixes that won't have groups (legacy)
 	}
@@ -452,8 +453,6 @@ func (s *GenericAPIServer) getAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 
 func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupVersion unversioned.GroupVersion) (*apiserver.APIGroupVersion, error) {
 	return &apiserver.APIGroupVersion{
-		RequestInfoResolver: s.NewRequestInfoResolver(),
-
 		GroupVersion: groupVersion,
 
 		ParameterCodec: apiGroupInfo.ParameterCodec,

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apiserver"
-	"k8s.io/kubernetes/pkg/apiserver/request"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
 	"k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -50,7 +49,6 @@ import (
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
-	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Info about an API group.
@@ -186,13 +184,6 @@ func (s *GenericAPIServer) RequestContextMapper() api.RequestContextMapper {
 // TODO refactor third party resource storage
 func (s *GenericAPIServer) MinRequestTimeout() time.Duration {
 	return s.minRequestTimeout
-}
-
-func (s *GenericAPIServer) NewRequestInfoResolver() *request.RequestInfoResolver {
-	return &request.RequestInfoResolver{
-		APIPrefixes:          sets.NewString(strings.Trim(s.legacyAPIPrefix, "/"), strings.Trim(s.apiPrefix, "/")), // all possible API prefixes
-		GrouplessAPIPrefixes: sets.NewString(strings.Trim(s.legacyAPIPrefix, "/")),                                 // APIPrefixes that won't have groups (legacy)
-	}
 }
 
 // HandleWithAuth adds an http.Handler for pattern to an http.ServeMux

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -785,9 +785,8 @@ func (m *Master) thirdpartyapi(group, kind, version, pluralResource string) *api
 
 	apiRoot := extensionsrest.MakeThirdPartyPath("")
 	return &apiserver.APIGroupVersion{
-		Root:                apiRoot,
-		GroupVersion:        externalVersion,
-		RequestInfoResolver: m.NewRequestInfoResolver(),
+		Root:         apiRoot,
+		GroupVersion: externalVersion,
 
 		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
 		Convertor: api.Scheme,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -47,7 +47,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extensionsapiv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/apiserver/request"
+	"k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/registry/core/endpoint"
@@ -72,7 +73,6 @@ import (
 	"github.com/go-openapi/validate"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"k8s.io/kubernetes/pkg/generated/openapi"
 )
 
 // setUp is a convience function for setting up for (most) tests.
@@ -192,7 +192,7 @@ func TestNamespaceSubresources(t *testing.T) {
 	master, etcdserver, _, _ := newMaster(t)
 	defer etcdserver.Terminate(t)
 
-	expectedSubresources := apiserver.NamespaceSubResourcesForTest
+	expectedSubresources := request.NamespaceSubResourcesForTest
 	foundSubresources := sets.NewString()
 
 	for k := range master.v1ResourcesStorage {


### PR DESCRIPTION
**Depends on https://github.com/kubernetes/kubernetes/pull/33478**

The `RequestInfoResolver` is used in the proxy handler and in the authorization code. It is passed through half of the apiserver code base to be available at those locations. This PR uses the context instead, which is our natural dependency injection mechanism in the handlers.

`RequestInfo` and all tooling around is moved to `pkg/apiserver/request` temporarily to avoid dependency cycles. This is necessary as long as `pkg/apiserver` implements the proxy and other handlers. Those might move to `pkg/apiserver/handlers` probably later.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33490)

<!-- Reviewable:end -->
