### PR TITLE
Automated cherry pick of #33794 #33610 origin release 1.4

### DIFF
--- a/test/e2e/federated-ingress.go
+++ b/test/e2e/federated-ingress.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	MaxRetriesOnFederatedApiserver = 3
-	FederatedIngressTimeout        = 60 * time.Second
+	FederatedIngressTimeout        = 120 * time.Second
 	FederatedIngressName           = "federated-ingress"
 	FederatedIngressServiceName    = "federated-ingress-service"
 	FederatedIngressServicePodName = "federated-ingress-service-test-pod"


### PR DESCRIPTION
Cherry pick of #33794 #33610 on release-1.4.
#33794: Enable kubectl describe rs to work when apiserver does not
#33610: Increase tineout for federated ingress test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34299)

<!-- Reviewable:end -->
