### PR TITLE
Don't tolerate unready endpoints in cockroachdb example

### DIFF
--- a/examples/cockroachdb/cockroachdb-petset.yaml
+++ b/examples/cockroachdb/cockroachdb-petset.yaml
@@ -24,8 +24,6 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    # Make sure DNS is resolvable during initialization.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"


### PR DESCRIPTION
That annotation was only included in the initial config due to cargo-culting, and
has the potential to break node startup if it resolves its own address
to gossip to.

@bprashanth @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33780)

<!-- Reviewable:end -->
