### PR TITLE
Add asgroups to audit log

### DIFF
--- a/pkg/apiserver/filters/audit_test.go
+++ b/pkg/apiserver/filters/audit_test.go
@@ -86,7 +86,7 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}


### PR DESCRIPTION
@deads2k || @sttts while reworking origing to use upstream I've noticed we're missing this, ptal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33934)

<!-- Reviewable:end -->
