### PR TITLE
Explicitly return nil for underlying cluster's service in Federated Service e2e cleanup function.

### DIFF
--- a/test/e2e/federation-util.go
+++ b/test/e2e/federation-util.go
@@ -303,10 +303,10 @@ func cleanupServiceShardsAndProviderResources(namespace string, service *v1.Serv
 			} else if errors.IsNotFound(err) {
 				cSvc = nil
 				By(fmt.Sprintf("Service %q in namespace %q in cluster %q not found", service.Name, namespace, name))
-				return true, nil
+				return true, err
 			}
 			By(fmt.Sprintf("Service %q in namespace %q in cluster %q found", service.Name, namespace, name))
-			return true, nil
+			return true, err
 		})
 
 		if err != nil || cSvc == nil {

--- a/test/e2e/federation-util.go
+++ b/test/e2e/federation-util.go
@@ -300,6 +300,10 @@ func cleanupServiceShardsAndProviderResources(namespace string, service *v1.Serv
 				// Get failed with an error, try again.
 				framework.Logf("Failed to find service %q in namespace %q, in cluster %q: %v. Trying again in %s", service.Name, namespace, name, err, framework.Poll)
 				return false, nil
+			} else if errors.IsNotFound(err) {
+				cSvc = nil
+				By(fmt.Sprintf("Service %q in namespace %q in cluster %q not found", service.Name, namespace, name))
+				return true, nil
 			}
 			By(fmt.Sprintf("Service %q in namespace %q in cluster %q found", service.Name, namespace, name))
 			return true, nil
@@ -307,7 +311,7 @@ func cleanupServiceShardsAndProviderResources(namespace string, service *v1.Serv
 
 		if err != nil || cSvc == nil {
 			By(fmt.Sprintf("Failed to find service %q in namespace %q, in cluster %q in %s", service.Name, namespace, name, FederatedServiceTimeout))
-			return
+			continue
 		}
 
 		err = cleanupServiceShard(c.Clientset, name, namespace, cSvc, FederatedServiceTimeout)


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33853)

<!-- Reviewable:end -->
