### PR TITLE
Include DaemonSets and Deployments in Namespace deletion

### DIFF
--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -365,6 +365,14 @@ func (nc *NamespaceController) delete(namespace *api_v1.Namespace) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete ingresses list from namespace: %v", err)
 	}
+	err = nc.federatedApiClient.Extensions().DaemonSets(namespace.Name).DeleteCollection(&api_v1.DeleteOptions{}, api_v1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete daemonsets list from namespace: %v", err)
+	}
+	err = nc.federatedApiClient.Extensions().Deployments(namespace.Name).DeleteCollection(&api_v1.DeleteOptions{}, api_v1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete deployments list from namespace: %v", err)
+	}
 	err = nc.federatedApiClient.Core().Events(namespace.Name).DeleteCollection(&api_v1.DeleteOptions{}, api_v1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete events list from namespace: %v", err)


### PR DESCRIPTION
More generic deletion should be added next week.

cc: @quinton-hoole

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34334)

<!-- Reviewable:end -->
