### PR TITLE
requests.storage is a standard resource name

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -171,6 +171,7 @@ var standardResources = sets.NewString(
 	string(ResourceConfigMaps),
 	string(ResourcePersistentVolumeClaims),
 	string(ResourceStorage),
+	string(ResourceRequestsStorage),
 )
 
 // IsStandardResourceName returns true if the resource is known to the system

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -6495,6 +6495,12 @@ func TestValidateResourceNames(t *testing.T) {
 	}{
 		{"memory", true, ""},
 		{"cpu", true, ""},
+		{"storage", true, ""},
+		{"requests.cpu", true, ""},
+		{"requests.memory", true, ""},
+		{"requests.storage", true, ""},
+		{"limits.cpu", true, ""},
+		{"limits.memory", true, ""},
 		{"network", false, ""},
 		{"disk", false, ""},
 		{"", false, ""},


### PR DESCRIPTION
The value `requests.storage` is a valid standard resource name but was omitted from the standard list.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34514)

<!-- Reviewable:end -->
