### PR TITLE
Change legacy API resource registration

### DIFF
--- a/federation/cmd/federation-apiserver/app/core.go
+++ b/federation/cmd/federation-apiserver/app/core.go
@@ -61,12 +61,11 @@ func installCoreAPIs(s *options.ServerRunOptions, g *genericapiserver.GenericAPI
 			v1.SchemeGroupVersion.Version: coreResources,
 		},
 		OptionsExternalVersion: &registered.GroupOrDie(core.GroupName).GroupVersion,
-		IsLegacyGroup:          true,
 		Scheme:                 core.Scheme,
 		ParameterCodec:         core.ParameterCodec,
 		NegotiatedSerializer:   core.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallLegacyAPIGroup(genericapiserver.LegacyAPIPrefix, &apiGroupInfo); err != nil {
 		glog.Fatalf("Error in registering group version: %+v.\n Error: %v\n", apiGroupInfo, err)
 	}
 }

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -56,6 +56,11 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
+const (
+	// LegacyAPIPrefix is where the the legacy APIs will be located
+	LegacyAPIPrefix = "/api"
+)
+
 // Config is a structure used to configure a GenericAPIServer.
 type Config struct {
 	// Destination for audit logs
@@ -73,7 +78,6 @@ type Config struct {
 	EnableProfiling         bool
 	EnableVersion           bool
 	EnableGarbageCollection bool
-	APIPrefix               string
 	APIGroupPrefix          string
 	CorsAllowedOriginList   []string
 	Authenticator           authenticator.Request
@@ -175,6 +179,10 @@ type Config struct {
 
 	// Build the handler chains by decorating the apiHandler.
 	BuildHandlerChainsFunc func(apiHandler http.Handler, c *Config) (secure, insecure http.Handler)
+
+	// LegacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
+	// to InstallLegacyAPIGroup
+	LegacyAPIGroupPrefixes sets.String
 }
 
 type ServingInfo struct {
@@ -234,7 +242,6 @@ func NewConfig(options *options.ServerRunOptions) *Config {
 
 	return &Config{
 		APIGroupPrefix:            options.APIGroupPrefix,
-		APIPrefix:                 options.APIPrefix,
 		CorsAllowedOriginList:     options.CorsAllowedOriginList,
 		AuditWriter:               auditWriter,
 		EnableGarbageCollection:   options.EnableGarbageCollection,
@@ -262,8 +269,9 @@ func NewConfig(options *options.ServerRunOptions) *Config {
 				Version: "unversioned",
 			},
 		},
-		MaxRequestsInFlight: options.MaxRequestsInFlight,
-		LongRunningFunc:     genericfilters.BasicLongRunningRequestCheck(longRunningRE, map[string]string{"watch": "true"}),
+		MaxRequestsInFlight:    options.MaxRequestsInFlight,
+		LongRunningFunc:        genericfilters.BasicLongRunningRequestCheck(longRunningRE, map[string]string{"watch": "true"}),
+		LegacyAPIGroupPrefixes: sets.NewString(LegacyAPIPrefix),
 	}
 }
 
@@ -364,13 +372,13 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	}
 
 	s := &GenericAPIServer{
-		ServiceClusterIPRange: c.ServiceClusterIPRange,
-		LoopbackClientConfig:  c.LoopbackClientConfig,
-		legacyAPIPrefix:       c.APIPrefix,
-		apiPrefix:             c.APIGroupPrefix,
-		admissionControl:      c.AdmissionControl,
-		requestContextMapper:  c.RequestContextMapper,
-		Serializer:            c.Serializer,
+		ServiceClusterIPRange:  c.ServiceClusterIPRange,
+		LoopbackClientConfig:   c.LoopbackClientConfig,
+		apiPrefix:              c.APIGroupPrefix,
+		legacyAPIGroupPrefixes: c.LegacyAPIGroupPrefixes,
+		admissionControl:       c.AdmissionControl,
+		requestContextMapper:   c.RequestContextMapper,
+		Serializer:             c.Serializer,
 
 		minRequestTimeout:    time.Duration(c.MinRequestTimeout) * time.Second,
 		enableSwaggerSupport: c.EnableSwaggerSupport,
@@ -501,8 +509,15 @@ func DefaultAndValidateRunOptions(options *options.ServerRunOptions) {
 }
 
 func NewRequestInfoResolver(c *Config) *request.RequestInfoFactory {
+	apiPrefixes := sets.NewString(strings.Trim(c.APIGroupPrefix, "/")) // all possible API prefixes
+	legacyAPIPrefixes := sets.String{}                                 // APIPrefixes that won't have groups (legacy)
+	for legacyAPIPrefix := range c.LegacyAPIGroupPrefixes {
+		apiPrefixes.Insert(strings.Trim(legacyAPIPrefix, "/"))
+		legacyAPIPrefixes.Insert(strings.Trim(legacyAPIPrefix, "/"))
+	}
+
 	return &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString(strings.Trim(c.APIPrefix, "/"), strings.Trim(c.APIGroupPrefix, "/")), // all possible API prefixes
-		GrouplessAPIPrefixes: sets.NewString(strings.Trim(c.APIPrefix, "/")),                                      // APIPrefixes that won't have groups (legacy)
+		APIPrefixes:          apiPrefixes,
+		GrouplessAPIPrefixes: legacyAPIPrefixes,
 	}
 }

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -49,6 +49,7 @@ import (
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Info about an API group.
@@ -56,8 +57,6 @@ type APIGroupInfo struct {
 	GroupMeta apimachinery.GroupMeta
 	// Info about the resources in this group. Its a map from version to resource to the storage.
 	VersionedResourcesStorageMap map[string]map[string]rest.Storage
-	// True, if this is the legacy group ("/v1").
-	IsLegacyGroup bool
 	// OptionsExternalVersion controls the APIVersion used for common objects in the
 	// schema like api.Status, api.DeleteOptions, and api.ListOptions. Other implementors may
 	// define a version "v1beta1" but want to use the Kubernetes "v1" internal objects.
@@ -102,12 +101,12 @@ type GenericAPIServer struct {
 	// TODO eventually we should be able to factor this out to take place during initialization.
 	enableSwaggerSupport bool
 
-	// legacyAPIPrefix is the prefix used for legacy API groups that existed before we had API groups
-	// usuallly /api
-	legacyAPIPrefix string
-
 	// apiPrefix is the prefix where API groups live, usually /apis
 	apiPrefix string
+
+	// legacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
+	// to InstallLegacyAPIGroup
+	legacyAPIGroupPrefixes sets.String
 
 	// admissionControl is used to build the RESTStorage that backs an API Group.
 	admissionControl admission.Interface
@@ -290,18 +289,9 @@ func (s *GenericAPIServer) Run() {
 	select {}
 }
 
-// Exposes the given api group in the API.
-func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
-	apiPrefix := s.apiPrefix
-	if apiGroupInfo.IsLegacyGroup {
-		apiPrefix = s.legacyAPIPrefix
-	}
-
-	// Install REST handlers for all the versions in this group.
-	apiVersions := []string{}
+// installAPIResources is a private method for installing the REST storage backing each api groupversionresource
+func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *APIGroupInfo) error {
 	for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
-		apiVersions = append(apiVersions, groupVersion.Version)
-
 		apiGroupVersion, err := s.getAPIGroupVersion(apiGroupInfo, groupVersion, apiPrefix)
 		if err != nil {
 			return err
@@ -314,51 +304,77 @@ func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
 			return fmt.Errorf("Unable to setup API %v: %v", apiGroupInfo, err)
 		}
 	}
-	// Install the version handler.
-	if apiGroupInfo.IsLegacyGroup {
-		// Add a handler at /api to enumerate the supported api versions.
-		apiserver.AddApiWebService(s.Serializer, s.HandlerContainer.Container, apiPrefix, func(req *restful.Request) *unversioned.APIVersions {
-			apiVersionsForDiscovery := unversioned.APIVersions{
-				ServerAddressByClientCIDRs: s.getServerAddressByClientCIDRs(req.Request),
-				Versions:                   apiVersions,
-			}
-			return &apiVersionsForDiscovery
-		})
-	} else {
-		// Do not register empty group or empty version.  Doing so claims /apis/ for the wrong entity to be returned.
-		// Catching these here places the error  much closer to its origin
-		if len(apiGroupInfo.GroupMeta.GroupVersion.Group) == 0 {
-			return fmt.Errorf("cannot register handler with an empty group for %#v", *apiGroupInfo)
-		}
-		if len(apiGroupInfo.GroupMeta.GroupVersion.Version) == 0 {
-			return fmt.Errorf("cannot register handler with an empty version for %#v", *apiGroupInfo)
-		}
 
-		// Add a handler at /apis/<groupName> to enumerate all versions supported by this group.
-		apiVersionsForDiscovery := []unversioned.GroupVersionForDiscovery{}
-		for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
-			// Check the config to make sure that we elide versions that don't have any resources
-			if len(apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version]) == 0 {
-				continue
-			}
-			apiVersionsForDiscovery = append(apiVersionsForDiscovery, unversioned.GroupVersionForDiscovery{
-				GroupVersion: groupVersion.String(),
-				Version:      groupVersion.Version,
-			})
-		}
-		preferedVersionForDiscovery := unversioned.GroupVersionForDiscovery{
-			GroupVersion: apiGroupInfo.GroupMeta.GroupVersion.String(),
-			Version:      apiGroupInfo.GroupMeta.GroupVersion.Version,
-		}
-		apiGroup := unversioned.APIGroup{
-			Name:             apiGroupInfo.GroupMeta.GroupVersion.Group,
-			Versions:         apiVersionsForDiscovery,
-			PreferredVersion: preferedVersionForDiscovery,
-		}
+	return nil
+}
 
-		s.AddAPIGroupForDiscovery(apiGroup)
-		s.HandlerContainer.Add(apiserver.NewGroupWebService(s.Serializer, apiPrefix+"/"+apiGroup.Name, apiGroup))
+func (s *GenericAPIServer) InstallLegacyAPIGroup(apiPrefix string, apiGroupInfo *APIGroupInfo) error {
+	if !s.legacyAPIGroupPrefixes.Has(apiPrefix) {
+		return fmt.Errorf("%q is not in the allowed legacy API prefixes: %v", apiPrefix, s.legacyAPIGroupPrefixes.List())
 	}
+	if err := s.installAPIResources(apiPrefix, apiGroupInfo); err != nil {
+		return err
+	}
+
+	// setup discovery
+	apiVersions := []string{}
+	for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
+		apiVersions = append(apiVersions, groupVersion.Version)
+	}
+	// Install the version handler.
+	// Add a handler at /<apiPrefix> to enumerate the supported api versions.
+	apiserver.AddApiWebService(s.Serializer, s.HandlerContainer.Container, apiPrefix, func(req *restful.Request) *unversioned.APIVersions {
+		apiVersionsForDiscovery := unversioned.APIVersions{
+			ServerAddressByClientCIDRs: s.getServerAddressByClientCIDRs(req.Request),
+			Versions:                   apiVersions,
+		}
+		return &apiVersionsForDiscovery
+	})
+	return nil
+}
+
+// Exposes the given api group in the API.
+func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
+	// Do not register empty group or empty version.  Doing so claims /apis/ for the wrong entity to be returned.
+	// Catching these here places the error  much closer to its origin
+	if len(apiGroupInfo.GroupMeta.GroupVersion.Group) == 0 {
+		return fmt.Errorf("cannot register handler with an empty group for %#v", *apiGroupInfo)
+	}
+	if len(apiGroupInfo.GroupMeta.GroupVersion.Version) == 0 {
+		return fmt.Errorf("cannot register handler with an empty version for %#v", *apiGroupInfo)
+	}
+
+	if err := s.installAPIResources(s.apiPrefix, apiGroupInfo); err != nil {
+		return err
+	}
+
+	// setup discovery
+	// Install the version handler.
+	// Add a handler at /apis/<groupName> to enumerate all versions supported by this group.
+	apiVersionsForDiscovery := []unversioned.GroupVersionForDiscovery{}
+	for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
+		// Check the config to make sure that we elide versions that don't have any resources
+		if len(apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version]) == 0 {
+			continue
+		}
+		apiVersionsForDiscovery = append(apiVersionsForDiscovery, unversioned.GroupVersionForDiscovery{
+			GroupVersion: groupVersion.String(),
+			Version:      groupVersion.Version,
+		})
+	}
+	preferedVersionForDiscovery := unversioned.GroupVersionForDiscovery{
+		GroupVersion: apiGroupInfo.GroupMeta.GroupVersion.String(),
+		Version:      apiGroupInfo.GroupMeta.GroupVersion.Version,
+	}
+	apiGroup := unversioned.APIGroup{
+		Name:             apiGroupInfo.GroupMeta.GroupVersion.Group,
+		Versions:         apiVersionsForDiscovery,
+		PreferredVersion: preferedVersionForDiscovery,
+	}
+
+	s.AddAPIGroupForDiscovery(apiGroup)
+	s.HandlerContainer.Add(apiserver.NewGroupWebService(s.Serializer, s.apiPrefix+"/"+apiGroup.Name, apiGroup))
+
 	return nil
 }
 

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -56,7 +56,6 @@ var AuthorizationModeChoices = []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABA
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
 	APIGroupPrefix             string
