### PR TITLE
Update documentation for running e2e tests locally

### DIFF
--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -383,6 +383,9 @@ sudo PATH=$PATH hack/local-up-cluster.sh
 This will start a single-node Kubernetes cluster than runs pods using the local
 docker daemon. Press Control-C to stop the cluster.
 
+You can generate a valid kubeconfig file by following instructions printed at the
+end of aforementioned script.
+
 #### Testing against local clusters
 
 In order to run an E2E test against a locally running cluster, point the tests
@@ -390,7 +393,9 @@ at a custom host directly:
 
 ```sh
 export KUBECONFIG=/path/to/kubeconfig
-go run hack/e2e.go -v --test --check_node_count=false
+export KUBE_MASTER_IP="http://127.0.0.1:<PORT>"
+export KUBE_MASTER=local
+go run hack/e2e.go -v --test
 ```
 
 To control the tests that are run:


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs for running e2e tests locally needs to be updated.
check_node_count option has been removed and developers usually
need to perform additional steps do get it going.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34239)

<!-- Reviewable:end -->
