### PR TITLE
cluster/gci: Minor spacing tweak

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -530,10 +530,10 @@ function start-kubelet {
     flags+=" --eviction-hard=${EVICTION_HARD}"
   fi
   if [[ "${ALLOCATE_NODE_CIDRS:-}" == "true" ]]; then
-     flags+=" --configure-cbr0=${ALLOCATE_NODE_CIDRS}"
+    flags+=" --configure-cbr0=${ALLOCATE_NODE_CIDRS}"
   fi
   if [[ -n "${FEATURE_GATES:-}" ]]; then
-     flags+=" --feature-gates=${FEATURE_GATES}"
+    flags+=" --feature-gates=${FEATURE_GATES}"
   fi
 
   local -r kubelet_env_file="/etc/default/kubelet"


### PR DESCRIPTION
Two shall be the number thou shalt indent, and the level of the indent
shall be two. Three shalt thou not indent, neither indent thou once,
excepting that thou then proceed to two. Five is right out.

/cc @andyzheng0831 @jlowdermilk

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33802)

<!-- Reviewable:end -->
