### PR TITLE
SELinux Overhaul

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -418,18 +418,6 @@ function start_kubelet {
 
     mkdir -p /var/lib/kubelet
     if [[ -z "${DOCKERIZE_KUBELET}" ]]; then
-      # On selinux enabled systems, it might
-      # require to relabel /var/lib/kubelet
-      if which selinuxenabled &> /dev/null && \
-         selinuxenabled && \
-         which chcon > /dev/null ; then
-         if [[ ! $(ls -Zd /var/lib/kubelet) =~ system_u:object_r:svirt_sandbox_file_t:s0 ]] ; then
-            echo "Applying SELinux label to /var/lib/kubelet directory."
-            if ! sudo chcon -Rt svirt_sandbox_file_t /var/lib/kubelet; then
-               echo "Failed to apply selinux label to /var/lib/kubelet."
-            fi
-         fi
-      fi
       # Enable dns
       if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
          dns_args="--cluster-dns=${DNS_SERVER_IP} --cluster-domain=${DNS_DOMAIN}"
@@ -515,7 +503,7 @@ function start_kubelet {
         --volume=/var/run:/var/run:rw \
         --volume=/sys:/sys:ro \
         --volume=/var/lib/docker/:/var/lib/docker:ro \
-        --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,z \
+        --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
         --volume=/dev:/dev \
         ${cred_bind} \
         --net=host \

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -152,20 +152,6 @@ else
     test_args="$test_args --disable-kubenet=true"
   fi
 
-  # On selinux enabled systems, it might
-  # require to relabel /var/lib/kubelet
-  if which selinuxenabled &> /dev/null && \
-     selinuxenabled && \
-     which chcon > /dev/null ; then
-     mkdir -p /var/lib/kubelet
-     if [[ ! $(ls -Zd /var/lib/kubelet) =~ svirt_sandbox_file_t ]] ; then
-        echo "Applying SELinux label to /var/lib/kubelet directory."
-        if ! sudo chcon -Rt svirt_sandbox_file_t /var/lib/kubelet; then
-           echo "Failed to apply selinux label to /var/lib/kubelet."
-        fi
-     fi
-  fi
-
   # Test using the host the script was run on
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -106,7 +106,6 @@ go_library(
         "//pkg/util/oom:go_default_library",
         "//pkg/util/procfs:go_default_library",
         "//pkg/util/runtime:go_default_library",
-        "//pkg/util/selinux:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/util/term:go_default_library",
         "//pkg/util/validation:go_default_library",

--- a/pkg/kubelet/dockertools/BUILD
+++ b/pkg/kubelet/dockertools/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//pkg/util/oom:go_default_library",
         "//pkg/util/procfs:go_default_library",
         "//pkg/util/runtime:go_default_library",
+        "//pkg/util/selinux:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/util/term:go_default_library",

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -666,6 +666,13 @@ func (dm *DockerManager) runContainer(
 		} else {
 			fs.Close() // Close immediately; we're just doing a `touch` here
 			b := fmt.Sprintf("%s:%s", containerLogPath, container.TerminationMessagePath)
+
+			// Have docker relabel the termination log path if SELinux is
+			// enabled.
+			if selinux.SELinuxEnabled() {
+				b += ":Z"
+			}
+
 			binds = append(binds, b)
 		}
 	}

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -65,6 +65,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/util/term"
@@ -507,20 +508,14 @@ func makeEnvList(envs []kubecontainer.EnvVar) (result []string) {
 // '<HostPath>:<ContainerPath>', or
 // '<HostPath>:<ContainerPath>:ro', if the path is read only, or
 // '<HostPath>:<ContainerPath>:Z', if the volume requires SELinux
-// relabeling and the pod provides an SELinux label
-func makeMountBindings(mounts []kubecontainer.Mount, podHasSELinuxLabel bool) (result []string) {
+// relabeling
+func makeMountBindings(mounts []kubecontainer.Mount) (result []string) {
 	for _, m := range mounts {
 		bind := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
 		if m.ReadOnly {
 			bind += ":ro"
 		}
-		// Only request relabeling if the pod provides an
-		// SELinux context. If the pod does not provide an
-		// SELinux context relabeling will label the volume
-		// with the container's randomly allocated MCS label.
-		// This would restrict access to the volume to the
-		// container which mounts it first.
-		if m.SELinuxRelabel && podHasSELinuxLabel {
+		if m.SELinuxRelabel && selinux.SELinuxEnabled() {
 			if m.ReadOnly {
 				bind += ",Z"
 			} else {
@@ -646,8 +641,7 @@ func (dm *DockerManager) runContainer(
 			{PathOnHost: "/dev/nvidia-uvm", PathInContainer: "/dev/nvidia-uvm", CgroupPermissions: "mrw"},
 		}
 	}
-	podHasSELinuxLabel := pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SELinuxOptions != nil
-	binds := makeMountBindings(opts.Mounts, podHasSELinuxLabel)
+	binds := makeMountBindings(opts.Mounts)
 	// The reason we create and mount the log file in here (not in kubelet) is because
 	// the file's location depends on the ID of the container, and we need to create and
 	// mount the file before actually starting the container.

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -133,10 +133,11 @@ func makeHostsMount(podDir, podIP, hostName, hostDomainName string) (*kubecontai
 		return nil, err
 	}
 	return &kubecontainer.Mount{
-		Name:          "k8s-managed-etc-hosts",
-		ContainerPath: etcHostsPath,
-		HostPath:      hostsFilePath,
-		ReadOnly:      false,
+		Name:           "k8s-managed-etc-hosts",
+		ContainerPath:  etcHostsPath,
+		HostPath:       hostsFilePath,
+		ReadOnly:       false,
+		SELinuxRelabel: true,
 	}, nil
 }
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -252,15 +252,6 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Cont
 	volumes := kl.volumeManager.GetMountedVolumesForPod(podName)
 
 	opts.PortMappings = makePortMappings(container)
-	// Docker does not relabel volumes if the container is running
-	// in the host pid or ipc namespaces so the kubelet must
-	// relabel the volumes
-	if pod.Spec.SecurityContext != nil && (pod.Spec.SecurityContext.HostIPC || pod.Spec.SecurityContext.HostPID) {
-		err = kl.relabelVolumes(pod, volumes)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	opts.Mounts, err = makeMounts(pod, kl.getPodDir(pod.UID), container, hostname, hostDomainName, podIP, volumes)
 	if err != nil {

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -19,16 +19,13 @@ package kubelet
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/types"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -79,51 +76,6 @@ func (kl *Kubelet) newVolumeMounterFromPlugins(spec *volume.Spec, pod *api.Pod, 
 	}
 	glog.V(10).Infof("Using volume plugin %q to mount %s", plugin.GetPluginName(), spec.Name())
 	return physicalMounter, nil
-}
-
-// relabelVolumes relabels SELinux volumes to match the pod's
-// SELinuxOptions specification. This is only needed if the pod uses
-// hostPID or hostIPC. Otherwise relabeling is delegated to docker.
-func (kl *Kubelet) relabelVolumes(pod *api.Pod, volumes kubecontainer.VolumeMap) error {
-	if pod.Spec.SecurityContext.SELinuxOptions == nil {
-		return nil
-	}
-
-	rootDirContext, err := kl.getRootDirContext()
-	if err != nil {
-		return err
-	}
-
-	selinuxRunner := selinux.NewSELinuxRunner()
-	// Apply the pod's Level to the rootDirContext
-	rootDirSELinuxOptions, err := securitycontext.ParseSELinuxOptions(rootDirContext)
-	if err != nil {
-		return err
-	}
-
-	rootDirSELinuxOptions.Level = pod.Spec.SecurityContext.SELinuxOptions.Level
-	volumeContext := fmt.Sprintf("%s:%s:%s:%s", rootDirSELinuxOptions.User, rootDirSELinuxOptions.Role, rootDirSELinuxOptions.Type, rootDirSELinuxOptions.Level)
-
-	for _, vol := range volumes {
-		if vol.Mounter.GetAttributes().Managed && vol.Mounter.GetAttributes().SupportsSELinux {
-			// Relabel the volume and its content to match the 'Level' of the pod
-			path, err := volume.GetPath(vol.Mounter)
-			if err != nil {
-				return err
-			}
-			err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				return selinuxRunner.Setfilecon(path, volumeContext)
-			})
-			if err != nil {
-				return err
-			}
-			vol.SELinuxLabeled = true
-		}
-	}
-	return nil
 }
 
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -94,7 +94,7 @@ func (kl *Kubelet) relabelVolumes(pod *api.Pod, volumes kubecontainer.VolumeMap)
 		return err
 	}
 
-	selinuxRunner := selinux.NewSelinuxContextRunner()
+	selinuxRunner := selinux.NewSELinuxRunner()
 	// Apply the pod's Level to the rootDirContext
 	rootDirSELinuxOptions, err := securitycontext.ParseSELinuxOptions(rootDirContext)
 	if err != nil {
@@ -115,7 +115,7 @@ func (kl *Kubelet) relabelVolumes(pod *api.Pod, volumes kubecontainer.VolumeMap)
 				if err != nil {
 					return err
 				}
-				return selinuxRunner.SetContext(path, volumeContext)
+				return selinuxRunner.Setfilecon(path, volumeContext)
 			})
 			if err != nil {
 				return err

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1082,7 +1082,7 @@ func (r *Runtime) preparePodArgs(manifest *appcschema.PodManifest, manifestFileN
 }
 
 func (r *Runtime) getSelinuxContext(opt *api.SELinuxOptions) (string, error) {
-	selinuxRunner := selinux.NewSelinuxContextRunner()
+	selinuxRunner := selinux.NewSELinuxRunner()
 	str, err := selinuxRunner.Getfilecon(r.config.Dir)
 	if err != nil {
 		return "", err

--- a/pkg/util/selinux/doc.go
+++ b/pkg/util/selinux/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package selinux contains selinux utility functions.
+// Package selinux contains wrapper functions for the libcontainer SELinux
+// package.  A NOP implementation is provided for non-linux platforms.
 package selinux // import "k8s.io/kubernetes/pkg/util/selinux"

--- a/pkg/util/selinux/selinux.go
+++ b/pkg/util/selinux/selinux.go
@@ -16,14 +16,24 @@ limitations under the License.
 
 package selinux
 
-// SelinuxContextRunner knows how to chcon of a directory and
-// how to get the selinux context of a file.
-type SelinuxContextRunner interface {
-	SetContext(dir, context string) error
+// Note: the libcontainer SELinux package is only built for Linux, so it is
+// necessary to have a NOP wrapper which is built for non-Linux platforms to
+// allow code that links to this package not to differentiate its own methods
+// for Linux and non-Linux platforms.
+//
+// SELinuxRunner wraps certain libcontainer SELinux calls. For more
+// information, see:
+//
+// https://github.com/opencontainers/runc/blob/master/libcontainer/selinux/selinux.go
+type SELinuxRunner interface {
+	// Getfilecon returns the SELinux context for the given path or returns an
+	// error.
 	Getfilecon(path string) (string, error)
 }
 
-// NewSelinuxContextRunner returns a new chconRunner.
-func NewSelinuxContextRunner() SelinuxContextRunner {
-	return &realSelinuxContextRunner{}
+// NewSELinuxRunner returns a new SELinuxRunner appropriate for the platform.
+// On Linux, all methods short-circuit and return NOP values if SELinux is
+// disabled. On non-Linux platforms, a NOP implementation is returned.
+func NewSELinuxRunner() SELinuxRunner {
+	return &realSELinuxRunner{}
 }

--- a/pkg/util/selinux/selinux_unsupported.go
+++ b/pkg/util/selinux/selinux_unsupported.go
@@ -18,14 +18,16 @@ limitations under the License.
 
 package selinux
 
-type realSelinuxContextRunner struct{}
-
-func (_ *realSelinuxContextRunner) SetContext(dir, context string) error {
-	// NOP
-	return nil
+// SELinuxEnabled always returns false on non-linux platforms.
+func SELinuxEnabled() bool {
+	return false
 }
 
-func (_ *realSelinuxContextRunner) Getfilecon(path string) (string, error) {
-	// NOP
+// realSELinuxRunner is the NOP implementation of the SELinuxRunner interface.
+type realSELinuxRunner struct{}
+
+var _ SELinuxRunner = &realSELinuxRunner{}
+
+func (_ *realSELinuxRunner) Getfilecon(path string) (string, error) {
 	return "", nil
 }

--- a/pkg/volume/empty_dir/BUILD
+++ b/pkg/volume/empty_dir/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//vendor:github.com/golang/glog",
-        "//vendor:github.com/opencontainers/runc/libcontainer/selinux",
     ],
 )
 

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -204,7 +205,7 @@ func (ed *emptyDir) SetUpAt(dir string, fsGroup *int64) error {
 
 	// Determine the effective SELinuxOptions to use for this volume.
 	securityContext := ""
-	if selinuxEnabled() {
+	if selinux.SELinuxEnabled() {
 		securityContext = ed.rootContext
 	}
 

--- a/pkg/volume/empty_dir/empty_dir_linux.go
+++ b/pkg/volume/empty_dir/empty_dir_linux.go
@@ -23,7 +23,6 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	"github.com/opencontainers/runc/libcontainer/selinux"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -51,9 +50,4 @@ func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, er
 		return mediumMemory, !notMnt, nil
 	}
 	return mediumUnknown, !notMnt, nil
-}
-
-// selinuxEnabled determines whether SELinux is enabled.
-func selinuxEnabled() bool {
-	return selinux.SelinuxEnabled()
 }

--- a/pkg/volume/empty_dir/empty_dir_unsupported.go
+++ b/pkg/volume/empty_dir/empty_dir_unsupported.go
@@ -30,7 +30,3 @@ type realMountDetector struct {
 func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, error) {
 	return mediumUnknown, false, nil
 }
-
-func selinuxEnabled() bool {
-	return false
-}


### PR DESCRIPTION
Overhauls handling of SELinux in Kubernetes.  TLDR: Kubelet dir no longer has to be labeled `svirt_sandbox_file_t`.

Fixes #33351 and #33510.  Implements #33951.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33663)

<!-- Reviewable:end -->
