### PR TITLE
add linebreak between resource groups

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -432,6 +432,14 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 				allErrs = append(allErrs, err)
 				continue
 			}
+
+			// add linebreak between resource groups (if there is more than one)
+			// skip linebreak above first resource group
+			noHeaders := cmdutil.GetFlagBool(cmd, "no-headers")
+			if lastMapping != nil && !noHeaders {
+				fmt.Fprintf(errOut, "%s\n", "")
+			}
+
 			lastMapping = mapping
 		}
 


### PR DESCRIPTION
**Release note**:

``` release-note
release-note-none
```

Printing multiple groups via `kubectl get all` can produce output that is
hard to read in cases where there are a lot of resource types to display
/ some resource types contain varying column amounts.

This patch adds a linebreak above each group of resources only when
there is more than one group to display, and always omitting the
linebreak above the first group. This makes for slightly improved
output.

Linebreaks are printed to stderr, and honor the `--no-headers` option.

**Before**

```
$ kubectl get all
NAME                     READY     STATUS    RESTARTS   AGE
po/database-1-u9m9l      1/1       Running   3          5d
po/idling-echo-1-9fmz6   2/2       Running   8          5d
po/idling-echo-1-gzb0v   2/2       Running   4          5d
NAME               DESIRED   CURRENT   READY     AGE
rc/database-1      1         1         1         6d
rc/idling-echo-1   2         2         2         6d
NAME              CLUSTER-IP       EXTERNAL-IP   PORT(S)
AGE
svc/database      172.30.11.104    <none>        5434/TCP
6d
svc/frontend      172.30.196.217   <none>        5432/TCP
6d
svc/idling-echo   172.30.115.67    <none>        8675/TCP,3090/UDP
6d
svc/kubernetes    172.30.0.1       <none>        443/TCP,53/UDP,53/TCP
6d
svc/mynodeport    172.30.81.254    <nodes>       8080/TCP
5d
svc/mynodeport1   172.30.198.193   <nodes>       8080/TCP
5d
svc/mynodeport2   172.30.149.48    <nodes>       8080/TCP
5d
svc/mynodeport3   172.30.195.235   <nodes>       8080/TCP
5d
```

**After**

```
$ kubectl get all
NAME                     READY     STATUS    RESTARTS   AGE
po/database-1-u9m9l      1/1       Running   3          5d
po/idling-echo-1-9fmz6   2/2       Running   8          5d
po/idling-echo-1-gzb0v   2/2       Running   4          5d

NAME               DESIRED   CURRENT   READY     AGE
rc/database-1      1         1         1         6d
rc/idling-echo-1   2         2         2         6d

NAME              CLUSTER-IP       EXTERNAL-IP   PORT(S)
AGE
svc/database      172.30.11.104    <none>        5434/TCP
6d
svc/frontend      172.30.196.217   <none>        5432/TCP
6d
svc/idling-echo   172.30.115.67    <none>        8675/TCP,3090/UDP
6d
svc/kubernetes    172.30.0.1       <none>        443/TCP,53/UDP,53/TCP
6d
svc/mynodeport    172.30.81.254    <nodes>       8080/TCP
5d
svc/mynodeport1   172.30.198.193   <nodes>       8080/TCP
5d
svc/mynodeport2   172.30.149.48    <nodes>       8080/TCP
5d
svc/mynodeport3   172.30.195.235   <nodes>       8080/TCP
5d
```

cc @fabianofranz @liggitt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33677)

<!-- Reviewable:end -->
