### PR TITLE
Add default cluster role bindings

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -419,6 +419,10 @@ runTests() {
 
   kubectl get "${kube_flags[@]}" --raw /version
 
+  # make sure the server was properly bootstrapped with clusterroles and bindings
+  kube::test::get_object_assert clusterroles/cluster-admin "{{.metadata.name}}" 'cluster-admin'
+  kube::test::get_object_assert clusterrolebindings/cluster-admin "{{.metadata.name}}" 'cluster-admin'
+
   ###########################
   # POD creation / deletion #
   ###########################

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5004,6 +5004,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 		Dependencies: []string{
 			"api.ObjectMeta", "rbac.RoleRef", "rbac.Subject", "unversioned.TypeMeta"},
 	},
+	"rbac.ClusterRoleBindingBuilder": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRoleBindingBuilder let's us attach methods.  A no-no for API types. We use it to construct bindings in code.  It's more compact than trying to write them out in a literal.",
+				Properties: map[string]spec.Schema{
+					"ClusterRoleBinding": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/rbac.ClusterRoleBinding"),
+						},
+					},
+				},
+				Required: []string{"ClusterRoleBinding"},
+			},
+		},
+		Dependencies: []string{
+			"rbac.ClusterRoleBinding"},
+	},
 	"rbac.ClusterRoleBindingList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
-	"k8s.io/kubernetes/pkg/auth/user"
+	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -43,18 +43,8 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if u, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && u.GetName() == s.superUser {
-			return s.StandardStorage.Create(ctx, obj)
-		}
-
-		// system:masters is special because the API server uses it for privileged loopback connections
-		// therefore we know that a member of system:masters can always do anything
-		for _, group := range u.GetGroups() {
-			if group == user.SystemPrivilegedGroup {
-				return s.StandardStorage.Create(ctx, obj)
-			}
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Create(ctx, obj)
 	}
 
 	clusterRole := obj.(*rbac.ClusterRole)
@@ -66,10 +56,8 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
-			return s.StandardStorage.Update(ctx, name, obj)
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Update(ctx, name, obj)
 	}
 
 	nonEscalatingInfo := wrapUpdatedObjectInfo(obj, func(ctx api.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
-	"k8s.io/kubernetes/pkg/auth/user"
+	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -43,18 +43,8 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if u, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && u.GetName() == s.superUser {
-			return s.StandardStorage.Create(ctx, obj)
-		}
-
-		// system:masters is special because the API server uses it for privileged loopback connections
-		// therefore we know that a member of system:masters can always do anything
-		for _, group := range u.GetGroups() {
-			if group == user.SystemPrivilegedGroup {
-				return s.StandardStorage.Create(ctx, obj)
-			}
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Create(ctx, obj)
 	}
 
 	clusterRoleBinding := obj.(*rbac.ClusterRoleBinding)
@@ -69,10 +59,8 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
-			return s.StandardStorage.Update(ctx, name, obj)
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Update(ctx, name, obj)
 	}
 
 	nonEscalatingInfo := wrapUpdatedObjectInfo(obj, func(ctx api.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {

--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+func EscalationAllowed(ctx api.Context, superUser string) bool {
+	u, ok := api.UserFrom(ctx)
+	if !ok {
+		// the only way to be without a user is to either have no authenticators by explicitly saying that's your preference
+		// or to be connecting via the insecure port, in which case this logically doesn't apply
+		return true
+	}
+
+	// check to see if this subject is allowed to escalate
+	if len(superUser) != 0 && u.GetName() == superUser {
+		return true
+	}
+	// system:masters is special because the API server uses it for privileged loopback connections
+	// therefore we know that a member of system:masters can always do anything
+	for _, group := range u.GetGroups() {
+		if group == user.SystemPrivilegedGroup {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/validation"
-	"k8s.io/kubernetes/pkg/auth/user"
+	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -43,18 +43,8 @@ func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRul
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if u, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && u.GetName() == s.superUser {
-			return s.StandardStorage.Create(ctx, obj)
-		}
-
-		// system:masters is special because the API server uses it for privileged loopback connections
-		// therefore we know that a member of system:masters can always do anything
-		for _, group := range u.GetGroups() {
-			if group == user.SystemPrivilegedGroup {
-				return s.StandardStorage.Create(ctx, obj)
-			}
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Create(ctx, obj)
 	}
 
 	roleBinding := obj.(*rbac.RoleBinding)
@@ -69,10 +59,8 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if user, ok := api.UserFrom(ctx); ok {
-		if s.superUser != "" && user.GetName() == s.superUser {
-			return s.StandardStorage.Update(ctx, name, obj)
-		}
+	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+		return s.StandardStorage.Update(ctx, name, obj)
 	}
 
 	nonEscalatingInfo := wrapUpdatedObjectInfo(obj, func(ctx api.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -19,6 +19,7 @@ package bootstrappolicy
 import (
 	"k8s.io/kubernetes/pkg/api"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/auth/user"
 )
 
 var (
@@ -46,5 +47,13 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("get").URLs("/version", "/api", "/api/*", "/apis", "/apis/*").RuleOrDie(),
 			},
 		},
+	}
+}
+
+// ClusterRoleBindings return default rolebindings to the default roles
+func ClusterRoleBindings() []rbac.ClusterRoleBinding {
+	return []rbac.ClusterRoleBinding{
+		rbac.NewClusterBinding("cluster-admin").Groups(user.SystemPrivilegedGroup).BindingOrDie(),
+		rbac.NewClusterBinding("system:discovery").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),
 	}
 }


### PR DESCRIPTION
Add default cluster roles bindings to rbac bootstrapping.  Also adds a case for allowing escalation when you have no authenticator.

@liggitt I expect you may need to make peace with this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34019)

<!-- Reviewable:end -->
