### PR TITLE
Simplify kubectl get --raw

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -138,19 +138,11 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		}
 		defer stream.Close()
 
-		for {
-			buffer := make([]byte, 1024, 1024)
-			bytesRead, err := stream.Read(buffer)
-			if bytesRead > 0 {
-				fmt.Printf("%s", string(buffer[:bytesRead]))
-			}
-			if err == io.EOF {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
+		_, err = io.Copy(out, stream)
+		if err != nil && err != io.EOF {
+			return err
 		}
+		return nil
 	}
 
 	selector := cmdutil.GetFlagString(cmd, "selector")


### PR DESCRIPTION
Write to configured output stream
Don't assume output is a string

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34243)

<!-- Reviewable:end -->
