### PR TITLE
Do not probe so aggressively which may lead to unnecessary restarts

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -195,6 +195,7 @@ func componentProbe(port int, path string) *api.Probe {
 		},
 		InitialDelaySeconds: 15,
 		TimeoutSeconds:      15,
+		FailureThreshold:    8,
 	}
 }
 


### PR DESCRIPTION
@errordeveloper @mikedanese PTAL

I came across a case where etcd restarted about 5-10 times because the load was very high on the machine. 
The load seems to have lead to that the `etcd` container occasionally didn't respond to the probe, which caused many restart and made the whole thing even worse.

Maybe we should remove the etcd probe totally? I don't know, what do you think?
This is at least a try to loosen the limits here...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33859)

<!-- Reviewable:end -->
