### PR TITLE
docs/networking: update IPv6 support section

### DIFF
--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -207,10 +207,13 @@ External IP assignment would also simplify DNS support (see below).
 
 ### IPv6
 
-IPv6 would be a nice option, also, but we can't depend on it yet. Docker support
-is in progress: [Docker issue #2974](https://github.com/dotcloud/docker/issues/2974),
-[Docker issue #6923](https://github.com/dotcloud/docker/issues/6923),
-[Docker issue #6975](https://github.com/dotcloud/docker/issues/6975).
+IPv6 support would be nice but requires significant internal changes in a few
+areas. First pods should be able to report multiple IP addresses
+[Kubernetes issue #27398](https://github.com/kubernetes/kubernetes/issues/27398)
+and the network plugin architecture Kubernetes uses needs to allow returning
+IPv6 addresses too [CNI issue #245](https://github.com/containernetworking/cni/issues/245).
+Kubernetes code that deals with IP addresses must then be audited and fixed to
+support both IPv4 and IPv6 addresses and not assume IPv4.
 Additionally, direct ipv6 assignment to instances doesn't appear to be supported
 by major cloud providers (e.g., AWS EC2, GCE) yet. We'd happily take pull
 requests from people running Kubernetes on bare metal, though. :-)


### PR DESCRIPTION
Update the state of IPv6 support.  Docker now supports IPv6, but network plugins and internal data structures are the main pain points now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33696)

<!-- Reviewable:end -->
