### PR TITLE
Make E2E tests easier to debug

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -90,12 +90,6 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		}
 
 		By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
-		defer func() {
-			By("Cleaning up the configMap")
-			if err := f.Client.ConfigMaps(f.Namespace.Name).Delete(configMap.Name); err != nil {
-				framework.Failf("unable to delete configMap %v: %v", configMap.Name, err)
-			}
-		}()
 		var err error
 		if configMap, err = f.Client.ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
@@ -135,11 +129,6 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 				RestartPolicy: api.RestartPolicyNever,
 			},
 		}
-
-		defer func() {
-			By("Deleting the pod")
-			f.PodClient().Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		By("Creating the pod")
 		f.PodClient().CreateSync(pod)
 
@@ -163,12 +152,6 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
-		defer func() {
-			By("Cleaning up the configMap")
-			if err := f.Client.ConfigMaps(f.Namespace.Name).Delete(configMap.Name); err != nil {
-				framework.Failf("unable to delete configMap %v: %v", configMap.Name, err)
-			}
-		}()
 		var err error
 		if configMap, err = f.Client.ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
@@ -219,12 +202,6 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		)
 
 		By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
-		defer func() {
-			By("Cleaning up the configMap")
-			if err := f.Client.ConfigMaps(f.Namespace.Name).Delete(configMap.Name); err != nil {
-				framework.Failf("unable to delete configMap %v: %v", configMap.Name, err)
-			}
-		}()
 		var err error
 		if configMap, err = f.Client.ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
@@ -310,12 +287,6 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, d
 	)
 
 	By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
-	defer func() {
-		By("Cleaning up the configMap")
-		if err := f.Client.ConfigMaps(f.Namespace.Name).Delete(configMap.Name); err != nil {
-			framework.Failf("unable to delete configMap %v: %v", configMap.Name, err)
-		}
-	}()
 	var err error
 	if configMap, err = f.Client.ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
@@ -394,12 +365,7 @@ func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, item
 	)
 
 	By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
-	defer func() {
-		By("Cleaning up the configMap")
-		if err := f.Client.ConfigMaps(f.Namespace.Name).Delete(configMap.Name); err != nil {
-			framework.Failf("unable to delete configMap %v: %v", configMap.Name, err)
-		}
-	}()
+
 	var err error
 	if configMap, err = f.Client.ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -89,10 +89,6 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		podName := "labelsupdate" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/labels")
 		containerName := "client-container"
-		defer func() {
-			By("Deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		By("Creating the pod")
 		podClient.CreateSync(pod)
 
@@ -119,10 +115,6 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/annotations")
 
 		containerName := "client-container"
-		defer func() {
-			By("Deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		By("Creating the pod")
 		podClient.CreateSync(pod)
 

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -76,7 +76,6 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 				},
 			},
 		}
-		defer podClient.Delete(pod.Name, nil)
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(api.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -140,7 +139,6 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 				},
 			},
 		}
-		defer podClient.Delete(pod.Name, nil)
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(api.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -204,7 +202,6 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 				},
 			},
 		}
-		defer podClient.Delete(pod.Name, nil)
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(api.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -316,8 +313,8 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 				},
 			},
 		}
-		defer podClient.Delete(pod.Name, nil)
 		startedPod := podClient.Create(pod)
