### PR TITLE
Workaround part of etcd3 slowness.

### DIFF
--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -328,7 +328,13 @@ func (s *store) watch(ctx context.Context, key string, rv string, pred storage.S
 		return nil, err
 	}
 	key = keyWithPrefix(s.pathPrefix, key)
-	return s.watcher.Watch(ctx, key, int64(rev), recursive, storage.SimpleFilter(pred))
+	var filter storage.FilterFunc
+	if pred.Label.Empty() && pred.Field.Empty() {
+		filter = storage.EverythingFunc
+	} else {
+		filter = storage.SimpleFilter(pred)
+	}
+	return s.watcher.Watch(ctx, key, int64(rev), recursive, filter)
 }
 
 func (s *store) getState(getResp *clientv3.GetResponse, key string, v reflect.Value, ignoreNotFound bool) (*objState, error) {


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/33653

With this PR, in practise etcd3 watcher no longer sends GET requests for all update events (because in practise we are using "cacher" which always sets Filter to Everything).

This should help (and hopefully also unblock) some scale testing with etcd3 before the proper fix is in.

@xiang90 @hongchaodeng @timothysc

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34083)

<!-- Reviewable:end -->
