### PR TITLE
Kubeadm: print information about certificates

### DIFF
--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -74,15 +74,16 @@ func PerformTLSBootstrap(s *kubeadmapi.KubeadmConfig, apiEndpoint string, caCert
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to generating private key [%v]", err)
 	}
-
 	cert, err := csr.RequestNodeCertificate(csrClient, key, nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to request signed certificate from the API server [%v]", err)
 	}
-
-	// TODO(phase1+) https://github.com/kubernetes/kubernetes/issues/33642
-	fmt.Println("<node/csr> received signed certificate from the API server, generating kubelet configuration")
-
+	fmtCert, err := certutil.FormatBytesCert(cert)
+	if err != nil {
+		return nil, fmt.Errorf("<node/csr> failed to format certificate [%v]", err)
+	}
+	fmt.Printf("<node/csr> received signed certificate from the API server:\n%s\n", fmtCert)
+	fmt.Println("<node/csr> generating kubelet configuration")
 	finalConfig := kubeadmutil.MakeClientConfigWithCerts(
 		bareClientConfig, "kubernetes", fmt.Sprintf("kubelet-%s", nodeName),
 		key, cert,

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -188,3 +188,31 @@ func GenerateSelfSignedCert(host, certPath, keyPath string, alternateIPs []net.I
 
 	return nil
 }
+
+// FormatBytesCert receives byte array certificate and formats in human-readable format
+func FormatBytesCert(cert []byte) (string, error) {
+	block, _ := pem.Decode(cert)
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate [%v]", err)
+	}
+	return FormatCert(c), nil
+}
+
+// FormatCert receives certificate and formats in human-readable format
+func FormatCert(c *x509.Certificate) string {
+	var ips []string
+	for _, ip := range c.IPAddresses {
+		ips = append(ips, ip.String())
+	}
+	altNames := append(ips, c.DNSNames...)
+	res := fmt.Sprintf(
+		"Issuer: CN=%s | Subject: CN=%s | CA: %t\n",
+		c.Issuer.CommonName, c.Subject.CommonName, c.IsCA,
+	)
+	res += fmt.Sprintf("Not before: %s Not After: %s", c.NotBefore, c.NotAfter)
+	if len(altNames) > 0 {
+		res += fmt.Sprintf("\nAlternate Names: %v", altNames)
+	}
+	return res
+}


### PR DESCRIPTION
Prints basic information about certificates to the user.

Example of `kubeadm init` output:

```
<master/pki> generated Certificate Authority key and certificate:
Issuer: CN=kubernetes | Subject: CN=kubernetes | CA: true
Not before: 2016-09-30 11:19:19 +0000 UTC Not After: 2026-09-28 11:19:19 +0000 UTC
Public: /etc/kubernetes/pki/ca-pub.pem
Private: /etc/kubernetes/pki/ca-key.pem
Cert: /etc/kubernetes/pki/ca.pem
<master/pki> generated API Server key and certificate:
Issuer: CN=kubernetes | Subject: CN=kube-apiserver | CA: false
Not before: 2016-09-30 11:19:19 +0000 UTC Not After: 2017-09-30 11:19:19 +0000 UTC
Alternate Names: [172.18.76.239 10.0.0.1 kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local]
Public: /etc/kubernetes/pki/apiserver-pub.pem
Private: /etc/kubernetes/pki/apiserver-key.pem
Cert: /etc/kubernetes/pki/apiserver.pem
<master/pki> generated Service Account Signing keys:
Public: /etc/kubernetes/pki/sa-pub.pem
Private: /etc/kubernetes/pki/sa-key.pem
```

Example of `kubeadm join` command:

```
<node/csr> received signed certificate from the API server:
Issuer: CN=kubernetes | Subject: CN=system:node:minion | CA: false
Not before: 2016-09-30 11:28:00 +0000 UTC Not After: 2017-09-30 11:28:00 +0000 UTC
```

Fixes #33642
cc @kubernetes/sig-cluster-lifecycle 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33831)

<!-- Reviewable:end -->
