### PR TITLE
Delete federation namespace after the test completes

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -269,6 +269,10 @@ func (f *Framework) BeforeEach() {
 }
 
 func (f *Framework) deleteFederationNs() {
+	if !f.federated {
+		// Nothing to do if this is not a federation setup.
+		return
+	}
 	ns := f.FederationNamespace
 	By(fmt.Sprintf("Destroying federation namespace %q for this suite.", ns.Name))
 	timeout := 5 * time.Minute
@@ -327,10 +331,7 @@ func (f *Framework) AfterEach() {
 				}
 			}
 			// Delete the federation namespace.
-			// TODO(nikhiljindal): Uncomment this, once https://github.com/kubernetes/kubernetes/issues/31077 is fixed.
-			// In the meantime, we will have these extra namespaces in all clusters.
-			// Note: this will not cause any failure since we create a new namespace for each test in BeforeEach().
-			// f.deleteFederationNs()
+			f.deleteFederationNs()
 		} else {
 			Logf("Found DeleteNamespace=false, skipping namespace deletion!")
 		}


### PR DESCRIPTION
The code was commented because of a bug in namespace deletion which is now fixed.
Note that this deletes the namespace in federation control plane. We still need to delete the namespace from each cluster (cascading deletion)

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34135)

<!-- Reviewable:end -->
