### PR TITLE
check if user is root before running any cmds

### DIFF
--- a/cmd/kubeadm/app/api/types.go
+++ b/cmd/kubeadm/app/api/types.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package api
 
-import (
-	"net"
-)
+import "net"
 
 // KubeadmConfig TODO add description
 // TODO(phase1+) @krousey: Please don't embed structs. It obfuscates the source of the fields and doesn't really buy you anything.

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -63,8 +63,6 @@ func NewKubeadmCommand(f *cmdutil.Factory, in io.Reader, out, err io.Writer, env
 
 		`),
 	}
-	// TODO(phase2+) figure out how to avoid running as root
-	//
 	// TODO(phase2) detect interactive vs non-interactive use and adjust output accordingly
 	// i.e. make it automation friendly
 	//

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -28,7 +28,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
 	kubemaster "k8s.io/kubernetes/cmd/kubeadm/app/master"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	netutil "k8s.io/kubernetes/pkg/util/net"
 )
 
@@ -50,7 +49,7 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 		Short: "Run this in order to set up the Kubernetes master.",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunInit(out, cmd, args, s, advertiseAddrs)
-			cmdutil.CheckErr(err)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 
@@ -111,6 +110,9 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 
 // RunInit executes master node provisioning, including certificates, needed static pod manifests, etc.
 func RunInit(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.KubeadmConfig, advertiseAddrs *[]string) error {
+	if u, ok := kubeadmutil.IsRoot(); !ok {
+		return &kubeadmutil.NotRootError{"Requires root priviledges", u}
+	}
 	// Auto-detect the IP
 	if len(*advertiseAddrs) == 0 {
 		// TODO(phase1+) perhaps we could actually grab eth0 and eth1

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -27,7 +27,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
 	kubenode "k8s.io/kubernetes/cmd/kubeadm/app/node"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 var (
@@ -48,7 +47,7 @@ func NewCmdJoin(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 		Short: "Run this on any machine you wish to join an existing cluster.",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunJoin(out, cmd, args, s)
-			cmdutil.CheckErr(err)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 
@@ -63,6 +62,9 @@ func NewCmdJoin(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 // RunJoin executes worked node provisioning and tries to join an existing cluster.
 func RunJoin(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.KubeadmConfig) error {
 	// TODO(phase1+) this we are missing args from the help text, there should be a way to tell cobra about it
+	if u, ok := kubeadmutil.IsRoot(); !ok {
+		return &kubeadmutil.NotRootError{"Requires root priviledges", u}
+	}
 	if len(args) == 0 {
 		return fmt.Errorf("<cmd/join> must specify master IP address (see --help)")
 	}

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -22,19 +22,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/renstrom/dedent"
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"
 )
-
-var AlphaWarningOnExit = dedent.Dedent(`
-	kubeadm: I am an alpha version, my authors welcome your feedback and bug reports
-	kubeadm: please create issue an using https://github.com/kubernetes/kubernetes/issues/new
-	kubeadm: and make sure to mention @kubernetes/sig-cluster-lifecycle. Thank you!
-`)
 
 // TODO(phase2) use componentconfig
 // we need some params for testing etc, let's keep these hidden for now

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/renstrom/dedent"
+)
+
+const (
+	DefaultErrorExitCode = 1
+	EX_USAGE             = 64
+	EX_DATAERR           = 65
+	EX_NOINPUT           = 66
+	EX_NOUSER            = 67
+	EX_NOHOST            = 68
+	EX_UNAVAILABLE       = 69
+	EX_SOFTWARE          = 70
+	EX_OSERR             = 71
+	EX_OSFILE            = 72
+	EX_CANTCREAT         = 73
+	EX_IOERR             = 74
+	EX_TEMPFAIL          = 75
+	EX_PROTOCOL          = 76
+	EX_NOPERM            = 77
+	EX_CONFIG            = 78
+)
+
+var AlphaWarningOnExit = dedent.Dedent(`
+	kubeadm: I am an alpha version, my authors welcome your feedback and bug reports
+	kubeadm: please create issue an using https://github.com/kubernetes/kubernetes/issues/new
+	kubeadm: and make sure to mention @kubernetes/sig-cluster-lifecycle. Thank you!
+`)
+
+type NotRootError struct {
+	Msg  string
+	User *user.User
+}
+
+func (e *NotRootError) Error() string {
+	return fmt.Sprintf("Current User: %s: %s", e.User.Username, e.Msg)
+}
+
+type debugError interface {
+	DebugError() (msg string, args []interface{})
+}
+
+var fatalErrHandler = fatal
+
+// BehaviorOnFatal allows you to override the default behavior when a fatal
+// error occurs, which is to call os.Exit(code). You can pass 'panic' as a function
+// here if you prefer the panic() over os.Exit(1).
+func BehaviorOnFatal(f func(string, int)) {
+	fatalErrHandler = f
+}
+
+// fatal prints the message if set and then exits. If V(2) or greater, glog.Fatal
+// is invoked for extended information.
+func fatal(msg string, code int) {
+	if len(msg) > 0 {
+		// add newline if needed
+		if !strings.HasSuffix(msg, "\n") {
+			msg += "\n"
+		}
+
+		if glog.V(2) {
+			glog.FatalDepth(2, msg)
+		}
+		fmt.Fprint(os.Stderr, msg)
+	}
+	os.Exit(code)
+}
+
+// CheckErr prints a user friendly error to STDERR and exits with a non-zero
+// exit code. Unrecognized errors will be printed with an "error: " prefix.
+//
+// This method is generic to the command in use and may be used by non-Kubectl
+// commands.
+func CheckErr(err error) {
+	checkErr("", err, fatalErrHandler)
+}
+
+// checkErr formats a given error as a string and calls the passed handleErr
+// func with that string and an kubectl exit code.
+func checkErr(prefix string, err error, handleErr func(string, int)) {
+	switch err.(type) {
+	case nil:
+		return
+	case *NotRootError:
+		handleErr(err.Error(), EX_NOPERM)
+	default:
+		fmt.Printf(AlphaWarningOnExit)
+		handleErr(err.Error(), DefaultErrorExitCode)
+	}
+}

--- a/cmd/kubeadm/app/util/user.go
+++ b/cmd/kubeadm/app/util/user.go
@@ -1,0 +1,15 @@
+package util
+
+import "os/user"
+
+const (
+	sudoUser = "0"
+)
+
+func IsRoot() (*user.User, bool) {
+	u, err := user.Current()
+	if err != nil || u.Uid != sudoUser {
+		return u, false
+	}
+	return u, true
+}

--- a/cmd/kubeadm/kubeadm.go
+++ b/cmd/kubeadm/kubeadm.go
@@ -21,12 +21,12 @@ import (
 	"os"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
-// TODO(phase1+): check for root
 func main() {
 	if err := app.Run(); err != nil {
-		fmt.Printf(app.AlphaWarningOnExit)
+		fmt.Printf(util.AlphaWarningOnExit)
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Checks that user running kubeadm init and join is root and will only execute
command if user is root. Moved away from using kubectl error handling to
having kubeadm handle its own errors. This should allow kubeadm to have
more meaningful errors, exit codes, and logging for specific kubeadm use
cases.

fixes #33908

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34340)

<!-- Reviewable:end -->
