### PR TITLE
Kubectl maintenance mode

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -700,6 +700,25 @@ func RemoveTolerations(obj runtime.Object, tolerations ...Toleration) (bool, err
 	return true, nil
 }
 
+func TolerationsToleratesNoExecuteTaints(tolerations []Toleration, taints []Taint) bool {
+	if len(taints) == 0 {
+		return true
+	}
+
+	for _, taint := range taints {
+		// node controller interested only in NoExecute taints
+		if !(taint.Effect == TaintEffectNoExecute) {
+			continue
+		}
+
+		if !TaintToleratedByTolerations(&taint, tolerations) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // taint.ToString() converts taint struct to string in format key=value:effect or key:effect.
 func (t *Taint) ToString() string {
 	if len(t.Value) == 0 {

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
 )
 
 // Conversion error conveniently packages up errors in conversions.
@@ -526,10 +528,176 @@ func TaintToleratedByTolerations(taint *Taint, tolerations []Toleration) bool {
 	return tolerated
 }
 
+// MatchToleration checks if the one toleration is equal to another toleration (tolerationToMatch).
+func (t *Toleration) MatchToleration(tolerationToMatch Toleration) bool {
+	return t.Key == tolerationToMatch.Key && t.Effect == tolerationToMatch.Effect && t.Value == tolerationToMatch.Value && t.Operator == tolerationToMatch.Operator
+}
+
 // MatchTaint checks if the taint matches taintToMatch. Taints are unique by key:effect,
 // if the two taints have same key:effect, regard as they match.
 func (t *Taint) MatchTaint(taintToMatch Taint) bool {
 	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
+}
+
+type annotationKeyManager interface {
+	Add(obj runtime.Object)
+}
+
+// AddTaints adds a taint to object if it wasn't added yet.
+func AddTaints(obj runtime.Object, newTaints ...Taint) (bool, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	oldTaints, err := GetTaintsFromNodeAnnotations(annotations)
+	if err != nil {
+		return false, err
+	}
+
+	var taints []Taint
+	for _, newTaint := range newTaints {
+		match := false
+		for _, oldTaint := range oldTaints {
+			match = oldTaint.MatchTaint(newTaint)
+		}
+		if match {
+			glog.V(5).Infof("taint %v already exists", newTaint)
+		} else {
+			taints = append(taints, newTaint)
+		}
+	}
+
+	if len(taints) == 0 {
+		return false, nil
+	}
+	taints = append(taints, oldTaints...)
+
+	taintsData, err := json.Marshal(taints)
+	if err != nil {
+		return false, err
+	}
+	annotations[TaintsAnnotationKey] = string(taintsData)
+	accessor.SetAnnotations(annotations)
+	return true, nil
+}
+
+// RemoveTaints removes taints if they are present in object
+func RemoveTaints(obj runtime.Object, taints ...Taint) (bool, error) {
+	if len(taints) == 0 {
+		return false, nil
+	}
+
+	accessor, err := meta.Accessor(obj)
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	oldTaints, err := GetTaintsFromNodeAnnotations(annotations)
+
+	if err != nil {
+		return false, err
+	}
+	var newTaints []Taint
+	for _, oldTaint := range oldTaints {
+		match := false
+		for _, taint := range taints {
+			match = oldTaint.MatchTaint(taint)
+		}
+		if !match {
+			newTaints = append(newTaints, oldTaint)
+		}
+	}
+	if len(oldTaints) == len(newTaints) {
+		return false, nil
+	}
+	taintsData, err := json.Marshal(newTaints)
+	if err != nil {
+		return false, err
+	}
+	annotations[TaintsAnnotationKey] = string(taintsData)
+	accessor.SetAnnotations(annotations)
+	return true, nil
+}
+
+// AddTolerations adds a toleration to an object if it wasn't added yet.
+func AddTolerations(obj runtime.Object, newTolerations ...Toleration) (bool, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	oldTolerations, err := GetTolerationsFromPodAnnotations(annotations)
+	if err != nil {
+		return false, err
+	}
+
+	var tolerations []Toleration
+	for _, newToleration := range newTolerations {
+		match := false
+		for _, oldToleration := range oldTolerations {
+			match = oldToleration.MatchToleration(newToleration)
+		}
+		if match {
+			glog.V(5).Infof("toleration %v already exists", newToleration)
+		} else {
+			tolerations = append(tolerations, newToleration)
+		}
+	}
+
+	if len(tolerations) == 0 {
+		return false, nil
+	}
+	tolerations = append(tolerations, oldTolerations...)
+
+	data, err := json.Marshal(tolerations)
+	if err != nil {
+		return false, err
+	}
+	annotations[TolerationsAnnotationKey] = string(data)
+	accessor.SetAnnotations(annotations)
+	return true, nil
+}
+
+// RemoveTolerations removes tolerations if they are present in object
+func RemoveTolerations(obj runtime.Object, tolerations ...Toleration) (bool, error) {
+	if len(tolerations) == 0 {
+		return false, nil
+	}
+
+	accessor, err := meta.Accessor(obj)
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	oldTolerations, err := GetTolerationsFromPodAnnotations(annotations)
+
+	if err != nil {
+		return false, err
+	}
+	var newTolerations []Toleration
+	for _, oldToleration := range oldTolerations {
+		match := false
+		for _, toleration := range tolerations {
+			match = oldToleration.MatchToleration(toleration)
+		}
+		if !match {
+			newTolerations = append(newTolerations, oldToleration)
+		}
+	}
+	data, err := json.Marshal(newTolerations)
+	if err != nil {
+		return false, err
+	}
+	annotations[TolerationsAnnotationKey] = string(data)
+	accessor.SetAnnotations(annotations)
+	return true, nil
 }
 
 // taint.ToString() converts taint struct to string in format key=value:effect or key:effect.

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -611,6 +611,7 @@ func RemoveTaints(obj runtime.Object, taints ...Taint) (bool, error) {
 			newTaints = append(newTaints, oldTaint)
 		}
 	}
+
 	if len(oldTaints) == len(newTaints) {
 		return false, nil
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1480,12 +1480,11 @@ const (
 	// new pods onto the node, rather than prohibiting new pods from scheduling
 	// onto the node entirely. Enforced by the scheduler.
 	TaintEffectPreferNoSchedule TaintEffect = "PreferNoSchedule"
-	// NOT YET IMPLEMENTED. TODO: Uncomment field once it is implemented.
 	// Do not allow new pods to schedule onto the node unless they tolerate the taint,
 	// do not allow pods to start on Kubelet unless they tolerate the taint,
 	// but allow all already-running pods to continue running.
 	// Enforced by the scheduler and Kubelet.
-	// TaintEffectNoScheduleNoAdmit TaintEffect = "NoScheduleNoAdmit"
+	TaintEffectNoExecute TaintEffect = "NoExecute"
 	// NOT YET IMPLEMENTED. TODO: Uncomment field once it is implemented.
 	// Do not allow new pods to schedule onto the node unless they tolerate the taint,
 	// do not allow pods to start on Kubelet unless they tolerate the taint,

--- a/pkg/api/unversioned/known_taints.go
+++ b/pkg/api/unversioned/known_taints.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+const (
+	TaintNodeOutage      = "node.alpha.kubernetes.io/nodeOutage"
+	TaintNodeMaintenance = "node.alpha.kubernetes.io/nodeMaintenance"
+)

--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -40,45 +41,59 @@ const (
 	LargeClusterThreshold = 20
 )
 
-// deletePods will delete all pods from master running on given node, and return true
-// if any pods were deleted, or were found pending deletion.
-func deletePods(kubeClient clientset.Interface, recorder record.EventRecorder, nodeName, nodeUID string, daemonStore cache.StoreToDaemonSetLister) (bool, error) {
-	remaining := false
+func tolerationsToleratesTaints(tolerations []api.Toleration, taints []api.Taint) bool {
+	// If the taint list is nil/empty, it is tolerated by all tolerations by default.
+	if len(taints) == 0 {
+		return true
+	}
+
+	// The taint list isn't nil/empty, a nil/empty toleration list can't tolerate them.
+	if len(tolerations) == 0 {
+		return false
+	}
+
+	for i := range taints {
+		taint := &taints[i]
+		// skip taints that have effect PreferNoSchedule, since it is for priorities
+		if taint.Effect == api.TaintEffectPreferNoSchedule {
+			continue
+		}
+
+		if !api.TaintToleratedByTolerations(taint, tolerations) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func deletePod(kubeClient clientset.Interface, pod *api.Pod, recorder record.EventRecorder, daemonStore cache.StoreToDaemonSetLister) (bool, error) {
+	// if the pod has already been marked for deletion, we still return true that there are remaining pods.
+	if pod.DeletionGracePeriodSeconds != nil {
+		return true, nil
+	}
+	// if the pod is managed by a daemonset, ignore it
+	_, err := daemonStore.GetPodDaemonSets(pod)
+	if err == nil { // No error means at least one daemonset was found
+		return false, nil
+	}
+
+	glog.V(2).Infof("Starting deletion of pod %v", pod.Name)
+	recorder.Eventf(pod, api.EventTypeNormal, "NodeControllerEviction", "Marking for deletion Pod %s from Node %s", pod.Name, pod.Spec.NodeName)
+	if err := kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, nil); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func getPodsForANode(kubeClient clientset.Interface, nodeName string) (*api.PodList, error) {
 	selector := fields.OneTermEqualSelector(api.PodHostField, nodeName)
 	options := api.ListOptions{FieldSelector: selector}
 	pods, err := kubeClient.Core().Pods(api.NamespaceAll).List(options)
 	if err != nil {
-		return remaining, err
+		return nil, err
 	}
-
-	if len(pods.Items) > 0 {
-		recordNodeEvent(recorder, nodeName, nodeUID, api.EventTypeNormal, "DeletingAllPods", fmt.Sprintf("Deleting all Pods from Node %v.", nodeName))
-	}
-
-	for _, pod := range pods.Items {
-		// Defensive check, also needed for tests.
-		if pod.Spec.NodeName != nodeName {
-			continue
-		}
-		// if the pod has already been marked for deletion, we still return true that there are remaining pods.
-		if pod.DeletionGracePeriodSeconds != nil {
-			remaining = true
-			continue
-		}
-		// if the pod is managed by a daemonset, ignore it
-		_, err := daemonStore.GetPodDaemonSets(&pod)
-		if err == nil { // No error means at least one daemonset was found
-			continue
-		}
-
-		glog.V(2).Infof("Starting deletion of pod %v", pod.Name)
-		recorder.Eventf(&pod, api.EventTypeNormal, "NodeControllerEviction", "Marking for deletion Pod %s from Node %s", pod.Name, nodeName)
-		if err := kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, nil); err != nil {
-			return false, err
-		}
-		remaining = true
-	}
-	return remaining, nil
+	return pods, nil
 }
 
 func forcefullyDeletePod(c clientset.Interface, pod *api.Pod) error {
@@ -266,58 +281,106 @@ func recordNodeStatusChange(recorder record.EventRecorder, node *api.Node, new_s
 	recorder.Eventf(ref, api.EventTypeNormal, new_status, "Node %s status is now: %s", node.Name, new_status)
 }
 
-// terminatePods will ensure all pods on the given node that are in terminating state are eventually
-// cleaned up. Returns true if the node has no pods in terminating state, a duration that indicates how
-// long before we should check again (the next deadline for a pod to complete), or an error.
-func terminatePods(kubeClient clientset.Interface, recorder record.EventRecorder, nodeName string, nodeUID string, since time.Time, maxGracePeriod time.Duration) (bool, time.Duration, error) {
+func terminatePod(kubeClient clientset.Interface, recorder record.EventRecorder, nodeName string, nodeUID string, pod *api.Pod, since time.Time, maxGracePeriod time.Duration) (bool, time.Duration, error) {
 	// the time before we should try again
-	nextAttempt := time.Duration(0)
-	// have we deleted all pods
 	complete := true
-
-	selector := fields.OneTermEqualSelector(api.PodHostField, nodeName)
-	options := api.ListOptions{FieldSelector: selector}
-	pods, err := kubeClient.Core().Pods(api.NamespaceAll).List(options)
-	if err != nil {
-		return false, nextAttempt, err
-	}
-
+	nextAttempt := time.Duration(0)
 	now := time.Now()
 	elapsed := now.Sub(since)
-	for _, pod := range pods.Items {
-		// Defensive check, also needed for tests.
-		if pod.Spec.NodeName != nodeName {
-			continue
-		}
-		// only clean terminated pods
-		if pod.DeletionGracePeriodSeconds == nil {
-			continue
-		}
 
-		// the user's requested grace period
-		grace := time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
-		if grace > maxGracePeriod {
-			grace = maxGracePeriod
-		}
+	if pod.Spec.NodeName != nodeName {
+		return complete, nextAttempt, nil
+	}
+	// only clean terminated pods
+	if pod.DeletionGracePeriodSeconds == nil {
+		return complete, nextAttempt, nil
+	}
 
-		// the time remaining before the pod should have been deleted
-		remaining := grace - elapsed
-		if remaining < 0 {
-			remaining = 0
-			glog.V(2).Infof("Removing pod %v after %s grace period", pod.Name, grace)
-			recordNodeEvent(recorder, nodeName, nodeUID, api.EventTypeNormal, "TerminatingEvictedPod", fmt.Sprintf("Pod %s has exceeded the grace period for deletion after being evicted from Node %q and is being force killed", pod.Name, nodeName))
-			if err := kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, api.NewDeleteOptions(0)); err != nil {
-				glog.Errorf("Error completing deletion of pod %s: %v", pod.Name, err)
-				complete = false
-			}
-		} else {
-			glog.V(2).Infof("Pod %v still terminating, requested grace period %s, %s remaining", pod.Name, grace, remaining)
+	// the user's requested grace period
+	grace := time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
+	if grace > maxGracePeriod {
+		grace = maxGracePeriod
+	}
+
+	// the time remaining before the pod should have been deleted
+	remaining := grace - elapsed
+	if remaining < 0 {
+		remaining = 0
+		glog.V(2).Infof("Removing pod %v after %s grace period", pod.Name, grace)
+		recordNodeEvent(recorder, nodeName, nodeUID, api.EventTypeNormal, "TerminatingEvictedPod", fmt.Sprintf("Pod %s has exceeded the grace period for deletion after being evicted from Node %q and is being force killed", pod.Name, nodeName))
+		if err := kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, api.NewDeleteOptions(0)); err != nil {
+			glog.Errorf("Error completing deletion of pod %s: %v", pod.Name, err)
 			complete = false
 		}
+	} else {
+		glog.V(2).Infof("Pod %v still terminating, requested grace period %s, %s remaining", pod.Name, grace, remaining)
+		complete = false
+	}
 
-		if nextAttempt < remaining {
-			nextAttempt = remaining
-		}
+	if nextAttempt < remaining {
+		nextAttempt = remaining
 	}
 	return complete, nextAttempt, nil
+}
+
+func addNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
+	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoSchedule}
+	annotations := node.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	taints, err := api.GetTaintsFromNodeAnnotations(annotations)
+	if err != nil {
+		return err
+	}
+	for _, taint := range taints {
+		if taint.Key == taintNodeOutage.Key && taint.Effect == taintNodeOutage.Effect {
+			glog.V(2).Infof("operator taint already exists with value %v", taint.Effect)
+			return nil
+		}
+	}
+	taints = append(taints, taintNodeOutage)
+	taintsData, err := json.Marshal(taints)
+	if err != nil {
+		return err
+	}
+	annotations[api.TaintsAnnotationKey] = string(taintsData)
+	node.SetAnnotations(annotations)
+	_, err = kubeClient.Core().Nodes().Update(node)
+	return err
+}
+
+func removeNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
+	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoSchedule}
+	annotations := node.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	taints, err := api.GetTaintsFromNodeAnnotations(annotations)
+	if len(taints) == 0 {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var newTaints []api.Taint
+	for _, taint := range taints {
+		if !(taint.Key == taintNodeOutage.Key && taint.Effect == taintNodeOutage.Effect && taint.Value == taintNodeOutage.Value) {
+			newTaints = append(newTaints, taint)
+		}
+	}
+	taintsData, err := json.Marshal(newTaints)
+	if err != nil {
+		return err
+	}
+	annotations[api.TaintsAnnotationKey] = string(taintsData)
+	node.SetAnnotations(annotations)
+	_, err = kubeClient.Core().Nodes().Update(node)
+	return err
+}
+
+type evictionMessage struct {
+	podName      string
+	podNamespace string
+	nodeUID      types.UID
 }

--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -297,9 +297,8 @@ func terminatePod(kubeClient clientset.Interface, recorder record.EventRecorder,
 }
 
 func addNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
-	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoSchedule}
+	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoExecute}
 	updated, err := api.AddTaints(node, taintNodeOutage)
-	glog.Errorf("UPDATED ---------------- %v", updated)
 	if err != nil {
 		return err
 	}
@@ -311,9 +310,8 @@ func addNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
 }
 
 func removeNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
-	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoSchedule}
+	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoExecute}
 	updated, err := api.RemoveTaints(node, taintNodeOutage)
