### PR TITLE
Generify kube-proxy conntracker setmax() and refactor util/sysctl

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -55,7 +55,7 @@ func (realConntracker) SetMax(max int) error {
 	}
 	// TODO: generify this and sysctl to a new sysfs.WriteInt()
 	glog.Infof("Setting conntrack hashsize to %d", max/4)
-	return ioutil.WriteFile("/sys/module/nf_conntrack/parameters/hashsize", []byte(strconv.Itoa(max/4)), 0640)
+	return writeIntStringFile("/sys/module/nf_conntrack/parameters/hashsize", max/4)
 }
 
 func (realConntracker) SetTCPEstablishedTimeout(seconds int) error {
@@ -85,4 +85,8 @@ func isSysFSWritable() (bool, error) {
 		break
 	}
 	return false, nil
+}
+
+func writeIntStringFile(filename string, value int) error {
+	return ioutil.WriteFile(filename, []byte(strconv.Itoa(value)), 0640)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Fix Kube-proxy `conntrack.go` **TODO** [here](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-proxy/app/conntrack.go#L56). This PR consists of two parts:
- Generify kube-proxy `realConntracker.SetMax(int)` 

That is, change

`ioutil.WriteFile("/sys/module/nf_conntrack/parameters/hashsize", []byte(strconv.Itoa(max/4)), 0640)` 

to

`sysctl.New().WriteValue("/sys/module/nf_conntrack/parameters/hashsize", max/4)`
- Refactor `sysctl.SetSysctl()` and `sysctl.GetSysctl()` to `WriteValue(path string, value string) error` and `GetValue(path value) (error, string)`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34385)

<!-- Reviewable:end -->