-	APIPrefix                  string
 	AdmissionControl           string
 	AdmissionControlConfigFile string
 	AdvertiseAddress           net.IP
@@ -125,7 +124,6 @@ type ServerRunOptions struct {
 func NewServerRunOptions() *ServerRunOptions {
 	return &ServerRunOptions{
 		APIGroupPrefix:                           "/apis",
-		APIPrefix:                                "/api",
 		AdmissionControl:                         "AlwaysAdmit",
 		AnonymousAuth:                            true,
 		AuthorizationMode:                        "AlwaysAllow",

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -88,7 +88,7 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	config.GenericConfig.Serializer = api.Codecs
 	config.KubeletClient = client.FakeKubeletClient{}
-	config.GenericConfig.APIPrefix = "/api"
+	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.GenericConfig.APIGroupPrefix = "/apis"
 	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
 	config.GenericConfig.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -96,11 +96,10 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	apiGroupInfo := genericapiserver.APIGroupInfo{
 		GroupMeta:                    *registered.GroupOrDie(api.GroupName),
 		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},
-		IsLegacyGroup:                true,
-		Scheme:                       api.Scheme,
-		ParameterCodec:               api.ParameterCodec,
-		NegotiatedSerializer:         api.Codecs,
-		SubresourceGroupVersionKind:  map[string]unversioned.GroupVersionKind{},
+		Scheme:                      api.Scheme,
+		ParameterCodec:              api.ParameterCodec,
+		NegotiatedSerializer:        api.Codecs,
+		SubresourceGroupVersionKind: map[string]unversioned.GroupVersionKind{},
 	}
 	if autoscalingGroupVersion := (unversioned.GroupVersion{Group: "autoscaling", Version: "v1"}); registered.IsEnabledVersion(autoscalingGroupVersion) {
 		apiGroupInfo.SubresourceGroupVersionKind["replicationcontrollers/scale"] = autoscalingGroupVersion.WithKind("Scale")

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
@@ -346,7 +347,7 @@ func NewMasterConfig() *master.Config {
 	return &master.Config{
 		GenericConfig: &genericapiserver.Config{
 			APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
-			APIPrefix:               "/api",
+			LegacyAPIGroupPrefixes:  sets.NewString("/api"),
 			APIGroupPrefix:          "/apis",
 			Authorizer:              authorizer.NewAlwaysAllowAuthorizer(),
 			AdmissionControl:        admit.NewAlwaysAdmit(),


### PR DESCRIPTION
Updates the legacy API resource registration to emphasize its different-ness and to simplify supporting objects.  The option has to remain in the genericapiserverconfig for multiple prefixes to enable cases where composers/extenders had composed additional groupless APIs. See OpenShift as an example.

However this is now transparent to "normal" composers.

@ncdc since sttts is out.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34551)

<!-- Reviewable:end -->
