### PR TITLE
Fake docker portfoward for in-process docker CRI integration

### DIFF
--- a/pkg/kubelet/dockershim/legacy.go
+++ b/pkg/kubelet/dockershim/legacy.go
@@ -40,7 +40,7 @@ func (ds *dockerService) GetContainerLogs(pod *api.Pod, containerID kubecontaine
 }
 
 func (ds *dockerService) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
-	return fmt.Errorf("not implemented")
+	return dockertools.PortForward(ds.client, pod, port, stream)
 }
 
 func (ds *dockerService) ExecInContainer(containerID kubecontainer.ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size) error {

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1273,11 +1273,16 @@ func noPodInfraContainerError(podName, podNamespace string) error {
 //  - should we support nsenter + socat on the host? (current impl)
 //  - should we support nsenter + socat in a container, running with elevated privs and --pid=host?
 func (dm *DockerManager) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+	return PortForward(dm.client, pod, port, stream)
+}
+
+// Temporarily export this function to share with dockershim.
+func PortForward(client DockerInterface, pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
 	podInfraContainer := pod.FindContainerByName(PodInfraContainerName)
 	if podInfraContainer == nil {
 		return noPodInfraContainerError(pod.Name, pod.Namespace)
 	}
-	container, err := dm.client.InspectContainer(podInfraContainer.ID.ID)
+	container, err := client.InspectContainer(podInfraContainer.ID.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is necessary to pass e2e tests for in-process docker CRI integration.

This is part of #31459.

cc/ @Random-Liu @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33810)

<!-- Reviewable:end -->
