### PR TITLE
Enable kubernetes_metadata by default for ELK stack

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -16,7 +16,7 @@
 
 PREFIX = gcr.io/google_containers
 IMAGE = fluentd-elasticsearch
-TAG = 1.20
+TAG = 1.21
 
 build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -279,10 +279,9 @@
   tag cluster-autoscaler
 </source>
 
-# Uncomment in a case of daemon-set usage
-#<filter kubernetes.**>
-#  type kubernetes_metadata
-#</filter>
+<filter kubernetes.**>
+  type kubernetes_metadata
+</filter>
 
 <match **>
    type elasticsearch


### PR DESCRIPTION
Looks like it was accidentally removed and was not restored back in this PR https://github.com/kubernetes/kubernetes/pull/29883
Because actually this plugin still exists in the image, but new ELK deployment don't allow you to index namespaces, pod names, etc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33584)

<!-- Reviewable:end -->
