### PR TITLE
CRI: Add presubmit CRI validation test.

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
@@ -1,0 +1,11 @@
+GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
+GCE_HOSTS=
+GCE_IMAGES=gci-dev-55-8820-0-0
+GCE_IMAGE_PROJECT=google-containers
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT}"
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
+SETUP_NODE=false
+TEST_ARGS='--runtime-integration-type=cri'


### PR DESCRIPTION
For #31459.

This PR adds a new suite for CRI presubmit validation which runs non-flaky, non-serial, non-slow test per-pr.

Except this PR, I'll also change the test-infra side. Ideally, after this is done, we should be be able to trigger CRI validation test per-pr with something like `@k8s-bot cri node e2e test this` and `@k8s-bot cri e2e test this`.

@yujuhong @feiskyer @yifan-gu @freehan 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34068)

<!-- Reviewable:end -->
