### PR TITLE
fix loopback client config for integration tests

### DIFF
--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -21,7 +21,6 @@ package auth
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,7 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/auth/user"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -57,20 +55,12 @@ func alwaysAlice(req *http.Request) (user.Info, bool, error) {
 }
 
 func TestSubjectAccessReview(t *testing.T) {
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
-	defer s.Close()
-
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authenticator = authenticator.RequestFunc(alwaysAlice)
 	masterConfig.GenericConfig.Authorizer = sarAuthorizer{}
 	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
-	m, err := masterConfig.Complete().New()
-	if err != nil {
-		t.Fatalf("error in bringing up the master: %v", err)
-	}
+	_, s := framework.RunAMaster(masterConfig)
+	defer s.Close()
 
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -113,7 +103,7 @@ func TestSubjectAccessReview(t *testing.T) {
 			},
 			expectedStatus: authorizationapi.SubjectAccessReviewStatus{
 				Allowed:         false,
-				Reason:          "no",
+				Reason:          "Not in privileged list.\nno",
 				EvaluationError: "I'm sorry, Dave",
 			},
 		},
@@ -156,12 +146,6 @@ func TestSubjectAccessReview(t *testing.T) {
 }
 
 func TestSelfSubjectAccessReview(t *testing.T) {
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
-	defer s.Close()
-
 	username := "alice"
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authenticator = authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
@@ -169,10 +153,8 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 	})
 	masterConfig.GenericConfig.Authorizer = sarAuthorizer{}
 	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
-	m, err := masterConfig.Complete().New()
-	if err != nil {
-		t.Fatalf("error in bringing up the master: %v", err)
-	}
+	_, s := framework.RunAMaster(masterConfig)
+	defer s.Close()
 
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -216,7 +198,7 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 			},
 			expectedStatus: authorizationapi.SubjectAccessReviewStatus{
 				Allowed:         false,
-				Reason:          "no",
+				Reason:          "Not in privileged list.\nno",
 				EvaluationError: "I'm sorry, Dave",
 			},
 		},
@@ -247,20 +229,12 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 }
 
 func TestLocalSubjectAccessReview(t *testing.T) {
-	var m *master.Master
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		m.Handler.ServeHTTP(w, req)
-	}))
-	defer s.Close()
-
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authenticator = authenticator.RequestFunc(alwaysAlice)
 	masterConfig.GenericConfig.Authorizer = sarAuthorizer{}
 	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
-	m, err := masterConfig.Complete().New()
-	if err != nil {
-		t.Fatalf("error in bringing up the master: %v", err)
-	}
+	_, s := framework.RunAMaster(masterConfig)
+	defer s.Close()
 
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 
@@ -310,7 +284,7 @@ func TestLocalSubjectAccessReview(t *testing.T) {
 			},
 			expectedStatus: authorizationapi.SubjectAccessReviewStatus{
 				Allowed:         false,
-				Reason:          "no",
+				Reason:          "Not in privileged list.\nno",
 				EvaluationError: "I'm sorry, Dave",
 			},
 		},
@@ -367,7 +341,7 @@ func TestLocalSubjectAccessReview(t *testing.T) {
 			continue
 		}
 		if response.Status != test.expectedStatus {
-			t.Errorf("%s: expected %v, got %v", test.name, test.expectedStatus, response.Status)
+			t.Errorf("%s: expected %#v, got %#v", test.name, test.expectedStatus, response.Status)
 			continue
 		}
 	}


### PR DESCRIPTION
Wires an authenticator/authorizer pair much closer to what the actual master start does.  Several pulls I have in progress require this.

@liggitt second commit wiring changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33948)

<!-- Reviewable:end -->
