### PR TITLE
Support for unix sockets in RESTClient and its transport

### DIFF
--- a/pkg/client/restclient/config.go
+++ b/pkg/client/restclient/config.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	gruntime "runtime"
@@ -45,10 +46,14 @@ const (
 // Config holds the common attributes that can be passed to a Kubernetes client on
 // initialization.
 type Config struct {
-	// Host must be a host string, a host:port pair, or a URL to the base of the apiserver.
-	// If a URL is given then the (optional) Path of that URL represents a prefix that must
-	// be appended to all request URIs used to access the apiserver. This allows a frontend
-	// proxy to easily relocate all of the apiserver endpoints.
+	// Scheme is the name of protocol used for communication with the server (http or
+	// unix).
+	Scheme string
+	// Host must be a host string, a host:port pair or a path to unix socket to the
+	// base of the apiserver. If a host is given then the (optional) Path of that
+	// represents a prefix that must be appended to create all request URIs used to
+	// access the apiserver. This allows a frontend proxy to easily relocate all of
+	// the apiserver endpoints.
 	Host string
 	// APIPath is a sub-path that points to an API root.
 	APIPath string
@@ -172,7 +177,15 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 		burst = DefaultBurst
 	}
 
-	baseURL, versionedAPIPath, err := defaultServerUrlFor(config)
+	var baseURL *url.URL
+	var versionedAPIPath string
+	var err error
+	switch config.Scheme {
+	case "", "http":
+		baseURL, versionedAPIPath, err = defaultServerUrlFor(config)
+	case "unix":
+		baseURL, versionedAPIPath, err = defaultServerUnixSocketPathFor(config)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -338,6 +351,7 @@ func AddUserAgent(config *Config, userAgent string) *Config {
 func AnonymousClientConfig(config *Config) *Config {
 	// copy only known safe fields
 	return &Config{
+		Scheme:        config.Scheme,
 		Host:          config.Host,
 		APIPath:       config.APIPath,
 		Prefix:        config.Prefix,

--- a/pkg/client/restclient/transport.go
+++ b/pkg/client/restclient/transport.go
@@ -41,6 +41,7 @@ func TransportFor(config *Config) (http.RoundTripper, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return transport.New(cfg)
 }
 
@@ -73,7 +74,10 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			wt = provider.WrapTransport
 		}
 	}
+
 	return &transport.Config{
+		Scheme:        c.Scheme,
+		Host:          c.Host,
 		UserAgent:     c.UserAgent,
 		Transport:     c.Transport,
 		WrapTransport: wt,

--- a/pkg/client/transport/config.go
+++ b/pkg/client/transport/config.go
@@ -20,6 +20,17 @@ import "net/http"
 
 // Config holds various options for establishing a transport.
 type Config struct {
+	// Scheme is the name of protocol to be used by transport (http
+	// or unix).
+	Scheme string
+
+	// Host must be a host string, a host:port pair, a URL or a path to unix socket to the
+	// base of the apiserver. If a URL is given then the (optional) Path of that URL
+	// represents a prefix that must be appended to all request URIs used to access the
+	// apiserver. This allows a frontend proxy to easily relocate all of the apiserver
+	// endpoints.
+	Host string
+
 	// UserAgent is an optional field that specifies the caller of this
 	// request.
 	UserAgent string

--- a/staging/src/k8s.io/client-go/1.5/rest/config.go
+++ b/staging/src/k8s.io/client-go/1.5/rest/config.go
@@ -45,6 +45,9 @@ const (
 // Config holds the common attributes that can be passed to a Kubernetes client on
 // initialization.
 type Config struct {
+	// Scheme is the name of protocol used for communication with the server (http or
+	// unix).
+	Scheme string
 	// Host must be a host string, a host:port pair, or a URL to the base of the apiserver.
 	// If a URL is given then the (optional) Path of that URL represents a prefix that must
 	// be appended to all request URIs used to access the apiserver. This allows a frontend


### PR DESCRIPTION
Introduce a config attribute UnixSocket to both RESTClient config and transport config. That setting may be used later by kubectl/cmd/factory for using unix sockets by cli.

Fixes #33657
Ref #31178

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33659)

<!-- Reviewable:end -->
