### PR TITLE
Add a check for file size if the reading content returns empty

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -587,6 +587,16 @@ func (f *Framework) ReadFileViaContainer(podName, containerName string, path str
 	return string(stdout), err
 }
 
+func (f *Framework) CheckFileSizeViaContainer(podName, containerName, path string) (string, error) {
+	By("checking a file size in the container")
+
+	stdout, stderr, err := kubectlExecWithRetry(f.Namespace.Name, podName, containerName, "--", "ls", "-l", path)
+	if err != nil {
+		Logf("error running kubectl exec to read file: %v\nstdout=%v\nstderr=%v)", err, string(stdout), string(stderr))
+	}
+	return string(stdout), err
+}
+
 // CreateServiceForSimpleAppWithPods is a convenience wrapper to create a service and its matching pods all at once.
 func (f *Framework) CreateServiceForSimpleAppWithPods(contPort int, svcPort int, appName string, podSpec func(n api.Node) api.PodSpec, count int, block bool) (error, *api.Service) {
 	var err error = nil

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -456,6 +456,13 @@ func verifyPDContentsViaContainer(f *framework.Framework, podName, containerName
 		}
 		framework.ExpectNoError(err)
 		framework.Logf("Read file %q with content: %v", filePath, v)
+		if strings.TrimSpace(v) != strings.TrimSpace(expectedContents) {
+			size, err := f.CheckFileSizeViaContainer(podName, containerName, filePath)
+			if err != nil {
+				framework.Logf("Error reading file: %v", err)
+			}
+			framework.Logf("Check file %q size: %q", filePath, size)
+		}
 		Expect(strings.TrimSpace(v)).To(Equal(strings.TrimSpace(expectedContents)))
 	}
 }


### PR DESCRIPTION
In order to debug the flaky tests for writing/reading files via
contains, this PR adds a check for file size if reading returns empty
content.

```release-note
Add a check for file size if the reading content returns empty
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33976)

<!-- Reviewable:end -->
