### PR TITLE
Fix alternative spelling

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -67,7 +67,7 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 	)
 	cmd.PersistentFlags().StringVar(
 		&cfg.Networking.ServiceSubnet, "service-cidr", kubeadmapi.DefaultServicesSubnet,
-		"Use alterantive range of IP address for service VIPs",
+		"Use alternative range of IP address for service VIPs",
 	)
 	cmd.PersistentFlags().StringVar(
 		&cfg.Networking.PodSubnet, "pod-network-cidr", "",

--- a/vendor/github.com/magiconair/properties/doc.go
+++ b/vendor/github.com/magiconair/properties/doc.go
@@ -102,7 +102,7 @@
 //   v = p.GetString("key", "def")
 //   v = p.GetDuration("key", 999)
 //
-// As an alterantive properties may be applied with the standard
+// As an alternative properties may be applied with the standard
 // library's flag implementation at any time.
 //
 //   # Standard configuration


### PR DESCRIPTION
Very simple pull request here, the misspelling of alternative was bothering me.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34305)

<!-- Reviewable:end -->
