### PR TITLE
test: bump deployment test timeout

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3542,7 +3542,7 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 		reason                    string
 	)
 
-	err := wait.Poll(Poll, 2*time.Minute, func() (bool, error) {
+	err := wait.Poll(Poll, 5*time.Minute, func() (bool, error) {
 		var err error
 		deployment, err = c.Extensions().Deployments(d.Namespace).Get(d.Name)
 		if err != nil {


### PR DESCRIPTION
Matches the timeout used in [WaitForDeploymentStatus](https://github.com/kubernetes/kubernetes/blob/6d56d0337abd424f089e9b66b0dc77002e6068b3/test/e2e/framework/util.go#L3610)

Fixes https://github.com/kubernetes/kubernetes/issues/31810

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34323)

<!-- Reviewable:end -->
