### PR TITLE
Fix edge case in qos evaluation

### DIFF
--- a/pkg/kubelet/qos/qos.go
+++ b/pkg/kubelet/qos/qos.go
@@ -68,11 +68,13 @@ func GetPodQOS(pod *api.Pod) QOSClass {
 			}
 		}
 		// process limits
+		qosLimitsFound := sets.NewString()
 		for name, quantity := range container.Resources.Limits {
 			if !supportedQoSComputeResources.Has(string(name)) {
 				continue
 			}
 			if quantity.Cmp(zeroQuantity) == 1 {
+				qosLimitsFound.Insert(string(name))
 				delta := quantity.Copy()
 				if _, exists := limits[name]; !exists {
 					limits[name] = *delta
@@ -82,7 +84,8 @@ func GetPodQOS(pod *api.Pod) QOSClass {
 				}
 			}
 		}
-		if len(limits) != len(supportedQoSComputeResources) {
+
+		if len(qosLimitsFound) != len(supportedQoSComputeResources) {
 			isGuaranteed = false
 		}
 	}

--- a/pkg/kubelet/qos/qos_test.go
+++ b/pkg/kubelet/qos/qos_test.go
@@ -136,9 +136,22 @@ func TestGetPodQOS(t *testing.T) {
 			expected: Burstable,
 		},
 		{
+			pod: newPod("burstable-no-limits", []api.Container{
+				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: Burstable,
+		},
+		{
 			pod: newPod("burstable-guaranteed", []api.Container{
 				newContainer("burstable", getResourceList("1", "100Mi"), getResourceList("2", "100Mi")),
 				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			expected: Burstable,
+		},
+		{
+			pod: newPod("burstable-unbounded-but-requests-match-limits", []api.Container{
+				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("200m", "200Mi")),
+				newContainer("burstable-unbounded", getResourceList("100m", "100Mi"), getResourceList("", "")),
 			}),
 			expected: Burstable,
 		},


### PR DESCRIPTION
If a pod has a container C1 and C2, where sum(C1.requests, C2.requests) equals (C1.Limits), the code was reporting that the pod had "Guaranteed" qos, when it should have been Burstable.

/cc @vishh @dchen1107

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34503)

<!-- Reviewable:end -->
