### PR TITLE
[Federation] Sleep for 2m (arbitrarily chosen) to let the underlying clusters to clean up all the resources they are holding.

### DIFF
--- a/hack/e2e-internal/e2e-down.sh
+++ b/hack/e2e-internal/e2e-down.sh
@@ -30,15 +30,25 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 prepare-e2e
 
 if [[ "${FEDERATION:-}" == "true" ]];then
-    source "${KUBE_ROOT}/federation/cluster/common.sh"
-    for zone in ${E2E_ZONES};do
-	# bring up e2e cluster
-	(
-	    set-federation-zone-vars "$zone"
-	    cleanup-federation-api-objects || echo "Couldn't cleanup federation api objects"
-	    test-teardown
-	)
-    done
+  source "${KUBE_ROOT}/federation/cluster/common.sh"
+  for zone in ${E2E_ZONES};do
+    # bring down an e2e cluster
+    (
+      set-federation-zone-vars "$zone"
+      cleanup-federation-api-objects || echo "Couldn't cleanup federation api objects"
+
+      # TODO(madhusudancs): This is an arbitrary amount of sleep to give Kubernetes
+      # clusters enough time to delete the underlying cloud provider resources
+      # corresponding to the Kubernetes resources we deleted as part of the test
+      # teardowns. It is shameful that we are doing this, but this is just a bandage
+      # to stop the bleeding. Please don't use this pattern anywhere. Remove this
+      # when proper cloud provider cleanups are implemented in the individual test
+      # `AfterEach` blocks.
+      sleep 2m
+
+      test-teardown
+    )
+done
 else
-    test-teardown
+  test-teardown
 fi


### PR DESCRIPTION
cc @kubernetes/sig-cluster-federation @colhom @nikhiljindal

Ref: Issue #33388, Issue #28615, Issue #31624.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33787)

<!-- Reviewable:end -->
