### PR TITLE
remove [Conformance] flag on some e2es 

### DIFF
--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -81,7 +81,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		})
 	})
 
-	It("should support subPath [Conformance]", func() {
+	It("should support subPath", func() {
 		volumePath := "/test-volume"
 		subPath := "sub-path"
 		fileName := "test-file"

--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -50,7 +50,7 @@ var _ = framework.KubeDescribe("ClusterDns [Feature:Example]", func() {
 		c = f.Client
 	})
 
-	It("should create pod that uses dns [Conformance]", func() {
+	It("should create pod that uses dns", func() {
 		mkpath := func(file string) string {
 			return filepath.Join(framework.TestContext.RepoRoot, "examples/cluster-dns", file)
 		}

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -50,7 +50,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 	})
 
 	// First test because it has no dependencies on variables created later on.
-	It("should provide unchanging, static URL paths for kubernetes api services [Conformance]", func() {
+	It("should provide unchanging, static URL paths for kubernetes api services", func() {
 		tests := []struct {
 			path string
 		}{

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -62,11 +62,11 @@ func proxyContext(version string) {
 	// Port here has to be kept in sync with default kubelet port.
 	It("should proxy logs on node with explicit kubelet port [Conformance]", func() { nodeProxyTest(f, prefix+"/proxy/nodes/", ":10250/logs/") })
 	It("should proxy logs on node [Conformance]", func() { nodeProxyTest(f, prefix+"/proxy/nodes/", "/logs/") })
-	It("should proxy to cadvisor [Conformance]", func() { nodeProxyTest(f, prefix+"/proxy/nodes/", ":4194/containers/") })
+	It("should proxy to cadvisor", func() { nodeProxyTest(f, prefix+"/proxy/nodes/", ":4194/containers/") })
 
 	It("should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]", func() { nodeProxyTest(f, prefix+"/nodes/", ":10250/proxy/logs/") })
 	It("should proxy logs on node using proxy subresource [Conformance]", func() { nodeProxyTest(f, prefix+"/nodes/", "/proxy/logs/") })
-	It("should proxy to cadvisor using proxy subresource [Conformance]", func() { nodeProxyTest(f, prefix+"/nodes/", ":4194/proxy/containers/") })
+	It("should proxy to cadvisor using proxy subresource", func() { nodeProxyTest(f, prefix+"/nodes/", ":4194/proxy/containers/") })
 
 	// using the porter image to serve content, access the content
 	// (of multiple pods?) from multiple (endpoints/services?)


### PR DESCRIPTION
Downstream distributions that absorb the upstream tests would like to give their customers a standard mechanism to validate their clusters, post setup. As of today [Conformance] works for most things, but there are a known set of tests that vary due to opinionated differences around networking, security, etc... and providing a complete skip list can be cumbersome.  To address this, we've simply modified the flag on some tests to [Conformance:Variant].  All existing behavior should be maintained. 

Fixes: #34105

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34140)

<!-- Reviewable:end -->
