### PR TITLE
use len(params["port"]) > 0 to replace port > 0

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -830,7 +830,7 @@ func updateV1PodPorts(params map[string]string, podSpec *v1.PodSpec) (err error)
 	}
 
 	// Don't include the port if it was not specified.
-	if port > 0 {
+	if len(params["port"]) > 0 {
 		podSpec.Containers[0].Ports = []v1.ContainerPort{
 			{
 				ContainerPort: int32(port),


### PR DESCRIPTION
**What this PR does / why we need it**:
port also needs to be passed to server when port is negative or zero.
this is an omission of pr https://github.com/kubernetes/kubernetes/pull/29605

**Which issue this PR fixes**: 

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33626)

<!-- Reviewable:end -->
