### PR TITLE
Add SynchronousGC option to DeleteOptions

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -233,6 +233,7 @@ func IsServiceIPRequested(service *Service) bool {
 var standardFinalizers = sets.NewString(
 	string(FinalizerKubernetes),
 	FinalizerOrphan,
+	FinalizerSynchronousGC,
 )
 
 func IsStandardFinalizerName(str string) bool {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2303,8 +2303,9 @@ type FinalizerName string
 
 // These are internal finalizer values to Kubernetes, must be qualified name unless defined here
 const (
-	FinalizerKubernetes FinalizerName = "kubernetes"
-	FinalizerOrphan     string        = "orphan"
+	FinalizerKubernetes    FinalizerName = "kubernetes"
+	FinalizerOrphan        string        = "orphan"
+	FinalizerSynchronousGC string        = "collectingGarbage"
 )
 
 // NamespaceStatus is information about the current status of a Namespace.
@@ -2379,6 +2380,12 @@ type DeleteOptions struct {
 	// Should the dependent objects be orphaned. If true/false, the "orphan"
 	// finalizer will be added to/removed from the object's finalizers list.
 	OrphanDependents *bool `json:"orphanDependents,omitempty"`
+
+	// Should the owner object keep existing in the key-value store until all dependents are removed.
+	// The option is cascading, i.e., the object’s dependents will be deleted with the same SynchronousGarbageCollection option.
+	// This option and OrphanDependents are exclusive.
+	// Defaults to false.
+	SynchronousGarbageCollection *bool
 }
 
 // ExportOptions is the query options to the standard REST get call.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2794,6 +2794,12 @@ type DeleteOptions struct {
 	// Should the dependent objects be orphaned. If true/false, the "orphan"
 	// finalizer will be added to/removed from the object's finalizers list.
 	OrphanDependents *bool `json:"orphanDependents,omitempty" protobuf:"varint,3,opt,name=orphanDependents"`
+
+	// Should the owner object keep existing in the key-value store until all dependents are removed.
+	// The option is cascading, i.e., the object’s dependents will be deleted with the same SynchronousGarbageCollection option.
+	// This option and OrphanDependents are exclusive.
+	// Defaults to false.
+	SynchronousGarbageCollection *bool
 }
 
 // ExportOptions is the query options to the standard REST get call.

--- a/pkg/api/v1/zz_generated.conversion.go
+++ b/pkg/api/v1/zz_generated.conversion.go
@@ -1439,6 +1439,7 @@ func autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *a
 		out.Preconditions = nil
 	}
 	out.OrphanDependents = in.OrphanDependents
+	out.SynchronousGarbageCollection = in.SynchronousGarbageCollection
 	return nil
 }
 
@@ -1461,6 +1462,7 @@ func autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, ou
 		out.Preconditions = nil
 	}
 	out.OrphanDependents = in.OrphanDependents
+	out.SynchronousGarbageCollection = in.SynchronousGarbageCollection
 	return nil
 }
 

--- a/pkg/api/v1/zz_generated.deepcopy.go
+++ b/pkg/api/v1/zz_generated.deepcopy.go
@@ -771,6 +771,13 @@ func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cl
 		} else {
 			out.OrphanDependents = nil
 		}
+		if in.SynchronousGarbageCollection != nil {
+			in, out := &in.SynchronousGarbageCollection, &out.SynchronousGarbageCollection
+			*out = new(bool)
+			**out = **in
+		} else {
+			out.SynchronousGarbageCollection = nil
+		}
 		return nil
 	}
 }

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -395,9 +395,7 @@ func ValidateObjectMeta(meta *api.ObjectMeta, requiresNamespace bool, nameFn Val
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabels(meta.Labels, fldPath.Child("labels"))...)
 	allErrs = append(allErrs, ValidateAnnotations(meta.Annotations, fldPath.Child("annotations"))...)
 	allErrs = append(allErrs, ValidateOwnerReferences(meta.OwnerReferences, fldPath.Child("ownerReferences"))...)
-	for _, finalizer := range meta.Finalizers {
-		allErrs = append(allErrs, validateFinalizerName(finalizer, fldPath.Child("finalizers"))...)
-	}
+	allErrs = append(allErrs, ValidateFinalizers(meta.Finalizers, fldPath.Child("finalizers"))...)
 	return allErrs
 }
 
