### PR TITLE
Clarify the purpose of dramatically-simplify-cluster-creation.md

### DIFF
--- a/docs/proposals/dramatically-simplify-cluster-creation.md
+++ b/docs/proposals/dramatically-simplify-cluster-creation.md
@@ -29,6 +29,10 @@ Documentation for other releases can be found at
 
 # Proposal: Dramatically Simplify Kubernetes Cluster Creation
 
+
+> ***Please note: this proposal doesn't reflect final implementation, it's here for the purpose of capturing the original ideas.***
+> ***You should probably [read `kubeadm` docs](kubernetes.io/docs/getting-started-guides/kubeadm/), to understand the end-result of this effor.*** 
+
 Luke Marsden & many others in [SIG-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle).
 
 17th August 2016

--- a/docs/proposals/dramatically-simplify-cluster-creation.md
+++ b/docs/proposals/dramatically-simplify-cluster-creation.md
@@ -29,9 +29,8 @@ Documentation for other releases can be found at
 
 # Proposal: Dramatically Simplify Kubernetes Cluster Creation
 
-
 > ***Please note: this proposal doesn't reflect final implementation, it's here for the purpose of capturing the original ideas.***
-> ***You should probably [read `kubeadm` docs](kubernetes.io/docs/getting-started-guides/kubeadm/), to understand the end-result of this effor.*** 
+> ***You should probably [read `kubeadm` docs](http://kubernetes.io/docs/getting-started-guides/kubeadm/), to understand the end-result of this effor.***
 
 Luke Marsden & many others in [SIG-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have merged `docs/proposals/dramatically-simplify-cluster-creation.md` mostly because we'd like to keep accurate historic records. This change adds a note to clarify this.

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33746)

<!-- Reviewable:end -->
