### PR TITLE
test: move deployment deletion in its own test

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -50,8 +50,14 @@ const (
 var _ = framework.KubeDescribe("Deployment", func() {
 	f := framework.NewDefaultFramework("deployment")
 
+	// TODO: Add failure traps once we have JustAfterEach
+	// See https://github.com/onsi/ginkgo/issues/303
+
 	It("deployment should create new pods", func() {
 		testNewDeployment(f)
+	})
+	It("deployment reaping should cascade to its replica sets and pods", func() {
+		testDeleteDeployment(f)
 	})
 	It("RollingUpdateDeployment should delete old pods and create new ones", func() {
 		testRollingUpdateDeployment(f)
@@ -90,6 +96,7 @@ var _ = framework.KubeDescribe("Deployment", func() {
 		testOverlappingDeployment(f)
 	})
 	// TODO: add tests that cover deployment.Spec.MinReadySeconds once we solved clock-skew issues
+	// See https://github.com/kubernetes/kubernetes/issues/29229
 })
 
 func newRS(rsName string, replicas int32, rsPodLabels map[string]string, imageName string, image string) *extensions.ReplicaSet {
@@ -181,15 +188,15 @@ func checkDeploymentRevision(c clientset.Interface, ns, deploymentName, revision
 	return deployment, newRS
 }
 
-func stopDeploymentOverlap(c clientset.Interface, oldC client.Interface, ns, deploymentName, overlapWith string) {
-	stopDeploymentMaybeOverlap(c, oldC, ns, deploymentName, overlapWith)
+func stopDeploymentOverlap(c clientset.Interface, ns, deploymentName, overlapWith string) {
+	stopDeploymentMaybeOverlap(c, ns, deploymentName, overlapWith)
 }
 
-func stopDeployment(c clientset.Interface, oldC client.Interface, ns, deploymentName string) {
-	stopDeploymentMaybeOverlap(c, oldC, ns, deploymentName, "")
+func stopDeployment(c clientset.Interface, ns, deploymentName string) {
+	stopDeploymentMaybeOverlap(c, ns, deploymentName, "")
 }
 
-func stopDeploymentMaybeOverlap(c clientset.Interface, oldC client.Interface, ns, deploymentName, overlapWith string) {
+func stopDeploymentMaybeOverlap(c clientset.Interface, ns, deploymentName, overlapWith string) {
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -251,8 +258,6 @@ func stopDeploymentMaybeOverlap(c clientset.Interface, oldC client.Interface, ns
 
 func testNewDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
-	// TODO: remove unversionedClient when the refactoring is done. Currently some
-	// functions like verifyPod still expects a unversioned#Client.
 	c := f.ClientSet
 
 	deploymentName := "test-new-deployment"
@@ -263,7 +268,6 @@ func testNewDeployment(f *framework.Framework) {
 	d.Annotations = map[string]string{"test": "should-copy-to-replica-set", annotations.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
 	deploy, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", nginxImage)
@@ -281,6 +285,37 @@ func testNewDeployment(f *framework.Framework) {
 	Expect(newRS.Annotations[annotations.LastAppliedConfigAnnotation]).Should(Equal(""))
 	Expect(deployment.Annotations["test"]).Should(Equal("should-copy-to-replica-set"))
 	Expect(deployment.Annotations[annotations.LastAppliedConfigAnnotation]).Should(Equal("should-not-copy-to-replica-set"))
+}
+
+func testDeleteDeployment(f *framework.Framework) {
+	ns := f.Namespace.Name
+	c := f.ClientSet
+
+	deploymentName := "test-new-deployment"
+	podLabels := map[string]string{"name": nginxImageName}
+	replicas := int32(1)
+	framework.Logf("Creating simple deployment %s", deploymentName)
+	d := newDeployment(deploymentName, replicas, podLabels, nginxImageName, nginxImage, extensions.RollingUpdateDeploymentStrategyType, nil)
+	d.Annotations = map[string]string{"test": "should-copy-to-replica-set", annotations.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
+	deploy, err := c.Extensions().Deployments(ns).Create(d)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Wait for it to be updated to revision 1
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", nginxImage)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = framework.WaitForDeploymentStatus(c, deploy)
+	Expect(err).NotTo(HaveOccurred())
+
+	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
+	Expect(err).NotTo(HaveOccurred())
+	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c)
+	Expect(err).NotTo(HaveOccurred())
+	if newRS == nil {
+		err = fmt.Errorf("expected a replica set, got nil")
+		Expect(err).NotTo(HaveOccurred())
+	}
+	stopDeployment(c, ns, deploymentName)
 }
 
 func testRollingUpdateDeployment(f *framework.Framework) {
@@ -312,7 +347,6 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	framework.Logf("Creating deployment %s", deploymentName)
 	deploy, err := c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
@@ -368,7 +402,6 @@ func testRollingUpdateDeploymentEvents(f *framework.Framework) {
 	framework.Logf("Creating deployment %s", deploymentName)
 	deploy, err := c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 3546343826724305833
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "3546343826724305833", redisImage)
@@ -424,7 +457,6 @@ func testRecreateDeployment(f *framework.Framework) {
 	framework.Logf("Creating deployment %s", deploymentName)
 	deploy, err := c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RecreateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
@@ -516,7 +548,6 @@ func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	}()
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RollingUpdateDeploymentStrategyType, revisionHistoryLimit))
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	err = framework.WaitForDeploymentOldRSsNum(c, ns, deploymentName, int(*revisionHistoryLimit))
 	Expect(err).NotTo(HaveOccurred())
@@ -563,7 +594,6 @@ func testRolloverDeployment(f *framework.Framework) {
 	}
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Verify that the pods were scaled up and down as expected.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
@@ -596,8 +626,6 @@ func testRolloverDeployment(f *framework.Framework) {
 
 func testPausedDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
-	// TODO: remove unversionedClient when the refactoring is done. Currently some
-	// functions like verifyPod still expects a unversioned#Client.
 	c := f.ClientSet
 	deploymentName := "test-paused-deployment"
 	podLabels := map[string]string{"name": nginxImageName}
@@ -608,7 +636,6 @@ func testPausedDeployment(f *framework.Framework) {
 	framework.Logf("Creating paused deployment %s", deploymentName)
 	_, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 	// Check that deployment is created fine.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
@@ -710,7 +737,6 @@ func testRollbackDeployment(f *framework.Framework) {
 	d.Annotations = createAnnotation
 	deploy, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
@@ -829,7 +855,6 @@ func testRollbackDeploymentRSNoRevision(f *framework.Framework) {
 	d := newDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType, nil)
 	deploy, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
@@ -962,7 +987,6 @@ func testDeploymentLabelAdopted(f *framework.Framework) {
 	framework.Logf("Creating deployment %s", deploymentName)
 	deploy, err := c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, podLabels, podName, image, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", image)
@@ -1006,7 +1030,6 @@ func testScalePausedDeployment(f *framework.Framework) {
 	framework.Logf("Creating deployment %q", deploymentName)
 	_, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Check that deployment is created fine.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
@@ -1060,7 +1083,6 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 	By(fmt.Sprintf("Creating deployment %q", deploymentName))
 	_, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
-	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Check that deployment is created fine.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
@@ -1211,8 +1233,6 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 
 func testOverlappingDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
-	// TODO: remove unversionedClient when the refactoring is done. Currently some
-	// functions like verifyPod still expects a unversioned#Client.
 	c := f.ClientSet
 
 	deploymentName := "first-deployment"
@@ -1233,7 +1253,6 @@ func testOverlappingDeployment(f *framework.Framework) {
 	d = newDeployment(deploymentName, replicas, podLabels, nginxImageName, nginxImage, extensions.RollingUpdateDeploymentStrategyType, nil)
 	deployOverlapping, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred(), "Failed creating the second deployment")
-	defer stopDeployment(c, f.Client, ns, deployOverlapping.Name)
 
 	// Wait for overlapping annotation updated to both deployments
 	By("Waiting for both deployments to have overlapping annotations")
@@ -1252,7 +1271,7 @@ func testOverlappingDeployment(f *framework.Framework) {
 	Expect(rsList.Items[0].Spec.Template.Spec.Containers[0].Image).To(Equal(deploy.Spec.Template.Spec.Containers[0].Image))
 
 	By("Deleting the first deployment")
-	stopDeploymentOverlap(c, f.Client, ns, deploy.Name, deployOverlapping.Name)
+	stopDeploymentOverlap(c, ns, deploy.Name, deployOverlapping.Name)
 
 	// Wait for overlapping annotation cleared
 	By("Waiting for the second deployment to clear overlapping annotation")
@@ -1277,7 +1296,6 @@ func testOverlappingDeployment(f *framework.Framework) {
 	d = newDeployment(deploymentName, replicas, podLabels, nginxImageName, nginxImage, extensions.RollingUpdateDeploymentStrategyType, nil)
 	deployLater, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred(), "Failed creating the third deployment")
-	defer stopDeployment(c, f.Client, ns, deployLater.Name)
 
 	// Wait for it to be updated to revision 1
 	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deployLater.Name, "1", nginxImage)


### PR DESCRIPTION
@kubernetes/deployment this PR moves the deletion of deployment in its own test (no need to delete deployments in every test since the namespace controller does that for us once the namespace gets deleted after the test finishes)

Fixes https://github.com/kubernetes/kubernetes/issues/33256

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34316)

<!-- Reviewable:end -->