+
 		w, err := podClient.Watch(api.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
 

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -48,7 +48,6 @@ var (
 // testHostIP tests that a pod gets a host IP
 func testHostIP(podClient *framework.PodClient, pod *api.Pod) {
 	By("creating pod")
-	defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 	podClient.CreateSync(pod)
 
 	// Try to make sure we get a hostIP for each pod.
@@ -179,10 +178,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to set up watch")
 
 		By("submitting the pod to kubernetes")
-		// We call defer here in case there is a problem with
-		// the test so we can ensure that we clean up after
-		// ourselves
-		defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 		podClient.Create(pod)
 
 		By("verifying the pod is in kubernetes")
@@ -288,10 +283,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}
 
 		By("submitting the pod to kubernetes")
-		defer func() {
-			By("deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		pod = podClient.CreateSync(pod)
 
 		By("verifying the pod is in kubernetes")
@@ -341,10 +332,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}
 
 		By("submitting the pod to kubernetes")
-		defer func() {
-			By("deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		podClient.CreateSync(pod)
 
 		By("verifying the pod is in kubernetes")
@@ -382,7 +369,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
-		defer podClient.Delete(serverPod.Name, api.NewDeleteOptions(0))
 		podClient.CreateSync(serverPod)
 
 		// This service exposes port 8080 of the test pod as a service on port 8765
@@ -410,7 +396,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
-		defer f.Client.Services(f.Namespace.Name).Delete(svc.Name)
 		_, err := f.Client.Services(f.Namespace.Name).Create(svc)
 		Expect(err).NotTo(HaveOccurred(), "failed to create service")
 
@@ -473,10 +458,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}
 
 		By("submitting the pod to kubernetes")
-		defer func() {
-			By("deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 		pod = podClient.CreateSync(pod)
 
 		req := f.Client.Get().
@@ -601,11 +582,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 			},
 		}
 
-		defer func() {
-			By("deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
-
 		delay1, delay2 := startPodAndGetBackOffs(podClient, pod, buildBackOffDuration)
 
 		By("updating the image")
@@ -646,11 +622,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
-
-		defer func() {
-			By("deleting the pod")
-			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		}()
 
 		podClient.CreateSync(pod)
 		time.Sleep(2 * kubelet.MaxContainerBackOff) // it takes slightly more than 2*x to get to a back-off of x

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -46,12 +46,6 @@ var _ = framework.KubeDescribe("Secrets", func() {
 		secret := secretForTest(f.Namespace.Name, name)
 
 		By(fmt.Sprintf("Creating secret with name %s", secret.Name))
-		defer func() {
-			By("Cleaning up the secret")
-			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
-			}
-		}()
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
@@ -119,12 +113,6 @@ var _ = framework.KubeDescribe("Secrets", func() {
 		)
 
 		By(fmt.Sprintf("Creating secret with name %s", secret.Name))
-		defer func() {
-			By("Cleaning up the secret")
-			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
-			}
-		}()
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
@@ -189,12 +177,6 @@ var _ = framework.KubeDescribe("Secrets", func() {
 		secret := secretForTest(f.Namespace.Name, name)
 
 		By(fmt.Sprintf("Creating secret with name %s", secret.Name))
-		defer func() {
-			By("Cleaning up the secret")
-			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
-			}
-		}()
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)

--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -196,7 +196,6 @@ var _ = framework.KubeDescribe("Sysctls", func() {
 		By("Creating a pod with one valid and two invalid sysctls")
 		client := f.Client.Pods(f.Namespace.Name)
 		_, err := client.Create(pod)
-		defer client.Delete(pod.Name, nil)
 
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring(`Invalid value: "foo-"`))

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2145,15 +2145,15 @@ func (f *Framework) MatchContainerOutput(
 	podClient := f.PodClient()
 	ns := f.Namespace.Name
 
-	podClient.Create(pod)
+	createdPod := podClient.Create(pod)
 
 	// Wait for client pod to complete.
-	if err := WaitForPodSuccessInNamespace(f.Client, pod.Name, ns); err != nil {
+	if err := WaitForPodSuccessInNamespace(f.Client, createdPod.Name, ns); err != nil {
 		return fmt.Errorf("expected pod %q success: %v", pod.Name, err)
 	}
 
 	// Grab its logs.  Get host first.
-	podStatus, err := podClient.Get(pod.Name)
+	podStatus, err := podClient.Get(createdPod.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get pod status: %v", err)
 	}
@@ -2162,7 +2162,7 @@ func (f *Framework) MatchContainerOutput(
 		podStatus.Spec.NodeName, podStatus.Name, containerName, err)
 
 	// Sometimes the actual containers take a second to get started, try to get logs for 60s
-	logs, err := GetPodLogs(f.Client, ns, pod.Name, containerName)
+	logs, err := GetPodLogs(f.Client, ns, podStatus.Name, containerName)
 	if err != nil {
 		Logf("Failed to get logs from node %q pod %q container %q. %v",
 			podStatus.Spec.NodeName, podStatus.Name, containerName, err)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2145,7 +2145,6 @@ func (f *Framework) MatchContainerOutput(
 	podClient := f.PodClient()
 	ns := f.Namespace.Name
 
-	defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 	podClient.Create(pod)
 
 	// Wait for client pod to complete.
@@ -4320,7 +4319,6 @@ func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeo
 	if err != nil {
 		return err
 	}
-	defer podClient.Delete(podName, nil)
 	err = WaitForPodSuccessInNamespace(f.Client, podName, f.Namespace.Name)
 
 	if err != nil {

--- a/test/e2e/generated_clientset.go
+++ b/test/e2e/generated_clientset.go
@@ -149,10 +149,6 @@ var _ = framework.KubeDescribe("Generated release_1_5 clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to create pod: %v", err)
 		}
-		// We call defer here in case there is a problem with
-		// the test so we can ensure that we clean up after
-		// ourselves
-		defer podClient.Delete(pod.Name, v1.NewDeleteOptions(0))
 
 		By("verifying the pod is in kubernetes")
 		options = v1.ListOptions{
@@ -212,10 +208,6 @@ var _ = framework.KubeDescribe("Staging client repo client", func() {
 		if err != nil {
 			framework.Failf("Failed to create pod: %v", err)
 		}
-		// We call defer here in case there is a problem with
-		// the test so we can ensure that we clean up after
-		// ourselves
-		defer podClient.Delete(pod.Name, clientapi.NewDeleteOptions(0))
 
 		By("verifying the pod is in kubernetes")
 		timeout := 1 * time.Minute

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -105,12 +105,6 @@ func proxyContext(version string) {
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		defer func(name string) {
-			err := f.Client.Services(f.Namespace.Name).Delete(name)
-			if err != nil {
-				framework.Logf("Failed deleting service %v: %v", name, err)
-			}
-		}(service.Name)
 
 		// Make an RC with a single pod. The 'porter' image is
 		// a simple server which serves the values of the

--- a/test/e2e/security_context.go
+++ b/test/e2e/security_context.go
@@ -171,7 +171,6 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	pod, err := client.Create(pod)
 
 	framework.ExpectNoError(err, "Error creating pod %v", pod)
-	defer client.Delete(pod.Name, nil)
 	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod))
 
 	testContent := "hello"
@@ -226,7 +225,6 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	}
 	_, err = client.Create(pod)
 	framework.ExpectNoError(err, "Error creating pod %v", pod)
-	defer client.Delete(pod.Name, nil)
 
 	err = f.WaitForPodRunning(pod.Name)
 	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -191,7 +191,7 @@ var _ = framework.KubeDescribe("ServiceAccounts", func() {
 
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				Name: "pod-service-account-" + string(uuid.NewUUID()),
+				GenerateName: "pod-service-account-" + string(uuid.NewUUID()) + "-",
 			},
 			Spec: api.PodSpec{
 				Containers: []api.Container{

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -127,7 +127,6 @@ func runServiceLatencies(f *framework.Framework, inParallel, total int) (output 
 	if err := framework.RunRC(cfg); err != nil {
 		return nil, err
 	}
-	defer framework.DeleteRCAndPods(f.Client, f.ClientSet, f.Namespace.Name, cfg.Name)
 
 	// Run a single watcher, to reduce the number of API calls we have to
 	// make; this is to minimize the timing error. It's how kube-proxy
@@ -331,7 +330,6 @@ func singleServiceLatency(f *framework.Framework, name string, q *endpointQuerie
 		return 0, err
 	}
 	framework.Logf("Created: %v", gotSvc.Name)
-	defer f.Client.Services(gotSvc.Namespace).Delete(gotSvc.Name)
 
 	if e := q.request(gotSvc.Name); e == nil {
 		return 0, fmt.Errorf("Never got a result for endpoint %v", gotSvc.Name)


### PR DESCRIPTION
This PR removes deferred deletion calls in E2E tests in order to make test easier to debug.  Some of these tests predate namespace finalization; we should just rely on that mechanism to ensure that framework test artifacts are deleted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33811)

<!-- Reviewable:end -->