@@ -3313,6 +3311,29 @@ func ValidateNamespace(namespace *api.Namespace) field.ErrorList {
 	allErrs := ValidateObjectMeta(&namespace.ObjectMeta, false, ValidateNamespaceName, field.NewPath("metadata"))
 	for i := range namespace.Spec.Finalizers {
 		allErrs = append(allErrs, validateFinalizerName(string(namespace.Spec.Finalizers[i]), field.NewPath("spec", "finalizers"))...)
+	}
+	return allErrs
+}
+
+// ValidateFinalizers tests if the finalizers name are valid, and if there are conflict finalizers
+func ValidateFinalizers(finalizers []string, fldPath *field.Path) field.ErrorList {
+	if fldPath == nil {
+		fldPath = field.NewPath("metadata", "finalizers")
+	}
+	allErrs := field.ErrorList{}
+	hasOrphanFinalizer := false
+	hasSynchronousGCFinalizer := false
+	for _, finalizer := range finalizers {
+		allErrs = append(allErrs, validateFinalizerName(finalizer, fldPath)...)
+		if finalizer == api.FinalizerOrphan {
+			hasOrphanFinalizer = true
+		}
+		if finalizer == api.FinalizerSynchronousGC {
+			hasSynchronousGCFinalizer = true
+		}
+	}
+	if hasSynchronousGCFinalizer && hasOrphanFinalizer {
+		allErrs = append(allErrs, field.Invalid(fldPath, finalizers, fmt.Sprintf("%s and %s cannot be both set", api.FinalizerOrphan, api.FinalizerSynchronousGC)))
 	}
 	return allErrs
 }

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -799,6 +799,13 @@ func DeepCopy_api_DeleteOptions(in interface{}, out interface{}, c *conversion.C
 		} else {
 			out.OrphanDependents = nil
 		}
+		if in.SynchronousGarbageCollection != nil {
+			in, out := &in.SynchronousGarbageCollection, &out.SynchronousGarbageCollection
+			*out = new(bool)
+			**out = **in
+		} else {
+			out.SynchronousGarbageCollection = nil
+		}
 		return nil
 	}
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7271,7 +7271,15 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+					"SynchronousGarbageCollection": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Should the owner object keep existing in the key-value store until all dependents are removed. The option is cascading, i.e., the object’s dependents will be deleted with the same SynchronousGarbageCollection. This option and OrphanDependents are exclusive. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
+				Required: []string{"SynchronousGarbageCollection"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/registry/generic/registry/store_test.go
+++ b/pkg/registry/generic/registry/store_test.go
@@ -1022,6 +1022,137 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 	}
 }
 
