### PR TITLE
Add node event for container/image GC failure

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -55,6 +55,8 @@ const (
 	HostNetworkNotSupported = "HostNetworkNotSupported"
 	UndefinedShaper         = "NilShaper"
 	NodeRebooted            = "Rebooted"
+	ContainerGCFailed       = "ContainerGCFailed"
+	ImageGCFailed           = "ImageGCFailed"
 
 	// Image manager event reason list
 	InvalidDiskCapacity = "InvalidDiskCapacity"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1121,6 +1121,7 @@ func (kl *Kubelet) StartGarbageCollection() {
 	go wait.Until(func() {
 		if err := kl.containerGC.GarbageCollect(kl.sourcesReady.AllReady()); err != nil {
 			glog.Errorf("Container garbage collection failed: %v", err)
+			kl.recorder.Eventf(kl.nodeRef, api.EventTypeWarning, events.ContainerGCFailed, err.Error())
 			loggedContainerGCFailure = true
 		} else {
 			var vLevel glog.Level = 4
@@ -1137,6 +1138,7 @@ func (kl *Kubelet) StartGarbageCollection() {
 	go wait.Until(func() {
 		if err := kl.imageManager.GarbageCollect(); err != nil {
 			glog.Errorf("Image garbage collection failed: %v", err)
+			kl.recorder.Eventf(kl.nodeRef, api.EventTypeWarning, events.ImageGCFailed, err.Error())
 			loggedImageGCFailure = true
 		} else {
 			var vLevel glog.Level = 4


### PR DESCRIPTION
Follow up to #31988.  Add an event for a node when container/image GC fails.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33567)

<!-- Reviewable:end -->
