### PR TITLE
e2e.go / kops: Add --kops-kube-version

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -52,12 +52,13 @@ var (
 	verbose              = flag.Bool("v", false, "If true, print all command output.")
 
 	// kops specific flags.
-	kopsPath    = flag.String("kops", "", "(kops only) Path to the kops binary. Must be set for kops.")
-	kopsCluster = flag.String("kops-cluster", "", "(kops only) Cluster name. Must be set for kops.")
-	kopsState   = flag.String("kops-state", os.Getenv("KOPS_STATE_STORE"), "(kops only) s3:// path to kops state store. Must be set. (This flag defaults to $KOPS_STATE_STORE, and overrides it if set.)")
-	kopsSSHKey  = flag.String("kops-ssh-key", os.Getenv("AWS_SSH_KEY"), "(kops only) Path to ssh key-pair for each node. (Defaults to $AWS_SSH_KEY or '~/.ssh/kube_aws_rsa'.)")
-	kopsZones   = flag.String("kops-zones", "us-west-2a", "(kops AWS only) AWS zones for kops deployment, comma delimited.")
-	kopsNodes   = flag.Int("kops-nodes", 2, "(kops only) Number of nodes to create.")
+	kopsPath        = flag.String("kops", "", "(kops only) Path to the kops binary. Must be set for kops.")
+	kopsCluster     = flag.String("kops-cluster", "", "(kops only) Cluster name. Must be set for kops.")
+	kopsState       = flag.String("kops-state", os.Getenv("KOPS_STATE_STORE"), "(kops only) s3:// path to kops state store. Must be set. (This flag defaults to $KOPS_STATE_STORE, and overrides it if set.)")
+	kopsSSHKey      = flag.String("kops-ssh-key", os.Getenv("AWS_SSH_KEY"), "(kops only) Path to ssh key-pair for each node. (Defaults to $AWS_SSH_KEY or '~/.ssh/kube_aws_rsa'.)")
+	kopsKubeVersion = flag.String("kops-kubernetes-version", "", "(kops only) If set, the version of Kubernetes to deploy (can be a URL to a GCS path where the release is stored) (Defaults to kops default, latest stable release.).")
+	kopsZones       = flag.String("kops-zones", "us-west-2a", "(kops AWS only) AWS zones for kops deployment, comma delimited.")
+	kopsNodes       = flag.Int("kops-nodes", 2, "(kops only) Number of nodes to create.")
 
 	// Deprecated flags.
 	deprecatedPush   = flag.Bool("push", false, "Deprecated. Does nothing.")
@@ -392,12 +393,13 @@ func (b bash) Down() error {
 }
 
 type kops struct {
-	path    string
-	sshKey  string
-	zones   []string
-	nodes   int
-	cluster string
-	kubecfg string
+	path        string
+	kubeVersion string
+	sshKey      string
+	zones       []string
+	nodes       int
+	cluster     string
+	kubecfg     string
 }
 
 func NewKops() (*kops, error) {
@@ -453,22 +455,28 @@ func NewKops() (*kops, error) {
 		return nil, err
 	}
 	return &kops{
-		path:    *kopsPath,
-		sshKey:  sshKey + ".pub", // kops only needs the public key, e2es need the private key.
-		zones:   zones,
-		nodes:   *kopsNodes,
-		cluster: *kopsCluster,
-		kubecfg: kubecfg,
+		path:        *kopsPath,
+		kubeVersion: *kopsKubeVersion,
+		sshKey:      sshKey + ".pub", // kops only needs the public key, e2es need the private key.
+		zones:       zones,
+		nodes:       *kopsNodes,
+		cluster:     *kopsCluster,
+		kubecfg:     kubecfg,
 	}, nil
 }
 
 func (k kops) Up() error {
-	if err := finishRunning("kops config", exec.Command(
-		k.path, "create", "cluster",
+	createArgs := []string{
+		"create", "cluster",
 		"--name", k.cluster,
 		"--ssh-public-key", k.sshKey,
 		"--node-count", strconv.Itoa(k.nodes),
-		"--zones", strings.Join(k.zones, ","))); err != nil {
+		"--zones", strings.Join(k.zones, ","),
+	}
+	if k.kubeVersion != "" {
+		createArgs = append(createArgs, "--kubernetes-version", k.kubeVersion)
+	}
+	if err := finishRunning("kops config", exec.Command(k.path, createArgs...)); err != nil {
 		return fmt.Errorf("kops configuration failed: %v", err)
 	}
 	if err := finishRunning("kops update", exec.Command(k.path, "update", "cluster", k.cluster, "--yes")); err != nil {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -275,6 +275,7 @@ k8s-build-output
 keep-gogoproto
 km-path
 kops-cluster
+kops-kubernetes-version
 kops-nodes
 kops-ssh-key
 kops-state


### PR DESCRIPTION
**What this PR does / why we need it**: This adds a flag to override the version we're deploying with kops for e2es. (The kops experience is disconnected from the actual source tree we're running tests from, which is similar to GKE.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34050)

<!-- Reviewable:end -->
