### PR TITLE
Test API more extensivelly before declaring readiness 

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -34,6 +34,7 @@ const (
 	KubeDNSImage         = "kube-dns"
 	KubeDNSmasqImage     = "dnsmasq"
 	KubeExechealthzImage = "exechealthz"
+	Pause                = "pause"
 
 	gcrPrefix   = "gcr.io/google_containers"
 	etcdVersion = "2.2.5"
@@ -41,6 +42,7 @@ const (
 	kubeDNSVersion     = "1.7"
 	dnsmasqVersion     = "1.3"
 	exechealthzVersion = "1.1"
+	pauseVersion       = "3.0"
 )
 
 func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideImage string) string {
@@ -62,5 +64,6 @@ func GetAddonImage(image string) string {
 		KubeDNSImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kubedns", runtime.GOARCH, kubeDNSVersion),
 		KubeDNSmasqImage:     fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-dnsmasq", runtime.GOARCH, dnsmasqVersion),
 		KubeExechealthzImage: fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "exechealthz", runtime.GOARCH, exechealthzVersion),
+		Pause:                fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "pause", runtime.GOARCH, pauseVersion),
 	}[image]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It's possible that first deployment kubeadm creates will hit `deployments.extensions "kube-discovery" is forbidden: not yet ready to handle request`, which comes from NamespaceLifecycle admission controller and has something to do with cache. According to @derekwaynecarr, we need to create a namespace-scoped resource to really check for this. I didn't want to make a check with deployment of whatever comes first right now, and decided to have explicit step for this in `apiclient.go`.

**Which issue this PR fixes**: fixes #34411

**Special notes for your reviewer**: @kubernetes/sig-cluster-lifecycle 

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34573)

<!-- Reviewable:end -->
