### PR TITLE
Fix kubectl create stdin reader

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	"unicode"
 
@@ -52,10 +53,16 @@ type YAMLToJSONDecoder struct {
 // stream in chunks by converting each document (as defined by
 // the YAML spec) into its own chunk, converting it to JSON via
 // yaml.YAMLToJSON, and then passing it to json.Decoder.
-func NewYAMLToJSONDecoder(r io.Reader) *YAMLToJSONDecoder {
+func NewYAMLToJSONDecoder(r io.Reader, bytes []byte, isStdin bool) *YAMLToJSONDecoder {
 	reader := bufio.NewReader(r)
-	return &YAMLToJSONDecoder{
-		reader: NewYAMLReader(reader),
+	if isStdin && sessionIsTTY() {
+		return &YAMLToJSONDecoder{
+			reader: NewYAMLByteReader(bytes),
+		}
+	} else {
+		return &YAMLToJSONDecoder{
+			reader: NewYAMLReader(reader),
+		}
 	}
 }
 
@@ -216,13 +223,14 @@ func NewYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
 func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	if d.decoder == nil {
 		buffer, origData, isJSON := GuessJSONStream(d.r, d.bufferSize)
+		isStdinReader := d.r == os.Stdin
 		if isJSON {
 			glog.V(4).Infof("decoding stream as JSON")
 			d.decoder = json.NewDecoder(buffer)
 			d.rawData = origData
 		} else {
 			glog.V(4).Infof("decoding stream as YAML")
-			d.decoder = NewYAMLToJSONDecoder(buffer)
+			d.decoder = NewYAMLToJSONDecoder(buffer, origData, isStdinReader)
 		}
 	}
 	err := d.decoder.Decode(into)
@@ -263,6 +271,33 @@ func NewYAMLReader(r *bufio.Reader) *YAMLReader {
 	return &YAMLReader{
 		reader: &LineReader{reader: r},
 	}
+}
+
+type YAMLByteReader struct {
+	bytes []byte
+}
+
+func NewYAMLByteReader(b []byte) *YAMLByteReader {
+	return &YAMLByteReader{bytes: b}
+}
+
+func (r *YAMLByteReader) Read() ([]byte, error) {
+	if len(r.bytes) == 0 {
+		return nil, io.EOF
+	}
+
+	var buffer bytes.Buffer
+	var lines = strings.SplitAfter(string(r.bytes), "\n")
+	for _, line := range lines {
+		var lineByte = []byte(line)
+		if line == separator && buffer.Len() != 0 {
+			return buffer.Bytes(), nil
+		} else {
+			buffer.Write(lineByte)
+		}
+	}
+	r.bytes = make([]byte, 0)
+	return buffer.Bytes(), nil
 }
 
 // Read returns a full YAML document.
@@ -343,4 +378,15 @@ func hasJSONPrefix(buf []byte) bool {
 func hasPrefix(buf []byte, prefix []byte) bool {
 	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
 	return bytes.HasPrefix(trim, prefix)
+}
+
+// sessionIsTTY returns true when the Stdin reader is reading from terminal
+// as opposed to having data being piped in
+func sessionIsTTY() bool {
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		return false
+	} else {
+		return true
+	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -106,8 +106,8 @@ func TestDecodeYAML(t *testing.T) {
 	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1
 
----   
-  `)))
+---
+  `)), nil, false)
 	obj := generic{}
 	if err := s.Decode(&obj); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -123,6 +123,30 @@ stuff: 1
 		t.Fatalf("unexpected object: %#v", obj)
 	}
 	obj = generic{}
+	if err := s.Decode(&obj); err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeStdinYAML(t *testing.T) {
+	byteStream := []byte(`---
+stuff: 1
+
+---
+  `)
+	s := NewYAMLToJSONDecoder(nil, byteStream, true)
+	obj := generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":1}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+
+	obj = generic{}
+	if len(obj) != 0 {
+		t.Fatalf("unexpected object: %#v", obj)
+	}
 	if err := s.Decode(&obj); err != io.EOF {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
When running the `kubectl create -f -` command, the Ctrl + D command is not behaving correctly. The EOF character was required twice in order to exit the stdin stream. This is only true when it's an interactive TTY however and not when data is piped in.

Working correctly:
`echo "test: 'yaml'" | kubectl create -f -`

Not working correctly:
`kubectl create -f -`

The issue was also only for the YAML documents, JSON documents are behaving correctly even in a TTY session.

More details can be found here: https://github.com/kubernetes/kubernetes/issues/34345#issuecomment-252455533

**Which issue this PR fixes** : fixes #34345

**Release note**: `NONE`

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34518)

<!-- Reviewable:end -->
