### PR TITLE
Enable service account signing key rotation

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -37,7 +37,7 @@ type APIServer struct {
 	MaxConnectionBytesPerSec    int64
 	SSHKeyfile                  string
 	SSHUser                     string
-	ServiceAccountKeyFile       string
+	ServiceAccountKeyFiles      []string
 	ServiceAccountLookup        bool
 	WebhookTokenAuthnConfigFile string
 	WebhookTokenAuthnCacheTTL   time.Duration
@@ -70,9 +70,10 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
 		"Amount of time to retain events. Default is 1h.")
 
-	fs.StringVar(&s.ServiceAccountKeyFile, "service-account-key-file", s.ServiceAccountKeyFile, ""+
-		"File containing PEM-encoded x509 RSA or ECDSA private or public key, used to verify "+
-		"ServiceAccount tokens. If unspecified, --tls-private-key-file is used.")
+	fs.StringArrayVar(&s.ServiceAccountKeyFiles, "service-account-key-file", s.ServiceAccountKeyFiles, ""+
+		"File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify "+
+		"ServiceAccount tokens. If unspecified, --tls-private-key-file is used. "+
+		"The specified file can contain multiple keys, and the flag can be specified multiple times with different files.")
 
 	fs.BoolVar(&s.ServiceAccountLookup, "service-account-lookup", s.ServiceAccountLookup,
 		"If true, validate ServiceAccount tokens exist in etcd as part of authentication.")

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -181,11 +181,11 @@ func Run(s *options.APIServer) error {
 	}
 
 	// Default to the private server key for service account token signing
-	if s.ServiceAccountKeyFile == "" && s.TLSPrivateKeyFile != "" {
+	if len(s.ServiceAccountKeyFiles) == 0 && s.TLSPrivateKeyFile != "" {
 		if authenticator.IsValidServiceAccountKeyFile(s.TLSPrivateKeyFile) {
-			s.ServiceAccountKeyFile = s.TLSPrivateKeyFile
+			s.ServiceAccountKeyFiles = []string{s.TLSPrivateKeyFile}
 		} else {
-			glog.Warning("No RSA key provided, service account token authentication disabled")
+			glog.Warning("No TLS key provided, service account token authentication disabled")
 		}
 	}
 
@@ -211,7 +211,7 @@ func Run(s *options.APIServer) error {
 		OIDCCAFile:                  s.OIDCCAFile,
 		OIDCUsernameClaim:           s.OIDCUsernameClaim,
 		OIDCGroupsClaim:             s.OIDCGroupsClaim,
-		ServiceAccountKeyFile:       s.ServiceAccountKeyFile,
+		ServiceAccountKeyFiles:      s.ServiceAccountKeyFiles,
 		ServiceAccountLookup:        s.ServiceAccountLookup,
 		ServiceAccountTokenGetter:   serviceAccountGetter,
 		KeystoneURL:                 s.KeystoneURL,

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -98,8 +98,8 @@ func getPrivateKey(data string) interface{} {
 }
 
 func getPublicKey(data string) interface{} {
-	key, _ := serviceaccount.ReadPublicKeyFromPEM([]byte(data))
-	return key
+	keys, _ := serviceaccount.ReadPublicKeysFromPEM([]byte(data))
+	return keys[0]
 }
 func TestReadPrivateKey(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
@@ -123,7 +123,7 @@ func TestReadPrivateKey(t *testing.T) {
 	}
 }
 
-func TestReadPublicKey(t *testing.T) {
+func TestReadPublicKeys(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Fatalf("error creating tmpfile: %v", err)
@@ -133,16 +133,30 @@ func TestReadPublicKey(t *testing.T) {
 	if err := ioutil.WriteFile(f.Name(), []byte(rsaPublicKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing public key to tmpfile: %v", err)
 	}
-	if _, err := serviceaccount.ReadPublicKey(f.Name()); err != nil {
+	if keys, err := serviceaccount.ReadPublicKeys(f.Name()); err != nil {
 		t.Fatalf("error reading RSA public key: %v", err)
+	} else if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
 	if err := ioutil.WriteFile(f.Name(), []byte(ecdsaPublicKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing public key to tmpfile: %v", err)
 	}
-	if _, err := serviceaccount.ReadPublicKey(f.Name()); err != nil {
+	if keys, err := serviceaccount.ReadPublicKeys(f.Name()); err != nil {
 		t.Fatalf("error reading ECDSA public key: %v", err)
+	} else if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
+
+	if err := ioutil.WriteFile(f.Name(), []byte(rsaPublicKey+"\n"+ecdsaPublicKey), os.FileMode(0600)); err != nil {
+		t.Fatalf("error writing public key to tmpfile: %v", err)
+	}
+	if keys, err := serviceaccount.ReadPublicKeys(f.Name()); err != nil {
+		t.Fatalf("error reading combined RSA/ECDSA public key file: %v", err)
+	} else if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+
 }
 
 func TestTokenGenerateAndValidate(t *testing.T) {


### PR DESCRIPTION
fixes #21007

``` release-note
The kube-apiserver --service-account-key-file option can be specified multiple times, or can point to a file containing multiple keys, to enable rotation of signing keys.
```

This PR enables the apiserver authenticator to verify service account tokens signed by different private keys. This can be done two different ways:
- including multiple keys in the specified keyfile (e.g. `--service-account-key-file=keys.pem`)
- specifying multiple key files (e.g. `--service-account-key-file current-key.pem --service-account-key-file=old-key.pem`)

This is part of enabling signing key rotation:
1. update apiserver(s) to verify tokens signed with a new public key while still allowing tokens signed with the current public key (which is what this PR enables)
2. give controllermanager the new private key to sign new tokens with
3. remove old service account tokens (determined by verifying signature or by checking creationTimestamp) once they are no longer in use (determined using garbage collection or magic) or some other algorithm (24 hours after rotation, etc). For the deletion to immediately revoke the token, `--service-account-lookup` must be enabled on the apiserver.
4. once all old tokens are gone, update apiservers again, removing the old public key.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34029)

<!-- Reviewable:end -->
