### PR TITLE
Automated cherry pick of #31894 #32422 #32406 #33146 #33774

### DIFF
--- a/build/kube-dns/Changelog
+++ b/build/kube-dns/Changelog
@@ -15,3 +15,6 @@
 
  ## Version 1.7 (Wed August 24 2016 Zihong Zheng <zihongz@google.com>)
  - Add support for ExternalName services (pr #31159)
+
+ ## Version 1.8 (Thu September 29 2016 Zihong Zheng <zihongz@google.com>)
+ - Add support for graceful termination (issue #31807)

--- a/build/kube-dns/Makefile
+++ b/build/kube-dns/Makefile
@@ -22,7 +22,7 @@
 # Default registry, arch and tag. This can be overwritten by arguments to make
 PLATFORM?=linux
 ARCH?=amd64
-TAG?=1.7
+TAG?=1.8
 REGISTRY?=gcr.io/google_containers
 
 GOLANG_VERSION=1.6

--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -68,7 +68,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -35,7 +35,6 @@ spec:
       labels:
         k8s-app: kube-dns
         version: v19
-        kubernetes.io/cluster-service: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -55,7 +54,7 @@ spec:
             memory: 70Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -85,6 +84,15 @@ spec:
           protocol: TCP
       - name: dnsmasq
         image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
         - --no-resolv
@@ -98,7 +106,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.1
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
         resources:
           limits:
             memory: 50Mi
@@ -110,9 +118,12 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1:10053 >/dev/null
-        - -port=8080
-        - -quiet
+        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -19,29 +19,29 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v20
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v20
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: __PILLAR__DNS__REPLICAS__
   selector:
     k8s-app: kube-dns
-    version: v19
+    version: v20
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
+        version: v20
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.7
+        image: gcr.io/google_containers/kubedns-amd64:1.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -83,7 +83,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -89,6 +89,7 @@ spec:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -69,7 +69,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -55,7 +55,7 @@ spec:
             memory: 70Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -97,8 +97,17 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.1
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
         resources:
           limits:
             memory: 50Mi
@@ -110,9 +119,12 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
-        - -port=8080
-        - -quiet
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -89,6 +89,7 @@ spec:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -19,30 +19,29 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v20
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v20
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v19
+    version: v20
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
-        kubernetes.io/cluster-service: "true"
+        version: v20
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.7
+        image: gcr.io/google_containers/kubedns-amd64:1.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -84,7 +83,16 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
         - --no-resolv
@@ -97,15 +105,6 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz-dnsmasq
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
       - name: healthz
         image: gcr.io/google_containers/exechealthz-amd64:1.2
         resources:

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -69,7 +69,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -88,6 +88,7 @@ spec:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -50,7 +50,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -68,6 +68,7 @@ spec:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -1,23 +1,25 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v15
+  name: kube-dns-v19
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v15
+    version: v19
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: ${DNS_REPLICAS}
   selector:
     k8s-app: kube-dns
-    version: v15
+    version: v19
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v15
-        kubernetes.io/cluster-service: "true"
+        version: v19
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
@@ -28,14 +30,13 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            cpu: 100m
             memory: 200Mi
           requests:
             cpu: 100m
             memory: 100Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -63,7 +64,16 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/dnsmasq:1.1
+        image: gcr.io/google_containers/dnsmasq:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
         - --no-resolv
@@ -77,18 +87,24 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            # Note that this container shouldn't really need 50Mi of memory. The
+            # limits are set higher than expected pending investigation on #29688.
+            # The extra memory was stolen from the kubedns container to keep the
+            # net memory requested by the pod constant.
+            memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1 >/dev/null
-        - -port=8080
+        - --cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v20
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v20
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: ${DNS_REPLICAS}
   selector:
     k8s-app: kube-dns
-    version: v19
+    version: v20
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
+        version: v20
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.7
+        image: gcr.io/google_containers/kubedns-amd64:1.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -64,7 +64,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/dnsmasq:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -12,30 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-rc.yaml
-
 # Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
 
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v18
+  name: kube-dns-v19
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v18
+    version: v19
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v18
+    version: v19
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v18
-        kubernetes.io/cluster-service: "true"
+        version: v19
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
@@ -46,14 +46,13 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            cpu: 100m
             memory: 200Mi
           requests:
             cpu: 100m
             memory: 100Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -84,6 +83,15 @@ spec:
           protocol: TCP
       - name: dnsmasq
         image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
         - --no-resolv
@@ -97,19 +105,24 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.0
+        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.2
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            # Note that this container shouldn't really need 50Mi of memory. The
+            # limits are set higher than expected pending investigation on #29688.
+            # The extra memory was stolen from the kubedns container to keep the
+            # net memory requested by the pod constant.
+            memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
-        - -port=8080
-        - -quiet
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -66,7 +66,7 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -17,29 +17,29 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kube-dns-v20
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v19
+    version: v20
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v19
+    version: v20
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
+        version: v20
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-{{ arch }}:1.7
+        image: gcr.io/google_containers/kubedns-{{ arch }}:1.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -82,7 +82,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -88,6 +88,7 @@ spec:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns

--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -125,12 +125,12 @@ func (server *KubeDNSServer) setupHealthzHandlers() {
 }
 
 // setupSignalHandlers runs a goroutine that waits on SIGINT or SIGTERM and logs it
-// before exiting.
+// program will be terminated by SIGKILL when grace period ends.
 func setupSignalHandlers() {
 	sigChan := make(chan os.Signal)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		glog.Fatalf("Received signal: %s", <-sigChan)
+		glog.Infof("Received signal: %s, will exit when the grace period ends", <-sigChan)
 	}()
 }
 


### PR DESCRIPTION
Cherry pick of #31894 #32422 #32406 #33146 #33774 on release-1.4.
#31894: Support graceful termination in kube-dns
#32422: Added --log-facility flag to enhance dnsmasq logging
#32406: Split dns healthcheck into two different urls
#33146: Tune down initialDelaySeconds for readinessProbe
#33774: Bump up addon kube-dns to v20 for graceful termination

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34290)

<!-- Reviewable:end -->
