### PR TITLE
hack: Update cherry-pick script to include original PR subject

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -111,6 +111,7 @@ function return_to_kansas {
 }
 trap return_to_kansas EXIT
 
+SUBJECTS=()
 function make-a-pr() {
   local rel="$(basename "${BRANCH}")"
   echo
@@ -125,6 +126,8 @@ function make-a-pr() {
 Automated cherry pick of ${PULLSUBJ}
 
 Cherry pick of ${PULLSUBJ} on ${rel}.
+
+$(printf '%s\n' "${SUBJECTS[@]}")
 EOF
 
   hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}"
@@ -165,6 +168,9 @@ for pull in "${PULLS[@]}"; do
       exit 1
     fi
   }
+  # set the subject
+  subject=$(grep "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH\] //g')
+  SUBJECTS+=("#${pull}: ${subject}")
 done
 gitamcleanup=false
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Updates the cherrypick script to include the original PR subject.

We need it because I know nothing about the original PR based off a number and this is more expressive.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34049)

<!-- Reviewable:end -->
