### PR TITLE
Update `gcloud docker` commands to use `gcloud docker -- ARGS`

### DIFF
--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -24,4 +24,4 @@ build:
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push: build
-	gcloud docker --server=gcr.io push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=gcr.io -- push gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -55,6 +55,6 @@ endif
 	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 
 push: build
-	gcloud docker push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
+	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
 
 all: push

--- a/build/kube-dns/Makefile
+++ b/build/kube-dns/Makefile
@@ -60,6 +60,6 @@ container:
 	rm -rf $(TEMP_DIR)
 
 push: container
-	gcloud docker push $(REGISTRY)/kubedns-$(ARCH):$(TAG)
+	gcloud docker -- push $(REGISTRY)/kubedns-$(ARCH):$(TAG)
 
 .PHONY: all container push

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -82,13 +82,13 @@ endif
 
 push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
-	gcloud docker push $(IMAGE):$(TAG)
+	gcloud docker -- push $(IMAGE):$(TAG)
 	touch $@
 
 push-legacy: .push-legacy-$(ARCH)
 .push-legacy-$(ARCH): .container-$(ARCH)
 ifeq ($(ARCH),amd64)
-	gcloud docker push $(LEGACY_AMD64_IMAGE):$(TAG)
+	gcloud docker -- push $(LEGACY_AMD64_IMAGE):$(TAG)
 endif
 	touch $@
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -63,11 +63,11 @@ endif
 	docker build -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 push: build
-	gcloud docker push $(IMAGE)-$(ARCH):$(VERSION)
+	gcloud docker -- push $(IMAGE)-$(ARCH):$(VERSION)
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag
 	docker tag -f $(IMAGE)-$(ARCH):$(VERSION) $(IMAGE):$(VERSION)
-	gcloud docker push $(IMAGE):$(VERSION)
+	gcloud docker -- push $(IMAGE):$(VERSION)
 endif
 
 clean:

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -22,7 +22,7 @@ build:	elasticsearch_logging_discovery
 	docker build -t gcr.io/google_containers/elasticsearch:$(TAG) .
 
 push:
-	gcloud docker push gcr.io/google_containers/elasticsearch:$(TAG)
+	gcloud docker -- push gcr.io/google_containers/elasticsearch:$(TAG)
 
 elasticsearch_logging_discovery:
 	go build elasticsearch_logging_discovery.go

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -17,8 +17,8 @@
 IMAGE = fluentd-elasticsearch
 TAG = 1.19
 
-build:	
+build:
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
-push:	
-	gcloud docker --server=gcr.io push gcr.io/google_containers/$(IMAGE):$(TAG)
+push:
+	gcloud docker --server=gcr.io -- push gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -20,4 +20,4 @@ build:
 	docker build -t gcr.io/google_containers/kibana:$(TAG) .
 
 push:
-	gcloud docker push gcr.io/google_containers/kibana:$(TAG)
+	gcloud docker -- push gcr.io/google_containers/kibana:$(TAG)

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -24,7 +24,7 @@
 # 4. Test etc.
 # 5. Issue PR.
 # 6. When PR is approved make the gcr.io version of the image: make build push
-# 7. Revert the referendes to kubernetes/fluentd-gcp:$(TAG) to gcr.io/google_containers/fluentd-gcp:$(TAG) 
+# 7. Revert the referendes to kubernetes/fluentd-gcp:$(TAG) to gcr.io/google_containers/fluentd-gcp:$(TAG)
 
 .PHONY:	kbuild kpush
 
@@ -47,4 +47,4 @@ build:
 
 
 push:
-	gcloud docker push gcr.io/google_containers/fluentd-gcp:$(TAG)
+	gcloud docker -- push gcr.io/google_containers/fluentd-gcp:$(TAG)

--- a/cluster/addons/python-image/Makefile
+++ b/cluster/addons/python-image/Makefile
@@ -21,5 +21,5 @@ build:
 	docker build -t "$(IMAGE):$(VERSION)" .
 
 push:
