### PR TITLE
Create a get-kube-binaries script to download client/server tarballs

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script downloads and installs the Kubernetes client and server binaries.
+# It is intended to be called from an extracted Kubernetes release tarball.
+#
+# We automatically choose the correct client binaries to download.
+#
+# Options:
+#  Set KUBERNETES_SERVER_ARCH to choose the server (Kubernetes cluster)
+#  architecture to download:
+#    * amd64 [default]
+#    * arm
+#    * arm64
+#    * ppc64le
+#
+#  Set KUBERNETES_SKIP_CONFIRM to skip the installation confirmation prompt.
+#  Set KUBERNETES_RELEASE_URL to choose where to download binaries from.
+#    (Defaults to https://storage.googleapis.com/kubernetes-release/release).
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
+
+KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://storage.googleapis.com/kubernetes-release/release}"
+
+function detect_kube_release() {
+  if [[ ! -e "${KUBE_ROOT}/version" ]]; then
+    echo "Can't determine Kubernetes release." >&2
+    echo "This script should only be run from a prebuilt Kubernetes release." >&2
+    echo "Did you mean to use get-kube.sh instead?" >&2
+    exit 1
+  fi
+
+  KUBERNETES_RELEASE=$(cat "${KUBE_ROOT}/version")
+  DOWNLOAD_URL_PREFIX="${KUBERNETES_RELEASE_URL}/${KUBERNETES_RELEASE}"
+}
+
+function detect_client_info() {
+  local kernel=$(uname -s)
+  case "${kernel}" in
+    Darwin)
+      CLIENT_PLATFORM="darwin"
+      ;;
+    Linux)
+      CLIENT_PLATFORM="linux"
+      ;;
+    *)
+      echo "Unknown, unsupported platform: ${kernel}." >&2
+      echo "Supported platforms: Linux, Darwin." >&2
+      echo "Bailing out." >&2
+      exit 2
+  esac
+
+  # TODO: migrate the kube::util::host_platform function out of hack/lib and
+  # use it here.
+  local machine=$(uname -m)
+  case "${machine}" in
+    x86_64*|i?86_64*|amd64*)
+      CLIENT_ARCH="amd64"
+      ;;
+    aarch64*|arm64*)
+      CLIENT_ARCH="arm64"
+      ;;
+    arm*)
+      CLIENT_ARCH="arm"
+      ;;
+    i?86*)
+      CLIENT_ARCH="386"
+      ;;
+    *)
+      echo "Unknown, unsupported architecture (${machine})." >&2
+      echo "Supported architectures x86_64, i686, arm, arm64." >&2
+      echo "Bailing out." >&2
+      exit 3
+      ;;
+  esac
+}
+
+function md5sum_file() {
+  if which md5 >/dev/null 2>&1; then
+    md5 -q "$1"
+  else
+    md5sum "$1" | awk '{ print $1 }'
+  fi
+}
+
+function sha1sum_file() {
+  if which shasum >/dev/null 2>&1; then
+    shasum -a1 "$1" | awk '{ print $1 }'
+  else
+    sha1sum "$1" | awk '{ print $1 }'
+  fi
+}
+
+function download_tarball() {
+  local -r download_path="$1"
+  local -r file="$2"
+  url="${DOWNLOAD_URL_PREFIX}/${file}"
+  mkdir -p "${download_path}"
+  if [[ $(which curl) ]]; then
+    curl -L "${url}" -o "${download_path}/${file}"
+  elif [[ $(which wget) ]]; then
+    wget "${url}" -O "${download_path}/${file}"
+  else
+    echo "Couldn't find curl or wget.  Bailing out." >&2
+    exit 4
+  fi
+  echo
+  local md5sum=$(md5sum_file "${download_path}/${file}")
+  echo "md5sum(${file})=${md5sum}"
+  local sha1sum=$(sha1sum_file "${download_path}/${file}")
+  echo "sha1sum(${file})=${sha1sum}"
+  echo
+  # TODO: add actual verification
+}
+
+function extract_tarball() {
+  local -r tarfile="$1"
+  local -r platform="$2"
+  local -r arch="$3"
+
+  platforms_dir="${KUBE_ROOT}/platforms/${platform}/${arch}"
+  echo "Extracting ${tarfile} into ${platforms_dir}"
+  mkdir -p "${platforms_dir}"
+  # Tarball looks like kubernetes/{client,server}/bin/BINARY"
+  tar -xzf "${tarfile}" --strip-components 3 -C "${platforms_dir}"
+  # Create convenience symlink
+  ln -sf "${platforms_dir}" "$(dirname ${tarfile})/bin"
+  echo "Add '$(dirname ${tarfile})/bin' to your PATH to use newly-installed binaries."
+}
+
+detect_kube_release
+
+SERVER_PLATFORM="linux"
+SERVER_ARCH="${KUBERNETES_SERVER_ARCH:-amd64}"
+SERVER_TAR="kubernetes-server-${SERVER_PLATFORM}-${SERVER_ARCH}.tar.gz"
+
+detect_client_info
+CLIENT_TAR="kubernetes-client-${CLIENT_PLATFORM}-${CLIENT_ARCH}.tar.gz"
+
+echo "Kubernetes release: ${KUBERNETES_RELEASE}"
+echo "Server: ${SERVER_PLATFORM}/${SERVER_ARCH}"
+echo "Client: ${CLIENT_PLATFORM}/${CLIENT_ARCH}"
+echo
+
+# TODO: remove this check and default to true when we stop shipping server
+# tarballs in kubernetes.tar.gz
+DOWNLOAD_SERVER_TAR=false
+if [[ ! -e "${KUBE_ROOT}/server/${SERVER_TAR}" ]]; then
+  DOWNLOAD_SERVER_TAR=true
+  echo "Will download ${SERVER_TAR} from ${DOWNLOAD_URL_PREFIX}"
+fi
+
+# TODO: remove this check and default to true when we stop shipping kubectl
+# in kubernetes.tar.gz
+DOWNLOAD_CLIENT_TAR=false
+if [[ ! -x "${KUBE_ROOT}/platforms/${CLIENT_PLATFORM}/${CLIENT_ARCH}/kubectl" ]]; then
+  DOWNLOAD_CLIENT_TAR=true
+  echo "Will download and extract ${CLIENT_TAR} from ${DOWNLOAD_URL_PREFIX}"
+fi
+
+if [[ "${DOWNLOAD_CLIENT_TAR}" == false && "${DOWNLOAD_SERVER_TAR}" == false ]]; then
+  echo "Nothing additional to download."
+  exit 0
+fi
+
+if [[ -z "${KUBERNETES_SKIP_CONFIRM-}" ]]; then
+  echo "Is this ok? [Y]/n"
+  read confirm
+  if [[ "${confirm}" =~ ^[nN]$ ]]; then
+    echo "Aborting."
+    exit 0
+  fi
+fi
+
+if "${DOWNLOAD_SERVER_TAR}"; then
+download_tarball "${KUBE_ROOT}/server" "${SERVER_TAR}"
+fi
+
+if "${DOWNLOAD_CLIENT_TAR}"; then
+  download_tarball "${KUBE_ROOT}/client" "${CLIENT_TAR}"
+  extract_tarball "${KUBE_ROOT}/client/${CLIENT_TAR}" "${CLIENT_PLATFORM}" "${CLIENT_ARCH}"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
One step towards removing all server and client binary tarballs from the kubernetes.tar.gz release tarball.

If someone uses `cluster/get-kube.sh` (or https://get.k8s.io, which needs to be synced), this will automatically download the necessary client and server tarballs as part of the flow, though as of right now this will largely be a no-op. (When we remove the client/server binaries, it will have more of an effect.)

I've opted to put this script inside the release tarball (rather than in get-kube.sh), since each release probably has a better idea which platforms/architectures/etc it supports.

Further improvements would probably include omitting downloading the server tarball entirely unless needed, but this seems like a reasonable first step.

This also fixes some errors in get-kube.sh, and remove client architectures we don't officially support.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #
x-ref #28629 and #28435

**Special notes for your reviewer**
Assigning to Tim semi-arbitrarily for now, but please reassign as you feel appropriate.

**Release note**:
We probably don't need a release note yet. We'll definitely want one when we remove the server and client binaries.

cc @jbeda @luxas @david-mcmahon @zmerlynn @gajju26

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33701)

<!-- Reviewable:end -->
