### PR TITLE
build: fix typo in error message help

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -262,7 +262,7 @@ Possible causes:
     - Linux: confirm via your init system
     - macOS w/ docker-machine: run `docker-machine ls` and `docker-machine start <name>`
     - macOS w/ Docker for Mac: Check the menu bar and start the Docker application
-  - DOCKER_HOST hasn't been set of is set incorrectly
+  - DOCKER_HOST hasn't been set or is set incorrectly
     - Linux: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`
     - macOS w/ docker-machine: run `eval "$(docker-machine env <name>)"`
     - macOS w/ Docker for Mac: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`


### PR DESCRIPTION
"hasn't been set of is set" --> "hasn't been set or is set"

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34330)

<!-- Reviewable:end -->
