### PR TITLE
Automated cherry pick of #32914

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -158,9 +158,6 @@ const (
 	// Period for performing image garbage collection.
 	ImageGCPeriod = 5 * time.Minute
 
-	// maxImagesInStatus is the number of max images we store in image status.
-	maxImagesInNodeStatus = 50
-
 	// Minimum number of dead containers to keep in a pod
 	minDeadContainerInPod = 1
 )

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -44,6 +44,10 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 )
 
+const (
+	maxImageTagsForTest = 20
+)
+
 // generateTestingImageList generate randomly generated image list and corresponding expectedImageList.
 func generateTestingImageList(count int) ([]kubecontainer.Image, []api.ContainerImage) {
 	// imageList is randomly generated image list
@@ -64,7 +68,7 @@ func generateTestingImageList(count int) ([]kubecontainer.Image, []api.Container
 	var expectedImageList []api.ContainerImage
 	for _, kubeImage := range imageList {
 		apiImage := api.ContainerImage{
-			Names:     kubeImage.RepoTags,
+			Names:     kubeImage.RepoTags[0:maxNamesPerImageInNodeStatus],
 			SizeBytes: kubeImage.Size,
 		}
 
@@ -76,7 +80,9 @@ func generateTestingImageList(count int) ([]kubecontainer.Image, []api.Container
 
 func generateImageTags() []string {
 	var tagList []string
-	count := rand.IntnRange(1, maxImageTagsForTest+1)
+	// Generate > maxNamesPerImageInNodeStatus tags so that the test can verify
+	// that kubelet report up to maxNamesPerImageInNodeStatus tags.
+	count := rand.IntnRange(maxNamesPerImageInNodeStatus+1, maxImageTagsForTest+1)
 	for ; count > 0; count-- {
 		tagList = append(tagList, "gcr.io/google_containers:v"+strconv.Itoa(count))
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -86,8 +86,6 @@ const (
 	testReservationCPU    = "200m"
 	testReservationMemory = "100M"
 
-	maxImageTagsForTest = 3
-
 	// TODO(harry) any global place for these two?
 	// Reasonable size range of all container images. 90%ile of images on dockerhub drops into this range.
 	minImgSize int64 = 23 * 1024 * 1024


### PR DESCRIPTION
Cherry pick of #32914 on release-1.4.
#32914: Limit the number of names per image reported in the node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34157)

<!-- Reviewable:end -->
