### PR TITLE
Use nodeutil.GetHostIP consistently when talking to nodes

### DIFF
--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -51,7 +51,7 @@ type KubeletClientConfig struct {
 
 // KubeletClient is an interface for all kubelet functionality
 type KubeletClient interface {
-	ConnectionInfoGetter
+	GetRawConnectionInfo(ctx api.Context, nodeName string) (scheme string, port uint, transport http.RoundTripper, err error)
 }
 
 type ConnectionInfoGetter interface {
@@ -98,7 +98,7 @@ func NewStaticKubeletClient(config *KubeletClientConfig) (KubeletClient, error) 
 }
 
 // In default HTTPKubeletClient ctx is unused.
-func (c *HTTPKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (c *HTTPKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	if errs := validation.ValidateNodeName(nodeName, false); len(errs) != 0 {
 		return "", 0, nil, fmt.Errorf("invalid node name: %s", strings.Join(errs, ";"))
 	}
@@ -114,7 +114,7 @@ func (c *HTTPKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) 
 // no kubelets.
 type FakeKubeletClient struct{}
 
-func (c FakeKubeletClient) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (c FakeKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	return "", 0, nil, errors.New("Not Implemented")
 }
 

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/transport"
+	"k8s.io/kubernetes/pkg/types"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
@@ -51,11 +52,11 @@ type KubeletClientConfig struct {
 
 // KubeletClient is an interface for all kubelet functionality
 type KubeletClient interface {
-	GetRawConnectionInfo(ctx api.Context, nodeName string) (scheme string, port uint, transport http.RoundTripper, err error)
+	GetRawConnectionInfo(ctx api.Context, nodeName types.NodeName) (scheme string, port uint, transport http.RoundTripper, err error)
 }
 
 type ConnectionInfoGetter interface {
-	GetConnectionInfo(ctx api.Context, nodeName string) (scheme string, port uint, transport http.RoundTripper, err error)
+	GetConnectionInfo(ctx api.Context, nodeName types.NodeName) (scheme string, host string, port uint, transport http.RoundTripper, err error)
 }
 
 // HTTPKubeletClient is the default implementation of KubeletHealthchecker, accesses the kubelet over HTTP.
@@ -98,8 +99,8 @@ func NewStaticKubeletClient(config *KubeletClientConfig) (KubeletClient, error) 
 }
 
 // In default HTTPKubeletClient ctx is unused.
-func (c *HTTPKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
-	if errs := validation.ValidateNodeName(nodeName, false); len(errs) != 0 {
+func (c *HTTPKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName types.NodeName) (string, uint, http.RoundTripper, error) {
+	if errs := validation.ValidateNodeName(string(nodeName), false); len(errs) != 0 {
 		return "", 0, nil, fmt.Errorf("invalid node name: %s", strings.Join(errs, ";"))
 	}
 	scheme := "http"
@@ -114,7 +115,7 @@ func (c *HTTPKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName strin
 // no kubelets.
 type FakeKubeletClient struct{}
 
-func (c FakeKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (c FakeKubeletClient) GetRawConnectionInfo(ctx api.Context, nodeName types.NodeName) (string, uint, http.RoundTripper, error) {
 	return "", 0, nil, errors.New("Not Implemented")
 }
 

--- a/pkg/kubelet/client/kubelet_client_test.go
+++ b/pkg/kubelet/client/kubelet_client_test.go
@@ -102,7 +102,7 @@ func TestNewKubeletClientTLSValid(t *testing.T) {
 	}
 
 	{
-		scheme, port, transport, err := client.GetConnectionInfo(nil, "foo")
+		scheme, port, transport, err := client.GetRawConnectionInfo(nil, "foo")
 		if err != nil {
 			t.Errorf("Error getting info: %v", err)
 		}
@@ -118,7 +118,7 @@ func TestNewKubeletClientTLSValid(t *testing.T) {
 	}
 
 	{
-		_, _, _, err := client.GetConnectionInfo(nil, "foo bar")
+		_, _, _, err := client.GetRawConnectionInfo(nil, "foo bar")
 		if err == nil {
 			t.Errorf("Expected error getting connection info for invalid node name, got none")
 		}

--- a/pkg/registry/core/node/etcd/etcd.go
+++ b/pkg/registry/core/node/etcd/etcd.go
@@ -41,7 +41,7 @@ type NodeStorage struct {
 
 type REST struct {
 	*registry.Store
-	connection     client.ConnectionInfoGetter
+	connection     client.KubeletClient
 	proxyTransport http.RoundTripper
 }
 
@@ -65,7 +65,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 }
 
 // NewStorage returns a NodeStorage object that will work against nodes.
-func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper) NodeStorage {
+func NewStorage(opts generic.RESTOptions, connection client.KubeletClient, proxyTransport http.RoundTripper) NodeStorage {
 	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
@@ -140,7 +140,7 @@ func (r *REST) getKubeletPort(ctx api.Context, nodeName string) (int, error) {
 }
 
 func (c *REST) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
-	scheme, port, transport, err := c.connection.GetConnectionInfo(ctx, nodeName)
+	scheme, port, transport, err := c.connection.GetRawConnectionInfo(ctx, nodeName)
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/pkg/registry/core/node/etcd/etcd_test.go
+++ b/pkg/registry/core/node/etcd/etcd_test.go
@@ -28,12 +28,13 @@ import (
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 type fakeConnectionInfoGetter struct {
 }
 
-func (fakeConnectionInfoGetter) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (fakeConnectionInfoGetter) GetRawConnectionInfo(ctx api.Context, nodeName types.NodeName) (string, uint, http.RoundTripper, error) {
 	return "http", 12345, nil, nil
 }
 

--- a/pkg/registry/core/node/etcd/etcd_test.go
+++ b/pkg/registry/core/node/etcd/etcd_test.go
@@ -33,7 +33,7 @@ import (
 type fakeConnectionInfoGetter struct {
 }
 
-func (fakeConnectionInfoGetter) GetConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
+func (fakeConnectionInfoGetter) GetRawConnectionInfo(ctx api.Context, nodeName string) (string, uint, http.RoundTripper, error) {
 	return "http", 12345, nil, nil
 }
 

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	pkgstorage "k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/types"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/validation/field"
@@ -189,13 +190,13 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	// We check if we want to get a default Kubelet's transport. It happens if either:
 	// - no port is specified in request (Kubelet's port is default),
 	// - we're using Port stored as a DaemonEndpoint and requested port is a Kubelet's port stored in the DaemonEndpoint,
-	// - there's no information in the API about DaemonEnpoint (legacy cluster) and requested port is equal to ports.KubeletPort (cluster-wide config)
+	// - there's no information in the API about DaemonEndpoint (legacy cluster) and requested port is equal to ports.KubeletPort (cluster-wide config)
 	kubeletPort := node.Status.DaemonEndpoints.KubeletEndpoint.Port
 	if kubeletPort == 0 {
 		kubeletPort = ports.KubeletPort
 	}
 	if portReq == "" || strconv.Itoa(int(kubeletPort)) == portReq {
-		scheme, port, kubeletTransport, err := connection.GetConnectionInfo(ctx, node.Name)
+		scheme, host, port, kubeletTransport, err := connection.GetConnectionInfo(ctx, types.NodeName(node.Name))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/types"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 )
@@ -299,12 +300,12 @@ func LogLocation(
 			return nil, nil, errors.NewBadRequest(fmt.Sprintf("container %s is not valid for pod %s", container, name))
 		}
 	}
-	nodeHost := pod.Spec.NodeName
-	if len(nodeHost) == 0 {
+	nodeName := types.NodeName(pod.Spec.NodeName)
+	if len(nodeName) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, nil
 	}
-	nodeScheme, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeHost)
+	nodeScheme, nodeHost, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -450,12 +451,12 @@ func streamLocation(
 			return nil, nil, errors.NewBadRequest(fmt.Sprintf("container %s is not valid for pod %s", container, name))
 		}
 	}
-	nodeHost := pod.Spec.NodeName
-	if len(nodeHost) == 0 {
+	nodeName := types.NodeName(pod.Spec.NodeName)
+	if len(nodeName) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("pod %s does not have a host assigned", name))
 	}
-	nodeScheme, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeHost)
+	nodeScheme, nodeHost, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -484,12 +485,12 @@ func PortForwardLocation(
 		return nil, nil, err
 	}
 
-	nodeHost := pod.Spec.NodeName
-	if len(nodeHost) == 0 {
+	nodeName := types.NodeName(pod.Spec.NodeName)
+	if len(nodeName) == 0 {
 		// If pod has not been assigned a host, return an empty location
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("pod %s does not have a host assigned", name))
 	}
-	nodeScheme, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeHost)
+	nodeScheme, nodeHost, nodePort, nodeTransport, err := connInfo.GetConnectionInfo(ctx, nodeName)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Most of our communications from apiserver -> nodes used
    nodutil.GetNodeHostIP, but a few places didn't - and this meant that the
    node name needed to be resolvable _and_ we needed to populate valid IP
    addresses.

``` release-note
The apiserver now uses addresses reported by the kubelet in the Node object's status for apiserver->kubelet communications, rather than the name of the Node object.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33718)

<!-- Reviewable:end -->
