### PR TITLE
Add local option to the label command

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -808,6 +808,16 @@ __EOF__
   [ "$(EDITOR=cat kubectl edit --windows-line-endings pod/valid-pod | file - | grep CRLF)" ]
   [ ! "$(EDITOR=cat kubectl edit --windows-line-endings=false pod/valid-pod | file - | grep CRLF)" ]
 
+  ### Label POD YAML file locally without effecting the live pod.
+  # Pre-condition: name is valid-pod
+  kube::test::get_object_assert 'pod valid-pod' "{{${labels_field}.name}}" 'valid-pod'
+  # Command
+  output_message=$(kubectl label --local --overwrite -f hack/testdata/pod.yaml name=localonlyvalue -o yaml "${kube_flags[@]}")
+  echo $output_message
+  # Post-condition: name is still valid-pod in the live pod, but command output is the new value
+  kube::test::get_object_assert 'pod valid-pod' "{{${labels_field}.name}}" 'valid-pod'
+  kube::test::if_has_string "${output_message}" "localonlyvalue"
+
   ### Overwriting an existing label is not permitted
   # Pre-condition: name is valid-pod
   kube::test::get_object_assert 'pod valid-pod' "{{${labels_field}.name}}" 'valid-pod'

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -383,6 +383,34 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	}
 }
 
+func TestLabelLocal(t *testing.T) {
+	f, tf, _, ns := NewAPIFactory()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
+			return nil, nil
+		}),
+	}
+	tf.Namespace = "test"
+	tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}}
+
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdLabel(f, buf)
+	cmd.Flags().Set("local", "true")
+	options := &resource.FilenameOptions{
+		Filenames: []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"},
+	}
+
+	err := RunLabel(f, buf, cmd, []string{"a=b"}, options)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "labeled") {
+		t.Errorf("did not set labels: %s", buf.String())
+	}
+}
+
 func TestLabelMultipleObjects(t *testing.T) {
 	pods, _, _ := testData()
 	f, tf, codec, ns := NewAPIFactory()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the --local option to be both consistent with other commands and so it can be used with  "set selector" and "create service".

**Which issue this PR fixes** 
Related: #7296

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
Add a new option "--local" to the `kubectl label`
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/33990)

<!-- Reviewable:end -->
