### PR TITLE
CRI: Change dockershim to use UnixNano instead of Unix.

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -280,7 +280,7 @@ func (ds *dockerService) ContainerStatus(containerID string) (*runtimeApi.Contai
 	}
 
 	// Convert to unix timestamps.
-	ct, st, ft := createdAt.Unix(), startedAt.Unix(), finishedAt.Unix()
+	ct, st, ft := createdAt.UnixNano(), startedAt.UnixNano(), finishedAt.UnixNano()
 	exitCode := int32(r.State.ExitCode)
 
 	metadata, err := parseContainerName(r.Name)

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -101,7 +101,7 @@ func TestContainerStatus(t *testing.T) {
 	config := makeContainerConfig(sConfig, "pause", "iamimage", 0, labels, annotations)
 
 	var defaultTime time.Time
-	dt := defaultTime.Unix()
+	dt := defaultTime.UnixNano()
 	ct, st, ft := dt, dt, dt
 	state := runtimeApi.ContainerState_CREATED
 	// The following variables are not set in FakeDockerClient.
@@ -127,7 +127,7 @@ func TestContainerStatus(t *testing.T) {
 
 	// Create the container.
 	fClock.SetTime(time.Now().Add(-1 * time.Hour))
-	*expected.CreatedAt = fClock.Now().Unix()
+	*expected.CreatedAt = fClock.Now().UnixNano()
 	const sandboxId = "sandboxid"
 	id, err := ds.CreateContainer(sandboxId, config, sConfig)
 
@@ -146,7 +146,7 @@ func TestContainerStatus(t *testing.T) {
 
 	// Advance the clock and start the container.
 	fClock.SetTime(time.Now())
-	*expected.StartedAt = fClock.Now().Unix()
+	*expected.StartedAt = fClock.Now().UnixNano()
 	*expected.State = runtimeApi.ContainerState_RUNNING
 
 	err = ds.StartContainer(id)
@@ -156,7 +156,7 @@ func TestContainerStatus(t *testing.T) {
 
 	// Advance the clock and stop the container.
 	fClock.SetTime(time.Now().Add(1 * time.Hour))
-	*expected.FinishedAt = fClock.Now().Unix()
+	*expected.FinishedAt = fClock.Now().UnixNano()
 	*expected.State = runtimeApi.ContainerState_EXITED
 	*expected.Reason = "Completed"
 

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -102,7 +102,7 @@ func (ds *dockerService) PodSandboxStatus(podSandboxID string) (*runtimeApi.PodS
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse timestamp for container %q: %v", podSandboxID, err)
 	}
-	ct := createdAt.Unix()
+	ct := createdAt.UnixNano()
 
 	// Translate container to sandbox state.
 	state := runtimeApi.PodSandBoxState_NOTREADY

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -111,7 +111,7 @@ func TestSandboxStatus(t *testing.T) {
 
 	// Create the sandbox.
 	fClock.SetTime(time.Now())
-	*expected.CreatedAt = fClock.Now().Unix()
+	*expected.CreatedAt = fClock.Now().UnixNano()
 	id, err := ds.RunPodSandbox(config)
 
 	// Check internal labels


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/34492.

This PR changes the dockershim to use `UnixNano` instead of `Unix` to return timestamp in nanoseconds.

@yujuhong

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34574)

<!-- Reviewable:end -->