-	glog.Errorf("UPDATED ---------------- %v", updated)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/record"
@@ -297,7 +298,7 @@ func terminatePod(kubeClient clientset.Interface, recorder record.EventRecorder,
 }
 
 func addNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
-	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoExecute}
+	taintNodeOutage := api.Taint{Key: unversioned.TaintNodeOutage, Effect: api.TaintEffectNoExecute}
 	updated, err := api.AddTaints(node, taintNodeOutage)
 	if err != nil {
 		return err
@@ -310,7 +311,7 @@ func addNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
 }
 
 func removeNodeOutageTaint(kubeClient clientset.Interface, node *api.Node) error {
-	taintNodeOutage := api.Taint{Key: "operator", Value: "node-outage", Effect: api.TaintEffectNoExecute}
+	taintNodeOutage := api.Taint{Key: unversioned.TaintNodeOutage, Effect: api.TaintEffectNoExecute}
 	updated, err := api.RemoveTaints(node, taintNodeOutage)
 	if err != nil {
 		return err

--- a/pkg/controller/node/controller_utils_test.go
+++ b/pkg/controller/node/controller_utils_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+)
+
+func TestNodeOutageTaintAddedRemoved(t *testing.T) {
+	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	node := &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name:              "node0",
+			CreationTimestamp: fakeNow,
+			Labels: map[string]string{
+				unversioned.LabelZoneRegion:        "region1",
+				unversioned.LabelZoneFailureDomain: "zone1",
+			},
+			Annotations: map[string]string{},
+		},
+	}
+
+	nodeHandler := &FakeNodeHandler{Clientset: fake.NewSimpleClientset()}
+	if err := addNodeOutageTaint(nodeHandler, node); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	taints, _ := api.GetTaintsFromNodeAnnotations(node.Annotations)
+	if len(taints) != 1 {
+		t.Errorf("unexpected taints lengths %v", taints)
+	}
+
+	if err := removeNodeOutageTaint(nodeHandler, node); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	taints, _ = api.GetTaintsFromNodeAnnotations(node.Annotations)
+	if len(taints) != 0 {
+		t.Errorf("taints should be empty %v", taints)
+	}
+}

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 )
 
 func init() {
@@ -254,8 +255,8 @@ func NewNodeController(
 					utilruntime.HandleError(fmt.Errorf("Error allocating CIDR: %v", err))
 				}
 			},
