### PR TITLE
Fix race condition in test with git server startup

### DIFF
--- a/test/e2e/empty_dir_wrapper.go
+++ b/test/e2e/empty_dir_wrapper.go
@@ -120,14 +120,7 @@ var _ = framework.KubeDescribe("EmptyDir wrapper volumes", func() {
 				},
 			},
 		}
-
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		if err != nil {
-			framework.Failf("unable to create pod %v: %v", pod.Name, err)
-		}
-
-		err = f.WaitForPodRunning(pod.Name)
-		Expect(err).NotTo(HaveOccurred(), "Failed waiting for pod %s to enter running state", pod.Name)
+		pod = f.PodClient().CreateSync(pod)
 
 		defer func() {
 			By("Cleaning up the secret")
@@ -139,8 +132,6 @@ var _ = framework.KubeDescribe("EmptyDir wrapper volumes", func() {
 				framework.Failf("unable to delete git vol pod %v: %v", pod.Name, err)
 			}
 		}()
-
-		framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod))
 	})
 
 	// The following two tests check for the problem fixed in #29641.
@@ -204,10 +195,7 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 			},
 		},
 	}
-
-	if gitServerPod, err = f.Client.Pods(f.Namespace.Name).Create(gitServerPod); err != nil {
-		framework.Failf("unable to create test git server pod %s: %v", gitServerPod.Name, err)
-	}
+	f.PodClient().CreateSync(gitServerPod)
 
 	// Portal IP and port
 	httpPort := 2345


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/32467 (hopefully)

Previously, the test didn't ensure the git server was running before attempting to connect to it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34565)

<!-- Reviewable:end -->
