### PR TITLE
Add ECDSA support for service account tokens

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -71,7 +71,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 		"Amount of time to retain events. Default is 1h.")
 
 	fs.StringVar(&s.ServiceAccountKeyFile, "service-account-key-file", s.ServiceAccountKeyFile, ""+
-		"File containing PEM-encoded x509 RSA private or public key, used to verify "+
+		"File containing PEM-encoded x509 RSA or ECDSA private or public key, used to verify "+
 		"ServiceAccount tokens. If unspecified, --tls-private-key-file is used.")
 
 	fs.BoolVar(&s.ServiceAccountLookup, "service-account-lookup", s.ServiceAccountLookup,

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -158,7 +158,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 		"Amount of time which we allow starting Node to be unresponsive before marking it unhealthy.")
 	fs.DurationVar(&s.NodeMonitorPeriod.Duration, "node-monitor-period", s.NodeMonitorPeriod.Duration,
 		"The period for syncing NodeStatus in NodeController.")
-	fs.StringVar(&s.ServiceAccountKeyFile, "service-account-private-key-file", s.ServiceAccountKeyFile, "Filename containing a PEM-encoded private RSA key used to sign service account tokens.")
+	fs.StringVar(&s.ServiceAccountKeyFile, "service-account-private-key-file", s.ServiceAccountKeyFile, "Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.")
 	fs.StringVar(&s.ClusterSigningCertFile, "cluster-signing-cert-file", s.ClusterSigningCertFile, "Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates")
 	fs.StringVar(&s.ClusterSigningKeyFile, "cluster-signing-key-file", s.ClusterSigningKeyFile, "Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates")
 	fs.StringVar(&s.ApproveAllKubeletCSRsForGroup, "insecure-experimental-approve-all-kubelet-csrs-for-group", s.ApproveAllKubeletCSRsForGroup, "The group for which the controller-manager will auto approve all CSRs for kubelet client certificates.")

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authenticator
 
 import (
-	"crypto/rsa"
 	"time"
 
 	"k8s.io/kubernetes/pkg/auth/authenticator"
@@ -183,7 +182,7 @@ func newServiceAccountAuthenticator(keyfile string, lookup bool, serviceAccountG
 		return nil, err
 	}
 
-	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]*rsa.PublicKey{publicKey}, lookup, serviceAccountGetter)
+	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]interface{}{publicKey}, lookup, serviceAccountGetter)
 	return bearertoken.New(tokenAuthenticator), nil
 }
 

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -18,6 +18,8 @@ package serviceaccount
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -54,43 +56,95 @@ type TokenGenerator interface {
 	GenerateToken(serviceAccount api.ServiceAccount, secret api.Secret) (string, error)
 }
 
