### PR TITLE
Add --delete flag when rsyncing into container.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -669,6 +669,7 @@ function kube::build::sync_to_container() {
   V=6 kube::log::status "Running rsync"
   rsync ${rsync_extra} \
     --archive \
+    --delete \
     --prune-empty-dirs \
     --password-file="${LOCAL_OUTPUT_BUILD_CONTEXT}/rsyncd.password" \
     --filter='- /.git/' \


### PR DESCRIPTION
If you delete a source file, we want to reflect that in the build container.  We
only use --delete going that one way as we don't want to accidentally delete
files in the user's source tree.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34553)

<!-- Reviewable:end -->
