### PR TITLE
Use default kubectl path for Centos

### DIFF
--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -28,9 +28,6 @@ readonly ROOT=$(dirname "${BASH_SOURCE}")
 source "${ROOT}/${KUBE_CONFIG_FILE:-"config-default.sh"}"
 source "$KUBE_ROOT/cluster/common.sh"
 
-
-KUBECTL_PATH=${KUBE_ROOT}/cluster/centos/binaries/kubectl
-
 # Directory to be used for master and node provisioning.
 KUBE_TEMP="~/kube_temp"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
- Fixes issue to setup Kubernetes cluster on centos nodes from MacOS.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Fixes issue to setup Kubernetes cluster on centos nodes from MacOS.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33833)

<!-- Reviewable:end -->
