### PR TITLE
Improve source ip preservation test, fail the test instead of panic.

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -2347,7 +2347,10 @@ func execSourceipTest(f *framework.Framework, c *client.Client, ns, nodeName, se
 	// the stdout return from RunHostCmd seems to come with "\n", so TrimSpace is needed
 	// desired stdout in this format: client_address=x.x.x.x
 	outputs := strings.Split(strings.TrimSpace(stdout), "=")
-	sourceIp := outputs[1]
-
-	return execPodIp, sourceIp
+	if len(outputs) != 2 {
+		// fail the test if output format is unexpected
+		framework.Failf("exec pod returned unexpected stdout format: [%v]\n", stdout)
+		return execPodIp, ""
+	}
+	return execPodIp, outputs[1]
 }


### PR DESCRIPTION
From #31085.

The source IP preserve test starts to be flake again. Sending out this PR to get rid of panicing and log the unexpected output for future investigation.

@freehan 

``` release-note
Improve source IP preservation test, fail the test instead of panic.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34030)

<!-- Reviewable:end -->
