### PR TITLE
Centos: download client and server tarballs instead of mondo-tarball

### DIFF
--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -50,7 +50,8 @@ function download-releases() {
   curl -L ${ETCD_DOWNLOAD_URL} -o ${RELEASES_DIR}/etcd.tar.gz
 
   echo "Download kubernetes release v${K8S_VERSION} ..."
-  curl -L ${K8S_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes.tar.gz
+  curl -L ${K8S_CLIENT_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes-client-linux-amd64.tar.gz
+  curl -L ${K8S_SERVER_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes-server-linux-amd64.tar.gz
 
   echo "Download docker release v${DOCKER_VERSION} ..."
   curl -L ${DOCKER_DOWNLOAD_URL} -o ${RELEASES_DIR}/docker.tar.gz
@@ -79,20 +80,18 @@ function unpack-releases() {
   fi
 
   # k8s
-  if [[ -f ${RELEASES_DIR}/kubernetes.tar.gz ]] ; then
-    tar xzf ${RELEASES_DIR}/kubernetes.tar.gz -C ${RELEASES_DIR}
+  if [[ -f ${RELEASES_DIR}/kubernetes-client-linux-amd64.tar.gz ]] ; then
+    tar xzf ${RELEASES_DIR}/kubernetes-client-linux-amd64.tar.gz -C ${RELEASES_DIR}
+    cp ${RELEASES_DIR}/kubernetes/client/bin/kubectl ${BINARY_DIR}
+  fi
 
-    pushd ${RELEASES_DIR}/kubernetes/server
-    tar xzf kubernetes-server-linux-amd64.tar.gz
-    popd
-    cp ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kube-apiserver \
-       ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kube-controller-manager \
-       ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kube-scheduler ${BINARY_DIR}/master/bin
-
-    cp ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kubelet \
-       ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kube-proxy ${BINARY_DIR}/node/bin
-
-    cp ${RELEASES_DIR}/kubernetes/server/kubernetes/server/bin/kubectl ${BINARY_DIR}
+  if [[ -f ${RELEASES_DIR}/kubernetes-server-linux-amd64.tar.gz ]] ; then
+    tar xzf ${RELEASES_DIR}/kubernetes-server-linux-amd64.tar.gz -C ${RELEASES_DIR}
+    cp ${RELEASES_DIR}/kubernetes/server/bin/kube-apiserver \
+       ${RELEASES_DIR}/kubernetes/server/bin/kube-controller-manager \
+       ${RELEASES_DIR}/kubernetes/server/bin/kube-scheduler ${BINARY_DIR}/master/bin
+    cp ${RELEASES_DIR}/kubernetes/server/bin/kubelet \
+       ${RELEASES_DIR}/kubernetes/server/bin/kube-proxy ${BINARY_DIR}/node/bin
   fi
 
   # docker

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -40,5 +40,8 @@ FLANNEL_DOWNLOAD_URL=\
 ETCD_DOWNLOAD_URL=\
 "https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
 
-K8S_DOWNLOAD_URL=\
-"https://github.com/kubernetes/kubernetes/releases/download/v${K8S_VERSION}/kubernetes.tar.gz"
+# TODO(#33726): switch to dl.k8s.io
+K8S_CLIENT_DOWNLOAD_URL=\
+"https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/kubernetes-client-linux-amd64.tar.gz"
+K8S_SERVER_DOWNLOAD_URL=\
+"https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/kubernetes-server-linux-amd64.tar.gz"


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/28629 / https://github.com/kubernetes/kubernetes/issues/28435.

This should be functionally the same, except that you will download ~1/3 the bytes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34370)

<!-- Reviewable:end -->
