### PR TITLE
Fix confusing log messages

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -677,7 +677,7 @@ func WaitForPodsRunningReady(c *client.Client, ns string, minPods int32, timeout
 				}
 			} else {
 				if pod.Status.Phase != api.PodFailed {
-					Logf("The status of Pod %s is %s, waiting for it to be either Running or Failed", pod.ObjectMeta.Name, pod.Status.Phase)
+					Logf("The status of Pod %s is %s (Ready = false), waiting for it to be either Running (with Ready = true) or Failed", pod.ObjectMeta.Name, pod.Status.Phase)
 					badPods = append(badPods, pod)
 				} else if !hasReplicationControllersForPod(rcList, pod) {
 					Logf("Pod %s is Failed, but it's not controlled by a ReplicationController", pod.ObjectMeta.Name)


### PR DESCRIPTION
While debugging https://github.com/kubernetes/kubernetes/issues/33876 , I noticed following confusing message:

```
The status of Pod kibana-logging-v1-j99la is Running, waiting for it to be either Running or Failed
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34346)

<!-- Reviewable:end -->
