### PR TITLE
fix example by using the spark-cluster namespace consistently

### DIFF
--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -258,7 +258,7 @@ Shakespeare.
 Take the Zeppelin pod from above and port-forward the WebUI port:
 
 ```console
-$ kubectl port-forward zeppelin-controller-ja09s 8080:8080
+$ kubectl port-forward --namespace=spark-cluster zeppelin-controller-ja09s 8080:8080
 ```
 
 This forwards `localhost` 8080 to container port 8080. You can then find
@@ -290,18 +290,18 @@ After it's setup:
 ```console
 kubectl get pods # Make sure everything is running
 kubectl proxy --port=8001 # Start an application proxy, if you want to see the Spark Master WebUI
-kubectl get pods -lcomponent=zeppelin # Get the driver pod to interact with.
+kubectl --namespace=spark-cluster get pods -lcomponent=zeppelin # Get the driver pod to interact with.
 ```
 
 At which point the Master UI will be available at
-[http://localhost:8001/api/v1/proxy/namespaces/spark-cluster/services/spark-webui/](http://localhost:8001/api/v1/proxy/namespaces/default/services/spark-webui/).
+[http://localhost:8001/api/v1/proxy/namespaces/spark-cluster/services/spark-webui/](http://localhost:8001/api/v1/proxy/namespaces/spark-cluster/services/spark-webui/).
 
 You can either interact with the Spark cluster the traditional `spark-shell` /
 `spark-subsubmit` / `pyspark` commands by using `kubectl exec` against the
 `zeppelin-controller` pod, or if you want to interact with Zeppelin:
 
 ```console
-kubectl port-forward zeppelin-controller-abc123 8080:8080 &
+kubectl port-forward --namespace=spark-cluster zeppelin-controller-abc123 8080:8080 &
 ```
 
 Then visit [http://localhost:8080/](http://localhost:8080/).

--- a/examples/spark/spark-master-controller.yaml
+++ b/examples/spark/spark-master-controller.yaml
@@ -2,6 +2,7 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-master-controller
+  namespace: spark-cluster
 spec:
   replicas: 1
   selector:

--- a/examples/spark/spark-master-service.yaml
+++ b/examples/spark/spark-master-service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: spark-master
+  namespace: spark-cluster
 spec:
   ports:
     - port: 7077

--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -2,6 +2,7 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-worker-controller
+  namespace: spark-cluster
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
While trying the spark-cluster example on master branch I noticed that it did not work because the spark-cluster namespace was used only for some recources and for others not. I fixed this by using the namespace on all recources and also updated the readme accordingly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33553)

<!-- Reviewable:end -->
