### PR TITLE
AWS: network providers required to update NetworkUnavailable

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -84,15 +84,22 @@ func effectiveHairpinMode(hairpinMode componentconfig.HairpinMode, containerRunt
 // providerRequiresNetworkingConfiguration returns whether the cloud provider
 // requires special networking configuration.
 func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
-	// TODO: We should have a mechanism to say whether native cloud provider
-	// is used or whether we are using overlay networking. We should return
-	// true for cloud providers if they implement Routes() interface and
-	// we are not using overlay networking.
-	if kl.cloud == nil || kl.cloud.ProviderName() != "gce" {
+	if kl.cloud == nil {
 		return false
 	}
-	_, supported := kl.cloud.Routes()
-	return supported
+
+	// This is a per-platform requirement on whether we require networking plugins
+	// to mark nodes with NodeNetworkUnavailable.
+	// In GCE it is required on 1.3 onwards
+	// In AWS it is required on 1.5 onwards
+	switch kl.cloud.ProviderName() {
+	case "gce":
+		return true
+	case "aws":
+		return true
+	default:
+		return false
+	}
 }
 
 // Returns the list of DNS servers and DNS search domains.


### PR DESCRIPTION
We require this on GCE since 1.3, so in 1.5 we will require it also on
AWS.

This means that we won't try to schedule pods onto a node until
networking is functional on it.

Fix #27828

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33573)

<!-- Reviewable:end -->
