### PR TITLE
CRI: Fix mount issue in dockershim.

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -227,7 +227,8 @@ func (ds *dockerService) ContainerStatus(containerID string) (*runtimeApi.Contai
 
 	// Convert the mounts.
 	mounts := []*runtimeApi.Mount{}
-	for _, m := range r.Mounts {
+	for i := range r.Mounts {
+		m := r.Mounts[i]
 		readonly := !m.RW
 		mounts = append(mounts, &runtimeApi.Mount{
 			Name:          &m.Name,


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/33189.

The test `Container Runtime Conformance Test container runtime conformance blackbox test when starting a container that exits should report termination message if TerminationMessagePath is set` flakes a lot. (see https://k8s-testgrid.appspot.com/google-node#kubelet-cri-gce-e2e&width=5)

After some investigation, I found the problem is that we are using pointer of iterator.

This fixes the flake.

@yujuhong @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33809)

<!-- Reviewable:end -->
