### PR TITLE
clean api server cruft

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -365,6 +365,6 @@ func Run(s *options.APIServer) error {
 	}
 
 	sharedInformers.Start(wait.NeverStop)
-	m.Run()
+	m.GenericAPIServer.Run()
 	return nil
 }

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -365,7 +365,6 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 
 	s := &GenericAPIServer{
 		ServiceClusterIPRange: c.ServiceClusterIPRange,
-		ServiceNodePortRange:  c.ServiceNodePortRange,
 		LoopbackClientConfig:  c.LoopbackClientConfig,
 		legacyAPIPrefix:       c.APIPrefix,
 		apiPrefix:             c.APIGroupPrefix,
@@ -381,11 +380,8 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 		InsecureServingInfo:  c.InsecureServingInfo,
 		ExternalAddress:      c.ExternalHost,
 		ClusterIP:            c.PublicAddress,
-		PublicReadWritePort:  c.ReadWritePort,
 		ServiceReadWriteIP:   c.ServiceReadWriteIP,
 		ServiceReadWritePort: c.ServiceReadWritePort,
-		ExtraServicePorts:    c.ExtraServicePorts,
-		ExtraEndpointPorts:   c.ExtraEndpointPorts,
 
 		KubernetesServiceNodePort: c.KubernetesServiceNodePort,
 		apiGroupsForDiscovery:     map[string]unversioned.APIGroup{},

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -90,10 +90,6 @@ type GenericAPIServer struct {
 	// truth for its value.
 	ServiceClusterIPRange *net.IPNet
 
-	// ServiceNodePortRange is only used for `master.go` to construct its RESTStorage for the legacy API group
-	// TODO refactor this closer to the point of use.
-	ServiceNodePortRange utilnet.PortRange
-
 	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
 	LoopbackClientConfig *restclient.Config
 
@@ -166,11 +162,8 @@ type GenericAPIServer struct {
 	openAPIDefinitions        *common.OpenAPIDefinitions
 	MasterCount               int
 	KubernetesServiceNodePort int // TODO(sttts): move into master
-	PublicReadWritePort       int
 	ServiceReadWriteIP        net.IP
 	ServiceReadWritePort      int
-	ExtraServicePorts         []api.ServicePort
-	ExtraEndpointPorts        []api.EndpointPort
 }
 
 func init() {

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -90,7 +90,6 @@ func TestNew(t *testing.T) {
 	serviceReadWriteIP, _ := ipallocator.GetIndexedIP(serviceClusterIPRange, 1)
 	assert.Equal(s.ServiceReadWriteIP, serviceReadWriteIP)
 	assert.Equal(s.ExternalAddress, net.JoinHostPort(config.PublicAddress.String(), "6443"))
-	assert.Equal(s.PublicReadWritePort, 6443)
 
 	// These functions should point to the same memory location
 	serverDialer, _ := utilnet.Dialer(s.ProxyTransport)
@@ -312,7 +311,6 @@ func TestInstallSwaggerAPI(t *testing.T) {
 	server.HandlerContainer = genericmux.NewAPIContainer(mux, nil)
 	server.ExternalAddress = ""
 	server.ClusterIP = net.IPv4(10, 10, 10, 10)
-	server.PublicReadWritePort = 1010
 	server.InstallSwaggerAPI()
 	if assert.NotEqual(0, len(ws), "SwaggerAPI not installed.") {
 		assert.Equal("/swaggerapi/", ws[0].RootPath(), "SwaggerAPI did not install to the proper path. %s != /swaggerapi", ws[0].RootPath())

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -175,7 +175,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 		s = incomingServer
 	} else {
 		s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			m.Handler.ServeHTTP(w, req)
+			m.GenericAPIServer.Handler.ServeHTTP(w, req)
 		}))
 	}
 

--- a/test/integration/kubectl/kubectl_test.go
+++ b/test/integration/kubectl/kubectl_test.go
@@ -47,7 +47,7 @@ func TestKubectlValidation(t *testing.T) {
 	ctx := clientcmdapi.NewContext()
 	cfg := clientcmdapi.NewConfig()
 	// Enable swagger api on master.
-	components.KubeMaster.InstallSwaggerAPI()
+	components.KubeMaster.GenericAPIServer.InstallSwaggerAPI()
 	cluster := clientcmdapi.NewCluster()
 
 	cluster.Server = components.ApiServer.URL

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -58,7 +58,7 @@ func TestQuota(t *testing.T) {
 	h := &framework.MasterHolder{Initialized: make(chan struct{})}
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		<-h.Initialized
-		h.M.Handler.ServeHTTP(w, req)
+		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 	defer s.Close()
 

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -51,7 +51,7 @@ func mustSetupScheduler() (schedulerConfigFactory *factory.ConfigFactory, destro
 		panic("error in brining up the master: " + err.Error())
 	}
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
+		m.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
 	c := client.NewOrDie(&restclient.Config{

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -342,7 +342,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	h := &framework.MasterHolder{Initialized: make(chan struct{})}
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		<-h.Initialized
-		h.M.Handler.ServeHTTP(w, req)
+		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
 	// Anonymous client config


### PR DESCRIPTION
Some cruft has developed over refactors.  Remove that cruft.

@liggitt probably last in the chain so far

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33842)

<!-- Reviewable:end -->
