### PR TITLE
Create restclient interface

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_group.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_group.go
@@ -60,10 +60,11 @@ func (g *genFakeForGroup) GenerateType(c *generator.Context, t *types.Type, w io
 	const pkgTestingCore = "k8s.io/kubernetes/pkg/client/testing/core"
 	const pkgRESTClient = "k8s.io/kubernetes/pkg/client/restclient"
 	m := map[string]interface{}{
-		"group":      g.group,
-		"Group":      namer.IC(g.group),
-		"Fake":       c.Universe.Type(types.Name{Package: pkgTestingCore, Name: "Fake"}),
-		"RESTClient": c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "RESTClient"}),
+		"group":               g.group,
+		"Group":               namer.IC(g.group),
+		"Fake":                c.Universe.Type(types.Name{Package: pkgTestingCore, Name: "Fake"}),
+		"RESTClientInterface": c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Interface"}),
+		"RESTClient":          c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "RESTClient"}),
 	}
 	sw.Do(groupClientTemplate, m)
 	for _, t := range g.types {
@@ -103,9 +104,10 @@ func (c *Fake$.Group$) $.type|publicPlural$() $.realClientPackage$.$.type|public
 `
 
 var getRESTClient = `
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *Fake$.Group$) GetRESTClient() *$.RESTClient|raw$ {
-  return nil
+func (c *Fake$.Group$) RESTClient() $.RESTClientInterface|raw$ {
+	var ret *$.RESTClient|raw$
+	return ret
 }
 `

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
@@ -92,7 +92,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		"allGroups":                        allGroups,
 		"Config":                           c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Config"}),
 		"DefaultKubernetesUserAgent":       c.Universe.Function(types.Name{Package: pkgRESTClient, Name: "DefaultKubernetesUserAgent"}),
-		"RESTClient":                       c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "RESTClient"}),
+		"RESTClientInterface":              c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Interface"}),
 		"DiscoveryInterface":               c.Universe.Type(types.Name{Package: pkgDiscovery, Name: "DiscoveryInterface"}),
 		"DiscoveryClient":                  c.Universe.Type(types.Name{Package: pkgDiscovery, Name: "DiscoveryClient"}),
 		"NewDiscoveryClientForConfig":      c.Universe.Function(types.Name{Package: pkgDiscovery, Name: "NewDiscoveryClientForConfig"}),
@@ -183,7 +183,7 @@ $end$
 
 var newClientsetForRESTClientTemplate = `
 // New creates a new Clientset for the given RESTClient.
-func New(c *$.RESTClient|raw$) *Clientset {
+func New(c $.RESTClientInterface|raw$) *Clientset {
 	var clientset Clientset
 $range .allGroups$    clientset.$.Group$Client =$.PackageName$.New(c)
 $end$

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
@@ -89,7 +89,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"types":                      g.types,
 		"Config":                     c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Config"}),
 		"DefaultKubernetesUserAgent": c.Universe.Function(types.Name{Package: pkgRESTClient, Name: "DefaultKubernetesUserAgent"}),
-		"RESTClient":                 c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "RESTClient"}),
+		"RESTClientInterface":        c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Interface"}),
 		"RESTClientFor":              c.Universe.Function(types.Name{Package: pkgRESTClient, Name: "RESTClientFor"}),
 		"latestGroup":                c.Universe.Variable(types.Name{Package: pkgRegistered, Name: "Group"}),
 		"GroupOrDie":                 c.Universe.Variable(types.Name{Package: pkgRegistered, Name: "GroupOrDie"}),
@@ -128,7 +128,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 
 var groupInterfaceTemplate = `
 type $.Group$Interface interface {
-    GetRESTClient() *$.RESTClient|raw$
+    RESTClient() $.RESTClientInterface|raw$
     $range .types$ $.|publicPlural$Getter
     $end$
 }
@@ -137,7 +137,7 @@ type $.Group$Interface interface {
 var groupClientTemplate = `
 // $.Group$Client is used to interact with features provided by the $.Group$ group.
 type $.Group$Client struct {
-	*$.RESTClient|raw$
+	restClient $.RESTClientInterface|raw$
 }
 `
 
@@ -181,19 +181,19 @@ func NewForConfigOrDie(c *$.Config|raw$) *$.Group$Client {
 `
 
 var getRESTClient = `
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *$.Group$Client) GetRESTClient() *$.RESTClient|raw$ {
+func (c *$.Group$Client) RESTClient() $.RESTClientInterface|raw$ {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }
 `
 
 var newClientForRESTClientTemplate = `
 // New creates a new $.Group$Client for the given RESTClient.
-func New(c *$.RESTClient|raw$) *$.Group$Client {
+func New(c $.RESTClientInterface|raw$) *$.Group$Client {
 	return &$.Group$Client{c}
 }
 `

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
@@ -69,14 +69,15 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 	pkg := filepath.Base(t.Name.Package)
 	namespaced := !extractBoolTagOrDie("nonNamespaced", t.SecondClosestCommentLines)
 	m := map[string]interface{}{
-		"type":              t,
-		"package":           pkg,
-		"Package":           namer.IC(pkg),
-		"Group":             namer.IC(g.group),
-		"watchInterface":    c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
-		"apiParameterCodec": c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ParameterCodec"}),
-		"PatchType":         c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "PatchType"}),
-		"namespaced":        namespaced,
+		"type":                t,
+		"package":             pkg,
+		"Package":             namer.IC(pkg),
+		"Group":               namer.IC(g.group),
+		"watchInterface":      c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
+		"RESTClientInterface": c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/client/restclient", Name: "Interface"}),
+		"apiParameterCodec":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ParameterCodec"}),
+		"PatchType":           c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "PatchType"}),
+		"namespaced":          namespaced,
 	}
 
 	if g.version == "unversioned" {
@@ -134,7 +135,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 
 // group client will implement this interface.
 var getterComment = `
-// $.type|publicPlural$Getter has a method to return a $.type|public$Interface. 
+// $.type|publicPlural$Getter has a method to return a $.type|public$Interface.
 // A group's client should implement this interface.`
 
 var getterNamesapced = `
@@ -179,7 +180,7 @@ var interfaceTemplate4 = `
 var structNamespaced = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
-	client *$.Group$Client
+	client $.RESTClientInterface|raw$
 	ns     string
 }
 `
@@ -188,7 +189,7 @@ type $.type|privatePlural$ struct {
 var structNonNamespaced = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
-	client *$.Group$Client
+	client $.RESTClientInterface|raw$
 }
 `
 
