### PR TITLE
CRI: Add serial and benchmark test suite.

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
@@ -1,0 +1,58 @@
+---
+images:
+  containervm-density1:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'create 35 pods with 0s? interval \[Benchmark\]'
+  containervm-density2:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  containervm-density2-qps60:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+  containervm-density3:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-2
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  containervm-density4:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'create 105 pods with 100ms interval \[Benchmark\]'
+  containervm-resource1:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  containervm-resource2:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  containervm-resource3:
+    image: gci-dev-55-8820-0-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    tests:
+      - 'resource tracking for 105 pods per node \[Benchmark\]'

--- a/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
@@ -1,0 +1,9 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]"'
+SETUP_NODE=false
+TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true'
+PARALLELISM=1

--- a/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
@@ -6,6 +6,8 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT}"
 CLEANUP=true
-GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
+GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
 SETUP_NODE=false
-TEST_ARGS='--runtime-integration-type=cri'
+TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true'
+PARALLELISM=1
+TIMEOUT=3h


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/31459.

The serial test result will be shown on test-grid.
The benchmark test result will be shown [node-perf-dash](http://node-perf-dash.k8s.io/#/builds)

This PR also changes the cri validation test to use the same gci image with node e2e instead of the canary image. The docker version is still 1.11.2.

@yujuhong @feiskyer @yifan-gu 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34141)

<!-- Reviewable:end -->