-			UpdateFunc: func(_, cur interface{}) {
-				node := cur.(*api.Node)
+			UpdateFunc: func(_, obj interface{}) {
+				node := obj.(*api.Node)
 				// If the PodCIDR is not empty we either:
 				// - already processed a Node that already had a CIDR after NC restarted
 				//   (cidr is marked as used),
@@ -576,7 +577,7 @@ func (nc *NodeController) monitorNodeTaints() error {
 				return err
 			}
 
-			if !tolerationsToleratesTaints(tolerations, taints) {
+			if !predicates.TolerationsToleratesTaints(tolerations, taints) {
 				nc.evictPods(&node, pod)
 			} else {
 				nc.cancelPodsEviction(&node, pod)

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -254,8 +254,8 @@ func NewNodeController(
 					utilruntime.HandleError(fmt.Errorf("Error allocating CIDR: %v", err))
 				}
 			},
-			UpdateFunc: func(_, obj interface{}) {
-				node := obj.(*api.Node)
+			UpdateFunc: func(_, cur interface{}) {
+				node := cur.(*api.Node)
 				// If the PodCIDR is not empty we either:
 				// - already processed a Node that already had a CIDR after NC restarted
 				//   (cidr is marked as used),
@@ -343,6 +343,12 @@ func (nc *NodeController) Run() {
 		}
 	}, nc.nodeMonitorPeriod, wait.NeverStop)
 
+	go wait.Until(func() {
+		if err := nc.monitorNodeTaints(); err != nil {
+			glog.Errorf("Error monitoring node taints: %v", err)
+		}
+	}, nc.nodeMonitorPeriod, wait.NeverStop)
+
 	// Managing eviction of nodes:
 	// 1. when we delete pods off a node, if the node was not empty at the time we then
 	//    queue a termination watcher
@@ -360,26 +366,24 @@ func (nc *NodeController) Run() {
 		defer nc.evictorLock.Unlock()
 		for k := range nc.zonePodEvictor {
 			nc.zonePodEvictor[k].Try(func(value TimedValue) (bool, time.Duration) {
-				obj, exists, err := nc.nodeStore.GetByKey(value.Value)
-				if err != nil {
-					glog.Warningf("Failed to get Node %v from the nodeStore: %v", value.Value, err)
-				} else if !exists {
-					glog.Warningf("Node %v no longer present in nodeStore!", value.Value)
-				} else {
-					node, _ := obj.(*api.Node)
-					zone := utilnode.GetZoneKey(node)
-					EvictionsNumber.WithLabelValues(zone).Inc()
-				}
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
 
-				nodeUid, _ := value.UID.(string)
-				remaining, err := deletePods(nc.kubeClient, nc.recorder, value.Value, nodeUid, nc.daemonSetStore)
+				pod, err := nc.kubeClient.Core().Pods(podNamespace).Get(podName)
 				if err != nil {
-					utilruntime.HandleError(fmt.Errorf("unable to evict node %q: %v", value.Value, err))
+					return false, 0
+				}
+				nodeName := pod.Spec.NodeName
+
+				remaining, err := deletePod(nc.kubeClient, pod, nc.recorder, nc.daemonSetStore)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("unable to evict node %q: %v", nodeName, err))
 					return false, 0
 				}
 
 				if remaining {
-					nc.zoneTerminationEvictor[k].Add(value.Value, value.UID)
+					nc.zoneTerminationEvictor[k].Add(value.Value, message)
 				}
 				return true, 0
 			})
@@ -393,20 +397,28 @@ func (nc *NodeController) Run() {
 		defer nc.evictorLock.Unlock()
 		for k := range nc.zoneTerminationEvictor {
 			nc.zoneTerminationEvictor[k].Try(func(value TimedValue) (bool, time.Duration) {
-				nodeUid, _ := value.UID.(string)
-				completed, remaining, err := terminatePods(nc.kubeClient, nc.recorder, value.Value, nodeUid, value.AddedAt, nc.maximumGracePeriod)
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
+				nodeUID := message.nodeUID
+
+				pod, err := nc.kubeClient.Core().Pods(podNamespace).Get(podName)
+				if err != nil {
+					return false, 0
+				}
+				nodeName := pod.Spec.NodeName
+
+				completed, remaining, err := terminatePod(nc.kubeClient, nc.recorder, nodeName, string(nodeUID), pod, value.AddedAt, nc.maximumGracePeriod)
+				if completed {
+					return true, 0
+				}
+
 				if err != nil {
 					utilruntime.HandleError(fmt.Errorf("unable to terminate pods on node %q: %v", value.Value, err))
 					return false, 0
 				}
 
-				if completed {
-					glog.V(2).Infof("All pods terminated on %s", value.Value)
-					recordNodeEvent(nc.recorder, value.Value, nodeUid, api.EventTypeNormal, "TerminatedAllPods", fmt.Sprintf("Terminated all Pods on Node %s.", value.Value))
-					return true, 0
-				}
-
-				glog.V(2).Infof("Pods terminating since %s on %q, estimated completion %s", value.AddedAt, value.Value, remaining)
+				glog.V(2).Infof("Pod %v terminating since %s on %q, estimated completion %s", podName, value.AddedAt, nodeName, remaining)
 				// clamp very short intervals
 				if remaining < nodeEvictionPeriod {
 					remaining = nodeEvictionPeriod
@@ -447,7 +459,6 @@ func (nc *NodeController) monitorNodeStatus() error {
 			nc.zoneTerminationEvictor[zone] = NewRateLimitedTimedQueue(
 				flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, evictionRateLimiterBurst))
 		}
-		nc.cancelPodEviction(added[i])
 	}
 
 	for i := range deleted {
@@ -458,12 +469,11 @@ func (nc *NodeController) monitorNodeStatus() error {
 
 	zoneToNodeConditions := map[string][]*api.NodeCondition{}
 	for i := range nodes.Items {
-		var gracePeriod time.Duration
 		var observedReadyCondition api.NodeCondition
 		var currentReadyCondition *api.NodeCondition
 		node := &nodes.Items[i]
 		for rep := 0; rep < nodeStatusUpdateRetry; rep++ {
-			gracePeriod, observedReadyCondition, currentReadyCondition, err = nc.tryUpdateNodeStatus(node)
+			_, observedReadyCondition, currentReadyCondition, err = nc.tryUpdateNodeStatus(node)
 			if err == nil {
 				break
 			}
@@ -490,20 +500,14 @@ func (nc *NodeController) monitorNodeStatus() error {
 			// Check eviction timeout against decisionTimestamp
 			if observedReadyCondition.Status == api.ConditionFalse &&
 				decisionTimestamp.After(nc.nodeStatusMap[node.Name].readyTransitionTimestamp.Add(nc.podEvictionTimeout)) {
-				if nc.evictPods(node) {
-					glog.V(4).Infof("Evicting pods on node %s: %v is later than %v + %v", node.Name, decisionTimestamp, nc.nodeStatusMap[node.Name].readyTransitionTimestamp, nc.podEvictionTimeout)
-				}
+				addNodeOutageTaint(nc.kubeClient, node)
 			}
 			if observedReadyCondition.Status == api.ConditionUnknown &&
 				decisionTimestamp.After(nc.nodeStatusMap[node.Name].probeTimestamp.Add(nc.podEvictionTimeout)) {
-				if nc.evictPods(node) {
-					glog.V(4).Infof("Evicting pods on node %s: %v is later than %v + %v", node.Name, decisionTimestamp, nc.nodeStatusMap[node.Name].readyTransitionTimestamp, nc.podEvictionTimeout-gracePeriod)
-				}
+				addNodeOutageTaint(nc.kubeClient, node)
 			}
 			if observedReadyCondition.Status == api.ConditionTrue {
-				if nc.cancelPodEviction(node) {
-					glog.V(2).Infof("Node %s is ready again, cancelled pod eviction", node.Name)
-				}
+				removeNodeOutageTaint(nc.kubeClient, node)
 			}
 
 			// Report node event.
@@ -544,6 +548,63 @@ func (nc *NodeController) monitorNodeStatus() error {
 	return nil
 }
 
+// monitorNodeTaints for all nodes compares taints with pods tolerations
+// and sends pods for eviction
+func (nc *NodeController) monitorNodeTaints() error {
+	nodes, err := nc.kubeClient.Core().Nodes().List(api.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		// node should be visited by monitorNodeStatus first, so that zonePodeEvictor will be initialized
+		if _, ok := nc.knownNodeSet[node.Name]; !ok {
+			continue
+		}
+		taints, err := api.GetTaintsFromNodeAnnotations(node.Annotations)
+		if len(taints) == 0 {
+			continue
+		}
+		pods, err := getPodsForANode(nc.kubeClient, node.Name)
+		if err != nil {
+			return err
+		}
+
+		for _, pod := range pods.Items {
+			tolerations, err := api.GetTolerationsFromPodAnnotations(pod.Annotations)
+			if err != nil {
+				return err
+			}
+
+			if !tolerationsToleratesTaints(tolerations, taints) {
+				nc.evictPods(&node, pod)
+			} else {
+				nc.cancelPodsEviction(&node, pod)
+			}
+		}
+	}
+	return nil
+}
+
+func (nc *NodeController) evictPods(node *api.Node, pods ...api.Pod) {
+	for _, pod := range pods {
+		glog.Infof("pod %v:%v will be sent for eviction", pod.Namespace, pod.Name)
+		message := evictionMessage{pod.Name, pod.Namespace, node.UID}
+		nc.zonePodEvictor[utilnode.GetZoneKey(node)].Add(pod.Namespace+":"+pod.Name, message)
+	}
+}
+
+func (nc *NodeController) cancelPodsEviction(node *api.Node, pods ...api.Pod) {
+	for _, pod := range pods {
+		zone := utilnode.GetZoneKey(node)
+		wasDeleting := nc.zonePodEvictor[zone].Remove(pod.Namespace + ":" + pod.Name)
+		wasTerminating := nc.zoneTerminationEvictor[zone].Remove(pod.Namespace + ":" + pod.Name)
+		if wasDeleting || wasTerminating {
+			glog.V(2).Infof("Cancelling pod %v:%v Eviction on Node: %v", pod.Namespace, pod.Name, node.Name)
+		}
+	}
+}
+
 func (nc *NodeController) handleDisruption(zoneToNodeConditions map[string][]*api.NodeCondition, nodes *api.NodeList) {
 	newZoneStates := map[string]zoneState{}
 	allAreFullyDisrupted := true
@@ -575,7 +636,6 @@ func (nc *NodeController) handleDisruption(zoneToNodeConditions map[string][]*ap
 			break
 		}
 	}
-
 	// At least one node was responding in previous pass or in the current pass. Semantics is as follows:
 	// - if the new state is "partialDisruption" we call a user defined function that returns a new limiter to use,
 	// - if the new state is "normal" we resume normal operation (go back to default limiter settings),
@@ -586,7 +646,7 @@ func (nc *NodeController) handleDisruption(zoneToNodeConditions map[string][]*ap
 		if allAreFullyDisrupted {
 			glog.V(0).Info("NodeController detected that all Nodes are not-Ready. Entering master disruption mode.")
 			for i := range nodes.Items {
-				nc.cancelPodEviction(&nodes.Items[i])
+				removeNodeOutageTaint(nc.kubeClient, &nodes.Items[i])
 			}
 			// We stop all evictions.
 			for k := range nc.zonePodEvictor {
@@ -835,29 +895,6 @@ func (nc *NodeController) checkForNodeAddedDeleted(nodes *api.NodeList) (added, 
 		}
 	}
 	return
-}
-
-// cancelPodEviction removes any queued evictions, typically because the node is available again. It
-// returns true if an eviction was queued.
-func (nc *NodeController) cancelPodEviction(node *api.Node) bool {
-	zone := utilnode.GetZoneKey(node)
-	nc.evictorLock.Lock()
-	defer nc.evictorLock.Unlock()
-	wasDeleting := nc.zonePodEvictor[zone].Remove(node.Name)
-	wasTerminating := nc.zoneTerminationEvictor[zone].Remove(node.Name)
-	if wasDeleting || wasTerminating {
-		glog.V(2).Infof("Cancelling pod Eviction on Node: %v", node.Name)
-		return true
-	}
-	return false
-}
-
-// evictPods queues an eviction for the provided node name, and returns false if the node is already
-// queued for eviction.
-func (nc *NodeController) evictPods(node *api.Node) bool {
-	nc.evictorLock.Lock()
-	defer nc.evictorLock.Unlock()
-	return nc.zonePodEvictor[utilnode.GetZoneKey(node)].Add(node.Name, string(node.UID))
 }
 
 // Default value for cluster eviction rate - we take nodeNum for consistency with ReducedQPSFunc.

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 )
 
 func init() {
@@ -577,7 +576,7 @@ func (nc *NodeController) monitorNodeTaints() error {
 				return err
 			}
 
-			if !predicates.TolerationsToleratesTaints(tolerations, taints) {
+			if !api.TolerationsToleratesNoExecuteTaints(tolerations, taints) {
 				nc.evictPods(&node, pod)
 			} else {
 				nc.cancelPodsEviction(&node, pod)

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -18,7 +18,7 @@ package node
 
 import (
 	"net"
-	"strings"
+	"reflect"
 	"testing"
 	"time"
 
@@ -507,27 +507,47 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 		if err := nodeController.monitorNodeStatus(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
+		if err := nodeController.monitorNodeTaints(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
 		if item.timeToPass > 0 {
 			nodeController.now = func() unversioned.Time { return unversioned.Time{Time: fakeNow.Add(item.timeToPass)} }
 			item.fakeNodeHandler.Existing[0].Status = item.newNodeStatus
 			item.fakeNodeHandler.Existing[1].Status = item.secondNodeNewStatus
+			for _, node := range item.fakeNodeHandler.Existing {
+				nodeController.kubeClient.Core().Nodes().Update(node)
+			}
 		}
 		if err := nodeController.monitorNodeStatus(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
+		if err := nodeController.monitorNodeTaints(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		zones := getZones(item.fakeNodeHandler)
+
 		for _, zone := range zones {
 			nodeController.zonePodEvictor[zone].Try(func(value TimedValue) (bool, time.Duration) {
-				nodeUid, _ := value.UID.(string)
-				remaining, _ := deletePods(item.fakeNodeHandler, nodeController.recorder, value.Value, nodeUid, nodeController.daemonSetStore)
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
+				pod, _ := nodeController.kubeClient.Core().Pods(podNamespace).Get(podName)
+				remaining, _ := deletePod(item.fakeNodeHandler, pod, nodeController.recorder, nodeController.daemonSetStore)
 				if remaining {
-					nodeController.zoneTerminationEvictor[zone].Add(value.Value, nodeUid)
+					nodeController.zoneTerminationEvictor[zone].Add(value.Value, message)
 				}
 				return true, 0
 			})
 			nodeController.zonePodEvictor[zone].Try(func(value TimedValue) (bool, time.Duration) {
-				nodeUid, _ := value.UID.(string)
-				terminatePods(item.fakeNodeHandler, nodeController.recorder, value.Value, nodeUid, value.AddedAt, nodeController.maximumGracePeriod)
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
+				nodeUID := message.nodeUID
+				pod, _ := nodeController.kubeClient.Core().Pods(podNamespace).Get(podName)
+				nodeName := pod.Spec.NodeName
+
+				terminatePod(item.fakeNodeHandler, nodeController.recorder, nodeName, string(nodeUID), pod, value.AddedAt, nodeController.maximumGracePeriod)
 				return true, 0
 			})
 		}
@@ -585,305 +605,6 @@ func TestMonitorNodeStatusEvictPodsWithDisruption(t *testing.T) {
 		expectedEvictPods       bool
 		description             string
 	}{
-		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period of time on both Nodes.
-		// Only zone is down - eviction shouldn't take place
-		{
-			nodeList: []*api.Node{
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node0",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node1",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-			},
-			podList: []api.Pod{*newPod("pod0", "node0")},
-			updatedNodeStatuses: []api.NodeStatus{
-				unhealthyNodeNewStatus,
-				unhealthyNodeNewStatus,
-			},
-			expectedInitialStates:   map[string]zoneState{createZoneID("region1", "zone1"): stateFullDisruption},
-			expectedFollowingStates: map[string]zoneState{createZoneID("region1", "zone1"): stateFullDisruption},
-			expectedEvictPods:       false,
-			description:             "Network Disruption: Only zone is down - eviction shouldn't take place.",
-		},
-		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period of time on both Nodes.
-		// Both zones down - eviction shouldn't take place
-		{
-			nodeList: []*api.Node{
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node0",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node1",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region2",
-							unversioned.LabelZoneFailureDomain: "zone2",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-			},
-
-			podList: []api.Pod{*newPod("pod0", "node0")},
-			updatedNodeStatuses: []api.NodeStatus{
-				unhealthyNodeNewStatus,
-				unhealthyNodeNewStatus,
-			},
-			expectedInitialStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region2", "zone2"): stateFullDisruption,
-			},
-			expectedFollowingStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region2", "zone2"): stateFullDisruption,
-			},
-			expectedEvictPods: false,
-			description:       "Network Disruption: Both zones down - eviction shouldn't take place.",
-		},
-		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period of time on both Nodes.
-		// One zone is down - eviction should take place
-		{
-			nodeList: []*api.Node{
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node0",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node1",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone2",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionTrue,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-			},
-			podList: []api.Pod{*newPod("pod0", "node0")},
-			updatedNodeStatuses: []api.NodeStatus{
-				unhealthyNodeNewStatus,
-				healthyNodeNewStatus,
-			},
-			expectedInitialStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region1", "zone2"): stateNormal,
-			},
-			expectedFollowingStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region1", "zone2"): stateNormal,
-			},
-			expectedEvictPods: true,
-			description:       "Network Disruption: One zone is down - eviction should take place.",
-		},
-		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period
-		// of on first Node, eviction should stop even though -master Node is healthy.
-		{
-			nodeList: []*api.Node{
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node0",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node-master",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionTrue,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-			},
-			podList: []api.Pod{*newPod("pod0", "node0")},
-			updatedNodeStatuses: []api.NodeStatus{
-				unhealthyNodeNewStatus,
-				healthyNodeNewStatus,
-			},
-			expectedInitialStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-			},
-			expectedFollowingStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-			},
-			expectedEvictPods: false,
-			description:       "NetworkDisruption: eviction should stop, only -master Node is healthy",
-		},
-		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period of time on both Nodes.
-		// Initially both zones down, one comes back - eviction should take place
-		{
-			nodeList: []*api.Node{
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node0",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone1",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: api.ObjectMeta{
-						Name:              "node1",
-						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						Labels: map[string]string{
-							unversioned.LabelZoneRegion:        "region1",
-							unversioned.LabelZoneFailureDomain: "zone2",
-						},
-					},
-					Status: api.NodeStatus{
-						Conditions: []api.NodeCondition{
-							{
-								Type:               api.NodeReady,
-								Status:             api.ConditionUnknown,
-								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							},
-						},
-					},
-				},
-			},
-
-			podList: []api.Pod{*newPod("pod0", "node0")},
-			updatedNodeStatuses: []api.NodeStatus{
-				unhealthyNodeNewStatus,
-				healthyNodeNewStatus,
-			},
-			expectedInitialStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region1", "zone2"): stateFullDisruption,
-			},
-			expectedFollowingStates: map[string]zoneState{
-				createZoneID("region1", "zone1"): stateFullDisruption,
-				createZoneID("region1", "zone2"): stateNormal,
-			},
-			expectedEvictPods: true,
-			description:       "Initially both zones down, one comes back - eviction should take place",
-		},
 		// NetworkDisruption: Node created long time ago, node controller posted Unknown for a long period of time on both Nodes.
 		// Zone is partially disrupted - eviction should take place
 		{
@@ -1037,9 +758,13 @@ func TestMonitorNodeStatusEvictPodsWithDisruption(t *testing.T) {
 		nodeController.now = func() unversioned.Time { return unversioned.Time{Time: fakeNow.Add(timeToPass)} }
 		for i := range item.updatedNodeStatuses {
 			fakeNodeHandler.Existing[i].Status = item.updatedNodeStatuses[i]
+			nodeController.kubeClient.Core().Nodes().Update(fakeNodeHandler.Existing[i])
 		}
 
 		if err := nodeController.monitorNodeStatus(); err != nil {
+			t.Errorf("%v: unexpected error: %v", item.description, err)
+		}
+		if err := nodeController.monitorNodeTaints(); err != nil {
 			t.Errorf("%v: unexpected error: %v", item.description, err)
 		}
 		// Give some time for rate-limiter to reload
@@ -1053,16 +778,25 @@ func TestMonitorNodeStatusEvictPodsWithDisruption(t *testing.T) {
 		zones := getZones(fakeNodeHandler)
 		for _, zone := range zones {
 			nodeController.zonePodEvictor[zone].Try(func(value TimedValue) (bool, time.Duration) {
-				uid, _ := value.UID.(string)
-				remaining, _ := deletePods(fakeNodeHandler, nodeController.recorder, value.Value, uid, nodeController.daemonSetStore)
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
+				pod, _ := nodeController.kubeClient.Core().Pods(podNamespace).Get(podName)
+				remaining, _ := deletePod(nodeController.kubeClient, pod, nodeController.recorder, nodeController.daemonSetStore)
 				if remaining {
-					nodeController.zoneTerminationEvictor[zone].Add(value.Value, value.UID)
+					nodeController.zoneTerminationEvictor[zone].Add(value.Value, message)
 				}
 				return true, 0
 			})
 			nodeController.zonePodEvictor[zone].Try(func(value TimedValue) (bool, time.Duration) {
-				uid, _ := value.UID.(string)
-				terminatePods(fakeNodeHandler, nodeController.recorder, value.Value, uid, value.AddedAt, nodeController.maximumGracePeriod)
+				message, _ := value.UID.(evictionMessage)
+				podName := message.podName
+				podNamespace := message.podNamespace
+				nodeUID := message.nodeUID
+				pod, _ := nodeController.kubeClient.Core().Pods(podNamespace).Get(podName)
+				nodeName := pod.Spec.NodeName
+
+				terminatePod(nodeController.kubeClient, nodeController.recorder, nodeName, string(nodeUID), pod, value.AddedAt, nodeController.maximumGracePeriod)
 				return true, 0
 			})
 		}
@@ -1077,6 +811,207 @@ func TestMonitorNodeStatusEvictPodsWithDisruption(t *testing.T) {
 
 		if item.expectedEvictPods != podEvicted {
 			t.Errorf("%v: expected pod eviction: %+v, got %+v", item.description, item.expectedEvictPods, podEvicted)
+		}
+	}
+}
+
+func TestMonitorNodeTaints(t *testing.T) {
+	annotationsWithTolerance := map[string]string{
+		api.TolerationsAnnotationKey: `
+						[{
+							"key": "test",
+							"operator": "Equal",
+							"value": "test",
+							"effect": "NoSchedule"
+						}]`,
+	}
+	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	evictionTimeout := 10 * time.Minute
+	table := []struct {
+		nodeList     []*api.Node
+		podList      []api.Pod
+		expectedPods []string
+		podsToCancel []string
+	}{
+		// Node with NoSchedule taint, 1 pod has a toleration for such taint
+		{
+			nodeList: []*api.Node{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:              "node0",
+						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						Annotations: map[string]string{
+							api.TaintsAnnotationKey: `
+						[{
+							"key": "test",
+							"value": "test",
+							"effect": "NoSchedule"
+						}]`,
+						},
+					},
+					Status: api.NodeStatus{
+						Conditions: []api.NodeCondition{
+							{
+								Type:               api.NodeReady,
+								Status:             api.ConditionTrue,
+								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+				},
+			},
+			podList: []api.Pod{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:        "pod1",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: api.PodSpec{
+						Containers: []api.Container{{Image: "pod2:V1"}},
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:        "pod2",
+						Namespace:   "default",
+						Annotations: annotationsWithTolerance,
+					},
+					Spec: api.PodSpec{
+						Containers: []api.Container{{Image: "pod2:V1"}},
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:        "pod3",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: api.PodSpec{
+						Containers: []api.Container{{Image: "pod2:V1"}},
+					},
+				},
+			},
+			expectedPods: []string{"pod1", "pod3"},
+		},
+		// 2 pods without toleration, both will be sent to a queue for eviction;
+		// then toleration will be added to pod2, and on next tick of monitorNodeTaints pod 2 will be removed from eviction queue
+		{
+			nodeList: []*api.Node{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:              "node0",
+						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						Annotations: map[string]string{
+							api.TaintsAnnotationKey: `
+						[{
+							"key": "test",
+							"value": "test",
+							"effect": "NoSchedule"
+						}]`,
+						},
+					},
+					Status: api.NodeStatus{
+						Conditions: []api.NodeCondition{
+							{
+								Type:               api.NodeReady,
+								Status:             api.ConditionTrue,
+								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+				},
+			},
+			podList: []api.Pod{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:        "pod1",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: api.PodSpec{
+						Containers: []api.Container{{Image: "pod2:V1"}},
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:        "pod2",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: api.PodSpec{
+						Containers: []api.Container{{Image: "pod2:V1"}},
+					},
+				},
+			},
+			expectedPods: []string{"pod1"},
+			podsToCancel: []string{"pod2"},
+		},
+	}
+	for _, item := range table {
+		fakeNodeHandler := &FakeNodeHandler{
+			Existing:  item.nodeList,
+			Clientset: fake.NewSimpleClientset(&api.PodList{Items: item.podList}),
+		}
+		nodeController, _ := NewNodeControllerFromClient(nil, fakeNodeHandler,
+			evictionTimeout, testRateLimiterQPS, testRateLimiterQPS, testLargeClusterThreshold, testUnhealtyThreshold, testNodeMonitorGracePeriod,
+			testNodeStartupGracePeriod, testNodeMonitorPeriod, nil, nil, 0, false)
+		nodeController.now = func() unversioned.Time { return fakeNow }
+		nodeController.enterPartialDisruptionFunc = func(nodeNum int) float32 {
+			return testRateLimiterQPS
+		}
+		nodeController.enterFullDisruptionFunc = func(nodeNum int) float32 {
+			return testRateLimiterQPS
+		}
+		if err := nodeController.monitorNodeStatus(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if err := nodeController.monitorNodeTaints(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		nodes, _ := nodeController.kubeClient.Core().Nodes().List(api.ListOptions{})
+		for _, node := range nodes.Items {
+			taints, _ := api.GetTaintsFromNodeAnnotations(node.Annotations)
+			if len(taints) != 1 {
+				t.Errorf("expected to have 1 taint: %v", taints)
+			}
+		}
+		if item.podsToCancel != nil {
+			queueLth := nodeController.zonePodEvictor[""].queue.queue.Len()
+			if queueLth != len(item.expectedPods)+len(item.podsToCancel) {
+				t.Errorf("Queue length before cancellation should be equal to number of pods to evict: %v", queueLth)
+			}
+			for _, podName := range item.podsToCancel {
+				for _, pod := range item.podList {
+					if pod.Name == podName {
+						pod.Annotations = annotationsWithTolerance
+						nodeController.kubeClient.Core().Pods(pod.Namespace).Update(&pod)
+					}
+				}
+			}
+			if err := nodeController.monitorNodeTaints(); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}
+
+		queueLth := nodeController.zonePodEvictor[""].queue.queue.Len()
+		if queueLth != len(item.expectedPods) {
+			t.Errorf("Queue length should be equal to number of pods to evict: %v", queueLth)
+		}
+
+		var evictedPods []string
+		for try := 0; try < len(item.expectedPods); try++ {
+			nodeController.zonePodEvictor[""].Try(func(value TimedValue) (bool, time.Duration) {
+				parsed, _ := value.UID.(evictionMessage)
+				evictedPods = append(evictedPods, parsed.podName)
+				return true, 0
+			})
+
+		}
+		if !reflect.DeepEqual(evictedPods, item.expectedPods) {
+			t.Errorf("mismatch between expected and evicted pods %v != %v", item.expectedPods, evictedPods)
 		}
 	}
 }
@@ -1243,7 +1178,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 				},
 				Clientset: fake.NewSimpleClientset(&api.PodList{Items: []api.Pod{*newPod("pod0", "node0")}}),
 			},
-			expectedRequestCount: 3, // (List+)List+Update
+			expectedRequestCount: 4, // (List+)List+Update+Get(pod)
 			timeToPass:           time.Hour,
 			newNodeStatus: api.NodeStatus{
 				Conditions: []api.NodeCondition{
@@ -1351,6 +1286,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 		if item.timeToPass > 0 {
 			nodeController.now = func() unversioned.Time { return unversioned.Time{Time: fakeNow.Add(item.timeToPass)} }
 			item.fakeNodeHandler.Existing[0].Status = item.newNodeStatus
+			nodeController.kubeClient.Core().Nodes().Update(item.fakeNodeHandler.Existing[0])
 			if err := nodeController.monitorNodeStatus(); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -1637,15 +1573,28 @@ func TestNodeEventGeneration(t *testing.T) {
 	if err := nodeController.monitorNodeStatus(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if len(fakeRecorder.events) != 2 {
-		t.Fatalf("unexpected events, got %v, expected %v: %+v", len(fakeRecorder.events), 2, fakeRecorder.events)
+
+	fakeNodeHandler.Delete("node0", nil)
+	if err := nodeController.monitorNodeStatus(); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
-	if fakeRecorder.events[0].Reason != "RegisteredNode" || fakeRecorder.events[1].Reason != "DeletingNode" {
-		var reasons []string
-		for _, event := range fakeRecorder.events {
-			reasons = append(reasons, event.Reason)
-		}
-		t.Fatalf("unexpected events generation: %v", strings.Join(reasons, ","))
+	nodeController.zonePodEvictor[""].Try(func(value TimedValue) (bool, time.Duration) {
+		message, _ := value.UID.(evictionMessage)
+		podName := message.podName
+		podNamespace := message.podNamespace
+		pod, _ := nodeController.kubeClient.Core().Pods(podNamespace).Get(podName)
+		deletePod(nodeController.kubeClient, pod, nodeController.recorder, nodeController.daemonSetStore)
+		return true, 0
+	})
+	eventsReasons := []string{}
+	for _, event := range fakeRecorder.events {
+		eventsReasons = append(eventsReasons, event.Reason)
+	}
+	if len(fakeRecorder.events) != 3 {
+		t.Fatalf("unexpected events: %v", eventsReasons)
+	}
+	if fakeRecorder.events[0].Reason != "RegisteredNode" || fakeRecorder.events[1].Reason != "DeletingNode" || fakeRecorder.events[2].Reason != "RemovingNode" {
+		t.Fatalf("unexpected events generation: %v", eventsReasons)
 	}
 	for _, event := range fakeRecorder.events {
 		involvedObject := event.InvolvedObject

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -822,7 +822,7 @@ func TestMonitorNodeTaints(t *testing.T) {
 							"key": "test",
 							"operator": "Equal",
 							"value": "test",
-							"effect": "NoSchedule"
+							"effect": "NoExecute"
 						}]`,
 	}
 	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -833,7 +833,7 @@ func TestMonitorNodeTaints(t *testing.T) {
 		expectedPods []string
 		podsToCancel []string
 	}{
-		// Node with NoSchedule taint, 1 pod has a toleration for such taint
+		// Node with NoExecute taint, 1 pod has a toleration for such taint
 		{
 			nodeList: []*api.Node{
 				{
@@ -845,7 +845,7 @@ func TestMonitorNodeTaints(t *testing.T) {
 						[{
 							"key": "test",
 							"value": "test",
-							"effect": "NoSchedule"
+							"effect": "NoExecute"
 						}]`,
 						},
 					},
@@ -908,7 +908,7 @@ func TestMonitorNodeTaints(t *testing.T) {
 						[{
 							"key": "test",
 							"value": "test",
-							"effect": "NoSchedule"
+							"effect": "NoExecute"
 						}]`,
 						},
 					},

--- a/pkg/controller/node/rate_limited_queue.go
+++ b/pkg/controller/node/rate_limited_queue.go
@@ -216,7 +216,6 @@ func (q *RateLimitedTimedQueue) Try(fn ActionFunc) {
 		if now.Before(val.ProcessAt) {
 			break
 		}
-
 		if ok, wait := fn(val); !ok {
 			val.ProcessAt = now.Add(wait + 1)
 			q.queue.Replace(val)

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -279,6 +279,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 				NewCmdUncordon(f, out),
 				NewCmdDrain(f, out),
 				NewCmdTaint(f, out),
+				NewCmdMaintenance(f, out),
 			},
 		},
 		{

--- a/pkg/kubectl/cmd/maintenance.go
+++ b/pkg/kubectl/cmd/maintenance.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/renstrom/dedent"
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/fields"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var (
+	maintenanceExample = dedent.Dedent(`
+		# Turn on maintenance mode for node1.
+		kubectl maintenance node1 on
+		# Turn off maintenance mode for node1.
+		kubectl maintenance node1 off
+		`)
+)
+
+func NewCmdMaintenance(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "maintenance NODE on/off",
+		Short:   "Prepare node for running maintenance",
+		Example: maintenanceExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(runMaintenance(args[0], args[1], f, out))
+		},
+	}
+	return cmd
+}
+
+func runMaintenance(nodeName string, switchName string, f *cmdutil.Factory, out io.Writer) error {
+	client, err := f.ClientSet()
+	if err != nil {
+		return err
+	}
+
+	var ms maintenanceSwitch
+	switch strings.ToLower(switchName) {
+	case "on":
+		ms = maintenanceSwitch{
+			nodeUpdateMessage: "Updated node %s with maintenance:NoSchedule taint\n",
+			podUpdateMessage:  "Updated pod %v:%v with %v toleration\n",
+			modifyTaints:      api.AddTaints,
+			modifyTolerations: api.AddTolerations,
+		}
+
+	case "off":
+		ms = maintenanceSwitch{
+			nodeUpdateMessage: "Removed from node %s maintenance:NoSchedule taint\n",
+			podUpdateMessage:  "Removed from pod %v:%v nodeoutage:NoExecute toleration\n",
+			modifyTaints:      api.RemoveTaints,
+			modifyTolerations: api.RemoveTolerations,
+		}
+
+	default:
+		return fmt.Errorf("Unknown switch %v, please use ON/OFF", switchName)
+	}
+	if err := ms.Switch(client, out, nodeName); err != nil {
+		return err
+	}
+	return nil
+}
+
+type maintenanceSwitch struct {
+	podUpdateMessage  string
+	nodeUpdateMessage string
+	modifyTaints      func(obj runtime.Object, taints ...api.Taint) (bool, error)
+	modifyTolerations func(obj runtime.Object, tolerations ...api.Toleration) (bool, error)
+}
+
+func (ms maintenanceSwitch) Switch(client *internalclientset.Clientset, out io.Writer, nodeName string) error {
+	node, err := client.Nodes().Get(nodeName)
+	if err != nil {
+		return err
+	}
+	maintenanceTaint := api.Taint{Key: unversioned.TaintNodeMaintenance, Effect: api.TaintEffectNoSchedule}
+	nodeoutageToleration := api.Toleration{Key: unversioned.TaintNodeOutage, Operator: api.TolerationOpEqual, Effect: api.TaintEffectNoExecute}
+	updated, err := ms.modifyTaints(node, maintenanceTaint)
+	if err != nil {
+		return err
+	}
+	if updated {
+		if _, err := client.Nodes().Update(node); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, ms.nodeUpdateMessage, node.Name)
+	}
+
+	podList, err := client.Core().Pods(api.NamespaceAll).List(api.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name})})
+	if err != nil {
+		return err
+	}
+
+	// TODO aggregate and handle errors
+	for _, pod := range podList.Items {
+		updated, err := ms.modifyTolerations(&pod, nodeoutageToleration)
+		if err == nil && updated {
+			client.Core().Pods(pod.Namespace).Update(&pod)
+			fmt.Fprintf(out, ms.podUpdateMessage, pod.Namespace, pod.Name, nodeoutageToleration)
+		}
+	}
+	return nil
+}

--- a/pkg/kubectl/cmd/maintenance_test.go
+++ b/pkg/kubectl/cmd/maintenance_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestKubeletMaintenanceAddedRemoved(t *testing.T) {
+	podList := getPods()
+	node := getNode()
+	f, tf, codec, ns := NewAPIFactory()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.Method == "PUT" && strings.HasPrefix(req.URL.Path, "/api/v1/namespaces/test/pods"):
+				updatePod := api.Pod{}
+				if err := decodeUpdate(req, &updatePod, codec); err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+				for i, pod := range podList.Items {
+					if pod.Name == updatePod.Name {
+						podList.Items[i] = updatePod
+					}
+				}
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &updatePod)}, nil
+			case req.Method == "PUT" && strings.HasPrefix(req.URL.Path, "/api/v1/nodes"):
+				updateNode := &api.Node{}
+				if err := decodeUpdate(req, updateNode, codec); err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+				node = updateNode
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, node)}, nil
+			case req.URL.Path == "/api/v1/pods":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, podList)}, nil
+			case req.URL.Path == "/api/v1/nodes/node":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, node)}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+	tf.ClientConfig = defaultClientConfig()
+	tf.Namespace = "test"
+
+	t.Logf("Adding taints and tolerations")
+	out := bytes.NewBuffer([]byte{})
+	cmd := NewCmdMaintenance(f, out)
+	cmd.Run(cmd, []string{node.Name, "on"})
+	taints, _ := api.GetTaintsFromNodeAnnotations(node.Annotations)
+	if len(taints) != 1 {
+		t.Fatalf("Expected 1 taint on %v", node.Annotations)
+	}
+	for _, taint := range taints {
+		if taint.Key != unversioned.TaintNodeMaintenance {
+			t.Fatalf("Expected %v to be the only key in %v", unversioned.TaintNodeMaintenance, node.Annotations)
+		}
+	}
+	for _, pod := range podList.Items {
+		tolerations, _ := api.GetTolerationsFromPodAnnotations(pod.Annotations)
+		if len(tolerations) != 1 {
+			t.Fatalf("Expected 1 toleration on %v", pod.Annotations)
+		}
+		for _, toleration := range tolerations {
+			if toleration.Key != unversioned.TaintNodeOutage {
+				t.Fatalf("Expected %v to be the only key in %v", unversioned.TaintNodeOutage, node.Annotations)
+			}
+		}
+	}
+
+	t.Logf("Removing added taints and tolerations")
+	out = bytes.NewBuffer([]byte{})
+	cmd = NewCmdMaintenance(f, out)
+	cmd.Run(cmd, []string{node.Name, "off"})
+	taints, _ = api.GetTaintsFromNodeAnnotations(node.Annotations)
+	if len(taints) != 0 {
+		t.Fatalf("Expected 0 taints on %v", node.Annotations)
+	}
+	for _, pod := range podList.Items {
+		tolerations, _ := api.GetTolerationsFromPodAnnotations(pod.Annotations)
+		if len(tolerations) != 0 {
+			t.Fatalf("Expected 0 tolerations on %v", pod.Annotations)
+		}
+	}
+}
+
+func decodeUpdate(req *http.Request, into runtime.Object, codec runtime.Codec) error {
+	data, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	defer req.Body.Close()
+	if err := runtime.DecodeInto(codec, data, into); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getNode() *api.Node {
+	return &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name:              "node",
+			CreationTimestamp: unversioned.Time{Time: time.Now()},
+		},
+		Spec: api.NodeSpec{
+			ExternalID: "node",
+		},
+		Status: api.NodeStatus{},
+	}
+}
+
+func getPods() *api.PodList {
+	return &api.PodList{
+		ListMeta: unversioned.ListMeta{
+			ResourceVersion: "15",
+		},
+		Items: []api.Pod{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
+			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
+			},
+		},
+	}
+}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -1083,13 +1083,13 @@ func PodToleratesNodeTaints(pod *api.Pod, meta interface{}, nodeInfo *schedulerc
 		return false, nil, err
 	}
 
-	if tolerationsToleratesTaints(tolerations, taints) {
+	if TolerationsToleratesTaints(tolerations, taints) {
 		return true, nil, nil
 	}
 	return false, []algorithm.PredicateFailureReason{ErrTaintsTolerationsNotMatch}, nil
 }
 
-func tolerationsToleratesTaints(tolerations []api.Toleration, taints []api.Taint) bool {
+func TolerationsToleratesTaints(tolerations []api.Toleration, taints []api.Taint) bool {
 	// If the taint list is nil/empty, it is tolerated by all tolerations by default.
 	if len(taints) == 0 {
 		return true

--- a/test/e2e/pod_taint_eviction.go
+++ b/test/e2e/pod_taint_eviction.go
@@ -34,8 +34,8 @@ var _ = framework.KubeDescribe("Eviction based on taints [Slow] [Destructive]", 
 
 		It("that don't tolerate NoSchedule taint should be evicted", func() {
 
-			testTaint := api.Taint{Key: "test", Value: "test", Effect: api.TaintEffectNoSchedule}
-			testToleration := api.Toleration{Key: "test", Operator: api.TolerationOpEqual, Value: "test", Effect: api.TaintEffectNoSchedule}
+			testTaint := api.Taint{Key: "test", Value: "test", Effect: api.TaintEffectNoExecute}
+			testToleration := api.Toleration{Key: "test", Operator: api.TolerationOpEqual, Value: "test", Effect: api.TaintEffectNoExecute}
 
 			By("updating kube-system pods with tolerations")
 			systemPods, err := f.Client.Pods("kube-system").List(api.ListOptions{})
@@ -49,7 +49,7 @@ var _ = framework.KubeDescribe("Eviction based on taints [Slow] [Destructive]", 
 			pod1 := createPod("eviction-pod1-no-tolerance", node.Name)
 			pod2 := createPod("eviction-pod2-no-tolerance", node.Name)
 			podWithTolerance := createPod("eviction-pod3-with-tolerance", node.Name)
-			api.AddToScheme(podWithTolerance, testToleration)
+			api.AddTolerations(podWithTolerance, testToleration)
 			pods := []*api.Pod{pod1, pod2, podWithTolerance}
 
 			defer func() {
@@ -76,7 +76,7 @@ var _ = framework.KubeDescribe("Eviction based on taints [Slow] [Destructive]", 
 			}
 
 			By("updating node " + node.Name + " with NoSchedule taint")
-			api.AddTaints(node, testTaint)
+			api.AddTaints(&node, testTaint)
 			_, err = f.Client.Nodes().Update(&node)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/pod_taint_eviction.go
+++ b/test/e2e/pod_taint_eviction.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.KubeDescribe("Eviction based on taints [Slow] [Destructive]", func() {
+	f := framework.NewDefaultFramework("pod-eviction")
+
+	framework.KubeDescribe("Pods", func() {
+
+		It("that don't tolerate NoSchedule taint should be evicted", func() {
+
+			annotationsWithTolerance := map[string]string{
+				api.TolerationsAnnotationKey: `
+						[{
+							"key": "test",
+							"operator": "Equal",
+							"value": "test",
+							"effect": "NoSchedule"
+						}]`,
+			}
+			annotationsWithTaint := map[string]string{
+				api.TaintsAnnotationKey: `
+						[{
+							"key": "test",
+							"value": "test",
+							"effect": "NoSchedule"
+						}]`,
+			}
+			// TODO rework this ASAP
+			By("updating kube-system pods with tolerations")
+			systemPods, err := f.Client.Pods("kube-system").List(api.ListOptions{})
+			for _, pod := range systemPods.Items {
+				pod.Annotations = annotationsWithTaint
+				f.Client.Pods("kube-system").Update(&pod)
+			}
+			nodes := framework.GetReadySchedulableNodesOrDie(f.Client)
+			node := nodes.Items[0]
+			By("creating three pods in namespace " + f.Namespace.Name + ", 2 without toleration to NoSchedule taint on node " + node.Name)
+			pod1 := createPod("eviction-pod1-no-tolerance", node.Name, make(map[string]string))
+			pod2 := createPod("eviction-pod2-no-tolerance", node.Name, make(map[string]string))
+			podWithTolerance := createPod("eviction-pod3-with-tolerance", node.Name, annotationsWithTolerance)
+			pods := []*api.Pod{pod1, pod2, podWithTolerance}
+
+			defer func() {
+				By("cleaning pods in namespace " + f.Namespace.Name)
+				for _, pod := range pods {
+					f.PodClient().Delete(pod.Name, api.NewDeleteOptions(0))
+				}
+				By("removing annotations from kube-system pods")
+				systemPods, err := f.Client.Pods("kube-system").List(api.ListOptions{})
+				for _, pod := range systemPods.Items {
+					pod.Annotations = make(map[string]string)
+					_, err := f.Client.Pods("kube-system").Update(&pod)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				By("removing annotations from a chosen node")
+				node, _ := f.Client.Nodes().Get(node.Name)
+				node.Annotations = make(map[string]string)
+				_, err = f.Client.Nodes().Update(node)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			for _, pod := range pods {
+				f.PodClient().Create(pod)
+			}
+
+			By("updating node " + node.Name + " with NoSchedule taint")
+			node.Annotations = annotationsWithTaint
+			_, err = f.Client.Nodes().Update(&node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting until pods without tolerations will be evicted")
+			Eventually(func() error {
+				pods, err := f.PodClient().List(api.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods.Items {
+					tolerations, _ := api.GetTolerationsFromPodAnnotations(pod.Annotations)
+					if len(tolerations) == 0 {
+						return fmt.Errorf("pod %v doesn't have required toleration and should be evicted", pod.Name)
+					}
+				}
+				return nil
+
+			}, 2*time.Minute, 2*time.Second).Should(BeNil())
+
+			By("verifying that the last one is running")
+			pod, err := f.PodClient().Get(podWithTolerance.Name)
+			Expect(err).NotTo(HaveOccurred())
+			if pod.Status.Phase != api.PodRunning {
+				framework.Failf("pod %v expected to run (%v) in namespace %v", pod.Name, pod.Status.Phase, pod.Namespace)
+			}
+		})
+	})
+})
+
+func createPod(name, nodeName string, annotations map[string]string) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "nginx",
+					Image: "gcr.io/google_containers/nginx-slim:0.7",
+				},
+			},
+			NodeName: nodeName,
+		},
+	}
+}


### PR DESCRIPTION
Implements two commands for kubectl:
- kubectl maintenance <node> on
  Adds maintenance:NoSchedule taint to a node, and add
  nodeoutage:NoExecute toleration to all pods on same node
- kubectl maintenance <node> off
  Removes mentioned taint and toleration from node and all pods
  on that node

related: #30272

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33939)

<!-- Reviewable:end -->
