### PR TITLE
Fix broken build/push-federation-images.sh

### DIFF
--- a/build/push-federation-images.sh
+++ b/build/push-federation-images.sh
@@ -23,7 +23,6 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${KUBE_ROOT}/build/util.sh"
-source "${KUBE_ROOT}/build/lib/release.sh"
 
 source "${KUBE_ROOT}/federation/cluster/common.sh"
 


### PR DESCRIPTION
The federation CI build is broken by #30787. A stray bash `source` caused an undefined variable reference.

Apparently the federation images have a parallel nad different "release" path that isn't tested by the pre-checkin tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34229)

<!-- Reviewable:end -->
