### PR TITLE
Fix formatting for generated md file

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -169,6 +169,7 @@ __custom_func() {
 	// and add a short forms entry in expandResourceShortcut() when appropriate.
 	// TODO: This should be populated using the discovery information from apiserver.
 	valid_resources = `Valid resource types include:
+
    * clusters (valid only for federation apiservers)
    * componentstatuses (aka 'cs')
    * configmaps (aka 'cm')


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix formatting for generated md file
Empty line is required before the list.
See broken formating here http://kubernetes.io/docs/user-guide/kubectl/kubectl_get/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34225)

<!-- Reviewable:end -->
