### PR TITLE
CRI: Fix cri pre-submit test.

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
@@ -3,7 +3,7 @@ GCE_HOSTS=
 GCE_IMAGES=gci-dev-55-8820-0-0
 GCE_IMAGE_PROJECT=google-containers
 GCE_ZONE=us-central1-f
-GCE_PROJECT=k8s-jkns-ci-node-e2e
+GCE_PROJECT=k8s-jkns-pr-node-e2e
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT}"
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/pull/33988#issuecomment-252134276.
We should use `k8s-jkns-pr-node-e2e` instead of `k8s-jkns-ci-node-e2e` for presubmit test.

@yujuhong @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34306)

<!-- Reviewable:end -->
