### PR TITLE
Correct env var name in configure-helper

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -590,7 +590,7 @@ function start-kube-proxy {
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
   if [[ -n "${KUBEPROXY_TEST_ARGS:-}" ]]; then
-    params+=" ${KUBE_PROXY_TEST_ARGS}"
+    params+=" ${KUBEPROXY_TEST_ARGS}"
   fi
   sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${src_file}
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${src_file}
@@ -1131,7 +1131,7 @@ function start-rescheduler {
 function setup-kubelet-dir {
     echo "Making /var/lib/kubelet executable for kubelet"
     mount --bind /var/lib/kubelet /var/lib/kubelet/
-    mount -B -o remount,exec,suid,dev /var/lib/kubelet    
+    mount -B -o remount,exec,suid,dev /var/lib/kubelet
 }
 
 function reset-motd {

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1130,7 +1130,7 @@ function start-rescheduler {
 # Setup working directory for kubelet.
 function setup-kubelet-dir {
     echo "Making /var/lib/kubelet executable for kubelet"
-    mount --bind /var/lib/kubelet /var/lib/kubelet/
+    mount -B /var/lib/kubelet /var/lib/kubelet/
     mount -B -o remount,exec,suid,dev /var/lib/kubelet
 }
 


### PR DESCRIPTION
The variable should be KUBEPROXY_TEST_ARGS, not KUBE_PROXY_TEST_ARGS.

```release-note
Correct env var name in configure-helper
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33848)

<!-- Reviewable:end -->