-// ReadPrivateKey is a helper function for reading an rsa.PrivateKey from a PEM-encoded file
-func ReadPrivateKey(file string) (*rsa.PrivateKey, error) {
+// ReadPrivateKey is a helper function for reading a private key from a PEM-encoded file
+func ReadPrivateKey(file string) (interface{}, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
-	return jwt.ParseRSAPrivateKeyFromPEM(data)
+	key, err := ReadPrivateKeyFromPEM(data)
+	if err != nil {
+		return nil, fmt.Errorf("error reading private key file %s: %v", file, err)
+	}
+	return key, nil
 }
 
-// ReadPublicKey is a helper function for reading an rsa.PublicKey from a PEM-encoded file
-// Reads public keys from both public and private key files
-func ReadPublicKey(file string) (*rsa.PublicKey, error) {
+// ReadPrivateKeyFromPEM is a helper function for reading a private key from a PEM-encoded file
+func ReadPrivateKeyFromPEM(data []byte) (interface{}, error) {
+	if key, err := jwt.ParseRSAPrivateKeyFromPEM(data); err == nil {
+		return key, nil
+	}
+	if key, err := jwt.ParseECPrivateKeyFromPEM(data); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("data does not contain a valid RSA or ECDSA private key")
+}
+
+// ReadPublicKey is a helper function for reading an rsa.PublicKey or ecdsa.PublicKey from a PEM-encoded file.
+// Reads public keys from both public and private key files.
+func ReadPublicKey(file string) (interface{}, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
+	key, err := ReadPublicKeyFromPEM(data)
+	if err != nil {
+		return nil, fmt.Errorf("error reading public key file %s: %v", file, err)
+	}
+	return key, nil
+}
 
+// ReadPublicKeyFromPEM is a helper function for reading an rsa.PublicKey or ecdsa.PublicKey from a PEM-encoded byte array.
+// Reads public keys from both public and private key files.
+func ReadPublicKeyFromPEM(data []byte) (interface{}, error) {
 	if privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(data); err == nil {
 		return &privateKey.PublicKey, nil
 	}
+	if publicKey, err := jwt.ParseRSAPublicKeyFromPEM(data); err == nil {
+		return publicKey, nil
+	}
 
-	return jwt.ParseRSAPublicKeyFromPEM(data)
+	if privateKey, err := jwt.ParseECPrivateKeyFromPEM(data); err == nil {
+		return &privateKey.PublicKey, nil
+	}
+	if publicKey, err := jwt.ParseECPublicKeyFromPEM(data); err == nil {
+		return publicKey, nil
+	}
+	return nil, fmt.Errorf("data does not contain a valid RSA or ECDSA key")
 }
 
 // JWTTokenGenerator returns a TokenGenerator that generates signed JWT tokens, using the given privateKey.
 // privateKey is a PEM-encoded byte array of a private RSA key.
 // JWTTokenAuthenticator()
-func JWTTokenGenerator(key *rsa.PrivateKey) TokenGenerator {
-	return &jwtTokenGenerator{key}
+func JWTTokenGenerator(privateKey interface{}) TokenGenerator {
+	return &jwtTokenGenerator{privateKey}
 }
 
 type jwtTokenGenerator struct {
-	key *rsa.PrivateKey
+	privateKey interface{}
 }
 
 func (j *jwtTokenGenerator) GenerateToken(serviceAccount api.ServiceAccount, secret api.Secret) (string, error) {
-	token := jwt.New(jwt.SigningMethodRS256)
+	var method jwt.SigningMethod
+	switch privateKey := j.privateKey.(type) {
+	case *rsa.PrivateKey:
+		method = jwt.SigningMethodRS256
+	case *ecdsa.PrivateKey:
+		switch privateKey.Curve {
+		case elliptic.P256():
+			method = jwt.SigningMethodES256
+		case elliptic.P384():
+			method = jwt.SigningMethodES384
+		case elliptic.P521():
+			method = jwt.SigningMethodES512
+		default:
+			return "", fmt.Errorf("unknown private key curve, must be 256, 384, or 521")
+		}
+	default:
+		return "", fmt.Errorf("unknown private key type %T, must be *rsa.PrivateKey or *ecdsa.PrivateKey", j.privateKey)
+	}
+
+	token := jwt.New(method)
 
 	claims, _ := token.Claims.(jwt.MapClaims)
 
@@ -107,21 +161,23 @@ func (j *jwtTokenGenerator) GenerateToken(serviceAccount api.ServiceAccount, sec
 	claims[SecretNameClaim] = secret.Name
 
 	// Sign and get the complete encoded token as a string
-	return token.SignedString(j.key)
+	return token.SignedString(j.privateKey)
 }
 
 // JWTTokenAuthenticator authenticates tokens as JWT tokens produced by JWTTokenGenerator
 // Token signatures are verified using each of the given public keys until one works (allowing key rotation)
 // If lookup is true, the service account and secret referenced as claims inside the token are retrieved and verified with the provided ServiceAccountTokenGetter
-func JWTTokenAuthenticator(keys []*rsa.PublicKey, lookup bool, getter ServiceAccountTokenGetter) authenticator.Token {
+func JWTTokenAuthenticator(keys []interface{}, lookup bool, getter ServiceAccountTokenGetter) authenticator.Token {
 	return &jwtTokenAuthenticator{keys, lookup, getter}
 }
 
 type jwtTokenAuthenticator struct {
-	keys   []*rsa.PublicKey
+	keys   []interface{}
 	lookup bool
 	getter ServiceAccountTokenGetter
 }
+
+var errMismatchedSigningMethod = errors.New("invalid signing method")
 
 func (j *jwtTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, error) {
 	var validationError error
@@ -129,10 +185,20 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool
 	for i, key := range j.keys {
 		// Attempt to verify with each key until we find one that works
 		parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
-			if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			switch token.Method.(type) {
+			case *jwt.SigningMethodRSA:
+				if _, ok := key.(*rsa.PublicKey); ok {
+					return key, nil
+				}
+				return nil, errMismatchedSigningMethod
+			case *jwt.SigningMethodECDSA:
+				if _, ok := key.(*ecdsa.PublicKey); ok {
+					return key, nil
+				}
+				return nil, errMismatchedSigningMethod
+			default:
 				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 			}
-			return key, nil
 		})
 
 		if err != nil {
@@ -147,6 +213,15 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool
 					// Signature error, perhaps one of the other keys will verify the signature
 					// If not, we want to return this error
 					glog.V(4).Infof("Signature error (key %d): %v", i, err)
+					validationError = err
+					continue
+				}
+
+				// This key doesn't apply to the given signature type
+				// Perhaps one of the other keys will verify the signature
+				// If not, we want to return this error
+				if err.Inner == errMismatchedSigningMethod {
+					glog.V(4).Infof("Mismatched key type (key %d): %v", i, err)
 					validationError = err
 					continue
 				}

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -361,7 +361,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	})
 	serviceAccountKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	serviceAccountTokenGetter := serviceaccountcontroller.NewGetterFromClient(rootClientset)
-	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]*rsa.PublicKey{&serviceAccountKey.PublicKey}, true, serviceAccountTokenGetter)
+	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]interface{}{&serviceAccountKey.PublicKey}, true, serviceAccountTokenGetter)
 	authenticator := union.New(
 		bearertoken.New(rootTokenAuth),
 		bearertoken.New(serviceAccountTokenAuth),


### PR DESCRIPTION
Fixes #28180

``` release-note
ECDSA keys can now be used for signing and verifying service account tokens.
```

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33565)

<!-- Reviewable:end -->
