### PR TITLE
[low priority] [idea] Match() cache.

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -28,6 +28,8 @@ type Labels interface {
 
 	// Get returns the value for the provided label.
 	Get(label string) (value string)
+
+	String() string
 }
 
 // Set is a map of label:value. It implements Labels.

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -103,6 +103,8 @@ func TestEverything(t *testing.T) {
 	}
 }
 
+// TODO Write TestLargeMatching function and confirm speedup w/ the new cache.
+
 func TestSelectorMatches(t *testing.T) {
 	expectMatch(t, "", Set{"x": "y"})
 	expectMatch(t, "x=y", Set{"x": "y"})


### PR DESCRIPTION
Problem:

`Match` is using alot of CPU in issues like #31795  .  

Solution:

Disclaimer: I havent investigated wether or not redundant calls to match are happening, but i suspect if you had 1000 nodes, and say 100 pods per node, and were scanning labels, you could have alot of string comparison churn if the pods were identical or similar.  I'd need to watch the match ops @ scale to really confirm if theres any redundancy. 

Anyway, Here's a possibility for optimizing `Match()` performance.  Could be improved via xref #33572 .  I'll write some tests to confirm its cache speeds things up (At least  in the obvious case scenarios).  The hard part will be determining in the "real world" wether or not we have a high likliehood of bursts of identical `Match` operations.  cc @kubernetes/sig-scheduling

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33580)

<!-- Reviewable:end -->
