### PR TITLE
try to use ifdown/ifup if available

### DIFF
--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 	It("each node by switching off the network interface and ensure they function upon switch on", func() {
 		// switch the network interface off for a while to simulate a network outage
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before network is down.
-		testReboot(f.Client, "nohup sh -c 'sleep 10 && sudo ip link set eth0 down && sleep 120 && sudo ip link set eth0 up' >/dev/null 2>&1 &")
+		testReboot(f.Client, "nohup sh -c 'sleep 10 && (sudo ifdown eth0 || sudo ip link set eth0 down) && sleep 120 && (sudo ifup eth0 || sudo ip link set eth0 up)' >/dev/null 2>&1 &")
 	})
 
 	It("each node by dropping all inbound packets for a while and ensure they function afterwards", func() {


### PR DESCRIPTION
Tried this on both ContainerVM and GCI image. 

`ip link set eth0 down` is too destructive for containerVM. It could not recover with correct network setup hence failing the test. Need to use ifdown/ifup on containerVM. 

reference:
http://serverfault.com/questions/603906/ip-link-set-not-assigning-ip-address-but-ifup-does

``` release-note
ContainerVm/GCI image: try to use ifdown/ifup if available
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33595)

<!-- Reviewable:end -->
