### PR TITLE
kubeadm: refactor config

### DIFF
--- a/cmd/kubeadm/app/api/defaults.go
+++ b/cmd/kubeadm/app/api/defaults.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+const (
+	DefaultServiceDNSDomain  = "cluster.local"
+	DefaultServicesSubnet    = "10.12.0.0/12"
+	DefaultKubernetesVersion = "v1.4.0"
+)

--- a/cmd/kubeadm/app/api/env.go
+++ b/cmd/kubeadm/app/api/env.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// TODO(phase2) use componentconfig
+// we need some params for testing etc, let's keep these hidden for now
+func GetEnvParams() map[string]string {
+
+	envParams := map[string]string{
+		// TODO(phase1+): Mode prefix and host_pki_path to another place as constants, and use them everywhere
+		// Right now they're used here and there, but not consequently
+		"kubernetes_dir":     "/etc/kubernetes",
+		"host_pki_path":      "/etc/kubernetes/pki",
+		"host_etcd_path":     "/var/lib/etcd",
+		"hyperkube_image":    "",
+		"discovery_image":    fmt.Sprintf("gcr.io/google_containers/kube-discovery-%s:%s", runtime.GOARCH, "1.0"),
+		"etcd_image":         "",
+		"component_loglevel": "--v=4",
+	}
+
+	for k := range envParams {
+		if v := os.Getenv(fmt.Sprintf("KUBE_%s", strings.ToUpper(k))); v != "" {
+			envParams[k] = v
+		}
+	}
+
+	return envParams
+}

--- a/cmd/kubeadm/app/api/types.go
+++ b/cmd/kubeadm/app/api/types.go
@@ -16,89 +16,54 @@ limitations under the License.
 
 package api
 
-import (
-	"net"
-)
+import "k8s.io/kubernetes/pkg/api/unversioned"
 