-	gcloud docker push "$(IMAGE):$(VERSION)"
+	gcloud docker -- push "$(IMAGE):$(VERSION)"
 

--- a/cluster/addons/registry/images/Makefile
+++ b/cluster/addons/registry/images/Makefile
@@ -21,4 +21,4 @@ build:
 	docker build -t $(REPO):$(TAG) .
 
 push:
-	gcloud docker push $(REPO):$(TAG)
+	gcloud docker -- push $(REPO):$(TAG)

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -29,4 +29,4 @@ build: clean
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 
 push: build
-	gcloud docker push $(IMAGE):$(TAG)
+	gcloud docker -- push $(IMAGE):$(TAG)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -68,7 +68,7 @@ ifeq ($(ARCH),amd64)
 		cp $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$tag; \
 	done
 else
-	
+
 	# Download etcd in a golang container and cross-compile it statically
 	# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
 	for tag in $(TAGS); do \
@@ -98,12 +98,12 @@ endif
 	docker build -t $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(TEMP_DIR)
 
 push: build
-	gcloud docker push $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG)
+	gcloud docker -- push $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG)
 
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag
 	docker tag $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(REGISTRY)/etcd:$(REGISTRY_TAG)
-	gcloud docker push $(REGISTRY)/etcd:$(REGISTRY_TAG)
+	gcloud docker -- push $(REGISTRY)/etcd:$(REGISTRY_TAG)
 endif
 
 all: build

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -105,10 +105,10 @@ endif
 	rm -rf "${TEMP_DIR}"
 
 push: build
-	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
+	gcloud docker -- push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
 	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
-	gcloud docker push ${REGISTRY}/hyperkube:${VERSION}
+	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
 .PHONY: all

--- a/cluster/images/kube-discovery/Makefile
+++ b/cluster/images/kube-discovery/Makefile
@@ -48,6 +48,6 @@ build:
 	rm -rf "${TEMP_DIR}"
 
 push: build
-	gcloud docker push ${REGISTRY}/kube-discovery-${ARCH}:${VERSION}
+	gcloud docker -- push ${REGISTRY}/kube-discovery-${ARCH}:${VERSION}
 
 .PHONY: all

--- a/cluster/images/kubemark/Makefile
+++ b/cluster/images/kubemark/Makefile
@@ -17,6 +17,6 @@
 
 all:
 	docker build -t gcr.io/$(PROJECT)/kubemark .
-	gcloud docker push gcr.io/$(PROJECT)/kubemark
+	gcloud docker -- push gcr.io/$(PROJECT)/kubemark
 
 .PHONY: all

--- a/examples/cluster-dns/images/backend/Makefile
+++ b/examples/cluster-dns/images/backend/Makefile
@@ -22,6 +22,6 @@ image:
 	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/$(IMAGE)
+	gcloud docker -- push $(PREFIX)/$(IMAGE)
 
 clean:

--- a/examples/cluster-dns/images/frontend/Makefile
+++ b/examples/cluster-dns/images/frontend/Makefile
@@ -22,6 +22,6 @@ image:
 	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/$(IMAGE)
+	gcloud docker -- push $(PREFIX)/$(IMAGE)
 
 clean:

--- a/examples/explorer/Makefile
+++ b/examples/explorer/Makefile
@@ -24,7 +24,7 @@ container: explorer
 	docker build -t gcr.io/google_containers/explorer:$(TAG) .
 
 push: container
-	gcloud docker push gcr.io/google_containers/explorer:$(TAG)
+	gcloud docker -- push gcr.io/google_containers/explorer:$(TAG)
 
 clean:
 	rm -f explorer

--- a/examples/guestbook-go/_src/Makefile
+++ b/examples/guestbook-go/_src/Makefile
@@ -28,10 +28,10 @@ build:
 
 # push the image to an registry
 push:
