### PR TITLE
Allow namespace prefix for kubectl get command

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -196,7 +196,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	isWatch, isWatchOnly := cmdutil.GetFlagBool(cmd, "watch"), cmdutil.GetFlagBool(cmd, "watch-only")
 	if isWatch || isWatchOnly {
 		r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
-			NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
+			NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).AllowNamespacePrefix().
 			FilenameParam(enforceNamespace, &options.FilenameOptions).
 			SelectorParam(selector).
 			ExportParam(export).
@@ -281,7 +281,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	}
 
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
-		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
+		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).AllowNamespacePrefix().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
 		SelectorParam(selector).
 		ExportParam(export).

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -299,6 +299,13 @@ func (b *Builder) AllNamespaces(allNamespace bool) *Builder {
 	return b
 }
 
+// AllowNamespacePrefix instruct the builder to accept namespace parameter also with namespace/
+// prefix.
+func (b *Builder) AllowNamespacePrefix() *Builder {
+	b.namespace = strings.TrimPrefix(b.namespace, "namespace/")
+	return b
+}
+
 // RequireNamespace instructs the builder to set the namespace value for any object found
 // to NamespaceParam() if empty, and if the value on the resource does not match
 // NamespaceParam() an error will be returned.


### PR DESCRIPTION
**What this PR does / why we need it**: Enhances support for scripting with kubectl. Check issue #29271 for more details.  

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #29271

**Special notes for your reviewer**: At the moment it supports only `kubectl get` command, to add support for more commands it's needed to add `AllowNamespacePrefix()` method to builder chains for other commands. 

@pwittrock @kubernetes/kubectl What commands should be supported?

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

Leaving empty at the moment as it may change.

CC @cheld

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34450)

<!-- Reviewable:end -->
