### PR TITLE
Remove headers that are unnecessary for proxy target

### DIFF
--- a/pkg/auth/handlers/handlers_test.go
+++ b/pkg/auth/handlers/handlers_test.go
@@ -40,18 +40,24 @@ func TestAuthenticateRequest(t *testing.T) {
 			if user == nil || !ok {
 				t.Errorf("no user stored in context: %#v", ctx)
 			}
+			if req.Header.Get("Authorization") != "" {
+				t.Errorf("Authorization header should be removed from request on success: %#v", req)
+			}
 			close(success)
 		}),
 		contextMapper,
 		authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
-			return &user.DefaultInfo{Name: "user"}, true, nil
+			if req.Header.Get("Authorization") == "Something" {
+				return &user.DefaultInfo{Name: "user"}, true, nil
+			}
+			return nil, false, errors.New("Authorization header is missing.")
 		}),
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			t.Errorf("unexpected call to failed")
 		}),
 	)
 
-	auth.ServeHTTP(httptest.NewRecorder(), &http.Request{})
+	auth.ServeHTTP(httptest.NewRecorder(), &http.Request{Header: map[string][]string{"Authorization": {"Something"}}})
 
 	<-success
 	empty, err := api.IsEmpty(contextMapper)


### PR DESCRIPTION
Some headers like authorization is unnecessary to pass to the proxy target. We should start removing these headers in proxy requests.

``` release-note
Remove headers that are unnecessary for proxy target
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34076)

<!-- Reviewable:end -->
