### PR TITLE
Move pod analyzer to federated utils

### DIFF
--- a/federation/pkg/federation-controller/deployment/deploymentcontroller.go
+++ b/federation/pkg/federation-controller/deployment/deploymentcontroller.go
@@ -29,10 +29,10 @@ import (
 	fed "k8s.io/kubernetes/federation/apis/federation"
 	fedv1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
-	"k8s.io/kubernetes/federation/pkg/federation-controller/replicaset"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/replicaset/planner"
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/eventsink"
+	"k8s.io/kubernetes/federation/pkg/federation-controller/util/podanalyzer"
 	"k8s.io/kubernetes/pkg/api"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -445,7 +445,7 @@ func (fdc *DeploymentController) reconcileDeployment(key string) (reconciliation
 	if err != nil {
 		return statusError, err
 	}
-	podStatus, err := replicaset.AnalysePods(fd.Spec.Selector, allPods, time.Now())
+	podStatus, err := podanalyzer.AnalysePods(fd.Spec.Selector, allPods, time.Now())
 	current := make(map[string]int64)
 	estimatedCapacity := make(map[string]int64)
 	for _, cluster := range clusters {

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -32,6 +32,7 @@ import (
 	planner "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset/planner"
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/eventsink"
+	"k8s.io/kubernetes/federation/pkg/federation-controller/util/podanalyzer"
 	"k8s.io/kubernetes/pkg/api"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -440,7 +441,7 @@ func (frsc *ReplicaSetController) reconcileReplicaSet(key string) (reconciliatio
 	if err != nil {
 		return statusError, err
 	}
-	podStatus, err := AnalysePods(frs.Spec.Selector, allPods, time.Now())
+	podStatus, err := podanalyzer.AnalysePods(frs.Spec.Selector, allPods, time.Now())
 	current := make(map[string]int64)
 	estimatedCapacity := make(map[string]int64)
 	for _, cluster := range clusters {

--- a/federation/pkg/federation-controller/util/podanalyzer/pod_helper.go
+++ b/federation/pkg/federation-controller/util/podanalyzer/pod_helper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicaset
+package podanalyzer
 
 import (
 	"fmt"

--- a/federation/pkg/federation-controller/util/podanalyzer/pod_helper_test.go
+++ b/federation/pkg/federation-controller/util/podanalyzer/pod_helper_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicaset
+package podanalyzer
 
 import (
 	"testing"


### PR DESCRIPTION
Both replicaset and deployment controllers are using it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34482)

<!-- Reviewable:end -->