@@ -196,7 +197,7 @@ var newStructNamespaced = `
 // new$.type|publicPlural$ returns a $.type|publicPlural$
 func new$.type|publicPlural$(c *$.Group$Client, namespace string) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }
@@ -206,7 +207,7 @@ var newStructNonNamespaced = `
 // new$.type|publicPlural$ returns a $.type|publicPlural$
 func new$.type|publicPlural$(c *$.Group$Client) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 `

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
@@ -82,7 +82,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 }
 
 // New creates a new Clientset for the given RESTClient.
-func New(c *restclient.RESTClient) *Clientset {
+func New(c restclient.Interface) *Clientset {
 	var clientset Clientset
 	clientset.TestgroupClient = unversionedtestgroup.New(c)
 

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset_test.go
@@ -35,7 +35,7 @@ func ClientSetRateLimiterTest(t *testing.T) {
 	if err != nil {
 		t.Errorf("creating clientset for config %v failed: %v", config, err)
 	}
-	testGroupThrottler := clientSet.Testgroup().GetRESTClient().GetRateLimiter()
+	testGroupThrottler := clientSet.Testgroup().RESTClient().GetRateLimiter()
 
 	if rateLimiter != testGroupThrottler {
 		t.Errorf("Clients in client set should use rateLimiter passed in config:\noriginal: %v\ntestGroup: %v", rateLimiter, testGroupThrottler)

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testgroup_client.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testgroup_client.go
@@ -30,8 +30,9 @@ func (c *FakeTestgroup) TestTypes(namespace string) unversioned.TestTypeInterfac
 	return &FakeTestTypes{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeTestgroup) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeTestgroup) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_client.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type TestgroupInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	TestTypesGetter
 }
 
 // TestgroupClient is used to interact with features provided by the Testgroup group.
 type TestgroupClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *TestgroupClient) TestTypes(namespace string) TestTypeInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *TestgroupClient {
 }
 
 // New creates a new TestgroupClient for the given RESTClient.
-func New(c *restclient.RESTClient) *TestgroupClient {
+func New(c restclient.Interface) *TestgroupClient {
 	return &TestgroupClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *TestgroupClient) GetRESTClient() *restclient.RESTClient {
+func (c *TestgroupClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	testgroup_k8s_io "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup.k8s.io"
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type TestTypeInterface interface {
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client *TestgroupClient
+	client restclient.Interface
 	ns     string
 }
 
 // newTestTypes returns a TestTypes
 func newTestTypes(c *TestgroupClient, namespace string) *testTypes {
 	return &testTypes{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/clientset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/clientset.go
@@ -114,7 +114,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 }
 
 // New creates a new Clientset for the given RESTClient.
-func New(c *restclient.RESTClient) *Clientset {
+func New(c restclient.Interface) *Clientset {
 	var clientset Clientset
 	clientset.FederationClient = unversionedfederation.New(c)
 	clientset.CoreClient = unversionedcore.New(c)

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/configmap.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/configmap.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type ConfigMapInterface interface {
 
 // configMaps implements ConfigMapInterface
 type configMaps struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newConfigMaps returns a ConfigMaps
 func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	return &configMaps{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/core_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/core_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ConfigMapsGetter
 	EventsGetter
 	NamespacesGetter
@@ -33,7 +33,7 @@ type CoreInterface interface {
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CoreClient) ConfigMaps(namespace string) ConfigMapInterface {
@@ -80,7 +80,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c restclient.Interface) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -109,11 +109,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/event.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/event.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type EventInterface interface {
 
 // events implements EventInterface
 type events struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEvents returns a Events
 func newEvents(c *CoreClient, namespace string) *events {
 	return &events{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_core_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_core_client.go
@@ -46,8 +46,9 @@ func (c *FakeCore) Services(namespace string) unversioned.ServiceInterface {
 	return &FakeServices{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCore) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCore) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/namespace.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type NamespaceInterface interface {
 
 // namespaces implements NamespaceInterface
 type namespaces struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNamespaces returns a Namespaces
 func newNamespaces(c *CoreClient) *namespaces {
 	return &namespaces{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/secret.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/secret.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type SecretInterface interface {
 
 // secrets implements SecretInterface
 type secrets struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newSecrets returns a Secrets
 func newSecrets(c *CoreClient, namespace string) *secrets {
 	return &secrets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ServiceInterface interface {
 
 // services implements ServiceInterface
 type services struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServices returns a Services
 func newServices(c *CoreClient, namespace string) *services {
 	return &services{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/daemonset.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type DaemonSetInterface interface {
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDaemonSets returns a DaemonSets
 func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	return &daemonSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/deployment.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type DeploymentInterface interface {
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDeployments returns a Deployments
 func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	return &deployments{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/extensions_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/extensions_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ExtensionsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	DaemonSetsGetter
 	DeploymentsGetter
 	IngressesGetter
@@ -32,7 +32,7 @@ type ExtensionsInterface interface {
 
 // ExtensionsClient is used to interact with features provided by the Extensions group.
 type ExtensionsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *ExtensionsClient) DaemonSets(namespace string) DaemonSetInterface {
@@ -75,7 +75,7 @@ func NewForConfigOrDie(c *restclient.Config) *ExtensionsClient {
 }
 
 // New creates a new ExtensionsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *ExtensionsClient {
+func New(c restclient.Interface) *ExtensionsClient {
 	return &ExtensionsClient{c}
 }
 
@@ -104,11 +104,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *ExtensionsClient) GetRESTClient() *restclient.RESTClient {
+func (c *ExtensionsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
@@ -42,8 +42,9 @@ func (c *FakeExtensions) ReplicaSets(namespace string) unversioned.ReplicaSetInt
 	return &FakeReplicaSets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeExtensions) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeExtensions) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/ingress.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type IngressInterface interface {
 
 // ingresses implements IngressInterface
 type ingresses struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newIngresses returns a Ingresses
 func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	return &ingresses{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/unversioned/replicaset.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ReplicaSetInterface interface {
 
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicaSets returns a ReplicaSets
 func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	return &replicaSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	federation "k8s.io/kubernetes/federation/apis/federation"
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type ClusterInterface interface {
 
 // clusters implements ClusterInterface
 type clusters struct {
-	client *FederationClient
+	client restclient.Interface
 }
 
 // newClusters returns a Clusters
 func newClusters(c *FederationClient) *clusters {
 	return &clusters{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_federation_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_federation_client.go
@@ -30,8 +30,9 @@ func (c *FakeFederation) Clusters() unversioned.ClusterInterface {
 	return &FakeClusters{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeFederation) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeFederation) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/federation_client.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/federation_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type FederationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ClustersGetter
 }
 
 // FederationClient is used to interact with features provided by the Federation group.
 type FederationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *FederationClient) Clusters() ClusterInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *FederationClient {
 }
 
 // New creates a new FederationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *FederationClient {
+func New(c restclient.Interface) *FederationClient {
 	return &FederationClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FederationClient) GetRESTClient() *restclient.RESTClient {
+func (c *FederationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/client/clientset_generated/federation_release_1_5/clientset.go
+++ b/federation/client/clientset_generated/federation_release_1_5/clientset.go
@@ -114,7 +114,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 }
 
 // New creates a new Clientset for the given RESTClient.
-func New(c *restclient.RESTClient) *Clientset {
+func New(c restclient.Interface) *Clientset {
 	var clientset Clientset
 	clientset.FederationClient = v1beta1federation.New(c)
 	clientset.CoreClient = v1core.New(c)

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/configmap.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/configmap.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ConfigMapInterface interface {
 
 // configMaps implements ConfigMapInterface
 type configMaps struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newConfigMaps returns a ConfigMaps
 func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	return &configMaps{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/core_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/core_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ConfigMapsGetter
 	EventsGetter
 	NamespacesGetter
@@ -34,7 +34,7 @@ type CoreInterface interface {
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CoreClient) ConfigMaps(namespace string) ConfigMapInterface {
@@ -81,7 +81,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c restclient.Interface) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -106,11 +106,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/event.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/event.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type EventInterface interface {
 
 // events implements EventInterface
 type events struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEvents returns a Events
 func newEvents(c *CoreClient, namespace string) *events {
 	return &events{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/fake/fake_core_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/fake/fake_core_client.go
@@ -46,8 +46,9 @@ func (c *FakeCore) Services(namespace string) v1.ServiceInterface {
 	return &FakeServices{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCore) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCore) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/namespace.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/namespace.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type NamespaceInterface interface {
 
 // namespaces implements NamespaceInterface
 type namespaces struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNamespaces returns a Namespaces
 func newNamespaces(c *CoreClient) *namespaces {
 	return &namespaces{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/secret.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/secret.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type SecretInterface interface {
 
 // secrets implements SecretInterface
 type secrets struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newSecrets returns a Secrets
 func newSecrets(c *CoreClient, namespace string) *secrets {
 	return &secrets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/service.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ServiceInterface interface {
 
 // services implements ServiceInterface
 type services struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServices returns a Services
 func newServices(c *CoreClient, namespace string) *services {
 	return &services{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/daemonset.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/daemonset.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type DaemonSetInterface interface {
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDaemonSets returns a DaemonSets
 func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	return &daemonSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/deployment.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type DeploymentInterface interface {
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDeployments returns a Deployments
 func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	return &deployments{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/extensions_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/extensions_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type ExtensionsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	DaemonSetsGetter
 	DeploymentsGetter
 	IngressesGetter
@@ -33,7 +33,7 @@ type ExtensionsInterface interface {
 
 // ExtensionsClient is used to interact with features provided by the Extensions group.
 type ExtensionsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *ExtensionsClient) DaemonSets(namespace string) DaemonSetInterface {
@@ -76,7 +76,7 @@ func NewForConfigOrDie(c *restclient.Config) *ExtensionsClient {
 }
 
 // New creates a new ExtensionsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *ExtensionsClient {
+func New(c restclient.Interface) *ExtensionsClient {
 	return &ExtensionsClient{c}
 }
 
@@ -101,11 +101,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *ExtensionsClient) GetRESTClient() *restclient.RESTClient {
+func (c *ExtensionsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/fake/fake_extensions_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/fake/fake_extensions_client.go
@@ -42,8 +42,9 @@ func (c *FakeExtensions) ReplicaSets(namespace string) v1beta1.ReplicaSetInterfa
 	return &FakeReplicaSets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeExtensions) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeExtensions) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/ingress.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/ingress.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type IngressInterface interface {
 
 // ingresses implements IngressInterface
 type ingresses struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newIngresses returns a Ingresses
 func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	return &ingresses{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/replicaset.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type ReplicaSetInterface interface {
 
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicaSets returns a ReplicaSets
 func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	return &replicaSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/cluster.go
@@ -20,6 +20,7 @@ import (
 	v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,13 +46,13 @@ type ClusterInterface interface {
 
 // clusters implements ClusterInterface
 type clusters struct {
-	client *FederationClient
+	client restclient.Interface
 }
 
 // newClusters returns a Clusters
 func newClusters(c *FederationClient) *clusters {
 	return &clusters{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/fake/fake_federation_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/fake/fake_federation_client.go
@@ -30,8 +30,9 @@ func (c *FakeFederation) Clusters() v1beta1.ClusterInterface {
 	return &FakeClusters{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeFederation) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeFederation) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/federation_client.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/federation_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type FederationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ClustersGetter
 }
 
 // FederationClient is used to interact with features provided by the Federation group.
 type FederationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *FederationClient) Clusters() ClusterInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *FederationClient {
 }
 
 // New creates a new FederationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *FederationClient {
+func New(c restclient.Interface) *FederationClient {
 	return &FederationClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FederationClient) GetRESTClient() *restclient.RESTClient {
+func (c *FederationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/federation/pkg/federation-controller/cluster/cluster_client.go
+++ b/federation/pkg/federation-controller/cluster/cluster_client.go
@@ -99,7 +99,7 @@ func (self *ClusterClient) GetClusterHealthStatus() *federation_v1beta1.ClusterS
 		LastProbeTime:      currentTime,
 		LastTransitionTime: currentTime,
 	}
-	body, err := self.discoveryClient.Get().AbsPath("/healthz").Do().Raw()
+	body, err := self.discoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
 	if err != nil {
 		clusterStatus.Conditions = append(clusterStatus.Conditions, newNodeOfflineCondition)
 	} else {

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -242,7 +242,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 }
 
 // New creates a new Clientset for the given RESTClient.
-func New(c *restclient.RESTClient) *Clientset {
+func New(c restclient.Interface) *Clientset {
 	var clientset Clientset
 	clientset.CoreClient = unversionedcore.New(c)
 	clientset.AuthenticationClient = unversionedauthentication.New(c)

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/apps_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/apps_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type AppsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	PetSetsGetter
 }
 
 // AppsClient is used to interact with features provided by the Apps group.
 type AppsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AppsClient) PetSets(namespace string) PetSetInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *AppsClient {
 }
 
 // New creates a new AppsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AppsClient {
+func New(c restclient.Interface) *AppsClient {
 	return &AppsClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AppsClient) GetRESTClient() *restclient.RESTClient {
+func (c *AppsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/fake/fake_apps_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/fake/fake_apps_client.go
@@ -30,8 +30,9 @@ func (c *FakeApps) PetSets(namespace string) unversioned.PetSetInterface {
 	return &FakePetSets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeApps) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeApps) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/petset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/unversioned/petset.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type PetSetInterface interface {
 
 // petSets implements PetSetInterface
 type petSets struct {
-	client *AppsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPetSets returns a PetSets
 func newPetSets(c *AppsClient, namespace string) *petSets {
 	return &petSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/authentication_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/authentication_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type AuthenticationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	TokenReviewsGetter
 }
 
 // AuthenticationClient is used to interact with features provided by the Authentication group.
 type AuthenticationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AuthenticationClient) TokenReviews() TokenReviewInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *AuthenticationClient {
 }
 
 // New creates a new AuthenticationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AuthenticationClient {
+func New(c restclient.Interface) *AuthenticationClient {
 	return &AuthenticationClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AuthenticationClient) GetRESTClient() *restclient.RESTClient {
+func (c *AuthenticationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/fake/fake_authentication_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/fake/fake_authentication_client.go
@@ -30,8 +30,9 @@ func (c *FakeAuthentication) TokenReviews() unversioned.TokenReviewInterface {
 	return &FakeTokenReviews{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAuthentication) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAuthentication) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/tokenreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned/tokenreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package unversioned
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // TokenReviewsGetter has a method to return a TokenReviewInterface.
 // A group's client should implement this interface.
 type TokenReviewsGetter interface {
@@ -29,12 +33,12 @@ type TokenReviewInterface interface {
 
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
-	client *AuthenticationClient
+	client restclient.Interface
 }
 
 // newTokenReviews returns a TokenReviews
 func newTokenReviews(c *AuthenticationClient) *tokenReviews {
 	return &tokenReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/authorization_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type AuthorizationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	LocalSubjectAccessReviewsGetter
 	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
@@ -31,7 +31,7 @@ type AuthorizationInterface interface {
 
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AuthorizationClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
@@ -70,7 +70,7 @@ func NewForConfigOrDie(c *restclient.Config) *AuthorizationClient {
 }
 
 // New creates a new AuthorizationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AuthorizationClient {
+func New(c restclient.Interface) *AuthorizationClient {
 	return &AuthorizationClient{c}
 }
 
@@ -99,11 +99,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AuthorizationClient) GetRESTClient() *restclient.RESTClient {
+func (c *AuthorizationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/fake/fake_authorization_client.go
@@ -38,8 +38,9 @@ func (c *FakeAuthorization) SubjectAccessReviews() unversioned.SubjectAccessRevi
 	return &FakeSubjectAccessReviews{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAuthorization) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAuthorization) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/localsubjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package unversioned
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // LocalSubjectAccessReviewsGetter has a method to return a LocalSubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type LocalSubjectAccessReviewsGetter interface {
@@ -29,14 +33,14 @@ type LocalSubjectAccessReviewInterface interface {
 
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 	ns     string
 }
 
 // newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
 func newLocalSubjectAccessReviews(c *AuthorizationClient, namespace string) *localSubjectAccessReviews {
 	return &localSubjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/selfsubjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package unversioned
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // SelfSubjectAccessReviewsGetter has a method to return a SelfSubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type SelfSubjectAccessReviewsGetter interface {
@@ -29,12 +33,12 @@ type SelfSubjectAccessReviewInterface interface {
 
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
 func newSelfSubjectAccessReviews(c *AuthorizationClient) *selfSubjectAccessReviews {
 	return &selfSubjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/subjectaccessreview.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned/subjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package unversioned
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // SubjectAccessReviewsGetter has a method to return a SubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type SubjectAccessReviewsGetter interface {
@@ -29,12 +33,12 @@ type SubjectAccessReviewInterface interface {
 
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews
 func newSubjectAccessReviews(c *AuthorizationClient) *subjectAccessReviews {
 	return &subjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/autoscaling_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/autoscaling_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type AutoscalingInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	HorizontalPodAutoscalersGetter
 }
 
 // AutoscalingClient is used to interact with features provided by the Autoscaling group.
 type AutoscalingClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AutoscalingClient) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *AutoscalingClient {
 }
 
 // New creates a new AutoscalingClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AutoscalingClient {
+func New(c restclient.Interface) *AutoscalingClient {
 	return &AutoscalingClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AutoscalingClient) GetRESTClient() *restclient.RESTClient {
+func (c *AutoscalingClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_autoscaling_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_autoscaling_client.go
@@ -30,8 +30,9 @@ func (c *FakeAutoscaling) HorizontalPodAutoscalers(namespace string) unversioned
 	return &FakeHorizontalPodAutoscalers{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAutoscaling) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAutoscaling) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type HorizontalPodAutoscalerInterface interface {
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
-	client *AutoscalingClient
+	client restclient.Interface
 	ns     string
 }
 
 // newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
 func newHorizontalPodAutoscalers(c *AutoscalingClient, namespace string) *horizontalPodAutoscalers {
 	return &horizontalPodAutoscalers{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
@@ -23,14 +23,14 @@ import (
 )
 
 type BatchInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	JobsGetter
 	ScheduledJobsGetter
 }
 
 // BatchClient is used to interact with features provided by the Batch group.
 type BatchClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *BatchClient) Jobs(namespace string) JobInterface {
@@ -65,7 +65,7 @@ func NewForConfigOrDie(c *restclient.Config) *BatchClient {
 }
 
 // New creates a new BatchClient for the given RESTClient.
-func New(c *restclient.RESTClient) *BatchClient {
+func New(c restclient.Interface) *BatchClient {
 	return &BatchClient{c}
 }
 
@@ -94,11 +94,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *BatchClient) GetRESTClient() *restclient.RESTClient {
+func (c *BatchClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_batch_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_batch_client.go
@@ -34,8 +34,9 @@ func (c *FakeBatch) ScheduledJobs(namespace string) unversioned.ScheduledJobInte
 	return &FakeScheduledJobs{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeBatch) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeBatch) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type JobInterface interface {
 
 // jobs implements JobInterface
 type jobs struct {
-	client *BatchClient
+	client restclient.Interface
 	ns     string
 }
 
 // newJobs returns a Jobs
 func newJobs(c *BatchClient, namespace string) *jobs {
 	return &jobs{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ScheduledJobInterface interface {
 
 // scheduledJobs implements ScheduledJobInterface
 type scheduledJobs struct {
-	client *BatchClient
+	client restclient.Interface
 	ns     string
 }
 
 // newScheduledJobs returns a ScheduledJobs
 func newScheduledJobs(c *BatchClient, namespace string) *scheduledJobs {
 	return &scheduledJobs{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificates_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificates_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type CertificatesInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	CertificateSigningRequestsGetter
 }
 
 // CertificatesClient is used to interact with features provided by the Certificates group.
 type CertificatesClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CertificatesClient) CertificateSigningRequests() CertificateSigningRequestInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *CertificatesClient {
 }
 
 // New creates a new CertificatesClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CertificatesClient {
+func New(c restclient.Interface) *CertificatesClient {
 	return &CertificatesClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CertificatesClient) GetRESTClient() *restclient.RESTClient {
+func (c *CertificatesClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/certificatesigningrequest.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type CertificateSigningRequestInterface interface {
 
 // certificateSigningRequests implements CertificateSigningRequestInterface
 type certificateSigningRequests struct {
-	client *CertificatesClient
+	client restclient.Interface
 }
 
 // newCertificateSigningRequests returns a CertificateSigningRequests
 func newCertificateSigningRequests(c *CertificatesClient) *certificateSigningRequests {
 	return &certificateSigningRequests{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificates_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned/fake/fake_certificates_client.go
@@ -30,8 +30,9 @@ func (c *FakeCertificates) CertificateSigningRequests() unversioned.CertificateS
 	return &FakeCertificateSigningRequests{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCertificates) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCertificates) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,13 +43,13 @@ type ComponentStatusInterface interface {
 
 // componentStatuses implements ComponentStatusInterface
 type componentStatuses struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newComponentStatuses returns a ComponentStatuses
 func newComponentStatuses(c *CoreClient) *componentStatuses {
 	return &componentStatuses{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type ConfigMapInterface interface {
 
 // configMaps implements ConfigMapInterface
 type configMaps struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newConfigMaps returns a ConfigMaps
 func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	return &configMaps{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ComponentStatusesGetter
 	ConfigMapsGetter
 	EndpointsGetter
@@ -44,7 +44,7 @@ type CoreInterface interface {
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CoreClient) ComponentStatuses() ComponentStatusInterface {
@@ -135,7 +135,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c restclient.Interface) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -164,11 +164,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type EndpointsInterface interface {
 
 // endpoints implements EndpointsInterface
 type endpoints struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEndpoints returns a Endpoints
 func newEndpoints(c *CoreClient, namespace string) *endpoints {
 	return &endpoints{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type EventInterface interface {
 
 // events implements EventInterface
 type events struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEvents returns a Events
 func newEvents(c *CoreClient, namespace string) *events {
 	return &events{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_core_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_core_client.go
@@ -90,8 +90,9 @@ func (c *FakeCore) ServiceAccounts(namespace string) unversioned.ServiceAccountI
 	return &FakeServiceAccounts{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCore) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCore) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type LimitRangeInterface interface {
 
 // limitRanges implements LimitRangeInterface
 type limitRanges struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newLimitRanges returns a LimitRanges
 func newLimitRanges(c *CoreClient, namespace string) *limitRanges {
 	return &limitRanges{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type NamespaceInterface interface {
 
 // namespaces implements NamespaceInterface
 type namespaces struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNamespaces returns a Namespaces
 func newNamespaces(c *CoreClient) *namespaces {
 	return &namespaces{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type NodeInterface interface {
 
 // nodes implements NodeInterface
 type nodes struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNodes returns a Nodes
 func newNodes(c *CoreClient) *nodes {
 	return &nodes{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type PersistentVolumeInterface interface {
 
 // persistentVolumes implements PersistentVolumeInterface
 type persistentVolumes struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newPersistentVolumes returns a PersistentVolumes
 func newPersistentVolumes(c *CoreClient) *persistentVolumes {
 	return &persistentVolumes{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type PersistentVolumeClaimInterface interface {
 
 // persistentVolumeClaims implements PersistentVolumeClaimInterface
 type persistentVolumeClaims struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPersistentVolumeClaims returns a PersistentVolumeClaims
 func newPersistentVolumeClaims(c *CoreClient, namespace string) *persistentVolumeClaims {
 	return &persistentVolumeClaims{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type PodInterface interface {
 
 // pods implements PodInterface
 type pods struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPods returns a Pods
 func newPods(c *CoreClient, namespace string) *pods {
 	return &pods{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type PodTemplateInterface interface {
 
 // podTemplates implements PodTemplateInterface
 type podTemplates struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPodTemplates returns a PodTemplates
 func newPodTemplates(c *CoreClient, namespace string) *podTemplates {
 	return &podTemplates{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ReplicationControllerInterface interface {
 
 // replicationControllers implements ReplicationControllerInterface
 type replicationControllers struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicationControllers returns a ReplicationControllers
 func newReplicationControllers(c *CoreClient, namespace string) *replicationControllers {
 	return &replicationControllers{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ResourceQuotaInterface interface {
 
 // resourceQuotas implements ResourceQuotaInterface
 type resourceQuotas struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newResourceQuotas returns a ResourceQuotas
 func newResourceQuotas(c *CoreClient, namespace string) *resourceQuotas {
 	return &resourceQuotas{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type SecretInterface interface {
 
 // secrets implements SecretInterface
 type secrets struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newSecrets returns a Secrets
 func newSecrets(c *CoreClient, namespace string) *secrets {
 	return &secrets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ServiceInterface interface {
 
 // services implements ServiceInterface
 type services struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServices returns a Services
 func newServices(c *CoreClient, namespace string) *services {
 	return &services{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -42,14 +43,14 @@ type ServiceAccountInterface interface {
 
 // serviceAccounts implements ServiceAccountInterface
 type serviceAccounts struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServiceAccounts returns a ServiceAccounts
 func newServiceAccounts(c *CoreClient, namespace string) *serviceAccounts {
 	return &serviceAccounts{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type DaemonSetInterface interface {
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDaemonSets returns a DaemonSets
 func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	return &daemonSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type DeploymentInterface interface {
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDeployments returns a Deployments
 func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	return &deployments{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/extensions_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/extensions_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ExtensionsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	DaemonSetsGetter
 	DeploymentsGetter
 	IngressesGetter
@@ -36,7 +36,7 @@ type ExtensionsInterface interface {
 
 // ExtensionsClient is used to interact with features provided by the Extensions group.
 type ExtensionsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *ExtensionsClient) DaemonSets(namespace string) DaemonSetInterface {
@@ -95,7 +95,7 @@ func NewForConfigOrDie(c *restclient.Config) *ExtensionsClient {
 }
 
 // New creates a new ExtensionsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *ExtensionsClient {
+func New(c restclient.Interface) *ExtensionsClient {
 	return &ExtensionsClient{c}
 }
 
@@ -124,11 +124,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *ExtensionsClient) GetRESTClient() *restclient.RESTClient {
+func (c *ExtensionsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
@@ -58,8 +58,9 @@ func (c *FakeExtensions) ThirdPartyResources() unversioned.ThirdPartyResourceInt
 	return &FakeThirdPartyResources{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeExtensions) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeExtensions) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type IngressInterface interface {
 
 // ingresses implements IngressInterface
 type ingresses struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newIngresses returns a Ingresses
 func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	return &ingresses{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/networkpolicy.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type NetworkPolicyInterface interface {
 
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newNetworkPolicies returns a NetworkPolicies
 func newNetworkPolicies(c *ExtensionsClient, namespace string) *networkPolicies {
 	return &networkPolicies{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type PodSecurityPolicyInterface interface {
 
 // podSecurityPolicies implements PodSecurityPolicyInterface
 type podSecurityPolicies struct {
-	client *ExtensionsClient
+	client restclient.Interface
 }
 
 // newPodSecurityPolicies returns a PodSecurityPolicies
 func newPodSecurityPolicies(c *ExtensionsClient) *podSecurityPolicies {
 	return &podSecurityPolicies{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ReplicaSetInterface interface {
 
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicaSets returns a ReplicaSets
 func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	return &replicaSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/scale.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/scale.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package unversioned
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // ScalesGetter has a method to return a ScaleInterface.
 // A group's client should implement this interface.
 type ScalesGetter interface {
@@ -29,14 +33,14 @@ type ScaleInterface interface {
 
 // scales implements ScaleInterface
 type scales struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newScales returns a Scales
 func newScales(c *ExtensionsClient, namespace string) *scales {
 	return &scales{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type ThirdPartyResourceInterface interface {
 
 // thirdPartyResources implements ThirdPartyResourceInterface
 type thirdPartyResources struct {
-	client *ExtensionsClient
+	client restclient.Interface
 }
 
 // newThirdPartyResources returns a ThirdPartyResources
 func newThirdPartyResources(c *ExtensionsClient) *thirdPartyResources {
 	return &thirdPartyResources{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/fake/fake_policy_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/fake/fake_policy_client.go
@@ -30,8 +30,9 @@ func (c *FakePolicy) PodDisruptionBudgets(namespace string) unversioned.PodDisru
 	return &FakePodDisruptionBudgets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakePolicy) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakePolicy) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/poddisruptionbudget.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type PodDisruptionBudgetInterface interface {
 
 // podDisruptionBudgets implements PodDisruptionBudgetInterface
 type podDisruptionBudgets struct {
-	client *PolicyClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPodDisruptionBudgets returns a PodDisruptionBudgets
 func newPodDisruptionBudgets(c *PolicyClient, namespace string) *podDisruptionBudgets {
 	return &podDisruptionBudgets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/policy_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/unversioned/policy_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type PolicyInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	PodDisruptionBudgetsGetter
 }
 
 // PolicyClient is used to interact with features provided by the Policy group.
 type PolicyClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *PolicyClient) PodDisruptionBudgets(namespace string) PodDisruptionBudgetInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *PolicyClient {
 }
 
 // New creates a new PolicyClient for the given RESTClient.
-func New(c *restclient.RESTClient) *PolicyClient {
+func New(c restclient.Interface) *PolicyClient {
 	return &PolicyClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *PolicyClient) GetRESTClient() *restclient.RESTClient {
+func (c *PolicyClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type ClusterRoleInterface interface {
 
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
-	client *RbacClient
+	client restclient.Interface
 }
 
 // newClusterRoles returns a ClusterRoles
 func newClusterRoles(c *RbacClient) *clusterRoles {
 	return &clusterRoles{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type ClusterRoleBindingInterface interface {
 
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
-	client *RbacClient
+	client restclient.Interface
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings
 func newClusterRoleBindings(c *RbacClient) *clusterRoleBindings {
 	return &clusterRoleBindings{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rbac_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rbac_client.go
@@ -42,8 +42,9 @@ func (c *FakeRbac) RoleBindings(namespace string) unversioned.RoleBindingInterfa
 	return &FakeRoleBindings{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeRbac) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeRbac) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rbac_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rbac_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type RbacInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ClusterRolesGetter
 	ClusterRoleBindingsGetter
 	RolesGetter
@@ -32,7 +32,7 @@ type RbacInterface interface {
 
 // RbacClient is used to interact with features provided by the Rbac group.
 type RbacClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *RbacClient) ClusterRoles() ClusterRoleInterface {
@@ -75,7 +75,7 @@ func NewForConfigOrDie(c *restclient.Config) *RbacClient {
 }
 
 // New creates a new RbacClient for the given RESTClient.
-func New(c *restclient.RESTClient) *RbacClient {
+func New(c restclient.Interface) *RbacClient {
 	return &RbacClient{c}
 }
 
@@ -104,11 +104,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *RbacClient) GetRESTClient() *restclient.RESTClient {
+func (c *RbacClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type RoleInterface interface {
 
 // roles implements RoleInterface
 type roles struct {
-	client *RbacClient
+	client restclient.Interface
 	ns     string
 }
 
 // newRoles returns a Roles
 func newRoles(c *RbacClient, namespace string) *roles {
 	return &roles{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type RoleBindingInterface interface {
 
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
-	client *RbacClient
+	client restclient.Interface
 	ns     string
 }
 
 // newRoleBindings returns a RoleBindings
 func newRoleBindings(c *RbacClient, namespace string) *roleBindings {
 	return &roleBindings{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/fake/fake_storage_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/fake/fake_storage_client.go
@@ -30,8 +30,9 @@ func (c *FakeStorage) StorageClasses() unversioned.StorageClassInterface {
 	return &FakeStorageClasses{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeStorage) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeStorage) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/storage_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/storage_client.go
@@ -23,13 +23,13 @@ import (
 )
 
 type StorageInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	StorageClassesGetter
 }
 
 // StorageClient is used to interact with features provided by the Storage group.
 type StorageClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *StorageClient) StorageClasses() StorageClassInterface {
@@ -60,7 +60,7 @@ func NewForConfigOrDie(c *restclient.Config) *StorageClient {
 }
 
 // New creates a new StorageClient for the given RESTClient.
-func New(c *restclient.RESTClient) *StorageClient {
+func New(c restclient.Interface) *StorageClient {
 	return &StorageClient{c}
 }
 
@@ -89,11 +89,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *StorageClient) GetRESTClient() *restclient.RESTClient {
+func (c *StorageClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/storageclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/unversioned/storageclass.go
@@ -19,6 +19,7 @@ package unversioned
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type StorageClassInterface interface {
 
 // storageClasses implements StorageClassInterface
 type storageClasses struct {
-	client *StorageClient
+	client restclient.Interface
 }
 
 // newStorageClasses returns a StorageClasses
 func newStorageClasses(c *StorageClient) *storageClasses {
 	return &storageClasses{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/clientset.go
+++ b/pkg/client/clientset_generated/release_1_5/clientset.go
@@ -242,7 +242,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 }
 
 // New creates a new Clientset for the given RESTClient.
-func New(c *restclient.RESTClient) *Clientset {
+func New(c restclient.Interface) *Clientset {
 	var clientset Clientset
 	clientset.CoreClient = v1core.New(c)
 	clientset.AppsClient = v1alpha1apps.New(c)

--- a/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/apps_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/apps_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type AppsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	PetSetsGetter
 }
 
 // AppsClient is used to interact with features provided by the Apps group.
 type AppsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AppsClient) PetSets(namespace string) PetSetInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *AppsClient {
 }
 
 // New creates a new AppsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AppsClient {
+func New(c restclient.Interface) *AppsClient {
 	return &AppsClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AppsClient) GetRESTClient() *restclient.RESTClient {
+func (c *AppsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/fake/fake_apps_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/fake/fake_apps_client.go
@@ -30,8 +30,9 @@ func (c *FakeApps) PetSets(namespace string) v1alpha1.PetSetInterface {
 	return &FakePetSets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeApps) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeApps) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/petset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/apps/v1alpha1/petset.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/apps/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type PetSetInterface interface {
 
 // petSets implements PetSetInterface
 type petSets struct {
-	client *AppsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPetSets returns a PetSets
 func newPetSets(c *AppsClient, namespace string) *petSets {
 	return &petSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/authentication_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/authentication_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type AuthenticationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	TokenReviewsGetter
 }
 
 // AuthenticationClient is used to interact with features provided by the Authentication group.
 type AuthenticationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AuthenticationClient) TokenReviews() TokenReviewInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *AuthenticationClient {
 }
 
 // New creates a new AuthenticationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AuthenticationClient {
+func New(c restclient.Interface) *AuthenticationClient {
 	return &AuthenticationClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AuthenticationClient) GetRESTClient() *restclient.RESTClient {
+func (c *AuthenticationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/fake/fake_authentication_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/fake/fake_authentication_client.go
@@ -30,8 +30,9 @@ func (c *FakeAuthentication) TokenReviews() v1beta1.TokenReviewInterface {
 	return &FakeTokenReviews{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAuthentication) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAuthentication) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/tokenreview.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1/tokenreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // TokenReviewsGetter has a method to return a TokenReviewInterface.
 // A group's client should implement this interface.
 type TokenReviewsGetter interface {
@@ -29,12 +33,12 @@ type TokenReviewInterface interface {
 
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
-	client *AuthenticationClient
+	client restclient.Interface
 }
 
 // newTokenReviews returns a TokenReviews
 func newTokenReviews(c *AuthenticationClient) *tokenReviews {
 	return &tokenReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/authorization_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type AuthorizationInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	LocalSubjectAccessReviewsGetter
 	SelfSubjectAccessReviewsGetter
 	SubjectAccessReviewsGetter
@@ -32,7 +32,7 @@ type AuthorizationInterface interface {
 
 // AuthorizationClient is used to interact with features provided by the Authorization group.
 type AuthorizationClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AuthorizationClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
@@ -71,7 +71,7 @@ func NewForConfigOrDie(c *restclient.Config) *AuthorizationClient {
 }
 
 // New creates a new AuthorizationClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AuthorizationClient {
+func New(c restclient.Interface) *AuthorizationClient {
 	return &AuthorizationClient{c}
 }
 
@@ -96,11 +96,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AuthorizationClient) GetRESTClient() *restclient.RESTClient {
+func (c *AuthorizationClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/fake/fake_authorization_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/fake/fake_authorization_client.go
@@ -38,8 +38,9 @@ func (c *FakeAuthorization) SubjectAccessReviews() v1beta1.SubjectAccessReviewIn
 	return &FakeSubjectAccessReviews{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAuthorization) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAuthorization) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // LocalSubjectAccessReviewsGetter has a method to return a LocalSubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type LocalSubjectAccessReviewsGetter interface {
@@ -29,14 +33,14 @@ type LocalSubjectAccessReviewInterface interface {
 
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 	ns     string
 }
 
 // newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
 func newLocalSubjectAccessReviews(c *AuthorizationClient, namespace string) *localSubjectAccessReviews {
 	return &localSubjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // SelfSubjectAccessReviewsGetter has a method to return a SelfSubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type SelfSubjectAccessReviewsGetter interface {
@@ -29,12 +33,12 @@ type SelfSubjectAccessReviewInterface interface {
 
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
 func newSelfSubjectAccessReviews(c *AuthorizationClient) *selfSubjectAccessReviews {
 	return &selfSubjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1/subjectaccessreview.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // SubjectAccessReviewsGetter has a method to return a SubjectAccessReviewInterface.
 // A group's client should implement this interface.
 type SubjectAccessReviewsGetter interface {
@@ -29,12 +33,12 @@ type SubjectAccessReviewInterface interface {
 
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
-	client *AuthorizationClient
+	client restclient.Interface
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews
 func newSubjectAccessReviews(c *AuthorizationClient) *subjectAccessReviews {
 	return &subjectAccessReviews{
-		client: c,
+		client: c.RESTClient(),
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/autoscaling_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/autoscaling_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type AutoscalingInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	HorizontalPodAutoscalersGetter
 }
 
 // AutoscalingClient is used to interact with features provided by the Autoscaling group.
 type AutoscalingClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *AutoscalingClient) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *AutoscalingClient {
 }
 
 // New creates a new AutoscalingClient for the given RESTClient.
-func New(c *restclient.RESTClient) *AutoscalingClient {
+func New(c restclient.Interface) *AutoscalingClient {
 	return &AutoscalingClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *AutoscalingClient) GetRESTClient() *restclient.RESTClient {
+func (c *AutoscalingClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/fake/fake_autoscaling_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/fake/fake_autoscaling_client.go
@@ -30,8 +30,9 @@ func (c *FakeAutoscaling) HorizontalPodAutoscalers(namespace string) v1.Horizont
 	return &FakeHorizontalPodAutoscalers{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeAutoscaling) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeAutoscaling) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1 "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type HorizontalPodAutoscalerInterface interface {
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
-	client *AutoscalingClient
+	client restclient.Interface
 	ns     string
 }
 
 // newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
 func newHorizontalPodAutoscalers(c *AutoscalingClient, namespace string) *horizontalPodAutoscalers {
 	return &horizontalPodAutoscalers{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v1/batch_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v1/batch_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type BatchInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	JobsGetter
 }
 
 // BatchClient is used to interact with features provided by the Batch group.
 type BatchClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *BatchClient) Jobs(namespace string) JobInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *BatchClient {
 }
 
 // New creates a new BatchClient for the given RESTClient.
-func New(c *restclient.RESTClient) *BatchClient {
+func New(c restclient.Interface) *BatchClient {
 	return &BatchClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *BatchClient) GetRESTClient() *restclient.RESTClient {
+func (c *BatchClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v1/fake/fake_batch_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v1/fake/fake_batch_client.go
@@ -30,8 +30,9 @@ func (c *FakeBatch) Jobs(namespace string) v1.JobInterface {
 	return &FakeJobs{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeBatch) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeBatch) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v1/job.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v1/job.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type JobInterface interface {
 
 // jobs implements JobInterface
 type jobs struct {
-	client *BatchClient
+	client restclient.Interface
 	ns     string
 }
 
 // newJobs returns a Jobs
 func newJobs(c *BatchClient, namespace string) *jobs {
 	return &jobs{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificates_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificates_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type CertificatesInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	CertificateSigningRequestsGetter
 }
 
 // CertificatesClient is used to interact with features provided by the Certificates group.
 type CertificatesClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CertificatesClient) CertificateSigningRequests() CertificateSigningRequestInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *CertificatesClient {
 }
 
 // New creates a new CertificatesClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CertificatesClient {
+func New(c restclient.Interface) *CertificatesClient {
 	return &CertificatesClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CertificatesClient) GetRESTClient() *restclient.RESTClient {
+func (c *CertificatesClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificatesigningrequest.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,13 +46,13 @@ type CertificateSigningRequestInterface interface {
 
 // certificateSigningRequests implements CertificateSigningRequestInterface
 type certificateSigningRequests struct {
-	client *CertificatesClient
+	client restclient.Interface
 }
 
 // newCertificateSigningRequests returns a CertificateSigningRequests
 func newCertificateSigningRequests(c *CertificatesClient) *certificateSigningRequests {
 	return &certificateSigningRequests{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/fake/fake_certificates_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/fake/fake_certificates_client.go
@@ -30,8 +30,9 @@ func (c *FakeCertificates) CertificateSigningRequests() v1alpha1.CertificateSign
 	return &FakeCertificateSigningRequests{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCertificates) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCertificates) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/componentstatus.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/componentstatus.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,13 +44,13 @@ type ComponentStatusInterface interface {
 
 // componentStatuses implements ComponentStatusInterface
 type componentStatuses struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newComponentStatuses returns a ComponentStatuses
 func newComponentStatuses(c *CoreClient) *componentStatuses {
 	return &componentStatuses{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/configmap.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/configmap.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ConfigMapInterface interface {
 
 // configMaps implements ConfigMapInterface
 type configMaps struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newConfigMaps returns a ConfigMaps
 func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	return &configMaps{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/core_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/core_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ComponentStatusesGetter
 	ConfigMapsGetter
 	EndpointsGetter
@@ -45,7 +45,7 @@ type CoreInterface interface {
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *CoreClient) ComponentStatuses() ComponentStatusInterface {
@@ -136,7 +136,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c restclient.Interface) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -161,11 +161,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/endpoints.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/endpoints.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type EndpointsInterface interface {
 
 // endpoints implements EndpointsInterface
 type endpoints struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEndpoints returns a Endpoints
 func newEndpoints(c *CoreClient, namespace string) *endpoints {
 	return &endpoints{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/event.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/event.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type EventInterface interface {
 
 // events implements EventInterface
 type events struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newEvents returns a Events
 func newEvents(c *CoreClient, namespace string) *events {
 	return &events{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/fake/fake_core_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/fake/fake_core_client.go
@@ -90,8 +90,9 @@ func (c *FakeCore) ServiceAccounts(namespace string) v1.ServiceAccountInterface 
 	return &FakeServiceAccounts{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCore) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeCore) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/limitrange.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/limitrange.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type LimitRangeInterface interface {
 
 // limitRanges implements LimitRangeInterface
 type limitRanges struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newLimitRanges returns a LimitRanges
 func newLimitRanges(c *CoreClient, namespace string) *limitRanges {
 	return &limitRanges{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/namespace.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/namespace.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type NamespaceInterface interface {
 
 // namespaces implements NamespaceInterface
 type namespaces struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNamespaces returns a Namespaces
 func newNamespaces(c *CoreClient) *namespaces {
 	return &namespaces{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/node.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/node.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type NodeInterface interface {
 
 // nodes implements NodeInterface
 type nodes struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newNodes returns a Nodes
 func newNodes(c *CoreClient) *nodes {
 	return &nodes{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolume.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type PersistentVolumeInterface interface {
 
 // persistentVolumes implements PersistentVolumeInterface
 type persistentVolumes struct {
-	client *CoreClient
+	client restclient.Interface
 }
 
 // newPersistentVolumes returns a PersistentVolumes
 func newPersistentVolumes(c *CoreClient) *persistentVolumes {
 	return &persistentVolumes{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolumeclaim.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type PersistentVolumeClaimInterface interface {
 
 // persistentVolumeClaims implements PersistentVolumeClaimInterface
 type persistentVolumeClaims struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPersistentVolumeClaims returns a PersistentVolumeClaims
 func newPersistentVolumeClaims(c *CoreClient, namespace string) *persistentVolumeClaims {
 	return &persistentVolumeClaims{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/pod.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/pod.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type PodInterface interface {
 
 // pods implements PodInterface
 type pods struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPods returns a Pods
 func newPods(c *CoreClient, namespace string) *pods {
 	return &pods{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/podtemplate.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/podtemplate.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type PodTemplateInterface interface {
 
 // podTemplates implements PodTemplateInterface
 type podTemplates struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPodTemplates returns a PodTemplates
 func newPodTemplates(c *CoreClient, namespace string) *podTemplates {
 	return &podTemplates{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/replicationcontroller.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ReplicationControllerInterface interface {
 
 // replicationControllers implements ReplicationControllerInterface
 type replicationControllers struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicationControllers returns a ReplicationControllers
 func newReplicationControllers(c *CoreClient, namespace string) *replicationControllers {
 	return &replicationControllers{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/resourcequota.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ResourceQuotaInterface interface {
 
 // resourceQuotas implements ResourceQuotaInterface
 type resourceQuotas struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newResourceQuotas returns a ResourceQuotas
 func newResourceQuotas(c *CoreClient, namespace string) *resourceQuotas {
 	return &resourceQuotas{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/secret.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/secret.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type SecretInterface interface {
 
 // secrets implements SecretInterface
 type secrets struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newSecrets returns a Secrets
 func newSecrets(c *CoreClient, namespace string) *secrets {
 	return &secrets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/service.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/service.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type ServiceInterface interface {
 
 // services implements ServiceInterface
 type services struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServices returns a Services
 func newServices(c *CoreClient, namespace string) *services {
 	return &services{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/serviceaccount.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/serviceaccount.go
@@ -19,6 +19,7 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -43,14 +44,14 @@ type ServiceAccountInterface interface {
 
 // serviceAccounts implements ServiceAccountInterface
 type serviceAccounts struct {
-	client *CoreClient
+	client restclient.Interface
 	ns     string
 }
 
 // newServiceAccounts returns a ServiceAccounts
 func newServiceAccounts(c *CoreClient, namespace string) *serviceAccounts {
 	return &serviceAccounts{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/daemonset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/daemonset.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type DaemonSetInterface interface {
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDaemonSets returns a DaemonSets
 func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	return &daemonSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/deployment.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/deployment.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type DeploymentInterface interface {
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newDeployments returns a Deployments
 func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	return &deployments{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/extensions_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/extensions_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type ExtensionsInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	DaemonSetsGetter
 	DeploymentsGetter
 	IngressesGetter
@@ -37,7 +37,7 @@ type ExtensionsInterface interface {
 
 // ExtensionsClient is used to interact with features provided by the Extensions group.
 type ExtensionsClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *ExtensionsClient) DaemonSets(namespace string) DaemonSetInterface {
@@ -96,7 +96,7 @@ func NewForConfigOrDie(c *restclient.Config) *ExtensionsClient {
 }
 
 // New creates a new ExtensionsClient for the given RESTClient.
-func New(c *restclient.RESTClient) *ExtensionsClient {
+func New(c restclient.Interface) *ExtensionsClient {
 	return &ExtensionsClient{c}
 }
 
@@ -121,11 +121,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *ExtensionsClient) GetRESTClient() *restclient.RESTClient {
+func (c *ExtensionsClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/fake/fake_extensions_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/fake/fake_extensions_client.go
@@ -58,8 +58,9 @@ func (c *FakeExtensions) ThirdPartyResources() v1beta1.ThirdPartyResourceInterfa
 	return &FakeThirdPartyResources{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeExtensions) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeExtensions) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/ingress.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/ingress.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type IngressInterface interface {
 
 // ingresses implements IngressInterface
 type ingresses struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newIngresses returns a Ingresses
 func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	return &ingresses{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/job.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/job.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type JobInterface interface {
 
 // jobs implements JobInterface
 type jobs struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newJobs returns a Jobs
 func newJobs(c *ExtensionsClient, namespace string) *jobs {
 	return &jobs{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type PodSecurityPolicyInterface interface {
 
 // podSecurityPolicies implements PodSecurityPolicyInterface
 type podSecurityPolicies struct {
-	client *ExtensionsClient
+	client restclient.Interface
 }
 
 // newPodSecurityPolicies returns a PodSecurityPolicies
 func newPodSecurityPolicies(c *ExtensionsClient) *podSecurityPolicies {
 	return &podSecurityPolicies{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/replicaset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/replicaset.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type ReplicaSetInterface interface {
 
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newReplicaSets returns a ReplicaSets
 func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	return &replicaSets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/scale.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/scale.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+)
+
 // ScalesGetter has a method to return a ScaleInterface.
 // A group's client should implement this interface.
 type ScalesGetter interface {
@@ -29,14 +33,14 @@ type ScaleInterface interface {
 
 // scales implements ScaleInterface
 type scales struct {
-	client *ExtensionsClient
+	client restclient.Interface
 	ns     string
 }
 
 // newScales returns a Scales
 func newScales(c *ExtensionsClient, namespace string) *scales {
 	return &scales{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/thirdpartyresource.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type ThirdPartyResourceInterface interface {
 
 // thirdPartyResources implements ThirdPartyResourceInterface
 type thirdPartyResources struct {
-	client *ExtensionsClient
+	client restclient.Interface
 }
 
 // newThirdPartyResources returns a ThirdPartyResources
 func newThirdPartyResources(c *ExtensionsClient) *thirdPartyResources {
 	return &thirdPartyResources{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/fake/fake_policy_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/fake/fake_policy_client.go
@@ -30,8 +30,9 @@ func (c *FakePolicy) PodDisruptionBudgets(namespace string) v1alpha1.PodDisrupti
 	return &FakePodDisruptionBudgets{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakePolicy) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakePolicy) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/poddisruptionbudget.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/policy/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,14 +46,14 @@ type PodDisruptionBudgetInterface interface {
 
 // podDisruptionBudgets implements PodDisruptionBudgetInterface
 type podDisruptionBudgets struct {
-	client *PolicyClient
+	client restclient.Interface
 	ns     string
 }
 
 // newPodDisruptionBudgets returns a PodDisruptionBudgets
 func newPodDisruptionBudgets(c *PolicyClient, namespace string) *podDisruptionBudgets {
 	return &podDisruptionBudgets{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/policy_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/policy/v1alpha1/policy_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type PolicyInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	PodDisruptionBudgetsGetter
 }
 
 // PolicyClient is used to interact with features provided by the Policy group.
 type PolicyClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *PolicyClient) PodDisruptionBudgets(namespace string) PodDisruptionBudgetInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *PolicyClient {
 }
 
 // New creates a new PolicyClient for the given RESTClient.
-func New(c *restclient.RESTClient) *PolicyClient {
+func New(c restclient.Interface) *PolicyClient {
 	return &PolicyClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *PolicyClient) GetRESTClient() *restclient.RESTClient {
+func (c *PolicyClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/clusterrole.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/clusterrole.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type ClusterRoleInterface interface {
 
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
-	client *RbacClient
+	client restclient.Interface
 }
 
 // newClusterRoles returns a ClusterRoles
 func newClusterRoles(c *RbacClient) *clusterRoles {
 	return &clusterRoles{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type ClusterRoleBindingInterface interface {
 
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
-	client *RbacClient
+	client restclient.Interface
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings
 func newClusterRoleBindings(c *RbacClient) *clusterRoleBindings {
 	return &clusterRoleBindings{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/fake/fake_rbac_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/fake/fake_rbac_client.go
@@ -42,8 +42,9 @@ func (c *FakeRbac) RoleBindings(namespace string) v1alpha1.RoleBindingInterface 
 	return &FakeRoleBindings{c, namespace}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeRbac) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeRbac) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/rbac_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/rbac_client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type RbacInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	ClusterRolesGetter
 	ClusterRoleBindingsGetter
 	RolesGetter
@@ -33,7 +33,7 @@ type RbacInterface interface {
 
 // RbacClient is used to interact with features provided by the Rbac group.
 type RbacClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *RbacClient) ClusterRoles() ClusterRoleInterface {
@@ -76,7 +76,7 @@ func NewForConfigOrDie(c *restclient.Config) *RbacClient {
 }
 
 // New creates a new RbacClient for the given RESTClient.
-func New(c *restclient.RESTClient) *RbacClient {
+func New(c restclient.Interface) *RbacClient {
 	return &RbacClient{c}
 }
 
@@ -101,11 +101,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *RbacClient) GetRESTClient() *restclient.RESTClient {
+func (c *RbacClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/role.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/role.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type RoleInterface interface {
 
 // roles implements RoleInterface
 type roles struct {
-	client *RbacClient
+	client restclient.Interface
 	ns     string
 }
 
 // newRoles returns a Roles
 func newRoles(c *RbacClient, namespace string) *roles {
 	return &roles{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/rolebinding.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1/rolebinding.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,14 +45,14 @@ type RoleBindingInterface interface {
 
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
-	client *RbacClient
+	client restclient.Interface
 	ns     string
 }
 
 // newRoleBindings returns a RoleBindings
 func newRoleBindings(c *RbacClient, namespace string) *roleBindings {
 	return &roleBindings{
-		client: c,
+		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/fake/fake_storage_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/fake/fake_storage_client.go
@@ -30,8 +30,9 @@ func (c *FakeStorage) StorageClasses() v1beta1.StorageClassInterface {
 	return &FakeStorageClasses{c}
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeStorage) GetRESTClient() *restclient.RESTClient {
-	return nil
+func (c *FakeStorage) RESTClient() restclient.Interface {
+	var ret *restclient.RESTClient
+	return ret
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/storage_client.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/storage_client.go
@@ -24,13 +24,13 @@ import (
 )
 
 type StorageInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	RESTClient() restclient.Interface
 	StorageClassesGetter
 }
 
 // StorageClient is used to interact with features provided by the Storage group.
 type StorageClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 }
 
 func (c *StorageClient) StorageClasses() StorageClassInterface {
@@ -61,7 +61,7 @@ func NewForConfigOrDie(c *restclient.Config) *StorageClient {
 }
 
 // New creates a new StorageClient for the given RESTClient.
-func New(c *restclient.RESTClient) *StorageClient {
+func New(c restclient.Interface) *StorageClient {
 	return &StorageClient{c}
 }
 
@@ -86,11 +86,11 @@ func setConfigDefaults(config *restclient.Config) error {
 	return nil
 }
 
-// GetRESTClient returns a RESTClient that is used to communicate
+// RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *StorageClient) GetRESTClient() *restclient.RESTClient {
+func (c *StorageClient) RESTClient() restclient.Interface {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c.restClient
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/storageclass.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1/storageclass.go
@@ -20,6 +20,7 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,13 +45,13 @@ type StorageClassInterface interface {
 
 // storageClasses implements StorageClassInterface
 type storageClasses struct {
-	client *StorageClient
+	client restclient.Interface
 }
 
 // newStorageClasses returns a StorageClasses
 func newStorageClasses(c *StorageClient) *storageClasses {
 	return &storageClasses{
-		client: c,
+		client: c.RESTClient(),
 	}
 }
 

--- a/pkg/client/restclient/client.go
+++ b/pkg/client/restclient/client.go
@@ -38,6 +38,18 @@ const (
 	envBackoffDuration = "KUBE_CLIENT_BACKOFF_DURATION"
 )
 
+// Interface captures the set of operations for generically interacting with Kubernetes REST apis.
+type Interface interface {
+	GetRateLimiter() flowcontrol.RateLimiter
+	Verb(verb string) *Request
+	Post() *Request
+	Put() *Request
+	Patch(pt api.PatchType) *Request
+	Get() *Request
+	Delete() *Request
+	APIVersion() unversioned.GroupVersion
+}
+
 // RESTClient imposes common Kubernetes API conventions on a set of resource paths.
 // The baseURL is expected to point to an HTTP or HTTPS path that is the parent
 // of one or more resources.  The server should return a decodable API resource

--- a/pkg/client/typed/discovery/discovery_client.go
+++ b/pkg/client/typed/discovery/discovery_client.go
@@ -38,6 +38,7 @@ import (
 // DiscoveryInterface holds the methods that discover server-supported API groups,
 // versions and resources.
 type DiscoveryInterface interface {
+	RESTClient() restclient.Interface
 	ServerGroupsInterface
 	ServerResourcesInterface
 	ServerVersionInterface
@@ -80,7 +81,7 @@ type SwaggerSchemaInterface interface {
 // DiscoveryClient implements the functions that discover server-supported API groups,
 // versions and resources.
 type DiscoveryClient struct {
-	*restclient.RESTClient
+	restClient restclient.Interface
 
 	LegacyPrefix string
 }
@@ -107,7 +108,7 @@ func apiVersionsToAPIGroup(apiVersions *unversioned.APIVersions) (apiGroup unver
 func (d *DiscoveryClient) ServerGroups() (apiGroupList *unversioned.APIGroupList, err error) {
 	// Get the groupVersions exposed at /api
 	v := &unversioned.APIVersions{}
-	err = d.Get().AbsPath(d.LegacyPrefix).Do().Into(v)
+	err = d.restClient.Get().AbsPath(d.LegacyPrefix).Do().Into(v)
 	apiGroup := unversioned.APIGroup{}
 	if err == nil {
 		apiGroup = apiVersionsToAPIGroup(v)
@@ -118,7 +119,7 @@ func (d *DiscoveryClient) ServerGroups() (apiGroupList *unversioned.APIGroupList
 
 	// Get the groupVersions exposed at /apis
 	apiGroupList = &unversioned.APIGroupList{}
-	err = d.Get().AbsPath("/apis").Do().Into(apiGroupList)
+	err = d.restClient.Get().AbsPath("/apis").Do().Into(apiGroupList)
 	if err != nil && !errors.IsNotFound(err) && !errors.IsForbidden(err) {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (d *DiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (r
 		url.Path = "/apis/" + groupVersion
 	}
 	resources = &unversioned.APIResourceList{}
-	err = d.Get().AbsPath(url.String()).Do().Into(resources)
+	err = d.restClient.Get().AbsPath(url.String()).Do().Into(resources)
 	if err != nil {
 		// ignore 403 or 404 error to be compatible with an v1.0 server.
 		if groupVersion == "v1" && (errors.IsNotFound(err) || errors.IsForbidden(err)) {
@@ -255,7 +256,7 @@ func (d *DiscoveryClient) ServerPreferredNamespacedResources() ([]unversioned.Gr
 
 // ServerVersion retrieves and parses the server's version (git version).
 func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
-	body, err := d.Get().AbsPath("/version").Do().Raw()
+	body, err := d.restClient.Get().AbsPath("/version").Do().Raw()
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,7 @@ func (d *DiscoveryClient) SwaggerSchema(version unversioned.GroupVersion) (*swag
 		path = "/swaggerapi/apis/" + version.Group + "/" + version.Version
 	}
 
-	body, err := d.Get().AbsPath(path).Do().Raw()
+	body, err := d.restClient.Get().AbsPath(path).Do().Raw()
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +324,7 @@ func NewDiscoveryClientForConfig(c *restclient.Config) (*DiscoveryClient, error)
 		return nil, err
 	}
 	client, err := restclient.UnversionedRESTClientFor(&config)
-	return &DiscoveryClient{RESTClient: client, LegacyPrefix: "/api"}, err
+	return &DiscoveryClient{restClient: client, LegacyPrefix: "/api"}, err
 }
 
 // NewDiscoveryClientForConfig creates a new DiscoveryClient for the given config. If
@@ -338,8 +339,8 @@ func NewDiscoveryClientForConfigOrDie(c *restclient.Config) *DiscoveryClient {
 }
 
 // New creates a new DiscoveryClient for the given RESTClient.
-func NewDiscoveryClient(c *restclient.RESTClient) *DiscoveryClient {
-	return &DiscoveryClient{RESTClient: c, LegacyPrefix: "/api"}
+func NewDiscoveryClient(c restclient.Interface) *DiscoveryClient {
+	return &DiscoveryClient{restClient: c, LegacyPrefix: "/api"}
 }
 
 func stringDoesntExistIn(str string, slice []string) bool {
@@ -349,4 +350,13 @@ func stringDoesntExistIn(str string, slice []string) bool {
 		}
 	}
 	return true
+}
+
+// RESTClient returns a RESTClient that is used to communicate
+// with API server by this client implementation.
+func (c *DiscoveryClient) RESTClient() restclient.Interface {
+	if c == nil {
+		return nil
+	}
+	return c.restClient
 }

--- a/pkg/client/typed/discovery/fake/discovery.go
+++ b/pkg/client/typed/discovery/fake/discovery.go
@@ -20,6 +20,7 @@ import (
 	"github.com/emicklei/go-restful/swagger"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/testing/core"
 	"k8s.io/kubernetes/pkg/version"
 )
@@ -79,4 +80,8 @@ func (c *FakeDiscovery) SwaggerSchema(version unversioned.GroupVersion) (*swagge
 
 	c.Invokes(action, nil)
 	return &swagger.ApiDeclaration{}, nil
+}
+
+func (c *FakeDiscovery) RESTClient() restclient.Interface {
+	return nil
 }

--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -23,10 +23,12 @@ import (
 	"net/url"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/flowcontrol"
 )
 
 func CreateHTTPClient(roundTripper func(*http.Request) (*http.Response, error)) *http.Client {
@@ -69,6 +71,18 @@ func (c *RESTClient) Post() *restclient.Request {
 
 func (c *RESTClient) Delete() *restclient.Request {
 	return c.request("DELETE")
+}
+
+func (c *RESTClient) Verb(verb string) *restclient.Request {
+	return c.request(verb)
+}
+
+func (c *RESTClient) APIVersion() unversioned.GroupVersion {
+	return *(testapi.Default.GroupVersion())
+}
+
+func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
+	return nil
 }
 
 func (c *RESTClient) request(verb string) *restclient.Request {

--- a/pkg/client/unversioned/helper_blackbox_test.go
+++ b/pkg/client/unversioned/helper_blackbox_test.go
@@ -140,7 +140,7 @@ func TestNegotiateVersion(t *testing.T) {
 			}),
 		}
 		c := unversioned.NewOrDie(test.config)
-		c.DiscoveryClient.Client = fakeClient.Client
+		c.DiscoveryClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 		response, err := unversioned.NegotiateVersion(c, test.config, test.version, test.clientVersions)
 		if err == nil && test.expectErr != nil {
 			t.Errorf("expected error, got nil for [%s].", test.name)

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -527,3 +527,7 @@ func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
 	versionInfo := version.Get()
 	return &versionInfo, nil
 }
+
+func (c *FakeDiscovery) RESTClient() restclient.Interface {
+	return nil
+}

--- a/pkg/controller/daemon/daemoncontroller.go
+++ b/pkg/controller/daemon/daemoncontroller.go
@@ -97,8 +97,8 @@ func NewDaemonSetsController(daemonSetInformer informers.DaemonSetInformer, podI
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: kubeClient.Core().Events("")})
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("daemon_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("daemon_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 	dsc := &DaemonSetsController{
 		kubeClient:    kubeClient,

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -93,8 +93,8 @@ func NewDeploymentController(dInformer informers.DeploymentInformer, rsInformer 
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: client.Core().Events("")})
 
-	if client != nil && client.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("deployment_controller", client.Core().GetRESTClient().GetRateLimiter())
+	if client != nil && client.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("deployment_controller", client.Core().RESTClient().GetRateLimiter())
 	}
 	dc := &DeploymentController{
 		client:        client,

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -70,8 +70,8 @@ var (
 
 // NewEndpointController returns a new *EndpointController.
 func NewEndpointController(podInformer cache.SharedIndexInformer, client clientset.Interface) *EndpointController {
-	if client != nil && client.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.Core().GetRESTClient().GetRateLimiter())
+	if client != nil && client.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.Core().RESTClient().GetRateLimiter())
 	}
 	e := &EndpointController{
 		client: client,

--- a/pkg/controller/job/jobcontroller.go
+++ b/pkg/controller/job/jobcontroller.go
@@ -84,8 +84,8 @@ func NewJobController(podInformer cache.SharedIndexInformer, kubeClient clientse
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: kubeClient.Core().Events("")})
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("job_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("job_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	jm := &JobController{

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -89,8 +89,8 @@ func NewNamespaceController(
 		finalizerToken:        finalizerToken,
 	}
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	// configure the backing store/controller

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -193,8 +193,8 @@ func NewNodeController(
 		glog.V(0).Infof("No api server defined - no events will be sent to API server.")
 	}
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	if allocateNodeCIDRs {

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -61,8 +61,8 @@ type PodGCController struct {
 }
 
 func NewPodGC(kubeClient clientset.Interface, podInformer cache.SharedIndexInformer, terminatedPodThreshold int) *PodGCController {
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -102,8 +102,8 @@ type ReplicaSetController struct {
 
 // NewReplicaSetController configures a replica set controller with the specified event recorder
 func NewReplicaSetController(rsInformer informers.ReplicaSetInformer, podInformer informers.PodInformer, kubeClient clientset.Interface, burstReplicas int, lookupCacheSize int, garbageCollectorEnabled bool) *ReplicaSetController {
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("replicaset_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("replicaset_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -130,8 +130,8 @@ func NewReplicationManager(podInformer cache.SharedIndexInformer, kubeClient cli
 
 // newReplicationManager configures a replication manager with the specified event recorder
 func newReplicationManager(eventRecorder record.EventRecorder, podInformer cache.SharedIndexInformer, kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc, burstReplicas int, lookupCacheSize int, garbageCollectorEnabled bool) *ReplicationManager {
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("replication_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("replication_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	rm := &ReplicationManager{

--- a/pkg/controller/resourcequota/replenishment_controller.go
+++ b/pkg/controller/resourcequota/replenishment_controller.go
@@ -113,8 +113,8 @@ func NewReplenishmentControllerFactoryFromClient(kubeClient clientset.Interface)
 
 func (r *replenishmentControllerFactory) NewController(options *ReplenishmentControllerOptions) (cache.ControllerInterface, error) {
 	var result cache.ControllerInterface
-	if r.kubeClient != nil && r.kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("replenishment_controller", r.kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if r.kubeClient != nil && r.kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("replenishment_controller", r.kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	switch options.GroupKind {

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -84,8 +84,8 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) *Resour
 		registry:                 options.Registry,
 		replenishmentControllers: []cache.ControllerInterface{},
 	}
-	if options.KubeClient != nil && options.KubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("resource_quota_controller", options.KubeClient.Core().GetRESTClient().GetRateLimiter())
+	if options.KubeClient != nil && options.KubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("resource_quota_controller", options.KubeClient.Core().RESTClient().GetRateLimiter())
 	}
 	// set the synchronization handler
 	rq.syncHandler = rq.syncResourceQuotaFromKey

--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -59,8 +59,8 @@ type RouteController struct {
 }
 
 func New(routes cloudprovider.Routes, kubeClient clientset.Interface, clusterName string, clusterCIDR *net.IPNet) *RouteController {
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 	rc := &RouteController{
 		routes:      routes,

--- a/pkg/controller/scheduledjob/controller.go
+++ b/pkg/controller/scheduledjob/controller.go
@@ -65,8 +65,8 @@ func NewScheduledJobController(kubeClient clientset.Interface) *ScheduledJobCont
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: kubeClient.Core().Events("")})
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("scheduledjob_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("scheduledjob_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	jm := &ScheduledJobController{

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -102,8 +102,8 @@ func New(cloud cloudprovider.Interface, kubeClient clientset.Interface, clusterN
 	broadcaster.StartRecordingToSink(&unversioned_core.EventSinkImpl{Interface: kubeClient.Core().Events("")})
 	recorder := broadcaster.NewRecorder(api.EventSource{Component: "service-controller"})
 
-	if kubeClient != nil && kubeClient.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("service_controller", kubeClient.Core().GetRESTClient().GetRateLimiter())
+	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("service_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
 
 	s := &ServiceController{
@@ -175,7 +175,7 @@ func (s *ServiceController) Run(workers int) {
 	for i := 0; i < workers; i++ {
 		go wait.Until(s.worker, time.Second, wait.NeverStop)
 	}
-	nodeLW := cache.NewListWatchFromClient(s.kubeClient.(*clientset.Clientset).CoreClient, "nodes", api.NamespaceAll, fields.Everything())
+	nodeLW := cache.NewListWatchFromClient(s.kubeClient.Core().RESTClient(), "nodes", api.NamespaceAll, fields.Everything())
 	cache.NewReflector(nodeLW, &api.Node{}, s.nodeLister.Store, 0).Run()
 	go wait.Until(s.nodeSyncLoop, nodeSyncPeriod, wait.NeverStop)
 }

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -71,8 +71,8 @@ func NewServiceAccountsController(cl clientset.Interface, options ServiceAccount
 		client:                  cl,
 		serviceAccountsToEnsure: options.ServiceAccounts,
 	}
-	if cl != nil && cl.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.Core().GetRESTClient().GetRateLimiter())
+	if cl != nil && cl.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.Core().RESTClient().GetRateLimiter())
 	}
 	accountSelector := fields.Everything()
 	if len(options.ServiceAccounts) == 1 {

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -85,8 +85,8 @@ func NewTokensController(cl clientset.Interface, options TokensControllerOptions
 
 		maxRetries: maxRetries,
 	}
-	if cl != nil && cl.Core().GetRESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.Core().GetRESTClient().GetRateLimiter())
+	if cl != nil && cl.Core().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.Core().RESTClient().GetRateLimiter())
 	}
 
 	e.serviceAccounts, e.serviceAccountController = cache.NewInformer(

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -243,7 +243,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 	// than the old rc. This selector is the hash of the rc, with a suffix to provide uniqueness for
 	// same-image updates.
 	if len(image) != 0 {
-		codec := api.Codecs.LegacyCodec(clientset.CoreClient.APIVersion())
+		codec := api.Codecs.LegacyCodec(clientset.CoreClient.RESTClient().APIVersion())
 		keepOldName = len(args) == 1
 		newName := findNewName(args, oldRc)
 		if newRc, err = kubectl.LoadExistingNextReplicationController(coreClient, cmdNamespace, newName); err != nil {

--- a/pkg/kubectl/cmd/util/clientcache.go
+++ b/pkg/kubectl/cmd/util/clientcache.go
@@ -165,5 +165,5 @@ func (c *ClientCache) FederationClientForVersion(version *unversioned.GroupVersi
 	if err != nil {
 		return nil, err
 	}
-	return fedClientSet.(*fed_clientset.Clientset).FederationClient.RESTClient, nil
+	return fedClientSet.Federation().RESTClient().(*restclient.RESTClient), nil
 }

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -28,7 +28,7 @@ import (
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
 func NewSourceApiserver(c *clientset.Clientset, nodeName types.NodeName, updates chan<- interface{}) {
-	lw := cache.NewListWatchFromClient(c.CoreClient, "pods", api.NamespaceAll, fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
+	lw := cache.NewListWatchFromClient(c.Core().RESTClient(), "pods", api.NamespaceAll, fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
 	newSourceApiserverFromLW(lw, updates)
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -357,7 +357,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 
 	serviceStore := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	if kubeClient != nil {
-		serviceLW := cache.NewListWatchFromClient(kubeClient.(*clientset.Clientset).CoreClient, "services", api.NamespaceAll, fields.Everything())
+		serviceLW := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "services", api.NamespaceAll, fields.Everything())
 		cache.NewReflector(serviceLW, &api.Service{}, serviceStore, 0).Run()
 	}
 	serviceLister := &cache.StoreToServiceLister{Indexer: serviceStore}
@@ -365,7 +365,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 	nodeStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	if kubeClient != nil {
 		fieldSelector := fields.Set{api.ObjectNameField: string(nodeName)}.AsSelector()
-		nodeLW := cache.NewListWatchFromClient(kubeClient.(*clientset.Clientset).CoreClient, "nodes", api.NamespaceAll, fieldSelector)
+		nodeLW := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "nodes", api.NamespaceAll, fieldSelector)
 		cache.NewReflector(nodeLW, &api.Node{}, nodeStore, 0).Run()
 	}
 	nodeLister := &cache.StoreToNodeLister{Store: nodeStore}

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -516,7 +516,7 @@ func getNodeConditionPredicate() cache.NodeConditionPredicate {
 // scheduled.
 func (factory *ConfigFactory) createUnassignedNonTerminatedPodLW() *cache.ListWatch {
 	selector := fields.ParseSelectorOrDie("spec.nodeName==" + "" + ",status.phase!=" + string(api.PodSucceeded) + ",status.phase!=" + string(api.PodFailed))
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "pods", api.NamespaceAll, selector)
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "pods", api.NamespaceAll, selector)
 }
 
 // Returns a cache.ListWatch that finds all pods that are
@@ -524,7 +524,7 @@ func (factory *ConfigFactory) createUnassignedNonTerminatedPodLW() *cache.ListWa
 // TODO: return a ListerWatcher interface instead?
 func (factory *ConfigFactory) createAssignedNonTerminatedPodLW() *cache.ListWatch {
 	selector := fields.ParseSelectorOrDie("spec.nodeName!=" + "" + ",status.phase!=" + string(api.PodSucceeded) + ",status.phase!=" + string(api.PodFailed))
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "pods", api.NamespaceAll, selector)
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "pods", api.NamespaceAll, selector)
 }
 
 // createNodeLW returns a cache.ListWatch that gets all changes to nodes.
@@ -532,32 +532,32 @@ func (factory *ConfigFactory) createNodeLW() *cache.ListWatch {
 	// all nodes are considered to ensure that the scheduler cache has access to all nodes for lookups
 	// the NodeCondition is used to filter out the nodes that are not ready or unschedulable
 	// the filtered list is used as the super set of nodes to consider for scheduling
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "nodes", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "nodes", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 // createPersistentVolumeLW returns a cache.ListWatch that gets all changes to persistentVolumes.
 func (factory *ConfigFactory) createPersistentVolumeLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "persistentVolumes", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "persistentVolumes", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 // createPersistentVolumeClaimLW returns a cache.ListWatch that gets all changes to persistentVolumeClaims.
 func (factory *ConfigFactory) createPersistentVolumeClaimLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "persistentVolumeClaims", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "persistentVolumeClaims", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 // Returns a cache.ListWatch that gets all changes to services.
 func (factory *ConfigFactory) createServiceLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "services", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "services", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 // Returns a cache.ListWatch that gets all changes to controllers.
 func (factory *ConfigFactory) createControllerLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client.Core().GetRESTClient(), "replicationControllers", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Core().RESTClient(), "replicationControllers", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 // Returns a cache.ListWatch that gets all changes to replicasets.
 func (factory *ConfigFactory) createReplicaSetLW() *cache.ListWatch {
-	return cache.NewListWatchFromClient(factory.Client.Extensions().GetRESTClient(), "replicasets", api.NamespaceAll, fields.ParseSelectorOrDie(""))
+	return cache.NewListWatchFromClient(factory.Client.Extensions().RESTClient(), "replicasets", api.NamespaceAll, fields.ParseSelectorOrDie(""))
 }
 
 func (factory *ConfigFactory) makeDefaultErrorFunc(backoff *podBackoff, podQueue *cache.FIFO) func(pod *api.Pod, err error) {
@@ -632,7 +632,7 @@ type binder struct {
 func (b *binder) Bind(binding *api.Binding) error {
 	glog.V(3).Infof("Attempting to bind %v to %v", binding.Name, binding.Target.Name)
 	ctx := api.WithNamespace(api.NewContext(), binding.Namespace)
-	return b.Client.Core().GetRESTClient().Post().Namespace(api.NamespaceValue(ctx)).Resource("bindings").Body(binding).Do().Error()
+	return b.Client.Core().RESTClient().Post().Namespace(api.NamespaceValue(ctx)).Resource("bindings").Body(binding).Do().Error()
 	// TODO: use Pods interface for binding once clusters are upgraded
 	// return b.Pods(binding.Namespace).Bind(binding)
 }


### PR DESCRIPTION
Refactoring of code to allow replace *restclient.RESTClient with any RESTClient implementation that implements restclient.RESTClientInterface interface.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34138)

<!-- Reviewable:end -->
