### PR TITLE
revert #32012 (Unshare cluster in each test suite)

### DIFF
--- a/pkg/storage/etcd3/watcher_test.go
+++ b/pkg/storage/etcd3/watcher_test.go
@@ -51,6 +51,8 @@ func TestWatchList(t *testing.T) {
 // - update should trigger Modified event
 // - update that gets filtered should trigger Deleted event
 func testWatch(t *testing.T, recursive bool) {
+	ctx, store, cluster := testSetup(t)
+	defer cluster.Terminate(t)
 	podFoo := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	podBar := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "bar"}}
 
@@ -90,7 +92,6 @@ func testWatch(t *testing.T, recursive bool) {
 		},
 	}}
 	for i, tt := range tests {
-		ctx, store, cluster := testSetup(t)
 		w, err := store.watch(ctx, tt.key, "0", storage.SimpleFilter(tt.pred), recursive)
 		if err != nil {
 			t.Fatalf("Watch failed: %v", err)
@@ -121,7 +122,6 @@ func testWatch(t *testing.T, recursive bool) {
 		}
 		w.Stop()
 		testCheckStop(t, i, w)
-		cluster.Terminate(t)
 	}
 }
 


### PR DESCRIPTION
revert https://github.com/kubernetes/kubernetes/pull/32012

Since #33393 is merged, the bug should have been fixed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33581)

<!-- Reviewable:end -->
