### PR TITLE
controller: save older revisions for Deployment's replica sets

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -2134,6 +2134,8 @@ __EOF__
   kubectl-with-retry rollout resume deployment nginx "${kube_flags[@]}"
   # The resumed deployment can now be rolled back
   kubectl rollout undo deployment nginx "${kube_flags[@]}"
+  # Check that the new replica set (nginx-618515232) has all old revisions stored in an annotation
+  kubectl get rs nginx-618515232 -o yaml | grep "deployment.kubernetes.io/revision-history: 1,3"
   # Clean up
   kubectl delete deployment nginx "${kube_flags[@]}"
 


### PR DESCRIPTION
@jwforres the only usable way  I could find for multiple old revisions for a single replica set is to stuff them as comma-separated values.

@kubernetes/deployment this retains old revisions served by a replica set inside an annotation.

Fixes https://github.com/kubernetes/kubernetes/issues/33844

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34249)

<!-- Reviewable:end -->
