### PR TITLE
split genericapiserver configuration apart so that you can run withou…

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -92,6 +92,13 @@ cluster's shared state through which all other components interact.`,
 func Run(s *options.APIServer) error {
 	genericvalidation.VerifyEtcdServersList(s.ServerRunOptions)
 	genericapiserver.DefaultAndValidateRunOptions(s.ServerRunOptions)
+	genericConfig := genericapiserver.NewConfig(). // create the new config
+							ApplyOptions(s.ServerRunOptions). // apply the options selected
+							Complete()                        // set default values based on the known values
+
+	if err := genericConfig.MaybeGenerateServingCerts(); err != nil {
+		glog.Fatalf("Failed to generate service certificate: %v", err)
+	}
 
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: s.AllowPrivileged,
@@ -322,8 +329,6 @@ func Run(s *options.APIServer) error {
 		glog.Fatalf("Failed to initialize plugins: %v", err)
 	}
 
-	genericConfig := genericapiserver.NewConfig(s.ServerRunOptions)
-	// TODO: Move the following to generic api server as well.
 	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0
@@ -341,7 +346,7 @@ func Run(s *options.APIServer) error {
 	genericConfig.EnableOpenAPISupport = true
 
 	config := &master.Config{
-		GenericConfig: genericConfig,
+		GenericConfig: genericConfig.Config,
 
 		StorageFactory:          storageFactory,
 		EnableWatchCache:        s.EnableWatchCache,

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -67,10 +67,15 @@ func Run(serverOptions *genericoptions.ServerRunOptions) error {
 	serverOptions.StorageConfig.ServerList = []string{"http://127.0.0.1:2379"}
 	genericvalidation.ValidateRunOptions(serverOptions)
 	genericvalidation.VerifyEtcdServersList(serverOptions)
-	config := genericapiserver.NewConfig(serverOptions)
+	config := genericapiserver.NewConfig().ApplyOptions(serverOptions).Complete()
+	if err := config.MaybeGenerateServingCerts(); err != nil {
+		// this wasn't treated as fatal for this process before
+		fmt.Printf("Error creating cert: %v", err)
+	}
+
 	config.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
 	config.Serializer = api.Codecs
-	s, err := config.Complete().New()
+	s, err := config.New()
 	if err != nil {
 		return fmt.Errorf("Error in bringing up the server: %v", err)
 	}

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -50,7 +50,7 @@ import (
 func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdServer, _ := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 
-	config := Config{}
+	config := NewConfig()
 	config.PublicAddress = net.ParseIP("192.168.10.4")
 	config.RequestContextMapper = api.NewRequestContextMapper()
 	config.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
@@ -59,7 +59,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.APIGroupPrefix = "/apis"
 
-	return etcdServer, config, assert.New(t)
+	return etcdServer, *config, assert.New(t)
 }
 
 func newMaster(t *testing.T) (*GenericAPIServer, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
@@ -84,7 +84,6 @@ func TestNew(t *testing.T) {
 	assert.Equal(s.apiPrefix, config.APIGroupPrefix)
 	assert.Equal(s.admissionControl, config.AdmissionControl)
 	assert.Equal(s.RequestContextMapper(), config.RequestContextMapper)
-	assert.Equal(s.ClusterIP, config.PublicAddress)
 
 	// these values get defaulted
 	_, serviceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")
@@ -109,7 +108,7 @@ func TestInstallAPIGroups(t *testing.T) {
 	config.LegacyAPIGroupPrefixes = sets.NewString("/apiPrefix")
 	config.APIGroupPrefix = "/apiGroupPrefix"
 
-	s, err := config.Complete().New()
+	s, err := config.SkipComplete().New()
 	if err != nil {
 		t.Fatalf("Error in bringing up the server: %v", err)
 	}
@@ -179,7 +178,7 @@ func TestCustomHandlerChain(t *testing.T) {
 		called = true
 	})
 
-	s, err := config.Complete().New()
+	s, err := config.SkipComplete().New()
 	if err != nil {
 		t.Fatalf("Error in bringing up the server: %v", err)
 	}
@@ -235,7 +234,7 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 	config.EnableSwaggerSupport = true
 	config.EnableVersion = true
 
-	s, err := config.Complete().New()
+	s, err := config.SkipComplete().New()
 	if err != nil {
 		t.Fatalf("Error in bringing up the server: %v", err)
 	}
@@ -311,7 +310,6 @@ func TestInstallSwaggerAPI(t *testing.T) {
 	mux = http.NewServeMux()
 	server.HandlerContainer = genericmux.NewAPIContainer(mux, nil)
 	server.ExternalAddress = ""
-	server.ClusterIP = net.IPv4(10, 10, 10, 10)
 	server.InstallSwaggerAPI()
 	if assert.NotEqual(0, len(ws), "SwaggerAPI not installed.") {
 		assert.Equal("/swaggerapi/", ws[0].RootPath(), "SwaggerAPI did not install to the proper path. %s != /swaggerapi", ws[0].RootPath())

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	// TODO: This can be tightened up. It still matches objects named watch or proxy.
-	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
+	DefaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
 )
 
 var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
@@ -139,7 +139,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		EnableWatchCache:                         true,
 		InsecureBindAddress:                      net.ParseIP("127.0.0.1"),
 		InsecurePort:                             8080,
-		LongRunningRequestRE:                     defaultLongRunningRequestRE,
+		LongRunningRequestRE:                     DefaultLongRunningRequestRE,
 		MasterCount:                              1,
 		MasterServiceNamespace:                   api.NamespaceDefault,
 		MaxRequestsInFlight:                      400,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -49,7 +49,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/restclient"
 	openapigen "k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
-	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -71,9 +70,7 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	server, storageConfig := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 
 	config := &Config{
-		GenericConfig: &genericapiserver.Config{
-			OpenAPIConfig: &common.Config{},
-		},
+		GenericConfig: genericapiserver.NewConfig(),
 	}
 
 	resourceEncoding := genericapiserver.NewDefaultResourceEncodingConfig()
@@ -163,10 +160,6 @@ func newLimitedMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Confi
 func TestNew(t *testing.T) {
 	master, etcdserver, config, assert := newMaster(t)
 	defer etcdserver.Terminate(t)
-
-	// Verify many of the variables match their config counterparts
-	assert.Equal(master.GenericAPIServer.RequestContextMapper(), config.GenericConfig.RequestContextMapper)
-	assert.Equal(master.GenericAPIServer.ClusterIP, config.GenericConfig.PublicAddress)
 
 	// these values get defaulted
 	_, serviceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")


### PR DESCRIPTION
…t flag options

@dims Take a look at this re-slicing of the `genericapiserver.Config` creation.   I think this helps composers overall and resolves the chicken/egg problem you were having.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34556)

<!-- Reviewable:end -->
