### PR TITLE
RFC: Add explicit capabilities to E2E tests

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -159,7 +159,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.FeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
 	flag.StringVar(&TestContext.Viper, "viper-config", "e2e", "The name of the viper config i.e. 'e2e' will read values from 'e2e.json' locally.  All e2e parameters are meant to be configurable by viper.")
-	flag.Var(csv(TestContext.Capabilities), "capabilities", "Comma-separated list of capabilities supported by the testing environment, such as 'AppArmor,Seccomp'")
+	flag.Var((*csv)(&TestContext.Capabilities), "capabilities", "Comma-separated list of capabilities supported by the testing environment, such as 'AppArmor,Seccomp'")
 }
 
 // Register flags specific to the cluster e2e test suite.
@@ -252,11 +252,11 @@ func ViperizeFlags() {
 // Helper for parsing comma separated values into a string set
 type csv sets.String
 
-func (v csv) Set(value string) error {
-	sets.String(v).Insert(strings.Split(value, ",")...)
+func (v *csv) Set(value string) error {
+	*v = csv(sets.NewString(strings.Split(value, ",")...))
 	return nil
 }
 
-func (v csv) String() string {
-	return strings.Join(sets.String(v).List(), ",")
+func (v *csv) String() string {
+	return strings.Join(sets.String(*v).List(), ",")
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -19,12 +19,14 @@ package framework
 import (
 	"flag"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/config"
 	"github.com/spf13/viper"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type TestContextType struct {
@@ -77,6 +79,9 @@ type TestContextType struct {
 	FeatureGates string
 	// Node e2e specific test context
 	NodeTestContextType
+	// Capabilities are the supported capabilities by the testing environment, for testing features
+	// that depend on specific system configurations, such as AppArmor or SELinux.
+	Capabilities sets.String
 
 	// Viper-only parameters.  These will in time replace all flags.
 
@@ -154,6 +159,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.FeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
 	flag.StringVar(&TestContext.Viper, "viper-config", "e2e", "The name of the viper config i.e. 'e2e' will read values from 'e2e.json' locally.  All e2e parameters are meant to be configurable by viper.")
+	flag.Var(csv(TestContext.Capabilities), "capabilities", "Comma-separated list of capabilities supported by the testing environment, such as 'AppArmor,Seccomp'")
 }
 
 // Register flags specific to the cluster e2e test suite.
@@ -241,4 +247,16 @@ func ViperizeFlags() {
 	*	flag.VisitAll(viperFlagSetter)
 	*
 	 */
+}
+
+// Helper for parsing comma separated values into a string set
+type csv sets.String
+
+func (v csv) Set(value string) error {
+	sets.String(v).Insert(strings.Split(value, ",")...)
+	return nil
+}
+
+func (v csv) String() string {
+	return strings.Join(sets.String(v).List(), ",")
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -451,6 +451,18 @@ func SkipIfMissingResource(clientPool dynamic.ClientPool, gvr unversioned.GroupV
 	}
 }
 
+func RunWithCapability(capability string) {
+	if !TestContext.Capabilities.Has(capability) {
+		Skipf("Capability %q not present, skipping test", capability)
+	}
+}
+
+func RunWithoutCapability(capability string) {
+	if TestContext.Capabilities.Has(capability) {
+		Skipf("Capability %q present, skipping test", capability)
+	}
+}
+
 // ProvidersWithSSH are those providers where each node is accessible with SSH
 var ProvidersWithSSH = []string{"gce", "gke", "aws"}
 

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -5,9 +5,11 @@ images:
   ubuntu-docker9:
     image: e2e-node-ubuntu-trusty-docker9-v1-image
     project: kubernetes-node-e2e-images
+    capabilities: AppArmor
   ubuntu-docker10:
     image: e2e-node-ubuntu-trusty-docker10-v1-image
     project: kubernetes-node-e2e-images
+    capabilities: AppArmor
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727
     project: coreos-cloud
@@ -19,3 +21,4 @@ images:
     image_regex: gci-dev-55-8820-0-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    capabilities: AppArmor


### PR DESCRIPTION
**Problem this PR fixes**

Tests should be explicit and dumb, otherwise you need tests for your tests. We have a lot of logic in our E2E's today that autodetects whether certain features (capabilities) are present, and tests them if they are, or skips the test if they're not (examples below). But what happens if there's a bug in the detection logic? Tests could be skipped (a.k.a. "passing") for a long time before anyone notices.

Examples:
- [AppArmor](https://github.com/kubernetes/kubernetes/blob/1e5e4fdb9d3dcd0e39a57e56eb9d71368673ba97/test/e2e_node/apparmor_test.go#L40)
- [Federation](https://github.com/kubernetes/kubernetes/blob/1e5e4fdb9d3dcd0e39a57e56eb9d71368673ba97/test/e2e/framework/util.go#L422)
- [sysctls](https://github.com/kubernetes/kubernetes/blob/1e5e4fdb9d3dcd0e39a57e56eb9d71368673ba97/test/e2e/common/sysctl.go#L103)

**What this PR does**

This adds a set of explicit capabilities to the `TestContext`, and 2 framework methods to check those capabilities:
- `framework.RunWithCapability(cap)` - Only run the test if the capability is present
- `framework.RunWithoutCapability(cap)` - Only run the test if the capability is NOT present

The examples above would check for capabilities like `"AppArmor"`, `"sysctls"`, `"Federated"`, and skip the tests as needed.

This makes the capabilities explicit, and moves the decisions into the test spec, so there are fewer opportunities for accidentally skipping tests.

As an example, I piped capabilities through to the node e2e image specs, and converted the AppArmor tests to use them. If we like this direction, we need to: pipe flags through cluster e2e tests, add some flags for manual testing, and convert more tests to use capabilities rather than auto detection.

**FAQ**
- _What about the [Feature:Foo] labels?_ - This would require a bunch of raw string parsing and having a central list of all the features. It also would require some hackery to make the `focus` and `skip` ginkgo flags continue to work. Also, see the examples above, these aren't sufficient.
- _Capabilities is an overloaded term! makes me think Linux capabilites!_ - It's a lot less overloaded than "Features", but let me know if you have a better idea.
- _So I need to list all the capabilities when I run tests?_ - If we move forward with this, I propose adding an optional `--autodetect-capabilities` flag for manual testing that performs all the autodetect logic we have today.
- _Why not SkipWith(out)Capability?_ - I thought the positive made the relationship a little clearer. Open to suggestions here...

Addresses https://github.com/kubernetes/kubernetes/issues/29346

@kubernetes/sig-testing @kubernetes/sig-node @Random-Liu

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33706)

<!-- Reviewable:end -->