-// KubeadmConfig TODO add description
-// TODO(phase1+) @krousey: Please don't embed structs. It obfuscates the source of the fields and doesn't really buy you anything.
-type KubeadmConfig struct {
-	InitFlags
-	JoinFlags
-	Secrets struct {
-		GivenToken  string // dot-separated `<TokenID>.<Token>` set by the user
-		TokenID     string // optional on master side, will be generated if not specified
-		Token       []byte // optional on master side, will be generated if not specified
-		BearerToken string // set based on Token
-	}
-	EnvParams map[string]string // TODO(phase2) this is likely to be come componentconfig
+type MasterConfiguration struct {
+	unversioned.TypeMeta
+
+	Secrets           Secrets
+	API               API
+	Etcd              Etcd
+	Networking        Networking
+	KubernetesVersion string
+	CloudProvider     string
 }
 
-// TODO(phase2) should we add validation functions for these structs?
-
-// TODO(phase1+) refactor token handling
-// - https://github.com/kubernetes/kubernetes/pull/33262/files#r80333662
-// - https://github.com/kubernetes/kubernetes/pull/33262/files#r80336374
-// - https://github.com/kubernetes/kubernetes/pull/33262/files#r80333982
-
-// InitFlags holds values for "kubeadm init" command flags.
-type InitFlags struct {
-	API struct {
-		AdvertiseAddrs   []net.IP
-		ExternalDNSNames []string
-		Etcd             struct {
-			ExternalEndpoints []string
-			ExternalCAFile    string
-			ExternalCertFile  string
-			ExternalKeyFile   string
-		}
-	}
-	Services struct {
-		CIDR      net.IPNet
-		DNSDomain string
-	}
-	PodNetwork struct {
-		CIDR net.IPNet
-	}
-	Versions struct {
-		Kubernetes string
-	}
-	CloudProvider string
+type API struct {
+	AdvertiseAddresses []string
+	ExternalDNSNames   []string
 }
 
-const (
-	DefaultServiceDNSDomain   = "cluster.local"
-	DefaultServicesCIDRString = "10.12.0.0/12"
-	DefaultKubernetesVersion  = "v1.4.0"
-)
-
-var (
-	DefaultServicesCIDR  *net.IPNet
-	ListOfCloudProviders = []string{
-		"aws",
-		"azure",
-		"cloudstack",
-		"gce",
-		"mesos",
-		"openstack",
-		"ovirt",
-		"rackspace",
-		"vsphere",
-	}
-)
-
-func init() {
-	_, DefaultServicesCIDR, _ = net.ParseCIDR(DefaultServicesCIDRString)
+type Networking struct {
+	ServiceSubnet string
+	PodSubnet     string
+	DNSDomain     string
 }
 
-// JoinFlags holds values for "kubeadm join" command flags.
-type JoinFlags struct {
-	MasterAddrs []net.IP
-	// TODO(phase1+) add manual mode flags here, e.g. RootCACertPath
+type Etcd struct {
+	Endpoints []string
+	CAFile    string
+	CertFile  string
+	KeyFile   string
+}
+
+type Secrets struct {
+	GivenToken  string // dot-separated `<TokenID>.<Token>` set by the user
+	TokenID     string // optional on master side, will be generated if not specified
+	Token       []byte // optional on master side, will be generated if not specified
+	BearerToken string // set based on Token
+}
+
+type NodeConfiguration struct {
+	unversioned.TypeMeta
+
+	MasterAddresses []string
+	Secrets         Secrets
 }
 
 // ClusterInfo TODO add description
 type ClusterInfo struct {
+	unversioned.TypeMeta
 	// TODO(phase1+) this may become simply `api.Config`
 	CertificateAuthorities []string `json:"certificateAuthorities"`
 	Endpoints              []string `json:"endpoints"`

--- a/cmd/kubeadm/app/api/validation.go
+++ b/cmd/kubeadm/app/api/validation.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+func ValidateMasterConfiguration(o *MasterConfiguration) error {
+	return nil
+}
+
+func ValidateNodeConfiguration(o *MasterConfiguration) error {
+	return nil
+}

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -22,12 +22,11 @@ import (
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/flag"
 )
 
-func NewKubeadmCommand(f *cmdutil.Factory, in io.Reader, out, err io.Writer, envParams map[string]string) *cobra.Command {
+func NewKubeadmCommand(f *cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "kubeadm",
 		Short: "kubeadm: easily bootstrap a secure Kubernetes cluster.",
@@ -76,14 +75,11 @@ func NewKubeadmCommand(f *cmdutil.Factory, in io.Reader, out, err io.Writer, env
 	// would then be able to look at files users has given an diff or validate if those are sane, we could also warn
 	// if any of the files had been deprecated
 
-	s := new(kubeadmapi.KubeadmConfig)
-	s.EnvParams = envParams
-
 	cmds.ResetFlags()
 	cmds.SetGlobalNormalizationFunc(flag.WarnWordSepNormalizeFunc)
 
-	cmds.AddCommand(NewCmdInit(out, s))
-	cmds.AddCommand(NewCmdJoin(out, s))
+	cmds.AddCommand(NewCmdInit(out))
+	cmds.AddCommand(NewCmdJoin(out))
 	cmds.AddCommand(NewCmdVersion(out))
 
 	return cmds

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -19,8 +19,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"net"
-	"strings"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -28,6 +26,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
 	kubemaster "k8s.io/kubernetes/cmd/kubeadm/app/master"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	netutil "k8s.io/kubernetes/pkg/util/net"
 )
@@ -43,66 +42,66 @@ var (
 )
 
 // NewCmdInit returns "kubeadm init" command.
-func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
-	advertiseAddrs := &[]string{} // TODO(pahse1+) make it work somehow else, custom flag or whatever
+func NewCmdInit(out io.Writer) *cobra.Command {
+	cfg := &kubeadmapi.MasterConfiguration{}
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Run this in order to set up the Kubernetes master.",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunInit(out, cmd, args, s, advertiseAddrs)
+			err := RunInit(out, cmd, args, cfg)
 			cmdutil.CheckErr(err)
 		},
 	}
 
 	cmd.PersistentFlags().StringVar(
-		&s.Secrets.GivenToken, "token", "",
+		&cfg.Secrets.GivenToken, "token", "",
 		"Shared secret used to secure cluster bootstrap; if none is provided, one will be generated for you",
 	)
 	cmd.PersistentFlags().StringSliceVar(
-		advertiseAddrs, "api-advertise-addresses", []string{},
+		&cfg.API.AdvertiseAddresses, "api-advertise-addresses", []string{},
 		"The IP addresses to advertise, in case autodetection fails",
 	)
 	cmd.PersistentFlags().StringSliceVar(
-		&s.InitFlags.API.ExternalDNSNames, "api-external-dns-names", []string{},
+		&cfg.API.ExternalDNSNames, "api-external-dns-names", []string{},
 		"The DNS names to advertise, in case you have configured them yourself",
 	)
-	cmd.PersistentFlags().IPNetVar(
-		&s.InitFlags.Services.CIDR, "service-cidr", *kubeadmapi.DefaultServicesCIDR,
-		`Use alterantive range of IP address for service VIPs, defaults to `+
-			kubeadmapi.DefaultServicesCIDRString,
+	cmd.PersistentFlags().StringVar(
+		&cfg.Networking.ServiceSubnet, "service-cidr", kubeadmapi.DefaultServicesSubnet,
+		"Use alterantive range of IP address for service VIPs",
 	)
-	cmd.PersistentFlags().IPNetVar(
-		&s.InitFlags.PodNetwork.CIDR, "pod-network-cidr", net.IPNet{},
+	cmd.PersistentFlags().StringVar(
+		&cfg.Networking.PodSubnet, "pod-network-cidr", "",
 		"Specify range of IP addresses for the pod network; if set, the control plane will automatically allocate CIDRs for every node",
 	)
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.Services.DNSDomain, "service-dns-domain", kubeadmapi.DefaultServiceDNSDomain,
+		&cfg.Networking.DNSDomain, "service-dns-domain", kubeadmapi.DefaultServiceDNSDomain,
 		`Use alternative domain for services, e.g. "myorg.internal"`,
 	)
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.CloudProvider, "cloud-provider", "",
+		&cfg.CloudProvider, "cloud-provider", "",
 		`Enable cloud provider features (external load-balancers, storage, etc), e.g. "gce"`,
 	)
+
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.Versions.Kubernetes, "use-kubernetes-version", kubeadmapi.DefaultKubernetesVersion,
+		&cfg.KubernetesVersion, "use-kubernetes-version", kubeadmapi.DefaultKubernetesVersion,
 		`Choose a specific Kubernetes version for the control plane`,
 	)
 
 	// TODO (phase1+) @errordeveloper make the flags below not show up in --help but rather on --advanced-help
 	cmd.PersistentFlags().StringSliceVar(
-		&s.InitFlags.API.Etcd.ExternalEndpoints, "external-etcd-endpoints", []string{},
+		&cfg.Etcd.Endpoints, "external-etcd-endpoints", []string{},
 		"etcd endpoints to use, in case you have an external cluster",
 	)
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.API.Etcd.ExternalCAFile, "external-etcd-cafile", "",
+		&cfg.Etcd.CAFile, "external-etcd-cafile", "",
 		"etcd certificate authority certificate file. Note: The path must be in /etc/ssl/certs",
 	)
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.API.Etcd.ExternalCertFile, "external-etcd-certfile", "",
+		&cfg.Etcd.CertFile, "external-etcd-certfile", "",
 		"etcd client certificate file. Note: The path must be in /etc/ssl/certs",
 	)
 	cmd.PersistentFlags().StringVar(
-		&s.InitFlags.API.Etcd.ExternalKeyFile, "external-etcd-keyfile", "",
+		&cfg.Etcd.KeyFile, "external-etcd-keyfile", "",
 		"etcd client key file. Note: The path must be in /etc/ssl/certs",
 	)
 
@@ -110,57 +109,40 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 }
 
 // RunInit executes master node provisioning, including certificates, needed static pod manifests, etc.
-func RunInit(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.KubeadmConfig, advertiseAddrs *[]string) error {
+func RunInit(out io.Writer, cmd *cobra.Command, args []string, cfg *kubeadmapi.MasterConfiguration) error {
 	// Auto-detect the IP
-	if len(*advertiseAddrs) == 0 {
+	if len(cfg.API.AdvertiseAddresses) == 0 {
 		// TODO(phase1+) perhaps we could actually grab eth0 and eth1
 		ip, err := netutil.ChooseHostInterface()
 		if err != nil {
 			return err
 		}
-		s.InitFlags.API.AdvertiseAddrs = []net.IP{ip}
-	} else {
-		for _, i := range *advertiseAddrs {
-			addr := net.ParseIP(i)
-			if addr == nil {
-				// TODO(phase1+) custom flag will help to get this error message into a better place
-				return fmt.Errorf("<cmd/init> failed to parse %q (in %q) as an IP address", i, "--api-advertise-addresses="+strings.Join(*advertiseAddrs, ","))
-			}
-			s.InitFlags.API.AdvertiseAddrs = append(s.InitFlags.API.AdvertiseAddrs, addr)
-		}
+		cfg.API.AdvertiseAddresses = []string{ip.String()}
 	}
 
 	// TODO(phase1+) create a custom flag
-	if s.InitFlags.CloudProvider != "" {
-		found := false
-		for _, provider := range kubeadmapi.ListOfCloudProviders {
-			if provider == s.InitFlags.CloudProvider {
-				found = true
-				break
-			}
-		}
-
-		if found {
-			fmt.Printf("<cmd/init> cloud provider %q initialized for the control plane. Remember to set the same cloud provider flag on the kubelet.\n", s.InitFlags.CloudProvider)
+	if cfg.CloudProvider != "" {
+		if cloudprovider.IsCloudProvider(cfg.CloudProvider) {
+			fmt.Printf("<cmd/init> cloud provider %q initialized for the control plane. Remember to set the same cloud provider flag on the kubelet.\n", cfg.CloudProvider)
 		} else {
-			return fmt.Errorf("<cmd/init> cloud provider %q is not supported, you can use any of %v, or leave it unset.\n", s.InitFlags.CloudProvider, kubeadmapi.ListOfCloudProviders)
+			return fmt.Errorf("<cmd/init> cloud provider %q is not supported, you can use any of %v, or leave it unset.\n", cfg.CloudProvider, cloudprovider.CloudProviders())
 		}
 	}
 
-	if err := kubemaster.CreateTokenAuthFile(s); err != nil {
+	if err := kubemaster.CreateTokenAuthFile(&cfg.Secrets); err != nil {
 		return err
 	}
 
-	if err := kubemaster.WriteStaticPodManifests(s); err != nil {
+	if err := kubemaster.WriteStaticPodManifests(cfg); err != nil {
 		return err
 	}
 
-	caKey, caCert, err := kubemaster.CreatePKIAssets(s)
+	caKey, caCert, err := kubemaster.CreatePKIAssets(cfg)
 	if err != nil {
 		return err
 	}
 
-	kubeconfigs, err := kubemaster.CreateCertsAndConfigForClients(s, []string{"kubelet", "admin"}, caKey, caCert)
+	kubeconfigs, err := kubemaster.CreateCertsAndConfigForClients(cfg.API.AdvertiseAddresses, []string{"kubelet", "admin"}, caKey, caCert)
 	if err != nil {
 		return err
 	}
@@ -175,7 +157,7 @@ func RunInit(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.Kub
 	// importing existing files, may be we could even make our command idempotant,
 	// or at least allow for external PKI and stuff)
 	for name, kubeconfig := range kubeconfigs {
-		if err := kubeadmutil.WriteKubeconfigIfNotExists(s, name, kubeconfig); err != nil {
+		if err := kubeadmutil.WriteKubeconfigIfNotExists(name, kubeconfig); err != nil {
 			return err
 		}
 	}
@@ -190,18 +172,18 @@ func RunInit(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.Kub
 		return err
 	}
 
-	if err := kubemaster.CreateDiscoveryDeploymentAndSecret(s, client, caCert); err != nil {
+	if err := kubemaster.CreateDiscoveryDeploymentAndSecret(cfg, client, caCert); err != nil {
 		return err
 	}
 
-	if err := kubemaster.CreateEssentialAddons(s, client); err != nil {
+	if err := kubemaster.CreateEssentialAddons(cfg, client); err != nil {
 		return err
 	}
 
 	// TODO(phase1+) use templates to reference struct fields directly as order of args is fragile
 	fmt.Fprintf(out, initDoneMsgf,
-		s.Secrets.GivenToken,
-		s.InitFlags.API.AdvertiseAddrs[0].String(),
+		cfg.Secrets.GivenToken,
+		cfg.API.AdvertiseAddresses[0],
 	)
 
 	return nil

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -43,17 +43,17 @@ const (
 	exechealthzVersion = "1.1"
 )
 
-func GetCoreImage(image string, cfg *kubeadmapi.KubeadmConfig, overrideImage string) string {
+func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideImage string) string {
 	if overrideImage != "" {
 		return overrideImage
 	}
 
 	return map[string]string{
 		KubeEtcdImage:              fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "etcd", runtime.GOARCH, etcdVersion),
-		KubeAPIServerImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-apiserver", runtime.GOARCH, cfg.Versions.Kubernetes),
-		KubeControllerManagerImage: fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-controller-manager", runtime.GOARCH, cfg.Versions.Kubernetes),
-		KubeSchedulerImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-scheduler", runtime.GOARCH, cfg.Versions.Kubernetes),
-		KubeProxyImage:             fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-proxy", runtime.GOARCH, cfg.Versions.Kubernetes),
+		KubeAPIServerImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-apiserver", runtime.GOARCH, cfg.KubernetesVersion),
+		KubeControllerManagerImage: fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-controller-manager", runtime.GOARCH, cfg.KubernetesVersion),
+		KubeSchedulerImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-scheduler", runtime.GOARCH, cfg.KubernetesVersion),
+		KubeProxyImage:             fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-proxy", runtime.GOARCH, cfg.KubernetesVersion),
 	}[image]
 }
 

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -17,10 +17,7 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
 	"os"
-	"runtime"
-	"strings"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/pflag"
@@ -36,31 +33,6 @@ var AlphaWarningOnExit = dedent.Dedent(`
 	kubeadm: and make sure to mention @kubernetes/sig-cluster-lifecycle. Thank you!
 `)
 
-// TODO(phase2) use componentconfig
-// we need some params for testing etc, let's keep these hidden for now
-func getEnvParams() map[string]string {
-
-	envParams := map[string]string{
-		// TODO(phase1+): Mode prefix and host_pki_path to another place as constants, and use them everywhere
-		// Right now they're used here and there, but not consequently
-		"kubernetes_dir":     "/etc/kubernetes",
-		"host_pki_path":      "/etc/kubernetes/pki",
-		"host_etcd_path":     "/var/lib/etcd",
-		"hyperkube_image":    "",
-		"discovery_image":    fmt.Sprintf("gcr.io/google_containers/kube-discovery-%s:%s", runtime.GOARCH, "1.0"),
-		"etcd_image":         "",
-		"component_loglevel": "--v=4",
-	}
-
-	for k := range envParams {
-		if v := os.Getenv(fmt.Sprintf("KUBE_%s", strings.ToUpper(k))); v != "" {
-			envParams[k] = v
-		}
-	}
-
-	return envParams
-}
-
 func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
@@ -69,6 +41,6 @@ func Run() error {
 	pflag.CommandLine.MarkHidden("google-json-key")
 	pflag.CommandLine.MarkHidden("log-flush-frequency")
 
-	cmd := cmd.NewKubeadmCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, getEnvParams())
+	cmd := cmd.NewKubeadmCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()
 }

--- a/cmd/kubeadm/app/master/kubeconfig.go
+++ b/cmd/kubeadm/app/master/kubeconfig.go
@@ -22,20 +22,19 @@ import (
 	"fmt"
 
 	// TODO: "k8s.io/client-go/client/tools/clientcmd/api"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
-func CreateCertsAndConfigForClients(s *kubeadmapi.KubeadmConfig, clientNames []string, caKey *rsa.PrivateKey, caCert *x509.Certificate) (map[string]*clientcmdapi.Config, error) {
+func CreateCertsAndConfigForClients(advertiseAddresses, clientNames []string, caKey *rsa.PrivateKey, caCert *x509.Certificate) (map[string]*clientcmdapi.Config, error) {
 
 	basicClientConfig := kubeadmutil.CreateBasicClientConfig(
 		"kubernetes",
 		// TODO this is not great, but there is only one address we can use here
 		// so we'll pick the first one, there is much of chance to have an empty
 		// slice by the time this gets called
-		fmt.Sprintf("https://%s:443", s.InitFlags.API.AdvertiseAddrs[0]),
+		fmt.Sprintf("https://%s:443", advertiseAddresses[0]),
 		certutil.EncodeCertPEM(caCert),
 	)
 

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -34,8 +34,8 @@ import (
 )
 
 // PerformTLSBootstrap creates a RESTful client in order to execute certificate signing request.
-func PerformTLSBootstrap(s *kubeadmapi.KubeadmConfig, apiEndpoint string, caCert []byte) (*clientcmdapi.Config, error) {
-	// TODO(phase2) try all the api servers until we find one that works
+func PerformTLSBootstrap(s *kubeadmapi.NodeConfiguration, apiEndpoint string, caCert []byte) (*clientcmdapi.Config, error) {
+	// TODO(phase1+) try all the api servers until we find one that works
 	bareClientConfig := kubeadmutil.CreateBasicClientConfig("kubernetes", apiEndpoint, caCert)
 
 	hostName, err := os.Hostname()

--- a/cmd/kubeadm/app/node/discovery.go
+++ b/cmd/kubeadm/app/node/discovery.go
@@ -28,8 +28,8 @@ import (
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
-func RetrieveTrustedClusterInfo(s *kubeadmapi.KubeadmConfig) (*clientcmdapi.Config, error) {
-	host, port := s.JoinFlags.MasterAddrs[0].String(), 9898
+func RetrieveTrustedClusterInfo(s *kubeadmapi.NodeConfiguration) (*clientcmdapi.Config, error) {
+	host, port := s.MasterAddresses[0], 9898
 	requestURL := fmt.Sprintf("http://%s:%d/cluster-info/v1/?token-id=%s", host, port, s.Secrets.TokenID)
 	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {

--- a/cmd/kubeadm/app/util/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig.go
@@ -75,12 +75,13 @@ func MakeClientConfigWithToken(config *clientcmdapi.Config, clusterName string, 
 	return newConfig
 }
 
-func WriteKubeconfigIfNotExists(s *kubeadmapi.KubeadmConfig, name string, kubeconfig *clientcmdapi.Config) error {
-	if err := os.MkdirAll(s.EnvParams["kubernetes_dir"], 0700); err != nil {
-		return fmt.Errorf("<util/kubeconfig> failed to create directory %q [%v]", s.EnvParams["kubernetes_dir"], err)
+func WriteKubeconfigIfNotExists(name string, kubeconfig *clientcmdapi.Config) error {
+	envParams := kubeadmapi.GetEnvParams()
+	if err := os.MkdirAll(envParams["kubernetes_dir"], 0700); err != nil {
+		return fmt.Errorf("<util/kubeconfig> failed to create directory %q [%v]", envParams["kubernetes_dir"], err)
 	}
 
-	filename := path.Join(s.EnvParams["kubernetes_dir"], fmt.Sprintf("%s.conf", name))
+	filename := path.Join(envParams["kubernetes_dir"], fmt.Sprintf("%s.conf", name))
 	// Create and open the file, only if it does not already exist.
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
 	if err != nil {

--- a/cmd/kubeadm/app/util/tokens.go
+++ b/cmd/kubeadm/app/util/tokens.go
@@ -42,7 +42,7 @@ func RandBytes(length int) ([]byte, string, error) {
 	return b, hex.EncodeToString(b), nil
 }
 
-func GenerateToken(s *kubeadmapi.KubeadmConfig) error {
+func GenerateToken(s *kubeadmapi.Secrets) error {
 	_, tokenID, err := RandBytes(TokenIDLen / 2)
 	if err != nil {
 		return err
@@ -53,19 +53,19 @@ func GenerateToken(s *kubeadmapi.KubeadmConfig) error {
 		return err
 	}
 
-	s.Secrets.TokenID = tokenID
-	s.Secrets.BearerToken = token
-	s.Secrets.Token = tokenBytes
-	s.Secrets.GivenToken = fmt.Sprintf("%s.%s", tokenID, token)
+	s.TokenID = tokenID
+	s.BearerToken = token
+	s.Token = tokenBytes
+	s.GivenToken = fmt.Sprintf("%s.%s", tokenID, token)
 	return nil
 }
 
-func UseGivenTokenIfValid(s *kubeadmapi.KubeadmConfig) (bool, error) {
-	if s.Secrets.GivenToken == "" {
+func UseGivenTokenIfValid(s *kubeadmapi.Secrets) (bool, error) {
+	if s.GivenToken == "" {
 		return false, nil // not given
 	}
 	fmt.Println("<util/tokens> validating provided token")
-	givenToken := strings.Split(strings.ToLower(s.Secrets.GivenToken), ".")
+	givenToken := strings.Split(strings.ToLower(s.GivenToken), ".")
 	// TODO(phase1+) print desired format
 	// TODO(phase1+) could also print more specific messages in each case
 	invalidErr := "<util/tokens> provided token is invalid - %s"
@@ -78,8 +78,8 @@ func UseGivenTokenIfValid(s *kubeadmapi.KubeadmConfig) (bool, error) {
 			len(givenToken[0]), TokenIDLen))
 	}
 	tokenBytes := []byte(givenToken[1])
-	s.Secrets.TokenID = givenToken[0]
-	s.Secrets.BearerToken = givenToken[1]
-	s.Secrets.Token = tokenBytes
+	s.TokenID = givenToken[0]
+	s.BearerToken = givenToken[1]
+	s.Token = tokenBytes
 	return true, nil // given and valid
 }

--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -32,8 +32,10 @@ import (
 type Factory func(config io.Reader) (Interface, error)
 
 // All registered cloud providers.
-var providersMutex sync.Mutex
-var providers = make(map[string]Factory)
+var (
+	providersMutex sync.Mutex
+	providers      = make(map[string]Factory)
+)
 
 // RegisterCloudProvider registers a cloudprovider.Factory by name.  This
 // is expected to happen during app startup.
@@ -45,6 +47,27 @@ func RegisterCloudProvider(name string, cloud Factory) {
 	}
 	glog.V(1).Infof("Registered cloud provider %q", name)
 	providers[name] = cloud
+}
+
+// IsCloudProvider returns true if name corresponds to an already registered
+// cloud provider.
+func IsCloudProvider(name string) bool {
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	_, found := providers[name]
+	return found
+}
+
+// CloudProviders returns the name of all registered cloud providers in a
+// string slice
+func CloudProviders() []string {
+	names := []string{}
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	for name := range providers {
+		names = append(names, name)
+	}
+	return names
 }
 
 // GetCloudProvider creates an instance of the named cloud provider, or nil if


### PR DESCRIPTION
1) break object into substructures
2) seperate a config object for master and node
3) centralize defaulting and validation

Hacked til it compiled. Have not done 3 yet.

Step one of #33715

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33728)

<!-- Reviewable:end -->
