### PR TITLE
rbd attach/detach refactoring

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -67,6 +67,7 @@ func ProbeAttachableVolumePlugins(config componentconfig.VolumeConfiguration) []
 	allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(config.FlexVolumePluginDir)...)
 	allPlugins = append(allPlugins, vsphere_volume.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, azure_dd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
 	return allPlugins
 }
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -422,7 +422,7 @@ func (adc *attachDetachController) createVolumeSpec(
 		return nil, fmt.Errorf("failed to cast clonedPodVolume %#v to api.Volume", clonedPodVolumeObj)
 	}
 
-	return volume.NewSpecFromVolume(&clonedPodVolume), nil
+	return volume.NewSpecFromVolumeWithNS(&clonedPodVolume, podNamespace), nil
 }
 
 // getPVCFromCacheExtractPV fetches the PVC object with the given namespace and
@@ -515,7 +515,7 @@ func (adc *attachDetachController) getPVSpecFromCache(
 			"failed to cast %q clonedPV %#v to PersistentVolume", name, pvObj)
 	}
 
-	return volume.NewSpecFromPersistentVolume(&clonedPV, pvcReadOnly), nil
+	return volume.NewSpecFromPersistentVolumeWithNS(&clonedPV, pvcReadOnly, pv.Spec.ClaimRef.Namespace), nil
 }
 
 // processVolumesInUse processes the list of volumes marked as "in-use"

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -339,7 +339,7 @@ func (dswp *desiredStateOfWorldPopulator) createVolumeSpec(
 			clonedPodVolumeObj)
 	}
 
-	return volume.NewSpecFromVolume(&clonedPodVolume), "", nil
+	return volume.NewSpecFromVolumeWithNS(&clonedPodVolume, podNamespace), "", nil
 }
 
 // getPVCExtractPV fetches the PVC object with the given namespace and name from
@@ -397,7 +397,7 @@ func (dswp *desiredStateOfWorldPopulator) getPVSpec(
 	}
 
 	volumeGidValue := getPVVolumeGidAnnotationValue(pv)
-	return volume.NewSpecFromPersistentVolume(pv, pvcReadOnly), volumeGidValue, nil
+	return volume.NewSpecFromPersistentVolumeWithNS(pv, pvcReadOnly, pv.Spec.ClaimRef.Namespace), volumeGidValue, nil
 }
 
 func getPVVolumeGidAnnotationValue(pv *api.PersistentVolume) string {

--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -220,7 +220,7 @@ func (plugin *awsElasticBlockStorePlugin) NewDetacher() (volume.Detacher, error)
 	}, nil
 }
 
