### PR TITLE
CRI: Add more docs abount pod sandbox config in CreateContainerRequest.

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -1523,7 +1523,10 @@ type CreateContainerRequest struct {
 	PodSandboxId *string `protobuf:"bytes,1,opt,name=pod_sandbox_id,json=podSandboxId" json:"pod_sandbox_id,omitempty"`
 	// The config of the container
 	Config *ContainerConfig `protobuf:"bytes,2,opt,name=config" json:"config,omitempty"`
-	// The config of the PodSandbox
+	// The config of the PodSandbox. This is the same config that was passed
+	// to RunPodSandboxRequest to create the PodSandbox. It is passed again
+	// here just for easy reference. The PodSandboxConfig is immutable and
+	// remains the same throughout the lifetime of the pod.
 	SandboxConfig    *PodSandboxConfig `protobuf:"bytes,3,opt,name=sandbox_config,json=sandboxConfig" json:"sandbox_config,omitempty"`
 	XXX_unrecognized []byte            `json:"-"`
 }

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -456,7 +456,10 @@ message CreateContainerRequest {
     optional string pod_sandbox_id = 1;
     // The config of the container
     optional ContainerConfig config = 2;
-    // The config of the PodSandbox
+    // The config of the PodSandbox. This is the same config that was passed
+    // to RunPodSandboxRequest to create the PodSandbox. It is passed again
+    // here just for easy reference. The PodSandboxConfig is immutable and
+    // remains the same throughout the lifetime of the pod.
     optional PodSandboxConfig sandbox_config = 3;
 }
 


### PR DESCRIPTION
Makes it clear that the config will not change during the pod lifecycle.
The field is only for convenience.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33516)

<!-- Reviewable:end -->
