### PR TITLE
Fix lint error in remotecommand.go

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -98,7 +98,7 @@ func NewExecutor(config *restclient.Config, method string, url *url.URL) (Stream
 // to wrap the round tripper. This method may be used by clients that are lower level than
 // Kubernetes clients or need to provide their own upgrade round tripper.
 func NewStreamExecutor(upgrader httpstream.UpgradeRoundTripper, fn func(http.RoundTripper) http.RoundTripper, method string, url *url.URL) (StreamExecutor, error) {
-	var rt http.RoundTripper = upgrader
+	rt := http.RoundTripper(upgrader)
 	if fn != nil {
 		rt = fn(rt)
 	}


### PR DESCRIPTION
Before:

```
pkg/client/unversioned/remotecommand/remotecommand.go:101:9: should omit type http.RoundTripper from declaration of var rt; it will be inferred from the right-hand side

Please fix the above errors. You can test via "golint" and commit the result.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34498)

<!-- Reviewable:end -->
