### PR TITLE
Check for empty string post trimming

### DIFF
--- a/test/e2e/networking_utils.go
+++ b/test/e2e/networking_utils.go
@@ -170,7 +170,10 @@ func (config *NetworkingTestConfig) dialFromContainer(protocol, containerIP, tar
 				continue
 			}
 			for _, hostName := range output["responses"] {
-				eps.Insert(hostName)
+				trimmed := strings.TrimSpace(hostName)
+				if trimmed != "" {
+					eps.Insert(trimmed)
+				}
 			}
 		}
 		framework.Logf("Waiting for endpoints: %v", expectedEps.Difference(eps))
@@ -217,7 +220,10 @@ func (config *NetworkingTestConfig) dialFromNode(protocol, targetIP string, targ
 			// we confirm unreachability.
 			framework.Logf("Failed to execute %v: %v", filterCmd, err)
 		} else {
-			eps.Insert(strings.TrimSpace(stdout))
+			trimmed := strings.TrimSpace(stdout)
+			if trimmed != "" {
+				eps.Insert(trimmed)
+			}
 		}
 		framework.Logf("Waiting for %+v endpoints, got endpoints %+v", expectedEps.Difference(eps), eps)
 


### PR DESCRIPTION
We curl in a retry loop and timeout,  trimming stdout to find endpoint names. When curl hits the timeout, stdout is empty, so we insert the empty string into the received set of endpoints. 

Fixes https://github.com/kubernetes/kubernetes/issues/32684

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34053)

<!-- Reviewable:end -->