+// Test the DeleteOptions.SynchronousGC is handled correctly
+func TestStoreDeleteWithSynchronousGC(t *testing.T) {
+	trueVar := true
+	initialGeneration := int64(1)
+
+	// defaultDeleteStrategy doesn't implement rest.GarbageCollectionDeleteStrategy.
+	defaultDeleteStrategy := &testRESTStrategy{api.Scheme, api.SimpleNameGenerator, true, false, true}
+	// orphanDeleteStrategy indicates the default garbage collection policy is
+	// to orphan dependentes.
+	orphanDeleteStrategy := &testOrphanDeleteStrategy{defaultDeleteStrategy}
+
+	testcases := map[string]struct {
+		options  *api.DeleteOptions
+		strategy rest.RESTDeleteStrategy
+		// finalizers that are already set in the object
+		existingFinalizers []string
+		// expected error occurs at deletion time
+		expectedError bool
+		// expected error message at deletion time
+		expectedErrorMessage string
+		expectedNotFound     bool
+		expectedFinalizers   []string
+	}{
+		"no existing finalizers, SyncGC=true, Orphan=true": {
+			options:              &api.DeleteOptions{OrphanDependents: &trueVar, SynchronousGarbageCollection: &trueVar},
+			strategy:             defaultDeleteStrategy,
+			expectedError:        true,
+			expectedErrorMessage: "cannot be both set",
+		},
+		"no existing finalizers, SyncGC=true, Orphan=nil, defaultDeleteStrategy": {
+			options:            &api.DeleteOptions{SynchronousGarbageCollection: &trueVar},
+			strategy:           defaultDeleteStrategy,
+			expectedFinalizers: []string{api.FinalizerSynchronousGC},
+		},
+		"no existing finalizers, SyncGC=true, Orphan=nil, orphanDeleteStrategy": {
+			options:            &api.DeleteOptions{SynchronousGarbageCollection: &trueVar},
+			strategy:           orphanDeleteStrategy,
+			expectedFinalizers: []string{api.FinalizerSynchronousGC},
+		},
+		"existing Orphan finalizer, SyncGC=true, Orphan=nil, defaultDeleteStrategy": {
+			existingFinalizers: []string{api.FinalizerOrphan},
+			options:            &api.DeleteOptions{SynchronousGarbageCollection: &trueVar},
+			strategy:           defaultDeleteStrategy,
+			expectedFinalizers: []string{api.FinalizerSynchronousGC},
+		},
+		"existing Orphan finalizer, SyncGC=true, Orphan=nil, orphanDeleteStrategy": {
+			existingFinalizers: []string{api.FinalizerOrphan},
+			options:            &api.DeleteOptions{SynchronousGarbageCollection: &trueVar},
+			strategy:           orphanDeleteStrategy,
+			expectedFinalizers: []string{api.FinalizerSynchronousGC},
+		},
+		"no existing finalizers, SyncGC=nil, Orphan=nil,defaultDeleteStrategy": {
+			options:          &api.DeleteOptions{},
+			strategy:         defaultDeleteStrategy,
+			expectedNotFound: true,
+		},
+		"no existing finalizers, SyncGC=nil, Orphan=nil,orphanDeleteStrategy": {
+			options:            &api.DeleteOptions{},
+			strategy:           orphanDeleteStrategy,
+			expectedFinalizers: []string{api.FinalizerOrphan},
+		},
+	}
+
+	testContext := api.WithNamespace(api.NewContext(), "test")
+	destroyFunc, registry := NewTestGenericStoreRegistry(t)
+	registry.EnableGarbageCollection = true
+	defer destroyFunc()
+
+	createPod := func(i int, finalizers []string) *api.Pod {
+		return &api.Pod{
+			ObjectMeta: api.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), Finalizers: finalizers, Generation: initialGeneration},
+			Spec:       api.PodSpec{NodeName: "machine"},
+		}
+	}
+
+	i := 0
+	for title, tc := range testcases {
+		t.Logf("case title: %s", title)
+		registry.DeleteStrategy = tc.strategy
+		i++
+		pod := createPod(i, tc.existingFinalizers)
+		// create pod
+		_, err := registry.Create(testContext, pod)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		_, err = registry.Delete(testContext, pod.Name, tc.options)
+		if !tc.expectedError && err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if tc.expectedError {
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if e, a := tc.expectedErrorMessage, err.Error(); !strings.Contains(a, e) {
+				t.Fatalf("expected error to contain %v, got %v", e, a)
+			}
+		}
+		obj, err := registry.Get(testContext, pod.Name)
+		if tc.expectedNotFound {
+			if err == nil || !errors.IsNotFound(err) {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			continue
+		}
+		if !tc.expectedNotFound && err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !tc.expectedNotFound {
+			pod, ok := obj.(*api.Pod)
+			if !ok {
+				t.Fatalf("Expect the object to be a pod, but got %#v", obj)
+			}
+			if e, a := tc.expectedFinalizers, pod.ObjectMeta.Finalizers; !reflect.DeepEqual(e, a) {
+				t.Errorf("%v: Expect object %s to have finalizers %v, got %v", pod.Name, pod.ObjectMeta.Name, e, a)
+			}
+			if !tc.expectedError {
+				if pod.ObjectMeta.DeletionTimestamp == nil {
+					t.Errorf("%v: Expect the object to have DeletionTimestamp set, but got %#v", pod.Name, pod.ObjectMeta)
+				}
+				if pod.ObjectMeta.DeletionGracePeriodSeconds == nil || *pod.ObjectMeta.DeletionGracePeriodSeconds != 0 {
+					t.Errorf("%v: Expect the object to have 0 DeletionGracePeriodSecond, but got %#v", pod.Name, pod.ObjectMeta)
+				}
+				if pod.Generation <= initialGeneration {
+					t.Errorf("%v: Deletion didn't increase Generation.", pod.Name)
+				}
+			}
+		}
+	}
+}
+
 func TestStoreDeleteCollection(t *testing.T) {
 	podA := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	podB := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "bar"}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

First step implementing synchronous garbage collection proposed in https://github.com/kubernetes/kubernetes/pull/32628.

Add SynchronousGC option to DeleteOptions; Handle SynchronousGC option in API server.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

@deads2k could you help review this since you had already skimmed the proposal?
cc @lavalamp @kubernetes/sig-api-machinery

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33799)

<!-- Reviewable:end -->
