### PR TITLE
Allow empty annotation values

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -624,6 +624,22 @@ runTests() {
   # Post-condition: valid-pod is labelled
   kube::test::get_object_assert 'pod valid-pod' "{{range$labels_field}}{{.}}:{{end}}" 'valid-pod:new-valid-pod:'
 
+  ### Label the valid-pod POD with empty label value
+  # Pre-condition: valid-pod does not have label "emptylabel"
+  kube::test::get_object_assert 'pod valid-pod' "{{range$labels_field}}{{.}}:{{end}}" 'valid-pod:new-valid-pod:'
+  # Command
+  kubectl label pods valid-pod emptylabel="" "${kube_flags[@]}"
+  # Post-condition: valid pod contains "emptylabel" with no value
+  kube::test::get_object_assert 'pod valid-pod' "{{${labels_field}.emptylabel}}" ''
+
+  ### Annotate the valid-pod POD with empty annotation value
+  # Pre-condition: valid-pod does not have annotation "emptyannotation"
+  kube::test::get_object_assert 'pod valid-pod' "{{${annotations_field}.emptyannotation}}" '<no value>'
+  # Command
+  kubectl annotate pods valid-pod emptyannotation="" "${kube_flags[@]}"
+  # Post-condition: valid pod contains "emptyannotation" with no value
+  kube::test::get_object_assert 'pod valid-pod' "{{${annotations_field}.emptyannotation}}" ''
+
   ### Record label change
   # Pre-condition: valid-pod does not have record annotation
   kube::test::get_object_assert 'pod valid-pod' "{{range.items}}{{$annotations_field}}:{{end}}" ''

--- a/pkg/kubectl/cmd/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate_test.go
@@ -143,15 +143,16 @@ func TestParseAnnotations(t *testing.T) {
 			expectErr:   true,
 		},
 		{
-			annotations: []string{"a="},
-			expectedErr: "invalid annotation format: a=",
-			scenario:    "incorrect annotation input (missing value)",
-			expectErr:   true,
+			annotations:    []string{"a="},
+			expected:       map[string]string{"a": ""},
+			expectedRemove: []string{},
+			scenario:       "add valid annotation with empty value",
+			expectErr:      false,
 		},
 		{
 			annotations: []string{"ab", "a="},
-			expectedErr: "invalid annotation format: ab, a=",
-			scenario:    "incorrect multiple annotation input (missing value)",
+			expectedErr: "invalid annotation format: ab",
+			scenario:    "incorrect annotation input (missing =value)",
 			expectErr:   true,
 		},
 	}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -121,7 +121,7 @@ func parseLabels(spec []string) (map[string]string, []string, error) {
 	for _, labelSpec := range spec {
 		if strings.Index(labelSpec, "=") != -1 {
 			parts := strings.Split(labelSpec, "=")
-			if len(parts) != 2 || len(parts[1]) == 0 {
+			if len(parts) != 2 {
 				return nil, nil, fmt.Errorf("invalid label spec: %v", labelSpec)
 			}
 			if errs := validation.IsValidLabelValue(parts[1]); len(errs) != 0 {

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -128,8 +128,8 @@ func TestParseLabels(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			labels:    []string{"a="},
-			expectErr: true,
+			labels:   []string{"a="},
+			expected: map[string]string{"a": ""},
 		},
 		{
 			labels:    []string{"a=%^$"},

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -605,7 +605,7 @@ func ParsePairs(pairArgs []string, pairType string, supportRemove bool) (newPair
 	for _, pairArg := range pairArgs {
 		if strings.Index(pairArg, "=") != -1 {
 			parts := strings.SplitN(pairArg, "=", 2)
-			if len(parts) != 2 || len(parts[1]) == 0 {
+			if len(parts) != 2 {
 				if invalidBuf.Len() > 0 {
 					invalidBuf.WriteString(", ")
 				}


### PR DESCRIPTION
Related downstream issue: https://github.com/openshift/origin/issues/11175

**Release note**:

``` release-note
release-note-none
```

Annotations with empty values can be used, for example, in diagnostics
logging. This patch removes the client-side check for empty values in
an annotation key-value pair.

**Before**

```
$ kubectl annotate pod zookeeper-1 node-selector="" --overwrite
error: invalid annotation format: node-selector=
```

**After**

```
$ kubectl annotate pod zookeeper-1 node-selector="" --overwrite
pod "zookeper-1" annotated
```

```
$ kubectl get po/zookeeper-1 --template='{{.metadata.annotations}}'
map[... node-selector: test-label:test]
```

@fabianofranz @liggitt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34020)

<!-- Reviewable:end -->
