### PR TITLE
storage.Interface: combine Watch() and WatchList()

### DIFF
--- a/pkg/registry/generic/registry/store.go
+++ b/pkg/registry/generic/registry/store.go
@@ -871,24 +871,7 @@ func (e *Store) Watch(ctx api.Context, options *api.ListOptions) (watch.Interfac
 
 // WatchPredicate starts a watch for the items that m matches.
 func (e *Store) WatchPredicate(ctx api.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
-	if name, ok := p.MatchesSingle(); ok {
-		if key, err := e.KeyFunc(ctx, name); err == nil {
-			if err != nil {
-				return nil, err
-			}
-			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
-			if err != nil {
-				return nil, err
-			}
-			if e.Decorator != nil {
-				return newDecoratedWatcher(w, e.Decorator), nil
-			}
-			return w, nil
-		}
-		// if we cannot extract a key based on the current context, the optimization is skipped
-	}
-
-	w, err := e.Storage.WatchList(ctx, e.KeyRootFunc(ctx), resourceVersion, p)
+	w, err := e.Storage.Watch(ctx, e.KeyRootFunc(ctx), resourceVersion, p, e.KeyFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -234,7 +234,7 @@ func TestWatch(t *testing.T) {
 	startVersion := strconv.Itoa(int(initialVersion))
 
 	// Set up Watch for object "podFoo".
-	watcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", startVersion, storage.Everything)
+	watcher, err := cacher.Watch(context.TODO(), "pods/ns/", startVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestWatch(t *testing.T) {
 	verifyWatchEvent(t, watcher, watch.Modified, podFooPrime)
 
 	// Check whether we get too-old error via the watch channel
-	tooOldWatcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", "1", storage.Everything)
+	tooOldWatcher, err := cacher.Watch(context.TODO(), "pods/ns/", "1", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Expected no direct error, got %v", err)
 	}
@@ -260,7 +260,7 @@ func TestWatch(t *testing.T) {
 	expectedGoneError := errors.NewGone("").ErrStatus
 	verifyWatchEvent(t, tooOldWatcher, watch.Error, &expectedGoneError)
 
-	initialWatcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", fooCreated.ResourceVersion, storage.Everything)
+	initialWatcher, err := cacher.Watch(context.TODO(), "pods/ns/", fooCreated.ResourceVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestWatch(t *testing.T) {
 	verifyWatchEvent(t, initialWatcher, watch.Modified, podFooPrime)
 
 	// Now test watch from "now".
-	nowWatcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", "0", storage.Everything)
+	nowWatcher, err := cacher.Watch(context.TODO(), "pods/ns/", "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -296,15 +296,8 @@ func TestWatcherTimeout(t *testing.T) {
 	}
 	startVersion := strconv.Itoa(int(initialVersion))
 
-	// Create a watcher that will not be reading any result.
-	watcher, err := cacher.WatchList(context.TODO(), "pods/ns", startVersion, storage.Everything)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	defer watcher.Stop()
-
-	// Create a second watcher that will be reading result.
-	readingWatcher, err := cacher.WatchList(context.TODO(), "pods/ns", startVersion, storage.Everything)
+	// Create a watcher that will be reading result.
+	readingWatcher, err := cacher.Watch(context.TODO(), "pods/ns/", startVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -325,7 +318,7 @@ func TestFiltering(t *testing.T) {
 
 	// Ensure that the cacher is initialized, before creating any pods,
 	// so that we are sure that all events will be present in cacher.
-	syncWatcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", "0", storage.Everything)
+	syncWatcher, err := cacher.Watch(context.TODO(), "pods/ns/", "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -367,7 +360,7 @@ func TestFiltering(t *testing.T) {
 			return labels.Set(metadata.GetLabels()), nil, nil
 		},
 	}
-	watcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", fooCreated.ResourceVersion, pred)
+	watcher, err := cacher.Watch(context.TODO(), "pods/ns/", fooCreated.ResourceVersion, pred, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -397,7 +390,7 @@ func TestStartingResourceVersion(t *testing.T) {
 	rv += 10
 	startVersion := strconv.Itoa(int(rv))
 
-	watcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", startVersion, storage.Everything)
+	watcher, err := cacher.Watch(context.TODO(), "pods/ns/", startVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -202,22 +202,7 @@ func (h *etcdHelper) Delete(ctx context.Context, key string, out runtime.Object,
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
-	if ctx == nil {
-		glog.Errorf("Context is nil")
-	}
-	watchRV, err := storage.ParseWatchResourceVersion(resourceVersion)
-	if err != nil {
-		return nil, err
-	}
-	key = h.prefixEtcdKey(key)
-	w := newEtcdWatcher(false, h.quorum, nil, storage.SimpleFilter(pred), h.codec, h.versioner, nil, h)
-	go w.etcdWatch(ctx, h.etcdKeysAPI, key, watchRV)
-	return w, nil
-}
-
-// Implements storage.Interface.
-func (h *etcdHelper) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, _ storage.KeyFunc) (watch.Interface, error) {
 	if ctx == nil {
 		glog.Errorf("Context is nil")
 	}

--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -289,10 +289,11 @@ func TestWatch(t *testing.T) {
 	codec := testapi.Default.Codec()
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	defer server.Terminate(t)
-	key := "/some/key"
+	prefix := "/some/"
+	key := path.Join(prefix, "key")
 	h := newEtcdHelper(server.Client, codec, etcdtest.PathPrefix())
 
-	watching, err := h.Watch(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), prefix, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -341,12 +342,13 @@ func makeSubsets(ip string, port int) []api.EndpointSubset {
 
 func TestWatchEtcdState(t *testing.T) {
 	codec := testapi.Default.Codec()
-	key := etcdtest.AddPrefix("/somekey/foo")
+	prefix := etcdtest.AddPrefix("/somekey")
+	key := path.Join(prefix, "foo")
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	defer server.Terminate(t)
 
 	h := newEtcdHelper(server.Client, codec, etcdtest.PathPrefix())
-	watching, err := h.Watch(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), prefix, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -399,7 +401,8 @@ func TestWatchFromZeroIndex(t *testing.T) {
 	codec := testapi.Default.Codec()
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 
-	key := etcdtest.AddPrefix("/somekey/foo")
+	prefix := etcdtest.AddPrefix("/somekey")
+	key := path.Join(prefix, "foo")
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	defer server.Terminate(t)
 
@@ -423,7 +426,7 @@ func TestWatchFromZeroIndex(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	watching, err := h.Watch(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), prefix, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -456,20 +459,21 @@ func TestWatchFromZeroIndex(t *testing.T) {
 	}
 }
 
-func TestWatchListFromZeroIndex(t *testing.T) {
+func TestWatchFromZeroIndex(t *testing.T) {
 	codec := testapi.Default.Codec()
-	key := etcdtest.AddPrefix("/some/key")
+	prefix := etcdtest.AddPrefix("/somekey")
+	key := path.Join(prefix, "foo")
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	defer server.Terminate(t)
 	h := newEtcdHelper(server.Client, codec, key)
 
-	watching, err := h.WatchList(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), prefix, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer watching.Stop()
 
-	// creates key/foo which should trigger the WatchList for "key"
+	// creates key/foo which should trigger the Watch for "key"
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	err = h.Create(context.TODO(), pod.Name, pod, pod, 0)
 	if err != nil {
@@ -486,7 +490,7 @@ func TestWatchListFromZeroIndex(t *testing.T) {
 	}
 }
 
-func TestWatchListIgnoresRootKey(t *testing.T) {
+func TestWatchIgnoresRootKey(t *testing.T) {
 	codec := testapi.Default.Codec()
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	key := etcdtest.AddPrefix("/some/key")
@@ -494,13 +498,13 @@ func TestWatchListIgnoresRootKey(t *testing.T) {
 	defer server.Terminate(t)
 	h := newEtcdHelper(server.Client, codec, key)
 
-	watching, err := h.WatchList(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), key, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer watching.Stop()
 
-	// creates key/foo which should trigger the WatchList for "key"
+	// creates key/foo which should trigger the Watch for "key"
 	err = h.Create(context.TODO(), key, pod, pod, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -521,11 +525,12 @@ func TestWatchPurposefulShutdown(t *testing.T) {
 	_, codec := testScheme(t)
 	server := etcdtesting.NewEtcdTestClientServer(t)
 	defer server.Terminate(t)
-	key := "/some/key"
+	prefix := etcdtest.AddPrefix("/somekey")
+	key := path.Join(prefix, "foo")
 	h := newEtcdHelper(server.Client, codec, etcdtest.PathPrefix())
 
 	// Test purposeful shutdown
-	watching, err := h.Watch(context.TODO(), key, "0", storage.Everything)
+	watching, err := h.Watch(context.TODO(), prefix, "0", storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -313,12 +313,7 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 }
 
 // Watch implements storage.Interface.Watch.
-func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
-	return s.watch(ctx, key, resourceVersion, storage.SimpleFilter(pred), false)
-}
-
-// WatchList implements storage.Interface.WatchList.
-func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, _ storage.KeyFunc) (watch.Interface, error) {
 	return s.watch(ctx, key, resourceVersion, storage.SimpleFilter(pred), true)
 }
 

--- a/pkg/storage/etcd3/store_test.go
+++ b/pkg/storage/etcd3/store_test.go
@@ -86,7 +86,7 @@ func TestCreateWithTTL(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	w, err := store.Watch(ctx, key, out.ResourceVersion, storage.Everything)
+	w, err := store.Watch(ctx, "/", out.ResourceVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Watch failed: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestGuaranteedUpdateWithTTL(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	w, err := store.Watch(ctx, key, out.ResourceVersion, storage.Everything)
+	w, err := store.Watch(ctx, "/", out.ResourceVersion, storage.Everything, nil)
 	if err != nil {
 		t.Fatalf("Watch failed: %v", err)
 	}


### PR DESCRIPTION
What?

This PR is trying to combine single key Watch() and list of items' WatchList() into a single method Watch(). The new method will watch on given key's items. Internally, it will do some optimization if we are only interested in one item.

Why?

This is not something new -- we are taking the optimization path from registry layer down to storage layer. This optimization could be provided in storage layer and in the future we will use different implementation, i.e. generic indexing for it.
Secondly, we try to make the interface smaller.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33633)

<!-- Reviewable:end -->
