### PR TITLE
formatting json printer for runtime.Unknown

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -275,7 +275,13 @@ func (p *JSONPrinter) AfterPrint(w io.Writer, res string) error {
 func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	switch obj := obj.(type) {
 	case *runtime.Unknown:
-		_, err := w.Write(obj.Raw)
+		var buf bytes.Buffer
+		err := json.Indent(&buf, obj.Raw, "", "    ")
+		if err != nil {
+			return err
+		}
+		buf.WriteRune('\n')
+		_, err = buf.WriteTo(w)
 		return err
 	}
 


### PR DESCRIPTION
Formatting JSONPrinter.
It prints everything in one single line before.
Now it prints in well-formatted way.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33686)

<!-- Reviewable:end -->