-func (detacher *awsElasticBlockStoreDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *awsElasticBlockStoreDetacher) Detach(_ *volume.Spec, deviceMountPath string, nodeName types.NodeName) error {
 	volumeID := path.Base(deviceMountPath)
 
 	attached, err := detacher.awsVolumes.DiskIsAttached(volumeID, nodeName)

--- a/pkg/volume/aws_ebs/attacher_test.go
+++ b/pkg/volume/aws_ebs/attacher_test.go
@@ -111,7 +111,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -121,7 +121,7 @@ func TestAttachDetach(t *testing.T) {
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -132,7 +132,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -143,7 +143,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, "", detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 			expectedError: detachError,
 		},

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -248,7 +248,7 @@ func (plugin *azureDataDiskPlugin) NewDetacher() (volume.Detacher, error) {
 }
 
 // Detach detaches disk from Azure VM.
-func (detacher *azureDiskDetacher) Detach(diskName string, nodeName types.NodeName) error {
+func (detacher *azureDiskDetacher) Detach(_ *volume.Spec, diskName string, nodeName types.NodeName) error {
 	if diskName == "" {
 		return fmt.Errorf("invalid disk to detach: %q", diskName)
 	}

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -248,7 +248,7 @@ func (plugin *cinderPlugin) NewDetacher() (volume.Detacher, error) {
 	}, nil
 }
 
-func (detacher *cinderDiskDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *cinderDiskDetacher) Detach(_ *volume.Spec, deviceMountPath string, nodeName types.NodeName) error {
 	volumeID := path.Base(deviceMountPath)
 	instances, res := detacher.cinderProvider.Instances()
 	if !res {

--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -162,7 +162,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -173,7 +173,7 @@ func TestAttachDetach(t *testing.T) {
 			diskIsAttached: diskIsAttachedCall{diskName, instanceID, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -185,7 +185,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -197,7 +197,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 			expectedError: detachError,
 		},

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -245,7 +245,7 @@ func (plugin *gcePersistentDiskPlugin) NewDetacher() (volume.Detacher, error) {
 // Callers are responsible for retryinging on failure.
 // Callers are responsible for thread safety between concurrent attach and detach
 // operations.
-func (detacher *gcePersistentDiskDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *gcePersistentDiskDetacher) Detach(_ *volume.Spec, deviceMountPath string, nodeName types.NodeName) error {
 	pdName := path.Base(deviceMountPath)
 
 	attached, err := detacher.gceDisks.DiskIsAttached(pdName, nodeName)

--- a/pkg/volume/gce_pd/attacher_test.go
+++ b/pkg/volume/gce_pd/attacher_test.go
@@ -148,7 +148,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, nil},
 			test: func(testcase *testcase) error {
 				detacher := newDetacher(testcase)
-				return detacher.Detach(diskName, nodeName)
+				return detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -158,7 +158,7 @@ func TestAttachDetach(t *testing.T) {
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
 			test: func(testcase *testcase) error {
 				detacher := newDetacher(testcase)
-				return detacher.Detach(diskName, nodeName)
+				return detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -169,7 +169,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, nil},
 			test: func(testcase *testcase) error {
 				detacher := newDetacher(testcase)
-				return detacher.Detach(diskName, nodeName)
+				return detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -180,7 +180,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, detachError},
 			test: func(testcase *testcase) error {
 				detacher := newDetacher(testcase)
-				return detacher.Detach(diskName, nodeName)
+				return detacher.Detach(nil, diskName, nodeName)
 			},
 			expectedReturn: detachError,
 		},

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -233,6 +233,7 @@ type Spec struct {
 	Volume           *api.Volume
 	PersistentVolume *api.PersistentVolume
 	ReadOnly         bool
+	NameSpace        string // NameSpace is only filled in Detach(). It helps plugins to locate objects in Pod's namespace.
 }
 
 // Name returns the name of either Volume or PersistentVolume, one of which must not be nil.
@@ -314,6 +315,23 @@ func NewSpecFromPersistentVolume(pv *api.PersistentVolume, readOnly bool) *Spec 
 	return &Spec{
 		PersistentVolume: pv,
 		ReadOnly:         readOnly,
+	}
+}
+
+// NewSpecFromVolumeWithNS creates an Spec from an api.Volume and a namespace
+func NewSpecFromVolumeWithNS(vs *api.Volume, nameSpace string) *Spec {
+	return &Spec{
+		Volume:    vs,
+		NameSpace: nameSpace,
+	}
+}
+
+// NewSpecFromPersistentVolumeWithNS creates an Spec from an api.PersistentVolume
+func NewSpecFromPersistentVolumeWithNS(pv *api.PersistentVolume, readOnly bool, nameSpace string) *Spec {
+	return &Spec{
+		PersistentVolume: pv,
+		ReadOnly:         readOnly,
+		NameSpace:        nameSpace,
 	}
 }
 

--- a/pkg/volume/rbd/BUILD
+++ b/pkg/volume/rbd/BUILD
@@ -13,9 +13,11 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "attacher.go",
         "disk_manager.go",
         "doc.go",
         "rbd.go",
+        "rbd_lock.go",
         "rbd_util.go",
     ],
     tags = ["automanaged"],
@@ -26,7 +28,6 @@ go_library(
         "//pkg/types:go_default_library",
         "//pkg/util/exec:go_default_library",
         "//pkg/util/mount:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/util/uuid:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// RBD Attach and Detach implementation
+// Attach: lock RBD image
+// Detach: release RBD image
+
+package rbd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+type rbdAttacher struct {
+	plugin  *rbdPlugin
+	locker  Locker
+	manager diskManager
+}
+
+var _ volume.Attacher = &rbdAttacher{}
+
+var _ volume.AttachableVolumePlugin = &rbdPlugin{}
+
+func (plugin *rbdPlugin) NewAttacher() (volume.Attacher, error) {
+	return &rbdAttacher{
+		plugin:  plugin,
+		locker:  &RBDLocker{},
+		manager: &RBDUtil{},
+	}, nil
+}
+
+func (plugin *rbdPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {
+	mounter := plugin.host.GetMounter()
+	return mount.GetMountRefs(mounter, deviceMountPath)
+}
+
+func (attacher *rbdAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+	mounter, err := volumeSpecToMounter(spec, attacher.plugin)
+	if err != nil {
+		glog.Warningf("failed to get rbd mounter: %v", err)
+		return "", err
+	}
+	id := "/dev/" + mounter.Pool + "/" + mounter.Image
+	return id, attacher.locker.Fencing(*mounter, string(nodeName))
+}
+
+func (attacher *rbdAttacher) WaitForAttach(spec *volume.Spec, _ string, timeout time.Duration) (string, error) {
+	mounter, err := volumeSpecToMounter(spec, attacher.plugin)
+	if err != nil {
+		glog.Warningf("failed to get rbd mounter: %v", err)
+		return "", err
+	}
+	return attacher.manager.AttachDisk(*mounter)
+}
+
+func (attacher *rbdAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+	volumesAttachedCheck := make(map[*volume.Spec]bool)
+	for _, spec := range specs {
+		mounter, err := volumeSpecToMounter(spec, attacher.plugin)
+		if err != nil {
+			glog.Warningf("failed to get rbd mounter: %v", err)
+			continue
+		}
+		volumesAttachedCheck[spec] = true
+		attached, _ := attacher.locker.IsLocked(*mounter, string(nodeName))
+		volumesAttachedCheck[spec] = attached
+	}
+	return volumesAttachedCheck, nil
+}
+
+func (attacher *rbdAttacher) GetDeviceMountPath(
+	spec *volume.Spec) (string, error) {
+	volumeSource, _, err := getVolumeSource(spec)
+	if err != nil {
+		glog.Warningf("failed to get rbd mounter: %v", err)
+		return "", err
+	}
+
+	return makePDNameInternal(attacher.plugin.host, volumeSource.RBDPool, volumeSource.RBDImage), nil
+}
+
+// FIXME: this method can be further pruned.
+func (attacher *rbdAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+	glog.V(4).Infof("mounting volume device %s to %s", devicePath, deviceMountPath)
+	mounter, err := volumeSpecToMounter(spec, attacher.plugin)
+	if err != nil {
+		glog.Warningf("failed to get rbd mounter for volume: %v", err)
+		return err
+	}
+	notMnt, err := mounter.mounter.IsLikelyNotMountPoint(deviceMountPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(deviceMountPath, 0750); err != nil {
+				return err
+			}
+			notMnt = true
+		} else {
+			return err
+		}
+	}
+	options := []string{}
+	if mounter.rbd.ReadOnly {
+		options = append(options, "ro")
+	}
+	if notMnt {
+		if err = mounter.mounter.FormatAndMount(devicePath, deviceMountPath, mounter.fsType, options); err != nil {
+			err = fmt.Errorf("rbd: failed to mount rbd device %s [%s] to %s, error %v", devicePath, mounter.fsType, deviceMountPath, err)
+		}
+	}
+	return err
+}
+
+type rbdDetacher struct {
+	mounter mount.Interface
+	plugin  *rbdPlugin
+	locker  Locker
+	manager diskManager
+}
+
+var _ volume.Detacher = &rbdDetacher{}
+
+func (plugin *rbdPlugin) NewDetacher() (volume.Detacher, error) {
+	return &rbdDetacher{
+		plugin:  plugin,
+		mounter: plugin.host.GetMounter(),
+		manager: &RBDUtil{},
+		locker:  &RBDLocker{},
+	}, nil
+}
+
+func (detacher *rbdDetacher) Detach(spec *volume.Spec, deviceMountPath string, nodeName types.NodeName) error {
+	glog.V(4).Infof("detaching %v from %s", deviceMountPath, nodeName)
+	mounter, err := volumeSpecToMounter(spec, detacher.plugin)
+	if err != nil {
+		glog.Warningf("failed to get rbd mounter: %v", err)
+		return err
+	}
+	return detacher.locker.Defencing(*mounter, string(nodeName))
+}
+
+//FIXME: let WaitForDetach DetachDisk once volumemgr uses it
+func (detacher *rbdDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
+	return nil
+}
+
+func (detacher *rbdDetacher) UnmountDevice(deviceMountPath string) error {
+	glog.V(4).Infof("unmount %v", deviceMountPath)
+	devicePath, _, _ := mount.GetDeviceNameFromMount(detacher.mounter, deviceMountPath)
+	// unmount device
+	err := volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
+	if err != nil {
+		return err
+	}
+	// unmap (i.e. detach) device
+	if len(devicePath) > 0 {
+		glog.V(4).Infof("unmap %v", devicePath)
+		err = detacher.manager.DetachDisk(detacher.plugin, devicePath)
+	}
+	return err
+}
+
+func volumeSpecToMounter(spec *volume.Spec, plugin *rbdPlugin) (*rbdMounter, error) {
+	var secret string
+	var err error
+	source, readOnly, err := getVolumeSource(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if source.SecretRef != nil {
+		if secret, err = parsePVSecret(spec.NameSpace, source.SecretRef.Name, plugin.host.GetKubeClient()); err != nil {
+			glog.Errorf("Couldn't get secret from %v/%v", spec.NameSpace, source.SecretRef)
+			return nil, err
+		}
+	}
+
+	pool := source.RBDPool
+	id := source.RadosUser
+	keyring := source.Keyring
+
+	return &rbdMounter{
+		rbd: &rbd{
+			Image:    source.RBDImage,
+			Pool:     pool,
+			ReadOnly: readOnly,
+			mounter:  &mount.SafeFormatAndMount{Interface: plugin.host.GetMounter(), Runner: exec.New()},
+			plugin:   plugin,
+		},
+		Mon:     source.CephMonitors,
+		Id:      id,
+		Keyring: keyring,
+		Secret:  secret,
+		fsType:  source.FSType,
+	}, nil
+}

--- a/pkg/volume/rbd/rbd_lock.go
+++ b/pkg/volume/rbd/rbd_lock.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// utility functions to setup rbd volume
+// mainly implement diskManager interface
+//
+
+package rbd
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// Abstract interface to RBD locker.
+type Locker interface {
+	// lock rbd image for a host
+	Fencing(b rbdMounter, hostName string) error
+	// release lock for a host
+	Defencing(c rbdMounter, hostName string) error
+	// query lock status
+	IsLocked(c rbdMounter, hostName string) (bool, error)
+}
+
+type RBDLocker struct{}
+
+func (locker *RBDLocker) rbdLock(b rbdMounter, hostName string, lock bool, queryOnly bool) (bool, error) {
+	var err error
+	var output, imageLocker string
+	var cmd []byte
+	var secret_opt []string
+
+	if b.Secret != "" {
+		secret_opt = []string{"--key=" + b.Secret}
+	} else {
+		secret_opt = []string{"-k", b.Keyring}
+	}
+	// construct lock id using host name and a magic prefix
+	lock_id := "kubelet_lock_magic_" + hostName
+
+	l := len(b.Mon)
+	// avoid mount storm, pick a host randomly
+	start := rand.Int() % l
+	// iterate all hosts until mount succeeds.
+	for i := start; i < start+l; i++ {
+		mon := b.Mon[i%l]
+		// cmd "rbd lock list" serves two purposes:
+		// for fencing, check if lock already held for this host
+		// this edge case happens if host crashes in the middle of acquiring lock and mounting rbd
+		// for defencing, get the locker name, something like "client.1234"
+		cmd, err = b.plugin.execCommand("rbd",
+			append([]string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
+		output = string(cmd)
+
+		if err != nil {
+			glog.Warningf("failed to list rbd image %v/%v, output: %v, err: %v", b.Pool, b.Image, output, err)
+			continue
+		}
+
+		if lock {
+			// check if lock is already held for this host by matching lock_id and rbd lock id
+			if strings.Contains(output, lock_id) {
+				// this host already holds the lock, exit
+				glog.V(1).Infof("rbd: lock already held for %s", lock_id)
+				return true, nil
+			}
+			if queryOnly {
+				return false, nil
+			}
+			// hold a lock: rbd lock add
+			cmd, err = b.plugin.execCommand("rbd",
+				append([]string{"lock", "add", b.Image, lock_id, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
+		} else {
+			// defencing, find locker name
+			ind := strings.LastIndex(output, lock_id) - 1
+			for i := ind; i >= 0; i-- {
+				if output[i] == '\n' {
+					imageLocker = output[(i + 1):ind]
+					break
+				}
+			}
+			// remove a lock: rbd lock remove
+			cmd, err = b.plugin.execCommand("rbd",
+				append([]string{"lock", "remove", b.Image, lock_id, imageLocker, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
+		}
+
+		if err == nil {
+			//locking operation is done
+			glog.V(3).Infof("rbd lock (locking %v) finished successfully on rbd image %v/%v", lock, b.Pool, b.Image)
+			break
+		}
+	}
+	return false, err
+}
+
+func (locker *RBDLocker) Defencing(c rbdMounter, hostName string) error {
+	// no need to fence readOnly
+	if c.ReadOnly {
+		return nil
+	}
+
+	_, err := locker.rbdLock(c, hostName, false, false)
+	return err
+}
+
+func (locker *RBDLocker) Fencing(b rbdMounter, hostName string) error {
+	// no need to fence readOnly
+	if (&b).GetAttributes().ReadOnly {
+		return nil
+	}
+	_, err := locker.rbdLock(b, hostName, true, false)
+	return err
+}
+
+func (locker *RBDLocker) IsLocked(c rbdMounter, hostName string) (bool, error) {
+	return locker.rbdLock(c, hostName, true, true)
+}

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -66,20 +66,20 @@ func (fake *fakeDiskManager) Cleanup() {
 	os.RemoveAll(fake.tmpDir)
 }
 
-func (fake *fakeDiskManager) MakeGlobalPDName(disk rbd) string {
+func (fake *fakeDiskManager) makeGlobalPDName() string {
 	return fake.tmpDir
 }
-func (fake *fakeDiskManager) AttachDisk(b rbdMounter) error {
-	globalPath := b.manager.MakeGlobalPDName(*b.rbd)
+func (fake *fakeDiskManager) AttachDisk(b rbdMounter) (string, error) {
+	globalPath := fake.makeGlobalPDName()
 	err := os.MkdirAll(globalPath, 0750)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return "", nil
 }
 
-func (fake *fakeDiskManager) DetachDisk(c rbdUnmounter, mntPath string) error {
-	globalPath := c.manager.MakeGlobalPDName(*c.rbd)
+func (fake *fakeDiskManager) DetachDisk(plugin *rbdPlugin, mntPath string) error {
+	globalPath := fake.makeGlobalPDName()
 	err := os.RemoveAll(globalPath)
 	if err != nil {
 		return err

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -22,7 +22,6 @@ limitations under the License.
 package rbd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -36,8 +35,6 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/exec"
-	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -91,129 +88,12 @@ func waitForPath(pool, image string, maxRetries int) (string, bool) {
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/pod/rbd/pool-image-image
 func makePDNameInternal(host volume.VolumeHost, pool string, image string) string {
-	return path.Join(host.GetPluginDir(rbdPluginName), "rbd", pool+"-image-"+image)
+	return path.Join(host.GetPluginDir(rbdPluginName), pool+"-image-"+image)
 }
 
 type RBDUtil struct{}
 
-func (util *RBDUtil) MakeGlobalPDName(rbd rbd) string {
-	return makePDNameInternal(rbd.plugin.host, rbd.Pool, rbd.Image)
-}
-
-func (util *RBDUtil) rbdLock(b rbdMounter, lock bool) error {
-	var err error
-	var output, locker string
-	var cmd []byte
-	var secret_opt []string
-
-	if b.Secret != "" {
-		secret_opt = []string{"--key=" + b.Secret}
-	} else {
-		secret_opt = []string{"-k", b.Keyring}
-	}
-	// construct lock id using host name and a magic prefix
-	lock_id := "kubelet_lock_magic_" + node.GetHostname("")
-
-	l := len(b.Mon)
-	// avoid mount storm, pick a host randomly
-	start := rand.Int() % l
-	// iterate all hosts until mount succeeds.
-	for i := start; i < start+l; i++ {
-		mon := b.Mon[i%l]
-		// cmd "rbd lock list" serves two purposes:
-		// for fencing, check if lock already held for this host
-		// this edge case happens if host crashes in the middle of acquiring lock and mounting rbd
-		// for defencing, get the locker name, something like "client.1234"
-		cmd, err = b.plugin.execCommand("rbd",
-			append([]string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
-		output = string(cmd)
-
-		if err != nil {
-			continue
-		}
-
-		if lock {
-			// check if lock is already held for this host by matching lock_id and rbd lock id
-			if strings.Contains(output, lock_id) {
-				// this host already holds the lock, exit
-				glog.V(1).Infof("rbd: lock already held for %s", lock_id)
-				return nil
-			}
-			// hold a lock: rbd lock add
-			cmd, err = b.plugin.execCommand("rbd",
-				append([]string{"lock", "add", b.Image, lock_id, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
-		} else {
-			// defencing, find locker name
-			ind := strings.LastIndex(output, lock_id) - 1
-			for i := ind; i >= 0; i-- {
-				if output[i] == '\n' {
-					locker = output[(i + 1):ind]
-					break
-				}
-			}
-			// remove a lock: rbd lock remove
-			cmd, err = b.plugin.execCommand("rbd",
-				append([]string{"lock", "remove", b.Image, lock_id, locker, "--pool", b.Pool, "--id", b.Id, "-m", mon}, secret_opt...))
-		}
-
-		if err == nil {
-			//lock is acquired
-			break
-		}
-	}
-	return err
-}
-
-func (util *RBDUtil) persistRBD(rbd rbdMounter, mnt string) error {
-	file := path.Join(mnt, "rbd.json")
-	fp, err := os.Create(file)
-	if err != nil {
-		return fmt.Errorf("rbd: create err %s/%s", file, err)
-	}
-	defer fp.Close()
-
-	encoder := json.NewEncoder(fp)
-	if err = encoder.Encode(rbd); err != nil {
-		return fmt.Errorf("rbd: encode err: %v.", err)
-	}
-
-	return nil
-}
-
-func (util *RBDUtil) loadRBD(mounter *rbdMounter, mnt string) error {
-	file := path.Join(mnt, "rbd.json")
-	fp, err := os.Open(file)
-	if err != nil {
-		return fmt.Errorf("rbd: open err %s/%s", file, err)
-	}
-	defer fp.Close()
-
-	decoder := json.NewDecoder(fp)
-	if err = decoder.Decode(mounter); err != nil {
-		return fmt.Errorf("rbd: decode err: %v.", err)
-	}
-
-	return nil
-}
-
-func (util *RBDUtil) fencing(b rbdMounter) error {
-	// no need to fence readOnly
-	if (&b).GetAttributes().ReadOnly {
-		return nil
-	}
-	return util.rbdLock(b, true)
-}
-
-func (util *RBDUtil) defencing(c rbdUnmounter) error {
-	// no need to fence readOnly
-	if c.ReadOnly {
-		return nil
-	}
-
-	return util.rbdLock(*c.rbdMounter, false)
-}
-
-func (util *RBDUtil) AttachDisk(b rbdMounter) error {
+func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 	var err error
 	var output []byte
 
@@ -222,7 +102,7 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) error {
 		// modprobe
 		_, err = b.plugin.execCommand("modprobe", []string{"rbd"})
 		if err != nil {
-			return fmt.Errorf("rbd: failed to modprobe rbd error:%v", err)
+			return "", fmt.Errorf("rbd: failed to modprobe rbd error:%v", err)
 		}
 		// rbd map
 		l := len(b.Mon)
@@ -245,71 +125,25 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) error {
 			glog.V(1).Infof("rbd: map error %v %s", err, string(output))
 		}
 		if err != nil {
-			return fmt.Errorf("rbd: map failed %v %s", err, string(output))
+			return "", fmt.Errorf("rbd: map failed %v %s", err, string(output))
 		}
 		devicePath, found = waitForPath(b.Pool, b.Image, 10)
 		if !found {
-			return errors.New("Could not map image: Timeout after 10s")
+			return "", errors.New("Could not map image: Timeout after 10s")
 		}
 	}
-	// mount it
-	globalPDPath := b.manager.MakeGlobalPDName(*b.rbd)
-	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
-	// in the first time, the path shouldn't exist and IsLikelyNotMountPoint is expected to get NotExist
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("rbd: %s failed to check mountpoint", globalPDPath)
-	}
-	if !notMnt {
-		return nil
-	}
 
-	if err := os.MkdirAll(globalPDPath, 0750); err != nil {
-		return fmt.Errorf("rbd: failed to mkdir %s, error", globalPDPath)
-	}
-
-	// fence off other mappers
-	if err := util.fencing(b); err != nil {
-		// rbd unmap before exit
-		b.plugin.execCommand("rbd", []string{"unmap", devicePath})
-		return fmt.Errorf("rbd: image %s is locked by other nodes", b.Image)
-	}
-	// rbd lock remove needs ceph and image config
-	// but kubelet doesn't get them from apiserver during teardown
-	// so persit rbd config so upon disk detach, rbd lock can be removed
-	// since rbd json is persisted in the same local directory that is used as rbd mountpoint later,
-	// the json file remains invisible during rbd mount and thus won't be removed accidentally.
-	util.persistRBD(b, globalPDPath)
-
-	if err = b.mounter.FormatAndMount(devicePath, globalPDPath, b.fsType, nil); err != nil {
-		err = fmt.Errorf("rbd: failed to mount rbd volume %s [%s] to %s, error %v", devicePath, b.fsType, globalPDPath, err)
-	}
-	return err
+	return devicePath, err
 }
 
-func (util *RBDUtil) DetachDisk(c rbdUnmounter, mntPath string) error {
-	device, cnt, err := mount.GetDeviceNameFromMount(c.mounter, mntPath)
+func (util *RBDUtil) DetachDisk(plugin *rbdPlugin, device string) error {
+	// rbd unmap
+	_, err := plugin.execCommand("rbd", []string{"unmap", device})
 	if err != nil {
-		return fmt.Errorf("rbd detach disk: failed to get device from mnt: %s\nError: %v", mntPath, err)
+		return fmt.Errorf("rbd: failed to unmap device %s:Error: %v", device, err)
 	}
-	if err = c.mounter.Unmount(mntPath); err != nil {
-		return fmt.Errorf("rbd detach disk: failed to umount: %s\nError: %v", mntPath, err)
-	}
-	// if device is no longer used, see if can unmap
-	if cnt <= 1 {
-		// rbd unmap
-		_, err = c.plugin.execCommand("rbd", []string{"unmap", device})
-		if err != nil {
-			return fmt.Errorf("rbd: failed to unmap device %s:Error: %v", device, err)
-		}
 
-		// load ceph and image/pool info to remove fencing
-		if err := util.loadRBD(c.rbdMounter, mntPath); err == nil {
-			// remove rbd lock
-			util.defencing(c)
-		}
-
-		glog.Infof("rbd: successfully unmap device %s", device)
-	}
+	glog.Infof("rbd: successfully unmap device %s", device)
 	return nil
 }
 

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -416,7 +416,7 @@ func (fv *FakeVolume) GetMountDeviceCallCount() int {
 	return fv.MountDeviceCallCount
 }
 
-func (fv *FakeVolume) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (fv *FakeVolume) Detach(_ *Spec, deviceMountPath string, nodeName types.NodeName) error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.DetachCallCount++

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -671,7 +671,7 @@ func (oe *operationExecutor) generateDetachVolumeFunc(
 			err = oe.verifyVolumeIsSafeToDetach(volumeToDetach)
 		}
 		if err == nil {
-			err = volumeDetacher.Detach(volumeName, volumeToDetach.NodeName)
+			err = volumeDetacher.Detach(volumeToDetach.VolumeSpec, volumeName, volumeToDetach.NodeName)
 		}
 		if err != nil {
 			// On failure, add volume back to ReportAsAttached list

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -170,7 +170,7 @@ type Attacher interface {
 // Detacher can detach a volume from a node.
 type Detacher interface {
 	// Detach the given device from the node with the given Name.
-	Detach(deviceName string, nodeName types.NodeName) error
+	Detach(spec *Spec, deviceName string, nodeName types.NodeName) error
 
 	// WaitForDetach blocks until the device is detached from this
 	// node. If the device does not detach within the given timeout

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -225,7 +225,7 @@ func (plugin *vsphereVolumePlugin) NewDetacher() (volume.Detacher, error) {
 }
 
 // Detach the given device from the given node.
-func (detacher *vsphereVMDKDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *vsphereVMDKDetacher) Detach(_ *volume.Spec, deviceMountPath string, nodeName types.NodeName) error {
 
 	volPath := getVolPathfromDeviceMountPath(deviceMountPath)
 	attached, err := detacher.vsphereVolumes.DiskIsAttached(volPath, nodeName)

--- a/pkg/volume/vsphere_volume/attacher_test.go
+++ b/pkg/volume/vsphere_volume/attacher_test.go
@@ -111,7 +111,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -121,7 +121,7 @@ func TestAttachDetach(t *testing.T) {
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -132,7 +132,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 		},
 
@@ -143,7 +143,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, nodeName, detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(nil, diskName, nodeName)
 			},
 			expectedError: detachError,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
RBD volume implements attach/detach interface to resolve rbd image locking.

`Attach()`: controller locks the rbd image
`Detach()`: controller removes the image lock
`WaitForAttach()`: node maps rbd image
`MountDevice()`: node mounts rbd device

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #
https://github.com/openshift/origin/issues/7983
**Special notes for your reviewer**:
There is also a short version to commit https://github.com/kubernetes/kubernetes/commit/4382260c99ae9c0d83d7fae8e3a0de5f7b2656a5. Instead of refactoring `NewFromVolume()`, we can add a new volume API `NewFromVolumeWithNameSpace()` and avoid massive refactoring. I am open to either implementation.

@kubernetes/sig-storage @elsonrodriguez @spinolacastro
**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33660)

<!-- Reviewable:end -->
