### PR TITLE
pass loopback config to poststart hooks

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -265,6 +265,10 @@ func Run(s *options.APIServer) error {
 	admissionControlPluginNames := strings.Split(s.AdmissionControl, ",")
 	privilegedLoopbackToken := uuid.NewRandom().String()
 
+	selfClientConfig, err := s.NewSelfClientConfig(privilegedLoopbackToken)
+	if err != nil {
+		glog.Fatalf("Failed to create clientset: %v", err)
+	}
 	client, err := s.NewSelfClient(privilegedLoopbackToken)
 	if err != nil {
 		glog.Errorf("Failed to create clientset: %v", err)
@@ -297,6 +301,7 @@ func Run(s *options.APIServer) error {
 
 	genericConfig := genericapiserver.NewConfig(s.ServerRunOptions)
 	// TODO: Move the following to generic api server as well.
+	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0
 	genericConfig.Authorizer = apiAuthorizer

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -279,15 +279,15 @@ func Run(s *options.APIServer) error {
 		var uid = uuid.NewRandom().String()
 		tokens := make(map[string]*user.DefaultInfo)
 		tokens[privilegedLoopbackToken] = &user.DefaultInfo{
-			Name:   "system:apiserver",
+			Name:   user.APIServerUser,
 			UID:    uid,
-			Groups: []string{"system:masters"},
+			Groups: []string{user.SystemPrivilegedGroup},
 		}
 
 		tokenAuthenticator := authenticator.NewAuthenticatorFromTokens(tokens)
 		apiAuthenticator = authenticatorunion.New(tokenAuthenticator, apiAuthenticator)
 
-		tokenAuthorizer := authorizer.NewPrivilegedGroups("system:masters")
+		tokenAuthorizer := authorizer.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 		apiAuthorizer = authorizerunion.New(tokenAuthorizer, apiAuthorizer)
 	}
 

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -187,15 +187,15 @@ func Run(s *options.ServerRunOptions) error {
 		var uid = uuid.NewRandom().String()
 		tokens := make(map[string]*user.DefaultInfo)
 		tokens[privilegedLoopbackToken] = &user.DefaultInfo{
-			Name:   "system:apiserver",
+			Name:   user.APIServerUser,
 			UID:    uid,
-			Groups: []string{"system:masters"},
+			Groups: []string{user.SystemPrivilegedGroup},
 		}
 
 		tokenAuthenticator := authenticator.NewAuthenticatorFromTokens(tokens)
 		apiAuthenticator = authenticatorunion.New(tokenAuthenticator, apiAuthenticator)
 
-		tokenAuthorizer := authorizer.NewPrivilegedGroups("system:masters")
+		tokenAuthorizer := authorizer.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 		apiAuthorizer = authorizerunion.New(tokenAuthorizer, apiAuthorizer)
 	}
 

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -173,6 +173,10 @@ func Run(s *options.ServerRunOptions) error {
 	admissionControlPluginNames := strings.Split(s.AdmissionControl, ",")
 	privilegedLoopbackToken := uuid.NewRandom().String()
 
+	selfClientConfig, err := s.NewSelfClientConfig(privilegedLoopbackToken)
+	if err != nil {
+		glog.Fatalf("Failed to create clientset: %v", err)
+	}
 	client, err := s.NewSelfClient(privilegedLoopbackToken)
 	if err != nil {
 		glog.Errorf("Failed to create clientset: %v", err)
@@ -204,6 +208,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 	genericConfig := genericapiserver.NewConfig(s.ServerRunOptions)
 	// TODO: Move the following to generic api server as well.
+	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0
 	genericConfig.Authorizer = apiAuthorizer

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -141,7 +141,7 @@ func New(config AuthenticatorConfig) (authenticator.Request, error) {
 
 	authenticator := union.New(authenticators...)
 
-	authenticator = group.NewGroupAdder(authenticator, []string{"system:authenticated"})
+	authenticator = group.NewGroupAdder(authenticator, []string{user.AllAuthenticated})
 
 	if config.Anonymous {
 		// If the authenticator chain returns an error, return an error (don't consider a bad bearer token anonymous).

--- a/pkg/auth/user/user.go
+++ b/pkg/auth/user/user.go
@@ -65,3 +65,13 @@ func (i *DefaultInfo) GetGroups() []string {
 func (i *DefaultInfo) GetExtra() map[string][]string {
 	return i.Extra
 }
+
+// well-known user and group names
+const (
+	SystemPrivilegedGroup = "system:masters"
+	AllUnauthenticated    = "system:unauthenticated"
+	AllAuthenticated      = "system:authenticated"
+
+	Anonymous     = "system:anonymous"
+	APIServerUser = "system:apiserver"
+)

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	authhandlers "k8s.io/kubernetes/pkg/auth/handlers"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	genericfilters "k8s.io/kubernetes/pkg/genericapiserver/filters"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
@@ -82,6 +83,9 @@ type Config struct {
 	MasterServiceNamespace string
 	// TODO(ericchiang): Determine if policy escalation checks should be an admission controller.
 	AuthorizerRBACSuperUser string
+
+	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
+	LoopbackClientConfig *restclient.Config
 
 	// Map requests to contexts. Exported so downstream consumers can provider their own mappers
 	RequestContextMapper api.RequestContextMapper
@@ -309,6 +313,7 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	s := &GenericAPIServer{
 		ServiceClusterIPRange: c.ServiceClusterIPRange,
 		ServiceNodePortRange:  c.ServiceNodePortRange,
+		LoopbackClientConfig:  c.LoopbackClientConfig,
 		legacyAPIPrefix:       c.APIPrefix,
 		apiPrefix:             c.APIGroupPrefix,
 		admissionControl:      c.AdmissionControl,

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
 	"k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -93,6 +94,9 @@ type GenericAPIServer struct {
 	// ServiceNodePortRange is only used for `master.go` to construct its RESTStorage for the legacy API group
 	// TODO refactor this closer to the point of use.
 	ServiceNodePortRange utilnet.PortRange
+
+	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
+	LoopbackClientConfig *restclient.Config
 
 	// minRequestTimeout is how short the request timeout can be.  This is used to build the RESTHandler
 	minRequestTimeout time.Duration
@@ -315,7 +319,7 @@ func (s *GenericAPIServer) Run(options *options.ServerRunOptions) {
 
 	<-secureStartedCh
 	<-insecureStartedCh
-	s.RunPostStartHooks(PostStartHookContext{})
+	s.RunPostStartHooks()
 
 	// err == systemd.SdNotifyNoSocket when not running on a systemd system
 	if err := systemd.SdNotify("READY=1\n"); err != nil && err != systemd.SdNotifyNoSocket {

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -211,6 +211,15 @@ func mergeGroupVersionIntoMap(gvList string, dest map[string]unversioned.GroupVe
 
 // Returns a clientset which can be used to talk to this apiserver.
 func (s *ServerRunOptions) NewSelfClient(token string) (clientset.Interface, error) {
+	clientConfig, err := s.NewSelfClientConfig(token)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.NewForConfig(clientConfig)
+}
+
+// Returns a clientconfig which can be used to talk to this apiserver.
+func (s *ServerRunOptions) NewSelfClientConfig(token string) (*restclient.Config, error) {
 	clientConfig := &restclient.Config{
 		// Increase QPS limits. The client is currently passed to all admission plugins,
 		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
@@ -228,7 +237,7 @@ func (s *ServerRunOptions) NewSelfClient(token string) (clientset.Interface, err
 		return nil, errors.New("Unable to set url for apiserver local client")
 	}
 
-	return clientset.NewForConfig(clientConfig)
+	return clientConfig, nil
 }
 
 // AddFlags adds flags for a specific APIServer to the specified FlagSet

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -46,6 +46,14 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 		if s.superUser != "" && user.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
+
+		// system:masters is special because the API server uses it for privileged loopback connections
+		// therefore we know that a member of system:masters can always do anything
+		for _, group := range user.GetGroups() {
+			if group == "system:masters" {
+				return s.StandardStorage.Create(ctx, obj)
+			}
+		}
 	}
 
 	clusterRole := obj.(*rbac.ClusterRole)

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -42,15 +43,15 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
+	if u, ok := api.UserFrom(ctx); ok {
+		if s.superUser != "" && u.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
 
 		// system:masters is special because the API server uses it for privileged loopback connections
 		// therefore we know that a member of system:masters can always do anything
-		for _, group := range user.GetGroups() {
-			if group == "system:masters" {
+		for _, group := range u.GetGroups() {
+			if group == user.SystemPrivilegedGroup {
 				return s.StandardStorage.Create(ctx, obj)
 			}
 		}

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -46,6 +46,14 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 		if s.superUser != "" && user.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
+
+		// system:masters is special because the API server uses it for privileged loopback connections
+		// therefore we know that a member of system:masters can always do anything
+		for _, group := range user.GetGroups() {
+			if group == "system:masters" {
+				return s.StandardStorage.Create(ctx, obj)
+			}
+		}
 	}
 
 	clusterRoleBinding := obj.(*rbac.ClusterRoleBinding)

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -42,15 +43,15 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
+	if u, ok := api.UserFrom(ctx); ok {
+		if s.superUser != "" && u.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
 
 		// system:masters is special because the API server uses it for privileged loopback connections
 		// therefore we know that a member of system:masters can always do anything
-		for _, group := range user.GetGroups() {
-			if group == "system:masters" {
+		for _, group := range u.GetGroups() {
+			if group == user.SystemPrivilegedGroup {
 				return s.StandardStorage.Create(ctx, obj)
 			}
 		}

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -46,6 +46,14 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 		if s.superUser != "" && user.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
+
+		// system:masters is special because the API server uses it for privileged loopback connections
+		// therefore we know that a member of system:masters can always do anything
+		for _, group := range user.GetGroups() {
+			if group == "system:masters" {
+				return s.StandardStorage.Create(ctx, obj)
+			}
+		}
 	}
 
 	role := obj.(*rbac.Role)

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -42,15 +43,15 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
+	if u, ok := api.UserFrom(ctx); ok {
+		if s.superUser != "" && u.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
 
 		// system:masters is special because the API server uses it for privileged loopback connections
 		// therefore we know that a member of system:masters can always do anything
-		for _, group := range user.GetGroups() {
-			if group == "system:masters" {
+		for _, group := range u.GetGroups() {
+			if group == user.SystemPrivilegedGroup {
 				return s.StandardStorage.Create(ctx, obj)
 			}
 		}

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -46,6 +46,14 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 		if s.superUser != "" && user.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
+
+		// system:masters is special because the API server uses it for privileged loopback connections
+		// therefore we know that a member of system:masters can always do anything
+		for _, group := range user.GetGroups() {
+			if group == "system:masters" {
+				return s.StandardStorage.Create(ctx, obj)
+			}
+		}
 	}
 
 	roleBinding := obj.(*rbac.RoleBinding)

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -42,15 +43,15 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
+	if u, ok := api.UserFrom(ctx); ok {
+		if s.superUser != "" && u.GetName() == s.superUser {
 			return s.StandardStorage.Create(ctx, obj)
 		}
 
 		// system:masters is special because the API server uses it for privileged loopback connections
 		// therefore we know that a member of system:masters can always do anything
-		for _, group := range user.GetGroups() {
-			if group == "system:masters" {
+		for _, group := range u.GetGroups() {
+			if group == user.SystemPrivilegedGroup {
 				return s.StandardStorage.Create(ctx, obj)
 			}
 		}

--- a/plugin/pkg/auth/authenticator/request/anonymous/anonymous.go
+++ b/plugin/pkg/auth/authenticator/request/anonymous/anonymous.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	anonymousUser = "system:anonymous"
+	anonymousUser = user.Anonymous
 
-	unauthenticatedGroup = "system:unauthenticated"
+	unauthenticatedGroup = user.AllUnauthenticated
 )
 
 func NewAuthenticator() authenticator.Request {

--- a/plugin/pkg/auth/authenticator/request/anonymous/anonymous_test.go
+++ b/plugin/pkg/auth/authenticator/request/anonymous/anonymous_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -32,10 +33,10 @@ func TestAnonymous(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unexpectedly unauthenticated")
 	}
-	if u.GetName() != "system:anonymous" {
-		t.Fatalf("Expected username %s, got %s", "system:anonymous", u.GetName())
+	if u.GetName() != user.Anonymous {
+		t.Fatalf("Expected username %s, got %s", user.Anonymous, u.GetName())
 	}
-	if !sets.NewString(u.GetGroups()...).Equal(sets.NewString("system:unauthenticated")) {
-		t.Fatalf("Expected group %s, got %v", "system:unauthenticated", u.GetGroups())
+	if !sets.NewString(u.GetGroups()...).Equal(sets.NewString(user.AllUnauthenticated)) {
+		t.Fatalf("Expected group %s, got %v", user.AllUnauthenticated, u.GetGroups())
 	}
 }

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -165,15 +165,15 @@ func startMasterOrDie(masterConfig *master.Config) (*master.Master, *httptest.Se
 	if masterConfig.GenericConfig.Authenticator != nil {
 		tokens := make(map[string]*user.DefaultInfo)
 		tokens[privilegedLoopbackToken] = &user.DefaultInfo{
-			Name:   "system:apiserver",
+			Name:   user.APIServerUser,
 			UID:    uuid.NewRandom().String(),
-			Groups: []string{"system:masters"},
+			Groups: []string{user.SystemPrivilegedGroup},
 		}
 
 		tokenAuthenticator := authenticator.NewAuthenticatorFromTokens(tokens)
 		masterConfig.GenericConfig.Authenticator = authenticatorunion.New(tokenAuthenticator, masterConfig.GenericConfig.Authenticator)
 
-		tokenAuthorizer := authorizer.NewPrivilegedGroups("system:masters")
+		tokenAuthorizer := authorizer.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 		masterConfig.GenericConfig.Authorizer = authorizerunion.New(tokenAuthorizer, masterConfig.GenericConfig.Authorizer)
 
 		masterConfig.GenericConfig.LoopbackClientConfig.BearerToken = privilegedLoopbackToken


### PR DESCRIPTION
Updates post start hooks to take a clientconfig with the new loopback credentials for bootstrapping.

@ericchiang This is a little bit of plumbing, but mainly auth I think.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33785)

<!-- Reviewable:end -->
