### PR TITLE
Federated ingress unit test fix

### DIFF
--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -73,6 +73,53 @@ func TestFake(t *testing.T) {
 	consumer(f)
 }
 
+func TestRaceFreeFake(t *testing.T) {
+	f := NewRaceFreeFake()
+
+	table := []struct {
+		t EventType
+		s testType
+	}{
+		{Added, testType("foo")},
+		{Modified, testType("qux")},
+		{Modified, testType("bar")},
+		{Deleted, testType("bar")},
+		{Error, testType("error: blah")},
+	}
+
+	// Prove that f implements Interface by phrasing this as a function.
+	consumer := func(w Interface) {
+		for _, expect := range table {
+			got, ok := <-w.ResultChan()
+			if !ok {
+				t.Fatalf("closed early")
+			}
+			if e, a := expect.t, got.Type; e != a {
+				t.Fatalf("Expected %v, got %v", e, a)
+			}
+			if a, ok := got.Object.(testType); !ok || a != expect.s {
+				t.Fatalf("Expected %v, got %v", expect.s, a)
+			}
+		}
+		_, stillOpen := <-w.ResultChan()
+		if stillOpen {
+			t.Fatal("Never stopped")
+		}
+	}
+
+	sender := func() {
+		f.Add(testType("foo"))
+		f.Action(Modified, testType("qux"))
+		f.Modify(testType("bar"))
+		f.Delete(testType("bar"))
+		f.Error(testType("error: blah"))
+		f.Stop()
+	}
+
+	go sender()
+	consumer(f)
+}
+
 func TestEmpty(t *testing.T) {
 	w := NewEmptyWatch()
 	_, ok := <-w.ResultChan()


### PR DESCRIPTION
Adds RaceFreeFakeWatcher to watch.go. If this struct succeeds with helping IngressController i will try to move all FakeWatchers to this implementation.

cc: @quinton-hoole @madhusudancs @wojtek-t @kubernetes/sig-cluster-federation

Should help with  #32685. 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34325)

<!-- Reviewable:end -->
