### PR TITLE
controller: set minReadySeconds in deployment's replica sets

### DIFF
--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -42,7 +42,7 @@ func (dc *DeploymentController) rolloutRecreate(deployment *extensions.Deploymen
 	}
 	if scaledDown {
 		// Update DeploymentStatus
-		return dc.updateDeploymentStatus(allRSs, newRS, deployment)
+		return dc.syncDeploymentStatus(allRSs, newRS, deployment)
 	}
 
 	// Wait for all old replica set to scale down to zero.
@@ -67,7 +67,7 @@ func (dc *DeploymentController) rolloutRecreate(deployment *extensions.Deploymen
 	}
 	if scaledUp {
 		// Update DeploymentStatus
-		return dc.updateDeploymentStatus(allRSs, newRS, deployment)
+		return dc.syncDeploymentStatus(allRSs, newRS, deployment)
 	}
 
 	dc.cleanupDeployment(oldRSs, deployment)

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -99,40 +99,6 @@ func newPod(now time.Time, ready bool, beforeSec int) api.Pod {
 	}
 }
 
-func TestCountAvailablePods(t *testing.T) {
-	now := time.Now()
-	tests := []struct {
-		pods            []api.Pod
-		minReadySeconds int
-		expected        int
-	}{
-		{
-			[]api.Pod{
-				newPod(now, true, 0),
-				newPod(now, true, 2),
-				newPod(now, false, 1),
-			},
-			1,
-			1,
-		},
-		{
-			[]api.Pod{
-				newPod(now, true, 2),
-				newPod(now, true, 11),
-				newPod(now, true, 5),
-			},
-			10,
-			1,
-		},
-	}
-
-	for _, test := range tests {
-		if count := countAvailablePods(test.pods, int32(test.minReadySeconds)); int(count) != test.expected {
-			t.Errorf("Pods = %#v, minReadySeconds = %d, expected %d, got %d", test.pods, test.minReadySeconds, test.expected, count)
-		}
-	}
-}
-
 // generatePodFromRS creates a pod, with the input ReplicaSet's selector and its template
 func generatePodFromRS(rs extensions.ReplicaSet) api.Pod {
 	return api.Pod{

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3507,10 +3507,6 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 			}
 		}
 		totalCreated := deploymentutil.GetReplicaCountForReplicaSets(allRSs)
-		totalAvailable, err := deploymentutil.GetAvailablePodsForDeployment(c, deployment)
-		if err != nil {
-			return false, err
-		}
 		maxCreated := deployment.Spec.Replicas + deploymentutil.MaxSurge(*deployment)
 		if totalCreated > maxCreated {
 			reason = fmt.Sprintf("total pods created: %d, more than the max allowed: %d", totalCreated, maxCreated)
@@ -3518,8 +3514,8 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 			return false, nil
 		}
 		minAvailable := deploymentutil.MinAvailable(deployment)
-		if totalAvailable < minAvailable {
-			reason = fmt.Sprintf("total pods available: %d, less than the min required: %d", totalAvailable, minAvailable)
+		if deployment.Status.AvailableReplicas < minAvailable {
+			reason = fmt.Sprintf("total pods available: %d, less than the min required: %d", deployment.Status.AvailableReplicas, minAvailable)
 			Logf(reason)
 			return false, nil
 		}
@@ -3568,10 +3564,6 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 			}
 		}
 		totalCreated := deploymentutil.GetReplicaCountForReplicaSets(allRSs)
-		totalAvailable, err := deploymentutil.GetAvailablePodsForDeployment(c, deployment)
-		if err != nil {
-			return false, err
-		}
 		maxCreated := deployment.Spec.Replicas + deploymentutil.MaxSurge(*deployment)
 		if totalCreated > maxCreated {
 			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
@@ -3579,10 +3571,10 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 			return false, fmt.Errorf("total pods created: %d, more than the max allowed: %d", totalCreated, maxCreated)
 		}
 		minAvailable := deploymentutil.MinAvailable(deployment)
-		if totalAvailable < minAvailable {
+		if deployment.Status.AvailableReplicas < minAvailable {
 			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
 			logPodsOfDeployment(c, deployment)
-			return false, fmt.Errorf("total pods available: %d, less than the min required: %d", totalAvailable, minAvailable)
+			return false, fmt.Errorf("total pods available: %d, less than the min required: %d", deployment.Status.AvailableReplicas, minAvailable)
 		}
 
 		// When the deployment status and its underlying resources reach the desired state, we're done


### PR DESCRIPTION
- Estimate available pods for a deployment by using minReadySeconds on
  the replica set.
- Stop requeueing deployments on pod events, superseded by following the
  replica set status.
- Cleanup redundant deployment utilities

Fixes https://github.com/kubernetes/kubernetes/issues/26079

@kubernetes/deployment ptal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34548)

<!-- Reviewable:end -->
