### PR TITLE
Adds OWNERS file for cluster/juju

### DIFF
--- a/cluster/juju/OWNERS
+++ b/cluster/juju/OWNERS
@@ -1,0 +1,8 @@
+assignees:
+  - chuckbutler
+  - mbruzek
+  - marcoceppi
+  - castrojo
+owners:
+  - chuckbutler
+  - mbruzek


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Adds an OWNERS file for the `cluster/juju` directory. This was requested by @mikedanese  over on https://github.com/kubernetes/kubernetes/pull/31736#issuecomment-252391221

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: N/A

**Special notes for your reviewer**: N/A

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` NONE
```

Inserts @chuckbutler and @mbruzek as reviewers for the juju cluster directory.
Additional assignee of @marcoceppi and @castrojo to help handle overflow.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34393)

<!-- Reviewable:end -->
