### PR TITLE
CRI: Fix bug in dockershim to set sandbox id properly.

### DIFF
--- a/pkg/kubelet/dockershim/convert.go
+++ b/pkg/kubelet/dockershim/convert.go
@@ -56,14 +56,16 @@ func toRuntimeAPIContainer(c *dockertypes.Container) (*runtimeApi.Container, err
 		return nil, err
 	}
 	labels, annotations := extractLabels(c.Labels)
+	sandboxID := c.Labels[sandboxIDLabelKey]
 	return &runtimeApi.Container{
-		Id:          &c.ID,
-		Metadata:    metadata,
-		Image:       &runtimeApi.ImageSpec{Image: &c.Image},
-		ImageRef:    &c.ImageID,
-		State:       &state,
-		Labels:      labels,
-		Annotations: annotations,
+		Id:           &c.ID,
+		PodSandboxId: &sandboxID,
+		Metadata:     metadata,
+		Image:        &runtimeApi.ImageSpec{Image: &c.Image},
+		ImageRef:     &c.ImageID,
+		State:        &state,
+		Labels:       labels,
+		Annotations:  annotations,
 	}, nil
 }
 

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -73,13 +73,14 @@ func TestListContainers(t *testing.T) {
 		// Prepend to the expected list because ListContainers returns
 		// the most recent containers first.
 		expected = append([]*runtimeApi.Container{{
-			Metadata:    configs[i].Metadata,
-			Id:          &id,
-			State:       &state,
-			Image:       configs[i].Image,
-			ImageRef:    &imageRef,
-			Labels:      configs[i].Labels,
-			Annotations: configs[i].Annotations,
+			Metadata:     configs[i].Metadata,
+			Id:           &id,
+			PodSandboxId: &sandboxID,
+			State:        &state,
+			Image:        configs[i].Image,
+			ImageRef:     &imageRef,
+			Labels:       configs[i].Labels,
+			Annotations:  configs[i].Annotations,
 		}}, expected...)
 	}
 	containers, err := ds.ListContainers(nil)


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/33189#issuecomment-249307796.

During debugging `Variable Expansion should allow composing env vars into new env vars`, I found that the root cause is that the sandbox was removed before all containers were deleted, which caused the pod to be started again after succeed.

This happened because the `PodSandboxID` field is not set. This PR fixes the bug.

Some other test flakes are also caused by this

```
Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set
Downward API volume should provide container's memory limit
EmptyDir volumes should support (non-root,0666,tmpfs)
...
```

/cc @yujuhong @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33889)

<!-- Reviewable:end -->