-	gcloud docker push ${REGISTRY}/guestbook:${VERSION}
-	
+	gcloud docker -- push ${REGISTRY}/guestbook:${VERSION}
+
 # remove previous images and containers
-clean: 
+clean:
 	docker rm -f ${REGISTRY}/guestbook-builder 2> /dev/null || true
 	docker rmi -f ${REGISTRY}/guestbook-builder || true
 	docker rmi -f "${REGISTRY}/guestbook:${VERSION}" || true

--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -41,7 +41,7 @@ container:
 
 push: container
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	gcloud docker push gcr.io/google_containers/kubectl:$(TAG)
+	gcloud docker -- push gcr.io/google_containers/kubectl:$(TAG)
 
 clean:
 	rm -f kubectl

--- a/examples/meteor/README.md
+++ b/examples/meteor/README.md
@@ -131,7 +131,7 @@ your app image with your project ID, and push to GCR. Replace
 
 ```
 docker tag my-meteor gcr.io/<project>/my-meteor
-gcloud docker push gcr.io/<project>/my-meteor
+gcloud docker -- push gcr.io/<project>/my-meteor
 ```
 
 Running

--- a/examples/storage/cassandra/image/Makefile
+++ b/examples/storage/cassandra/image/Makefile
@@ -29,6 +29,6 @@ build: kubernetes-cassandra.jar
 	docker build -t ${PROJECT}/cassandra:${VERSION} .
 
 push: build
