### PR TITLE
Update scheduler perf to spin up similar client to other tests

### DIFF
--- a/test/integration/scheduler_perf/test-performance.sh
+++ b/test/integration/scheduler_perf/test-performance.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../../../..
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../../../
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
@@ -35,15 +35,18 @@ cleanup() {
 trap cleanup EXIT
 
 kube::etcd::start
-kube::log::status "performance test start"
 
 # We are using the benchmark suite to do profiling. Because it only runs a few pods and
 # theoretically it has less variance.
 if ${RUN_BENCHMARK:-false}; then
+  kube::log::status "performance test (benchmark) compiling"
   go test -c -o "perf.test"
+
+  kube::log::status "performance test (benchmark) start"
   "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false
-  kube::log::status "benchmark tests finished"
+  kube::log::status "...benchmark tests finished"
 fi
 # Running density tests. It might take a long time.
+kube::log::status "performance test (density) start"
 go test -test.run=. -test.timeout=60m -test.short=false
-kube::log::status "density tests finished"
+kube::log::status "...density tests finished"


### PR DESCRIPTION
Seems to Fix #34504 .  But I'm not sure what the mechanics of the underlying client objects is all supposed to be.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34506)

<!-- Reviewable:end -->
