### PR TITLE
OpenStack integration (detach a volume before trying to attach it to another node).

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -59,6 +59,7 @@ func (os *OpenStack) AttachDisk(instanceID string, diskName string) (string, err
 			if err != nil {
 				glog.Errorf(err.Error())
 			}
+			return "", errors.New(errMsg)
 		}
 	}
 	// add read only flag here if possible spothanis

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -53,9 +53,12 @@ func (os *OpenStack) AttachDisk(instanceID string, diskName string) (string, err
 			glog.V(4).Infof("Disk: %q is already attached to compute: %q", diskName, instanceID)
 			return disk.ID, nil
 		} else {
-			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, should be detached before proceeding", diskName, disk.Attachments[0]["server_id"])
+			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, detaching", diskName, disk.Attachments[0]["server_id"])
 			glog.Errorf(errMsg)
-			return "", errors.New(errMsg)
+			err = os.DetachDisk(fmt.Sprintf("%s", disk.Attachments[0]["server_id"]), diskName)
+			if err != nil {
+				glog.Errorf(err.Error())
+			}
 		}
 	}
 	// add read only flag here if possible spothanis

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -138,7 +138,7 @@ func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath 
 				return devicePath, nil
 			} else {
 				//Log error, if any, and continue checking periodically
-				glog.Errorf("Error Stat Cinder disk (%q) is attached: %v", volumeID, err)
+				glog.Errorf("Error Stat Cinder disk (%q) (path: %q) is attached: %v", volumeID, devicePath, err)
 			}
 		case <-timer.C:
 			return "", fmt.Errorf("Could not find attached Cinder disk %q. Timeout waiting for mount paths to be created.", volumeID)


### PR DESCRIPTION
**What this PR does / why we need it**: It may help to fix #33288
In a nutshell if volume is attached to another node controller-manager is not trying to detach it for some reason even though it is fully "aware" of the situation (it has information on the node that has the volume attached, the volume itself and the node that the volume should be attached to).

**Which issue this PR fixes** fixes #33288

**Special notes for your reviewer**: I'm not a go person, and my understanding of kubernetes codebase is very limited, it is more of a proof of concept than production ready fix.

**Release note**:

```
OpenStack integration: try to detach a volume before attaching if it is already attached to another compute node.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33734)

<!-- Reviewable:end -->
