### PR TITLE
Fixes in HPA: consider only running pods; proper denominator in avg.

### DIFF
--- a/pkg/controller/podautoscaler/metrics/metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client.go
@@ -123,8 +123,8 @@ func (h *HeapsterMetricsClient) GetCpuConsumptionAndRequestInMillis(namespace st
 	requestSum := int64(0)
 	missing := false
 	for _, pod := range podList.Items {
-		if pod.Status.Phase == api.PodPending {
-			// Skip pending pods.
+		if pod.Status.Phase != api.PodRunning {
+			// Count only running pods.
 			continue
 		}
 
@@ -144,7 +144,7 @@ func (h *HeapsterMetricsClient) GetCpuConsumptionAndRequestInMillis(namespace st
 		return 0, 0, time.Time{}, fmt.Errorf("some pods do not have request for cpu")
 	}
 	glog.V(4).Infof("%s %s - sum of CPU requested: %d", namespace, selector, requestSum)
-	requestAvg := requestSum / int64(len(podList.Items))
+	requestAvg := requestSum / int64(len(podNames))
 	// Consumption is already averaged and in millis.
 	consumption, timestamp, err := h.getCpuUtilizationForPods(namespace, selector, podNames)
 	if err != nil {


### PR DESCRIPTION
``` release-note
Fixes in HPA: consider only running pods; proper denominator in avg request calculations.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33735)

<!-- Reviewable:end -->
