### PR TITLE
Escape special characters in jsonpath field names.

### DIFF
--- a/pkg/util/jsonpath/jsonpath_test.go
+++ b/pkg/util/jsonpath/jsonpath_test.go
@@ -206,7 +206,12 @@ func TestKubernetes(t *testing.T) {
 	  "items":[
 		{
 		  "kind":"None",
-		  "metadata":{"name":"127.0.0.1"},
+		  "metadata":{
+		    "name":"127.0.0.1",
+			"labels":{
+			  "kubernetes.io/hostname":"127.0.0.1"
+			}
+		  },
 		  "status":{
 			"capacity":{"cpu":"4"},
 			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}]
@@ -214,7 +219,12 @@ func TestKubernetes(t *testing.T) {
 		},
 		{
 		  "kind":"None",
-		  "metadata":{"name":"127.0.0.2"},
+		  "metadata":{
+			"name":"127.0.0.2",
+			"labels":{
+			  "kubernetes.io/hostname":"127.0.0.2"
+			}
+		  },
 		  "status":{
 			"capacity":{"cpu":"8"},
 			"addresses":[
@@ -254,6 +264,8 @@ func TestKubernetes(t *testing.T) {
 		{"range nodes capacity", `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}`, nodesData,
 			"[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]] "},
 		{"user password", `{.users[?(@.name=="e2e")].user.password}`, &nodesData, "secret"},
+		{"hostname", `{.items[0].metadata.labels.kubernetes\.io/hostname}`, &nodesData, "127.0.0.1"},
+		{"hostname filter", `{.items[?(@.metadata.labels.kubernetes\.io/hostname=="127.0.0.1")].kind}`, &nodesData, "None"},
 	}
 	testJSONPath(nodesTests, t)
 

--- a/pkg/util/jsonpath/parser.go
+++ b/pkg/util/jsonpath/parser.go
@@ -382,7 +382,8 @@ Loop:
 // parseField scans a field until a terminator
 func (p *Parser) parseField(cur *ListNode) error {
 	p.consumeText()
-	for p.advance() {}
+	for p.advance() {
+	}
 	value := p.consumeText()
 	if value == "*" {
 		cur.append(newWildcard())

--- a/pkg/util/jsonpath/parser.go
+++ b/pkg/util/jsonpath/parser.go
@@ -382,19 +382,21 @@ Loop:
 // parseField scans a field until a terminator
 func (p *Parser) parseField(cur *ListNode) error {
 	p.consumeText()
-	var r rune
+Loop:
 	for {
-		r = p.next()
-		if isTerminator(r) {
+		switch r := p.next(); {
+		case r == '\\':
+			p.next()
+		case isTerminator(r):
 			p.backup()
-			break
+			break Loop
 		}
 	}
 	value := p.consumeText()
 	if value == "*" {
 		cur.append(newWildcard())
 	} else {
-		cur.append(newField(value))
+		cur.append(newField(strings.Replace(value, "\\", "", -1)))
 	}
 	return p.parseInsideAction(cur)
 }

--- a/pkg/util/jsonpath/parser.go
+++ b/pkg/util/jsonpath/parser.go
@@ -382,16 +382,7 @@ Loop:
 // parseField scans a field until a terminator
 func (p *Parser) parseField(cur *ListNode) error {
 	p.consumeText()
-Loop:
-	for {
-		switch r := p.next(); {
-		case r == '\\':
-			p.next()
-		case isTerminator(r):
-			p.backup()
-			break Loop
-		}
-	}
+	for p.advance() {}
 	value := p.consumeText()
 	if value == "*" {
 		cur.append(newWildcard())
@@ -399,6 +390,18 @@ Loop:
 		cur.append(newField(strings.Replace(value, "\\", "", -1)))
 	}
 	return p.parseInsideAction(cur)
+}
+
+// advance scans until next non-escaped terminator
+func (p *Parser) advance() bool {
+	r := p.next()
+	if r == '\\' {
+		p.next()
+	} else if isTerminator(r) {
+		p.backup()
+		return false
+	}
+	return true
 }
 
 // isTerminator reports whether the input is at valid termination character to appear after an identifier.


### PR DESCRIPTION
There may be a better way to do this, but this seemed like the simplest possible version.

Example: `{.items[*].metadata.labels.kubernetes\.io/hostname}`

[Resolves #31984]

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33901)

<!-- Reviewable:end -->
