### PR TITLE
Fix call to Index call in listers

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -62,7 +62,7 @@ func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selec
 		return nil
 	}
 
-	items, err := indexer.Index(NamespaceIndex, api.ObjectMeta{Namespace: namespace})
+	items, err := indexer.Index(NamespaceIndex, &api.ObjectMeta{Namespace: namespace})
 	if err != nil {
 		// Ignore error; do slow search without index.
 		glog.Warningf("can not retrieve list of objects using index : %v", err)


### PR DESCRIPTION
This will actually eliminated all logs like this:

```
can not retrieve list of objects using index : object has no meta: object does not implement the Object interfaces
```

And it should also speed up different things (as so far we we basically not using indexes at all.

@kubernetes/sig-api-machinery

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34093)

<!-- Reviewable:end -->
