### PR TITLE
Add e2e test for daemonset pod affinity

### DIFF
--- a/pkg/controller/daemon/daemoncontroller.go
+++ b/pkg/controller/daemon/daemoncontroller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -382,7 +383,7 @@ func (dsc *DaemonSetsController) addNode(obj interface{}) {
 	node := obj.(*v1.Node)
 	for i := range dsList.Items {
 		ds := &dsList.Items[i]
-		shouldEnqueue := dsc.nodeShouldRunDaemonPod(node, ds)
+		shouldEnqueue := dsc.nodeShouldRunDaemonPod(node, ds, nil)
 		if shouldEnqueue {
 			dsc.enqueueDaemonSet(ds)
 		}
@@ -403,7 +404,8 @@ func (dsc *DaemonSetsController) updateNode(old, cur interface{}) {
 	}
 	for i := range dsList.Items {
 		ds := &dsList.Items[i]
-		shouldEnqueue := (dsc.nodeShouldRunDaemonPod(oldNode, ds) != dsc.nodeShouldRunDaemonPod(curNode, ds))
+		// TBD: fix false positives (don't pass nil as nodeToDaemonPods)
+		shouldEnqueue := (dsc.nodeShouldRunDaemonPod(oldNode, ds, nil) != dsc.nodeShouldRunDaemonPod(curNode, ds, nil))
 		if shouldEnqueue {
 			dsc.enqueueDaemonSet(ds)
 		}
@@ -446,7 +448,7 @@ func (dsc *DaemonSetsController) manage(ds *extensions.DaemonSet) error {
 	}
 	var nodesNeedingDaemonPods, podsToDelete []string
 	for _, node := range nodeList.Items {
-		shouldRun := dsc.nodeShouldRunDaemonPod(&node, ds)
+		shouldRun := dsc.nodeShouldRunDaemonPod(&node, ds, nodeToDaemonPods)
 
 		daemonPods, isRunning := nodeToDaemonPods[node.Name]
 
@@ -574,7 +576,7 @@ func (dsc *DaemonSetsController) updateDaemonSetStatus(ds *extensions.DaemonSet)
 
 	var desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady int
 	for _, node := range nodeList.Items {
-		shouldRun := dsc.nodeShouldRunDaemonPod(&node, ds)
+		shouldRun := dsc.nodeShouldRunDaemonPod(&node, ds, nodeToDaemonPods)
 
 		scheduled := len(nodeToDaemonPods[node.Name]) > 0
 
@@ -644,7 +646,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(key string) error {
 	return dsc.updateDaemonSetStatus(ds)
 }
 
-func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *extensions.DaemonSet) bool {
+func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *extensions.DaemonSet, nodeToDaemonPods map[string][]*v1.Pod) bool {
 	// If the daemon set specifies a node name, check that it matches with node.Name.
 	if !(ds.Spec.Template.Spec.NodeName == "" || ds.Spec.Template.Spec.NodeName == node.Name) {
 		return false
@@ -695,6 +697,29 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *exten
 				dsc.eventRecorder.Eventf(ds, v1.EventTypeNormal, "FailedPlacement", "failed to place pod on %q: host port conflict", node.ObjectMeta.Name)
 			}
 		}
+	}
+	if !fit {
+		return false
+	}
+
+	if nodeToDaemonPods != nil && len(nodeToDaemonPods[node.Name]) != 0 {
+		// pod (anti)affinity is currently schedule-only,
+		// so let's not delete the pod if it's already
+		// being run
+		return true
+	}
+
+	podAffinityChecker := predicates.NewPodAffinityPredicate(
+		&predicates.CachedNodeInfo{StoreToNodeLister: dsc.nodeStore},
+		dsc.podStore,
+		// problem: that should be obtained from --failure-domains flag
+		strings.Split(v1.DefaultFailureDomains, ","))
+	fit, reasons, err = podAffinityChecker(newPod, nil, nodeInfo)
+	if err != nil {
+		glog.Warningf("Pod affinity checker failed on pod %s due to unexpected error: %v", newPod.Name, err)
+	}
+	for _, r := range reasons {
+		glog.V(2).Infof("Pod affinity checker failed on pod %s for reason: %v", newPod.Name, r.GetReason())
 	}
 	return fit
 }

--- a/pkg/controller/daemon/daemoncontroller_test.go
+++ b/pkg/controller/daemon/daemoncontroller_test.go
@@ -41,6 +41,31 @@ var (
 	simpleNodeLabel       = map[string]string{"color": "blue", "speed": "fast"}
 	simpleNodeLabel2      = map[string]string{"color": "red", "speed": "fast"}
 	alwaysReady           = func() bool { return true }
+	podAffinity           = map[string]string{
+		v1.AffinityAnnotationKey: `
+			{"podAffinity": { "requiredDuringSchedulingIgnoredDuringExecution": [{
+				"labelSelector": {
+					"matchLabels": {
+						"foobar": "foo"
+					}
+				},
+				"topologyKey": "kubernetes.io/hostname",
+				"namespaces": []
+		}]}}`,
+	}
+	podAntiAffinity = map[string]string{
+		// make the pod "antiaffine" with itself, too
+		v1.AffinityAnnotationKey: `
+			{"podAntiAffinity": { "requiredDuringSchedulingIgnoredDuringExecution": [{
+				"labelSelector": {
+					"matchLabels": {
+						"type": "production"
+					}
+				},
+				"topologyKey": "kubernetes.io/hostname",
+				"namespaces": []
+		}]}}`,
+	}
 )
 
 func getKey(ds *extensions.DaemonSet, t *testing.T) string {
@@ -594,4 +619,56 @@ func TestNumberReadyStatus(t *testing.T) {
 	if daemon.Status.NumberReady != 2 {
 		t.Errorf("Wrong daemon %s status: %v", daemon.Name, daemon.Status)
 	}
+}
+
+func testAffinityUsingSinglePod(t *testing.T, annotations map[string]string, expectedCreates int) {
+	manager, podControl := newTestController()
+	addNodes(manager.nodeStore.Store, 0, 1, map[string]string{
+		"kubernetes.io/hostname": "node-0",
+	})
+	daemon := newDaemonSet("foo")
+	daemon.Spec.Template.ObjectMeta.Annotations = annotations
+	manager.dsStore.Add(daemon)
+	syncAndValidateDaemonSets(t, manager, daemon, podControl, expectedCreates, 0)
+}
+
+func testAffinityUsingTwoPods(t *testing.T, annotations map[string]string, expectedCreates int) {
+	manager, podControl := newTestController()
+	addNodes(manager.nodeStore.Store, 0, 1, map[string]string{
+		"kubernetes.io/hostname": "node-0",
+	})
+	manager.podStore.Indexer.Add(&v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: registered.GroupOrDie(v1.GroupName).GroupVersion.String()},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "samplepod",
+			Labels: map[string]string{
+				"type":   "production",
+				"foobar": "foo",
+			},
+			Namespace: v1.NamespaceDefault,
+		},
+		Spec: v1.PodSpec{
+			NodeName: "default/node-0",
+		},
+	})
+	daemon := newDaemonSet("foo")
+	daemon.Spec.Template.ObjectMeta.Annotations = annotations
+	manager.dsStore.Add(daemon)
+	syncAndValidateDaemonSets(t, manager, daemon, podControl, expectedCreates, 0)
+}
+
+func TestPodAffinityDaemonDoesntLaunchNonMatchingPods(t *testing.T) {
+	testAffinityUsingSinglePod(t, podAffinity, 0)
+}
+
+func TestPodAffinityDaemonLaunchesMatchingPods(t *testing.T) {
+	testAffinityUsingTwoPods(t, podAffinity, 1)
+}
+
+func TestPodAntiAffinityDaemonLaunchesMatchingPods(t *testing.T) {
+	testAffinityUsingSinglePod(t, podAntiAffinity, 1)
+}
+
+func TestPodAntiAffinityDaemonDoesntLaunchNonMatchingPods(t *testing.T) {
+	testAffinityUsingTwoPods(t, podAntiAffinity, 0)
 }

