### PR TITLE
add e2e test for kubectl in a Pod

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -90,6 +90,7 @@ const (
 	kubeCtlManifestPath      = "test/e2e/testing-manifests/kubectl"
 	redisControllerFilename  = "redis-master-controller.json"
 	redisServiceFilename     = "redis-master-service.json"
+	kubectlInPodFilename     = "kubectl-in-pod.json"
 )
 
 var (
@@ -500,9 +501,6 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 				Expect(logOutput).ToNot(ContainSubstring("stdin closed"))
 				return strings.Contains(logOutput, "abcd1234"), nil
 			})
-			if err != nil {
-				os.Exit(1)
-			}
 			Expect(err).To(BeNil())
 
 			Expect(c.Batch().Jobs(ns).Delete("run-test-3", nil)).To(BeNil())
@@ -523,6 +521,30 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			if !strings.Contains(body, nginxDefaultOutput) {
 				framework.Failf("Container port output missing expected value. Wanted:'%s', got: %s", nginxDefaultOutput, body)
 			}
+		})
+	})
+
+	framework.KubeDescribe("Kubectl should be able to talk to api server", func() {
+		It("kubectl running in a pod could talk to api server [Conformance]", func() {
+			framework.SkipUnlessProviderIs("gke")
+			nsFlag := fmt.Sprintf("--namespace=%v", ns)
+			podJson := readTestFileOrDie(kubectlInPodFilename)
+			By("validating api verions")
+			framework.RunKubectlOrDieInput(string(podJson), "create", "-f", "-", nsFlag)
+			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+				output := framework.RunKubectlOrDie("get", "pods/kubectl-in-pod", nsFlag)
+				if strings.Contains(output, "Running") {
+					return true, nil
+				} else {
+					return false, nil
+				}
+			})
+			Expect(err).To(BeNil())
+			output := framework.RunKubectlOrDie("exec", "kubectl-in-pod", nsFlag, "--", "kubectl", "version")
+			if !strings.Contains(output, "Server Version") {
+				framework.Failf("kubectl in the pod fails to talk to api server")
+			}
+			framework.RunKubectlOrDie("delete", "pods", "kubectl-in-pod", nsFlag)
 		})
 	})
 

--- a/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
+++ b/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "kubectl-in-pod"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "busybox",
+        "image": "busybox",
+        "stdin": true,
+        "stdinOnce": true,
+        "tty": true,
+        "volumeMounts": [{
+          "mountPath": "/usr/bin/kubectl",
+          "name": "kubectl"
+        }]
+      }
+    ],
+    "volumes": [{
+      "name":"kubectl",
+      "hostPath":{"path": "/usr/bin/kubectl"}
+    }]
+  }
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -202,6 +202,7 @@ Kubectl client Kubectl run deployment should create a deployment from an image,j
 Kubectl client Kubectl run job should create a job from an image when restart is OnFailure,soltysh,0
 Kubectl client Kubectl run pod should create a pod from an image when restart is Never,janetkuo,0
 Kubectl client Kubectl run rc should create an rc from an image,janetkuo,0
+Kubectl client Kubectl should be able to talk to api server kubectl running in a pod could talk to api server,ymqytw,0
 Kubectl client Kubectl taint should remove all the taints with the same key off a node,erictune,1
 Kubectl client Kubectl taint should update the taint on a node,pwittrock,0
 Kubectl client Kubectl version should check is all data is printed,janetkuo,0


### PR DESCRIPTION
Add a e2e test to make sure kubectl can talk to the api server when it is mounted in a pod.
Fixes: #33138

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33850)

<!-- Reviewable:end -->
