### PR TITLE
Fix panic in #34459

### DIFF
--- a/pkg/registry/extensions/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/codec.go
@@ -418,7 +418,7 @@ func (t *thirdPartyResourceDataDecoder) Decode(data []byte, gvk *unversioned.Gro
 			return nil, nil, fmt.Errorf("unexpected object for 'kind': %v", kindObj)
 		}
 		if len(t.kind) > 0 && kindStr != t.kind {
-			return nil, nil, fmt.Errorf("kind doesn't match, expecting: %s, got %s", gvk.Kind, kindStr)
+			return nil, nil, fmt.Errorf("kind doesn't match, expecting: %s, got %s", t.kind, kindStr)
 		}
 		actual.Kind = kindStr
 	}

--- a/pkg/registry/extensions/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/codec_test.go
@@ -81,6 +81,15 @@ func TestCodec(t *testing.T) {
 			name: "basic",
 		},
 		{
+			into: &extensions.ThirdPartyResourceData{},
+			obj: &Foo{
+				ObjectMeta: api.ObjectMeta{Name: "bar"},
+				TypeMeta:   unversioned.TypeMeta{Kind: "ThirdPartyResourceData"},
+			},
+			expectErr: true,
+			name:      "broken kind",
+		},
+		{
 			obj: &Foo{
 				ObjectMeta: api.ObjectMeta{Name: "bar", ResourceVersion: "baz"},
 				TypeMeta:   unversioned.TypeMeta{APIVersion: "company.com/v1", Kind: "Foo"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Use the correct variable in the thirdpartyresourcedata codec so it doesn't panic on a nil pointer reference

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #34459

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34461)

<!-- Reviewable:end -->
