### PR TITLE
e2e.go / kops: Add ssh-key option to override ssh key

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -276,6 +276,7 @@ keep-gogoproto
 km-path
 kops-cluster
 kops-nodes
+kops-ssh-key
 kops-state
 kops-zones
 kube-api-burst


### PR DESCRIPTION
**What this PR does / why we need it**: By default, Jenkins stuffs the ssh key in `/workspace/.aws/kube_aws_rsa`. This allow the SSH key to be overridden easily on the command line.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33982)

<!-- Reviewable:end -->
