### PR TITLE
Kubeadm: fix SELinux rules for kubernetes discovery service

### DIFF
--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -81,6 +81,15 @@ func newKubeDiscoveryPodSpec(s *kubeadmapi.KubeadmConfig) api.PodSpec {
 				// `HostIP: s.API.AdvertiseAddrs[0]`, if there is only one address`
 				{Name: "http", ContainerPort: 9898, HostPort: 9898},
 			},
+			SecurityContext: &api.SecurityContext{
+				SELinuxOptions: &api.SELinuxOptions{
+					// TODO: This implies our discovery container is not being restricted by
+					// SELinux. This is not optimal and would be nice to adjust in future
+					// so it can read /tmp/secret, but for now this avoids recommending
+					// setenforce 0 system-wide.
+					Type: "unconfined_t",
+				},
+			},
 		}},
 		Volumes: []api.Volume{{
 			Name: kubeDiscoverySecretName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes problems with SELinux on CentOS for discovery container which cannot read data from `/tmp/secret` directory.

**Which issue this PR fixes**
Fixed #33541

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33555)

<!-- Reviewable:end -->
