### PR TITLE
kubeadm: mark etcd flags as deprecated

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -92,18 +92,25 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 		&cfg.Etcd.Endpoints, "external-etcd-endpoints", []string{},
 		"etcd endpoints to use, in case you have an external cluster",
 	)
+	cmd.PersistentFlags().MarkDeprecated("external-etcd-endpoints", "this flag will be removed when componentconfig exists")
+
 	cmd.PersistentFlags().StringVar(
 		&cfg.Etcd.CAFile, "external-etcd-cafile", "",
 		"etcd certificate authority certificate file. Note: The path must be in /etc/ssl/certs",
 	)
+	cmd.PersistentFlags().MarkDeprecated("external-etcd-cafile", "this flag will be removed when componentconfig exists")
+
 	cmd.PersistentFlags().StringVar(
 		&cfg.Etcd.CertFile, "external-etcd-certfile", "",
 		"etcd client certificate file. Note: The path must be in /etc/ssl/certs",
 	)
+	cmd.PersistentFlags().MarkDeprecated("external-etcd-certfile", "this flag will be removed when componentconfig exists")
+
 	cmd.PersistentFlags().StringVar(
 		&cfg.Etcd.KeyFile, "external-etcd-keyfile", "",
 		"etcd client key file. Note: The path must be in /etc/ssl/certs",
 	)
+	cmd.PersistentFlags().MarkDeprecated("external-etcd-keyfile", "this flag will be removed when componentconfig exists")
 
 	return cmd
 }


### PR DESCRIPTION
Lets mark flags that we don't plan on exposing through the command line permanently as deprecated from now on.

@kubernetes/sig-cluster-lifecycle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34142)

<!-- Reviewable:end -->
