### PR TITLE
Assign options.Err in "set image"

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -249,7 +249,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 				NewCmdCreate(f, out),
 				NewCmdExposeService(f, out),
 				NewCmdRun(f, in, out, err),
-				set.NewCmdSet(f, out),
+				set.NewCmdSet(f, out, err),
 			},
 		},
 		{

--- a/pkg/kubectl/cmd/set/set.go
+++ b/pkg/kubectl/cmd/set/set.go
@@ -32,7 +32,7 @@ var (
 	set_example = dedent.Dedent(``)
 )
 
-func NewCmdSet(f cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdSet(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "set SUBCOMMAND",
@@ -45,7 +45,7 @@ func NewCmdSet(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	// add subcommands
-	cmd.AddCommand(NewCmdImage(f, out))
+	cmd.AddCommand(NewCmdImage(f, out, err))
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -78,9 +78,10 @@ var (
 		kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml`)
 )
 
-func NewCmdImage(f cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	options := &ImageOptions{
 		Out: out,
+		Err: err,
 	}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a usage of options.Err in a Printf, but this option is never set.
This patch passes the stderr into the command and assigns the option correctly.

**Which issue this PR fixes**
fixes #34433 

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34434)

<!-- Reviewable:end -->
