### PR TITLE
Make kubemark/run-test use ginkgo-e2e so it will return 0 in case of …

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -39,4 +39,4 @@ else
 	ARGS=$@
 fi
 
-go run ./hack/e2e.go -v --check_version_skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
+"${KUBE_ROOT}/hack/ginkgo-e2e.sh" "--e2e-verify-service-account=false" "--dump-logs-on-failure=false" ${ARGS}


### PR DESCRIPTION
Fix part of #33459

If I'm not mistaken the main problem was that the `run-e2e-test.sh` was returning non-zero values, because `go run hack/e2e.go` does that in case of failure. If I'm not missing anything `ginkgo-e2e.sh` returns `0` even in the case of test failure.

cc @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33661)

<!-- Reviewable:end -->
