### PR TITLE
Automated cherry pick of #32593

### DIFF
--- a/pkg/apiserver/audit/audit_test.go
+++ b/pkg/apiserver/audit/audit_test.go
@@ -95,14 +95,14 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}
 	if !match {
 		t.Errorf("Unexpected first line of audit: %s", line[0])
 	}
-	match, err = regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	match, err = regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" response="200"`, line[1])
 	if err != nil {
 		t.Errorf("Unexpected error matching second line: %v", err)
 	}

--- a/pkg/apiserver/audit/audit_test.go
+++ b/pkg/apiserver/audit/audit_test.go
@@ -95,14 +95,14 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}
 	if !match {
 		t.Errorf("Unexpected first line of audit: %s", line[0])
 	}
-	match, err = regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	match, err = regexp.MatchString(`[\d\:\-\.\+,T,Z]+ AUDIT: id="[\w-]+" response="200"`, line[1])
 	if err != nil {
 		t.Errorf("Unexpected error matching second line: %v", err)
 	}


### PR DESCRIPTION
Cherry pick of #32593 on release-1.4.
#32593: Subject: [PATCH 1/2] Fix audit_test regex for iso8601 timestamps

Subject: [PATCH 2/2] Fixed edited regex in audit_test unit test

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34228)

<!-- Reviewable:end -->
