### PR TITLE
Add the ability to only compile and install dependencies, but not build the binaries

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -650,13 +650,17 @@ kube::golang::build_binaries() {
         # Assume arguments starting with a dash are flags to pass to go.
         goflags+=("${arg}")
       else
-        targets+=("${arg}")
+        all_targets+=("${arg}")
       fi
     done
 
-    if [[ ${#targets[@]} -eq 0 ]]; then
-      targets=("${KUBE_ALL_TARGETS[@]}")
+    if [[ ${#all_targets[@]} -eq 0 ]]; then
+      all_targets=("${KUBE_ALL_TARGETS[@]}")
     fi
+
+    # Dedup the `all_targets` list.
+    # Credit: http://stackoverflow.com/a/13648438
+    targets=($(echo "${all_targets[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
     local -a platforms=(${KUBE_BUILD_PLATFORMS:-})
     if [[ ${#platforms[@]} -eq 0 ]]; then


### PR DESCRIPTION
Linking is terribly slow. Sometimes I don't actually care about the binary, but I only want to make sure that the code compiles. This is especially true while refactoring. These changes enable just building the code without actually linking the final binaries.

cc @mikedanese @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33731)

<!-- Reviewable:end -->
