### PR TITLE
Match GroupVersionKind against specific version

### DIFF
--- a/pkg/api/unversioned/group_version_test.go
+++ b/pkg/api/unversioned/group_version_test.go
@@ -147,3 +147,47 @@ func TestGroupVersionMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestKindForGroupVersionKinds(t *testing.T) {
+	gvks := GroupVersions{
+		GroupVersion{Group: "batch", Version: "v1"},
+		GroupVersion{Group: "batch", Version: "v2alpha1"},
+		GroupVersion{Group: "policy", Version: "v1alpha1"},
+	}
+	cases := []struct {
+		input  []GroupVersionKind
+		target GroupVersionKind
+		ok     bool
+	}{
+		{
+			input:  []GroupVersionKind{{Group: "batch", Version: "v2alpha1", Kind: "ScheduledJob"}},
+			target: GroupVersionKind{Group: "batch", Version: "v2alpha1", Kind: "ScheduledJob"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "batch", Version: "v3alpha1", Kind: "CronJob"}},
+			target: GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "policy", Version: "v1alpha1", Kind: "PodDisruptionBudget"}},
+			target: GroupVersionKind{Group: "policy", Version: "v1alpha1", Kind: "PodDisruptionBudget"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "apps", Version: "v1alpha1", Kind: "PetSet"}},
+			target: GroupVersionKind{},
+			ok:     false,
+		},
+	}
+
+	for i, c := range cases {
+		target, ok := gvks.KindForGroupVersionKinds(c.input)
+		if c.target != target {
+			t.Errorf("%d: unexpected target: %v, expected %v", i, target, c.target)
+		}
+		if c.ok != ok {
+			t.Errorf("%d: unexpected ok: %v, expected %v", i, ok, c.ok)
+		}
+	}
+}

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -602,12 +602,15 @@ func TestConvertToVersion(t *testing.T) {
 			gv:     unversioned.GroupVersion{Version: "__internal"},
 			out:    &TestType1{A: "test"},
 		},
-		// prefers the first group version in the list
+		// prefers the best match
 		{
 			scheme: GetTestScheme(),
 			in:     &ExternalTestType1{A: "test"},
 			gv:     unversioned.GroupVersions{{Version: "__internal"}, {Version: "v1"}},
-			out:    &TestType1{A: "test"},
+			out: &ExternalTestType1{
+				MyWeirdCustomEmbeddedVersionKindField: MyWeirdCustomEmbeddedVersionKindField{APIVersion: "v1", ObjectKind: "TestType1"},
+				A: "test",
+			},
 		},
 		// unversioned type returned as-is
 		{


### PR DESCRIPTION
Currently when multiple GVK match a specific kind in `KindForGroupVersionKinds` only the first will be matched, which not necessarily will be the correct one. I'm proposing to extend this to pick the best match, instead.

Here's my problematic use-case, of course it involves ScheduledJobs :wink::
I have a `GroupVersions` with `batch/v1` and `batch/v2alpha1` in that order. I'm calling `KindForGroupVersionKinds` with kind `batch/v2alpha1 ScheduledJob` and that currently results this matching first `GroupVersion`, instead of picking more concrete one. There's a [clear description](https://github.com/kubernetes/kubernetes/blob/ee77d4e6ca1e174a189071e50997a377bcb6fc37/pkg/api/unversioned/group_version.go#L183) why it is on single `GroupVersion`, but `GroupVersions` should pick this more carefully.

@deads2k this is your baby, wdyt?

``` release-note
Match GroupVersionKind against specific version
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34010)

<!-- Reviewable:end -->
