### PR TITLE
Fix wait.JitterUntil

### DIFF
--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"math/rand"
 	"time"
+
+	"k8s.io/kubernetes/pkg/util/runtime"
 )
 
 // For any test of the style:
@@ -81,6 +83,7 @@ func JitterUntil(f func(), period time.Duration, jitterFactor float64, sliding b
 		}
 
 		func() {
+			defer runtime.HandleCrash()
 			f()
 		}()
 

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/pkg/util/runtime"
 )
 
 func TestUntil(t *testing.T) {
@@ -106,6 +108,41 @@ func TestJitterUntilReturnsImmediately(t *testing.T) {
 	}, 30*time.Second, 1.0, true, ch)
 	if now.Add(25 * time.Second).Before(time.Now()) {
 		t.Errorf("JitterUntil did not return immediately when the stop chan was closed inside the func")
+	}
+}
+
+func TestJitterUntilRecoversPanic(t *testing.T) {
+	// Save and restore crash handlers
+	originalReallyCrash := runtime.ReallyCrash
+	originalHandlers := runtime.PanicHandlers
+	defer func() {
+		runtime.ReallyCrash = originalReallyCrash
+		runtime.PanicHandlers = originalHandlers
+	}()
+
+	called := 0
+	handled := 0
+
+	// Hook up a custom crash handler to ensure it is called when a jitter function panics
+	runtime.ReallyCrash = false
+	runtime.PanicHandlers = []func(interface{}){
+		func(p interface{}) {
+			handled++
+		},
+	}
+
+	ch := make(chan struct{})
+	JitterUntil(func() {
+		called++
+		if called > 2 {
+			close(ch)
+			return
+		}
+		panic("TestJitterUntilRecoversPanic")
+	}, time.Millisecond, 1.0, true, ch)
+
+	if called != 3 {
+		t.Errorf("Expected panic recovers")
 	}
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/29743 changed a util method to cause process exits if a handler function panics.

Utility methods should not make process exit decisions. If a process (like the controller manager) wants to exit on panic, appending a panic handler or setting `ReallyCrash = true` is the right way to do that (discussed [here](https://github.com/kubernetes/kubernetes/pull/29743#r75509074)).

This restores the documented behavior of wait.JitterUntil

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34139)

<!-- Reviewable:end -->
