### PR TITLE
kubeadm: fix conversion macros and add kubeadm to round trip testing

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/defaults.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package kubeadm
 
 const (
 	DefaultServiceDNSDomain  = "cluster.local"

--- a/cmd/kubeadm/app/apis/kubeadm/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/doc.go
@@ -14,8 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
-
 // +groupName=kubeadm.k8s.io
-package api // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+package kubeadm // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"

--- a/cmd/kubeadm/app/apis/kubeadm/env.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package kubeadm
 
 import (
 	"fmt"

--- a/cmd/kubeadm/app/apis/kubeadm/install/install.go
+++ b/cmd/kubeadm/app/apis/kubeadm/install/install.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/pkg/apimachinery/announced"
+)
+
+func init() {
+	if err := announced.NewGroupMetaFactory(
+		&announced.GroupMetaFactoryArgs{
+			GroupName:                  kubeadm.GroupName,
+			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
+			ImportPrefix:               "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm",
+			AddInternalObjectsToScheme: kubeadm.AddToScheme,
+		},
+		announced.VersionToSchemeFunc{
+			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
+		},
+	).Announce().RegisterAndEnable(); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/kubeadm/app/apis/kubeadm/register.go
+++ b/cmd/kubeadm/app/apis/kubeadm/register.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package kubeadm
 
 import (
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -27,7 +28,7 @@ var (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "kubeadm"
+const GroupName = "kubeadm.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
@@ -47,6 +48,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MasterConfiguration{},
 		&NodeConfiguration{},
 		&ClusterInfo{},
+		&api.ListOptions{},
+		&api.DeleteOptions{},
 	)
 	return nil
 }

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package kubeadm
 
 import "k8s.io/kubernetes/pkg/api/unversioned"
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/doc.go
@@ -14,8 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
-
 // +groupName=kubeadm.k8s.io
 package v1alpha1 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -27,7 +28,7 @@ var (
 )
 
 // GroupName is the group name use in this package
-const GroupName = "kubeadm"
+const GroupName = "kubeadm.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}
@@ -47,6 +48,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MasterConfiguration{},
 		&NodeConfiguration{},
 		&ClusterInfo{},
+		&v1.ListOptions{},
+		&v1.DeleteOptions{},
 	)
 	return nil
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -23,6 +23,7 @@ type MasterConfiguration struct {
 
 	Secrets           Secrets    `json:"secrets"`
 	API               API        `json:"api"`
+	Etcd              Etcd       `json:"etcd"`
 	Networking        Networking `json:"networking"`
 	KubernetesVersion string     `json:"kubernetesVersion"`
 	CloudProvider     string     `json:"cloudProvider"`
@@ -57,6 +58,7 @@ type NodeConfiguration struct {
 	unversioned.TypeMeta
 
 	MasterAddresses []string `json:"masterAddresses"`
+	Secrets         Secrets  `json:"secrets"`
 }
 
 // ClusterInfo TODO add description

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -16,6 +16,7 @@ cmd/kube-dns
 cmd/kube-proxy
 cmd/kubeadm
 cmd/kubeadm
+cmd/kubeadm/app/apis/kubeadm/install
 cmd/kubectl
 cmd/kubelet
 cmd/kubernetes-discovery

--- a/pkg/api/serialization_proto_test.go
+++ b/pkg/api/serialization_proto_test.go
@@ -36,7 +36,9 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-var nonProtobaleAPIGroups = sets.NewString()
+var nonProtobaleAPIGroups = sets.NewString(
+	"kubeadm.k8s.io",
+)
 
 func init() {
 	codecsToTest = append(codecsToTest, func(version unversioned.GroupVersion, item runtime.Object) (runtime.Codec, bool, error) {

--- a/pkg/api/serialization_proto_test.go
+++ b/pkg/api/serialization_proto_test.go
@@ -33,12 +33,18 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/protobuf"
 	"k8s.io/kubernetes/pkg/util/diff"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
+var nonProtobaleAPIGroups = sets.NewString()
+
 func init() {
-	codecsToTest = append(codecsToTest, func(version unversioned.GroupVersion, item runtime.Object) (runtime.Codec, error) {
+	codecsToTest = append(codecsToTest, func(version unversioned.GroupVersion, item runtime.Object) (runtime.Codec, bool, error) {
+		if nonProtobaleAPIGroups.Has(version.Group) {
+			return nil, false, nil
+		}
 		s := protobuf.NewSerializer(api.Scheme, api.Scheme, "application/arbitrary.content.type")
-		return api.Codecs.CodecForVersions(s, s, testapi.ExternalGroupVersions(), nil), nil
+		return api.Codecs.CodecForVersions(s, s, testapi.ExternalGroupVersions(), nil), true, nil
 	})
 }
 

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -30,6 +30,7 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
@@ -47,6 +48,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/recognizer"
 
+	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
 	_ "k8s.io/kubernetes/federation/apis/federation/install"
 	_ "k8s.io/kubernetes/pkg/api/install"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
@@ -247,13 +249,21 @@ func init() {
 			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
 		}
 	}
-
 	if _, ok := Groups[imagepolicy.GroupName]; !ok {
 		externalGroupVersion := unversioned.GroupVersion{Group: imagepolicy.GroupName, Version: registered.GroupOrDie(imagepolicy.GroupName).GroupVersion.Version}
 		Groups[imagepolicy.GroupName] = TestGroup{
 			externalGroupVersion: externalGroupVersion,
 			internalGroupVersion: imagepolicy.SchemeGroupVersion,
 			internalTypes:        api.Scheme.KnownTypes(imagepolicy.SchemeGroupVersion),
+			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
+		}
+	}
+	if _, ok := Groups[kubeadm.GroupName]; !ok {
+		externalGroupVersion := unversioned.GroupVersion{Group: kubeadm.GroupName, Version: registered.GroupOrDie(kubeadm.GroupName).GroupVersion.Version}
+		Groups[kubeadm.GroupName] = TestGroup{
+			externalGroupVersion: externalGroupVersion,
+			internalGroupVersion: kubeadm.SchemeGroupVersion,
+			internalTypes:        api.Scheme.KnownTypes(kubeadm.SchemeGroupVersion),
 			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
 		}
 	}


### PR DESCRIPTION
Tests are probably broken but I'll fix. @jbeda this probably fixes your change unless we decide we need generated deep copies or conversions.

@kubernetes/sig-cluster-lifecycle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34555)

<!-- Reviewable:end -->