-	gcloud docker push ${PROJECT}/cassandra:${VERSION}
+	gcloud docker -- push ${PROJECT}/cassandra:${VERSION}
 
 .PHONY: all build push

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -318,7 +318,7 @@ function push-federation-images {
         kube::log::status "Pushing ${docker_image_tag}"
         if [[ "${FEDERATION_PUSH_REPO_BASE}" == "gcr.io/"* ]]; then
             echo " -> GCR repository detected. Using gcloud"
-            gcloud docker push "${docker_image_tag}"
+            gcloud docker -- push "${docker_image_tag}"
         else
             docker push "${docker_image_tag}"
         fi

--- a/federation/develop/develop.sh
+++ b/federation/develop/develop.sh
@@ -127,7 +127,7 @@ function push() {
   fi
 
   kube::log::status "Pushing hyperkube image to the registry"
-  gcloud docker push "${KUBE_REGISTRY}/hyperkube-amd64:${kube_version}"
+  gcloud docker -- push "${KUBE_REGISTRY}/hyperkube-amd64:${kube_version}"
 
   # Update config after build and push, but before turning up the clusters
   # to ensure the config has the right image version tags.

--- a/test/images/clusterapi-tester/Makefile
+++ b/test/images/clusterapi-tester/Makefile
@@ -25,7 +25,7 @@ container: main
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	rm -f main

--- a/test/images/dnsutils/Makefile
+++ b/test/images/dnsutils/Makefile
@@ -22,6 +22,6 @@ image:
 	docker build -t $(PREFIX)/dnsutils .
 
 push: image
-	gcloud docker push $(PREFIX)/dnsutils
+	gcloud docker -- push $(PREFIX)/dnsutils
 
 clean:

--- a/test/images/fakegitserver/Makefile
+++ b/test/images/fakegitserver/Makefile
@@ -24,7 +24,7 @@ image:
 	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/$(IMAGE):$(TAG)
+	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)
 
 all: push
 

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -24,7 +24,7 @@ image: goproxy
 	docker build -t $(PREFIX)/goproxy:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/goproxy:$(TAG)
+	gcloud docker -- push $(PREFIX)/goproxy:$(TAG)
 
 clean:
 	rm -f goproxy

--- a/test/images/hostexec/Makefile
+++ b/test/images/hostexec/Makefile
@@ -24,7 +24,7 @@ image:
 	docker build -t $(PREFIX)/hostexec:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/hostexec:$(TAG)
+	gcloud docker -- push $(PREFIX)/hostexec:$(TAG)
 
 clean:
 	rm -f hostexec

--- a/test/images/iperf/Makefile
+++ b/test/images/iperf/Makefile
@@ -25,7 +25,7 @@ image:
 	docker tag $(PREFIX)/${IMAGE} $(PREFIX)/${IMAGE}:$(TAG) # Add the version tag to the latest image
 
 push: image
-	gcloud docker push $(PREFIX)/${IMAGE} # Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/${IMAGE}:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker -- push $(PREFIX)/${IMAGE} # Push image tagged as latest to repository
+	gcloud docker -- push $(PREFIX)/${IMAGE}:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/jessie-dnsutils/Makefile
+++ b/test/images/jessie-dnsutils/Makefile
@@ -22,6 +22,6 @@ image:
 	docker build -t $(PREFIX)/jessie-dnsutils .
 
 push: image
-	gcloud docker push $(PREFIX)/jessie-dnsutils
+	gcloud docker -- push $(PREFIX)/jessie-dnsutils
 
 clean:

--- a/test/images/mount-tester-user/Makefile
+++ b/test/images/mount-tester-user/Makefile
@@ -21,6 +21,6 @@ image:
 	sudo docker build -t $(PREFIX)/mounttest-user:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/mounttest-user:$(TAG)
+	gcloud docker -- push $(PREFIX)/mounttest-user:$(TAG)
 
 clean:

--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -24,7 +24,7 @@ image: mt
 	sudo docker build -t $(PREFIX)/mounttest:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/mounttest:$(TAG)
+	gcloud docker -- push $(PREFIX)/mounttest:$(TAG)
 
 clean:
 	rm -f mt

--- a/test/images/n-way-http/Makefile
+++ b/test/images/n-way-http/Makefile
@@ -25,7 +25,7 @@ container: server
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	rm -f server

--- a/test/images/netexec/Makefile
+++ b/test/images/netexec/Makefile
@@ -27,7 +27,7 @@ image: netexec
 	docker build -t $(PREFIX)/netexec:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/netexec:$(TAG)
+	gcloud docker -- push $(PREFIX)/netexec:$(TAG)
 
 clean:
 	rm -f netexec

--- a/test/images/network-tester/Makefile
+++ b/test/images/network-tester/Makefile
@@ -26,7 +26,7 @@ image: webserver
 	docker build -t $(PREFIX)/nettest:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/nettest:$(TAG)
+	gcloud docker -- push $(PREFIX)/nettest:$(TAG)
 
 clean:
 	rm -f webserver

--- a/test/images/pets/redis/Makefile
+++ b/test/images/pets/redis/Makefile
@@ -21,7 +21,7 @@ container:
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	docker rmi $(PREFIX):$(TAG)

--- a/test/images/pets/zookeeper/Makefile
+++ b/test/images/pets/zookeeper/Makefile
@@ -21,7 +21,7 @@ container:
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	docker rmi $(PREFIX):$(TAG)

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -24,7 +24,7 @@ image: portforwardtester
 	docker build -t $(PREFIX)/portforwardtester:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/portforwardtester:$(TAG)
+	gcloud docker -- push $(PREFIX)/portforwardtester:$(TAG)
 
 clean:
 	rm -f portforwardtester

--- a/test/images/porter/Makefile
+++ b/test/images/porter/Makefile
@@ -41,7 +41,7 @@ image:
 
 push:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
-	gcloud docker push $(PREFIX)/porter:$(TAG)
+	gcloud docker -- push $(PREFIX)/porter:$(TAG)
 
 clean:
 	rm -f porter

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -32,8 +32,8 @@ run_container:
 	docker run --publish=8080:8080 $(PREFIX)/resource_consumer:$(TAG)
 
 push:
-	gcloud docker push ${PREFIX}/resource_consumer:${TAG}
-	gcloud docker push ${PREFIX}/resource_consumer/controller:${TAG}
+	gcloud docker -- push ${PREFIX}/resource_consumer:${TAG}
+	gcloud docker -- push ${PREFIX}/resource_consumer/controller:${TAG}
 
 clean:
 	rm -f consumer

--- a/test/images/serve_hostname/Makefile
+++ b/test/images/serve_hostname/Makefile
@@ -90,9 +90,9 @@ container: .container-$(ARCH)
 
 push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
-	gcloud docker push $(IMAGE):$(TAG)
+	gcloud docker -- push $(IMAGE):$(TAG)
 	if [ -n "$(TEST_REGISTRY)" ]; then \
-		gcloud docker push $(TEST_IMAGE):$(TAG) ;\
+		gcloud docker -- push $(TEST_IMAGE):$(TAG) ;\
 	fi
 
 clean:

--- a/test/images/volumes-tester/ceph/Makefile
+++ b/test/images/volumes-tester/ceph/Makefile
@@ -24,7 +24,7 @@ image:
 	docker tag $(PREFIX)/volume-ceph $(PREFIX)/volume-ceph:$(TAG)  # Add the version tag to the latest image
 
 push: image
-	gcloud docker push $(PREFIX)/volume-ceph # Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker -- push $(PREFIX)/volume-ceph # Push image tagged as latest to repository
+	gcloud docker -- push $(PREFIX)/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -21,10 +21,10 @@ container: image
 
 image:
 	docker build -t $(PREFIX)/volume-gluster . # Build new image and automatically tag it as latest
-	docker tag $(PREFIX)/volume-gluster $(PREFIX)/volume-gluster:$(TAG)  # Add the version tag to the latest image 
+	docker tag $(PREFIX)/volume-gluster $(PREFIX)/volume-gluster:$(TAG)  # Add the version tag to the latest image
 
 push: image
-	gcloud docker push $(PREFIX)/volume-gluster # Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker -- push $(PREFIX)/volume-gluster # Push image tagged as latest to repository
+	gcloud docker -- push $(PREFIX)/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -34,8 +34,8 @@ block:
 
 push: image
 	# Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/volume-iscsi
+	gcloud docker -- push $(PREFIX)/volume-iscsi
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push $(PREFIX)/volume-iscsi:$(TAG)
+	gcloud docker -- push $(PREFIX)/volume-iscsi:$(TAG)
 
 clean:

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -24,7 +24,7 @@ image:
 	docker tag $(PREFIX)/volume-nfs $(PREFIX)/volume-nfs:$(TAG) # Add the version tag to the latest image
 
 push: image
-	gcloud docker push $(PREFIX)/volume-nfs # Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker -- push $(PREFIX)/volume-nfs # Push image tagged as latest to repository
+	gcloud docker -- push $(PREFIX)/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -22,7 +22,7 @@ container: image
 image:
 	# Build new image and automatically tag it as latest
 	docker build -t $(PREFIX)/volume-rbd .
-	# Add the version tag to the latest image 
+	# Add the version tag to the latest image
 	docker tag $(PREFIX)/volume-rbd $(PREFIX)/volume-rbd:$(TAG)
 
 block:
@@ -34,8 +34,8 @@ block:
 
 push: image
 	# Push image tagged as latest to repository
-	gcloud docker push $(PREFIX)/volume-rbd
+	gcloud docker -- push $(PREFIX)/volume-rbd
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push $(PREFIX)/volume-rbd:$(TAG)
+	gcloud docker -- push $(PREFIX)/volume-rbd:$(TAG)
 
 clean:


### PR DESCRIPTION
We can then avoid the following warning:

```
WARNING: The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right. IMPORTANT: previously, commands allowed the omission of the --, and unparsed arguments were treated as implementation args. This usage is being deprecated and will be removed in March 2017.
This will be strictly enforced in March 2017. Use 'gcloud beta docker' to see new behavior.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34487)

<!-- Reviewable:end -->
