### PR TITLE
wait for federation informer store to catch up before update

### DIFF
--- a/federation/pkg/federation-controller/namespace/namespace_controller_test.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller_test.go
@@ -31,6 +31,7 @@ import (
 	fake_kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -110,6 +111,12 @@ func TestNamespaceController(t *testing.T) {
 	createdNamespace := GetNamespaceFromChan(cluster1CreateChan)
 	assert.NotNil(t, createdNamespace)
 	assert.Equal(t, ns1.Name, createdNamespace.Name)
+
+	// Wait for the secret to appear in the informer store
+	err := WaitForStoreUpdate(
+		namespaceController.namespaceFederatedInformer.GetTargetStore(),
+		cluster1.Name, ns1.Name, wait.ForeverTestTimeout)
+	assert.Nil(t, err, "namespace should have appeared in the informer store")
 
 	// Test update federated namespace.
 	ns1.Annotations = map[string]string{

--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -28,6 +28,7 @@ import (
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/golang/glog"
@@ -210,4 +211,14 @@ func NewCluster(name string, readyStatus api_v1.ConditionStatus) *federation_api
 			},
 		},
 	}
+}
+
+// Ensure a key is in the store before returning (or timeout w/ error)
+func WaitForStoreUpdate(store util.FederatedReadOnlyStore, clusterName, key string, timeout time.Duration) error {
+	retryInterval := 100 * time.Millisecond
+	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		_, found, err := store.GetByKey(clusterName, key)
+		return found, err
+	})
+	return err
 }


### PR DESCRIPTION
Fixes #33838 #33880 

There is a flake in the federation-controller code where an update to a resource is done too quickly after the create.  Because the resource is not yet in the federated informer store, when the reconcile<Resource>() is called, it can't find the resource and treats the change as a create rather than a update.

This causes a failure (actually a panic) in the test code, which expects an update event, not a create, in response to the resource modification.

@derekwaynecarr @apelisse @mwielgus

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33866)

<!-- Reviewable:end -->
