### PR TITLE
Add local option to annotate

### DIFF
--- a/pkg/kubectl/cmd/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate_test.go
@@ -517,6 +517,34 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	}
 }
 
+func TestAnnotateLocal(t *testing.T) {
+	f, tf, _, ns := NewAPIFactory()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
+			return nil, nil
+		}),
+	}
+	tf.Namespace = "test"
+	tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}}
+
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdAnnotate(f, buf)
+	options := &AnnotateOptions{local: true}
+	options.Filenames = []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"}
+	args := []string{"a=b"}
+	if err := options.Complete(f, buf, cmd, args); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := options.Validate(args); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := options.RunAnnotate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestAnnotateMultipleObjects(t *testing.T) {
 	pods, _, _ := testData()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the --local option to be both consistent with other commands and so it can be used with "set selector" and "create service".

**Which issue this PR fixes** 
Related: #7296

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
Add a new option "--local" to the `kubectl annotate`
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34074)

<!-- Reviewable:end -->