--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -81,6 +81,7 @@ var _ = framework.KubeDescribe("Daemon set [Serial]", func() {
 
 	var ns string
 	var c clientset.Interface
+	ignoreLabels := framework.ImagePullerLabels
 
 	BeforeEach(func() {
 		ns = f.Namespace.Name
@@ -271,6 +272,115 @@ var _ = framework.KubeDescribe("Daemon set [Serial]", func() {
 		By("We should now be able to delete the daemon set.")
 		Expect(c.Extensions().DaemonSets(ns).Delete(dsName, nil)).NotTo(HaveOccurred())
 
+	})
+
+	It("should respect InterPodAffinity", func() {
+		nodeNames, cleanupPods := getTwoNodesByCreatingTwoPods(f)
+		cleanupPods()
+
+		By("Trying to create a DaemonSet that runs on one of the nodes but not another")
+		node0Affinity := map[string]string{
+			v1.AffinityAnnotationKey: `{
+				"nodeAffinity": {
+					"requiredDuringSchedulingIgnoredDuringExecution": {
+						"nodeSelectorTerms": [{
+							"matchExpressions": [{
+								"key": "kubernetes.io/hostname",
+								"operator": "In",
+								"values": ["` + nodeNames[0] + `"]
+							}]
+						}]
+					}
+				}
+			}`,
+		}
+		_, err := c.Extensions().DaemonSets(ns).Create(&extensions.DaemonSet{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "ds1",
+			},
+			Spec: extensions.DaemonSetSpec{
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels:      map[string]string{"e2e-ds-antiaffinity-test": "true"},
+						Annotations: node0Affinity,
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "ds1",
+								Image: framework.GetPauseImageName(f.ClientSet),
+							},
+						},
+					},
+				},
+			},
+		})
+		framework.ExpectNoError(err)
+
+		err = framework.WaitForPodsRunningReady(c, ns, 1, framework.PodReadyBeforeTimeout, ignoreLabels, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Trying to create a DaemonSet that attempts to run on both nodes but can only run on one of them due to PodAntiAffinity")
+		node01AffinityAndPodAntiAffinity := map[string]string{
+			v1.AffinityAnnotationKey: `{
+				"nodeAffinity": {
+					"requiredDuringSchedulingIgnoredDuringExecution": {
+						"nodeSelectorTerms": [{
+							"matchExpressions": [{
+								"key": "kubernetes.io/hostname",
+								"operator": "In",
+								"values": ["` + nodeNames[0] + `", "` + nodeNames[1] + `"]
+							}]
+						}]
+					}
+				},
+				"podAntiAffinity": {
+						"requiredDuringSchedulingIgnoredDuringExecution": [{
+						"labelSelector": {
+							"matchLabels": {
+								"e2e-ds-antiaffinity-test": "true"
+							}
+						},
+						"topologyKey": "kubernetes.io/hostname"
+					}]
+				}
+			}`,
+		}
+		_, err = c.Extensions().DaemonSets(ns).Create(&extensions.DaemonSet{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "ds2",
+			},
+			Spec: extensions.DaemonSetSpec{
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels:      map[string]string{"e2e-foo": "bar"},
+						Annotations: node01AffinityAndPodAntiAffinity,
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "ds2",
+								Image: framework.GetPauseImageName(f.ClientSet),
+							},
+						},
+					},
+				},
+			},
+		})
+		framework.ExpectNoError(err)
+
+		err = framework.WaitForPodsRunningReady(c, ns, 2, framework.PodReadyBeforeTimeout, ignoreLabels, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting 10 seconds")
+		time.Sleep(time.Duration(10 * time.Second))
+
+		By("Verifying daemon pods")
+		ds, err := c.Extensions().DaemonSets(ns).Get("ds2", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		Expect(ds.Status.DesiredNumberScheduled).To(Equal(int32(1)))
+		Expect(ds.Status.CurrentNumberScheduled).To(Equal(int32(1)))
 	})
 })
 

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -507,18 +507,8 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 
 	// test when the pod anti affinity rule is not satisfied, the pod would stay pending.
 	It("validates that InterPodAntiAffinity is respected if matching 2", func() {
-		// launch pods to find nodes which can launch a pod. We intentionally do
-		// not just take the node list and choose the first and the second of them.
-		// Depending on the cluster and the scheduler it might be that a "normal" pod
-		// cannot be scheduled onto it.
-		By("Launching two pods on two distinct nodes to get two node names")
-		CreateHostPortPods(f, "host-port", 2, true)
-		defer framework.DeleteRCAndPods(f.ClientSet, f.InternalClientset, ns, "host-port")
-		podList, err := cs.Core().Pods(ns).List(v1.ListOptions{})
-		framework.ExpectNoError(err)
-		Expect(len(podList.Items)).To(Equal(2))
-		nodeNames := []string{podList.Items[0].Spec.NodeName, podList.Items[1].Spec.NodeName}
-		Expect(nodeNames[0]).ToNot(Equal(nodeNames[1]))
+		nodeNames, cleanupPods := getTwoNodesByCreatingTwoPods(f)
+		defer cleanupPods()
 
 		By("Applying a random label to both nodes.")
 		k := "e2e.inter-pod-affinity.kubernetes.io/zone"
@@ -954,4 +944,21 @@ func getNodeThatCanRunPod(f *framework.Framework) string {
 func getNodeThatCanRunPodWithoutToleration(f *framework.Framework) string {
 	By("Trying to launch a pod without a toleration to get a node which can launch it.")
 	return runPodAndGetNodeName(f, pausePodConfig{Name: "without-toleration"})
+}
+
+func getTwoNodesByCreatingTwoPods(f *framework.Framework) ([]string, func()) {
+	// launch pods to find nodes which can launch a pod. We intentionally do
+	// not just take the node list and choose the first and the second of them.
+	// Depending on the cluster and the scheduler it might be that a "normal" pod
+	// cannot be scheduled onto it.
+	By("Launching two pods on two distinct nodes to get two node names")
+	CreateHostPortPods(f, "host-port", 2, true)
+	podList, err := f.ClientSet.Core().Pods(f.Namespace.Name).List(v1.ListOptions{})
+	framework.ExpectNoError(err)
+	Expect(len(podList.Items)).To(Equal(2))
+	nodeNames := []string{podList.Items[0].Spec.NodeName, podList.Items[1].Spec.NodeName}
+	Expect(nodeNames[0]).ToNot(Equal(nodeNames[1]))
+	return nodeNames, func() {
+		framework.DeleteRCAndPods(f.ClientSet, f.InternalClientset, f.Namespace.Name, "host-port")
+	}
 }


### PR DESCRIPTION
Add e2e test for #31136. Includes commits from #31136 and #33451, will linearize the history if/when these PRs are merged.

EDIT: #33451 got merged so I updated this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33523)

<!-- Reviewable:end -->
