### PR TITLE
gce/coreos: Fix dnsmasq image name

### DIFF
--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -64,7 +64,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/dnsmasq:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq


### PR DESCRIPTION
This bug was inadvertently introduced in #32406.

The longer term plan (shouldn't be too much longer) is to remove this
file entirely and rely on the `gci-trusty` version of it, but to stop
some bleeding and allow our jenkins using kube-up + coreos to work, we
should merge this fix until we have the more complete solution.

cc @MrHohn @yifan-gu @thockin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33791)

<!-- Reviewable:end -->
