### PR TITLE
Revert "Work around the etcd watch issue"

### DIFF
--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -34,8 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/wait"
-
-	"golang.org/x/net/context"
 )
 
 type Tester struct {
@@ -1235,7 +1233,6 @@ func (t *Tester) testWatchFields(obj runtime.Object, emitFn EmitFunc, fieldsPass
 	for _, field := range fieldsPass {
 		for _, action := range actions {
 			options := &api.ListOptions{FieldSelector: field.AsSelector(), ResourceVersion: "1"}
-			ctx = context.WithValue(context.WithValue(ctx, "field", field), "action", action)
 			watcher, err := t.storage.(rest.Watcher).Watch(ctx, options)
 			if err != nil {
 				t.Errorf("unexpected error: %v, %v", err, action)
@@ -1260,7 +1257,6 @@ func (t *Tester) testWatchFields(obj runtime.Object, emitFn EmitFunc, fieldsPass
 	for _, field := range fieldsFail {
 		for _, action := range actions {
 			options := &api.ListOptions{FieldSelector: field.AsSelector(), ResourceVersion: "1"}
-			ctx = context.WithValue(context.WithValue(ctx, "field", field), "action", action)
 			watcher, err := t.storage.(rest.Watcher).Watch(ctx, options)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -1281,12 +1277,11 @@ func (t *Tester) testWatchFields(obj runtime.Object, emitFn EmitFunc, fieldsPass
 }
 
 func (t *Tester) testWatchLabels(obj runtime.Object, emitFn EmitFunc, labelsPass, labelsFail []labels.Set, actions []string) {
-	ctx := t.TestContext().(context.Context)
+	ctx := t.TestContext()
 
 	for _, label := range labelsPass {
 		for _, action := range actions {
 			options := &api.ListOptions{LabelSelector: label.AsSelector(), ResourceVersion: "1"}
-			ctx = context.WithValue(context.WithValue(ctx, "label", label), "action", action)
 			watcher, err := t.storage.(rest.Watcher).Watch(ctx, options)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -1310,7 +1305,6 @@ func (t *Tester) testWatchLabels(obj runtime.Object, emitFn EmitFunc, labelsPass
 	for _, label := range labelsFail {
 		for _, action := range actions {
 			options := &api.ListOptions{LabelSelector: label.AsSelector(), ResourceVersion: "1"}
-			ctx = context.WithValue(context.WithValue(ctx, "label", label), "action", action)
 			watcher, err := t.storage.(rest.Watcher).Watch(ctx, options)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#33101

Since #33393 is merged, the bug should have been fixed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33536)

<!-- Reviewable:end -->
