### PR TITLE
remove unused constant

### DIFF
--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -56,8 +56,6 @@ const (
 const (
 	// StatusSuccess represents the successful completion of command.
 	StatusSuccess = "Success"
-	// StatusFailed represents that the command failed.
-	StatusFailure = "Failed"
 	// StatusNotSupported represents that the command is not supported.
 	StatusNotSupported = "Not supported"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

In flexvolume constant definitions, fix typo StatusFailure string to "Failure", not "Failed" at 

https://github.com/kubernetes/kubernetes/blob/b359034817685a8d25bb51bae765308d9d200da0/pkg/volume/flexvolume/flexvolume_util.go#L45

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #
#34510

**Special notes for your reviewer**:
Simple string literal change, but hopefully will prevent future confusion for developers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34515)

<!-- Reviewable:end -->
