### PR TITLE
Convert more tests to use the PodClient interface

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -98,6 +98,9 @@ type Framework struct {
 	// Federation specific params. These are set only if federated = true.
 	FederationClientset_1_5 *federation_release_1_5.Clientset
 	FederationNamespace     *v1.Namespace
+
+	// Cached PodClient
+	podClient *PodClient
 }
 
 type TestDataSummary interface {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -666,14 +666,13 @@ func (f *Framework) CreatePodsPerNodeForSimpleApp(appName string, podSpec func(n
 		// one per node, but no more than maxCount.
 		if i <= maxCount {
 			Logf("%v/%v : Creating container with label app=%v-pod", i, maxCount, appName)
-			_, err := f.Client.Pods(f.Namespace.Name).Create(&api.Pod{
+			f.PodClient().Create(&api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Name:   fmt.Sprintf(appName+"-pod-%v", i),
 					Labels: labels,
 				},
 				Spec: podSpec(node),
 			})
-			ExpectNoError(err)
 		}
 	}
 	return labels

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -41,10 +41,13 @@ var ImageWhiteList sets.String
 // possibly applying test-suite specific transformations to the pod spec, e.g. for
 // node e2e pod scheduling.
 func (f *Framework) PodClient() *PodClient {
-	return &PodClient{
-		f:            f,
-		PodInterface: f.Client.Pods(f.Namespace.Name),
+	if f.podClient == nil {
+		f.podClient = &PodClient{
+			f:            f,
+			PodInterface: f.Client.Pods(f.Namespace.Name),
+		}
 	}
+	return f.podClient
 }
 
 type PodClient struct {

--- a/test/e2e/initial_resources.go
+++ b/test/e2e/initial_resources.go
@@ -65,8 +65,5 @@ func runPod(f *framework.Framework, name, image string) *api.Pod {
 			},
 		},
 	}
-	createdPod, err := f.Client.Pods(f.Namespace.Name).Create(pod)
-	framework.ExpectNoError(err)
-	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, createdPod))
-	return createdPod
+	return f.PodClient().Create(pod)
 }

--- a/test/e2e/limit_range.go
+++ b/test/e2e/limit_range.go
@@ -54,8 +54,7 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 
 		By("Creating a Pod with no resource requirements")
 		pod := newTestPod(f, "pod-no-resources", api.ResourceList{}, api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 
 		By("Ensuring Pod has resource requirements applied from LimitRange")
 		pod, err = f.Client.Pods(f.Namespace.Name).Get(pod.Name)
@@ -71,8 +70,7 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 
 		By("Creating a Pod with partial resource requirements")
 		pod = newTestPod(f, "pod-partial-resources", getResourceList("", "150Mi"), getResourceList("300m", ""))
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 
 		By("Ensuring Pod has merged resource requirements applied from LimitRange")
 		pod, err = f.Client.Pods(f.Namespace.Name).Get(pod.Name)
@@ -92,13 +90,11 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 
 		By("Failing to create a Pod with less than min resources")
 		pod = newTestPod(f, podName, getResourceList("10m", "50Mi"), api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).To(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 
 		By("Failing to create a Pod with more than max resources")
 		pod = newTestPod(f, podName, getResourceList("600m", "600Mi"), api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).To(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 	})
 
 })

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -102,11 +102,7 @@ func ensurePodsAreRemovedWhenNamespaceIsDeleted(f *framework.Framework) {
 			},
 		},
 	}
-	pod, err = f.Client.Pods(namespace.Name).Create(pod)
-	Expect(err).NotTo(HaveOccurred())
-
-	By("Waiting for the pod to have running status")
-	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod))
+	pod = f.PodClient().CreateSync(pod)
 
 	By("Deleting the namespace")
 	err = f.Client.Namespaces().Delete(namespace.Name)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -305,15 +305,14 @@ var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func(
 				NodeName: node.Name,
 			},
 		}
-		pod, err := f.Client.Pods(f.Namespace.Name).Create(pod)
-		framework.ExpectNoError(err)
+		pod = f.PodClient().Create(pod)
 
 		By("creating petset with conflicting port in namespace " + f.Namespace.Name)
 		ps := newPetSet(petSetName, f.Namespace.Name, headlessSvcName, 1, nil, nil, labels)
 		petContainer := &ps.Spec.Template.Spec.Containers[0]
 		petContainer.Ports = append(petContainer.Ports, conflictingPort)
 		ps.Spec.Template.Spec.NodeName = node.Name
-		_, err = f.Client.Apps().PetSets(f.Namespace.Name).Create(ps)
+		_, err := f.Client.Apps().PetSets(f.Namespace.Name).Create(ps)
 		framework.ExpectNoError(err)
 
 		By("waiting until pod " + podName + " will start running in namespace " + f.Namespace.Name)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -305,7 +305,7 @@ var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func(
 				NodeName: node.Name,
 			},
 		}
-		pod = f.PodClient().Create(pod)
+		pod = f.PodClient().CreateSync(pod)
 
 		By("creating petset with conflicting port in namespace " + f.Namespace.Name)
 		ps := newPetSet(petSetName, f.Namespace.Name, headlessSvcName, 1, nil, nil, labels)
@@ -314,11 +314,6 @@ var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func(
 		ps.Spec.Template.Spec.NodeName = node.Name
 		_, err := f.Client.Apps().PetSets(f.Namespace.Name).Create(ps)
 		framework.ExpectNoError(err)
-
-		By("waiting until pod " + podName + " will start running in namespace " + f.Namespace.Name)
-		if err := f.WaitForPodRunning(podName); err != nil {
-			framework.Failf("Pod %v did not start running: %v", podName, err)
-		}
 
 		var initialPetPodUID types.UID
 		By("waiting until pet pod " + petPodName + " will be recreated and deleted at least once in namespace " + f.Namespace.Name)

--- a/test/e2e/pod_gc.go
+++ b/test/e2e/pod_gc.go
@@ -36,10 +36,10 @@ var _ = framework.KubeDescribe("Pod garbage collector [Feature:PodGarbageCollect
 	It("should handle the creation of 1000 pods", func() {
 		var count int
 		for count < 1000 {
-			pod, err := createTerminatingPod(f)
+			pod := createTerminatingPod(f)
 			pod.ResourceVersion = ""
 			pod.Status.Phase = api.PodFailed
-			pod, err = f.Client.Pods(f.Namespace.Name).UpdateStatus(pod)
+			pod, err := f.Client.Pods(f.Namespace.Name).UpdateStatus(pod)
 			if err != nil {
 				framework.Failf("err failing pod: %v", err)
 			}
@@ -78,7 +78,7 @@ var _ = framework.KubeDescribe("Pod garbage collector [Feature:PodGarbageCollect
 	})
 })
 
-func createTerminatingPod(f *framework.Framework) (*api.Pod, error) {
+func createTerminatingPod(f *framework.Framework) *api.Pod {
 	uuid := uuid.NewUUID()
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
@@ -96,5 +96,5 @@ func createTerminatingPod(f *framework.Framework) (*api.Pod, error) {
 			},
 		},
 	}
-	return f.Client.Pods(f.Namespace.Name).Create(pod)
+	return f.PodClient().Create(pod)
 }

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -177,12 +177,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 		It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("abc", "1", "1", "1")
-			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
-				framework.Failf("Couldn't create pod: %v", err)
-			}
-			if err := f.WaitForPodRunning(pod.Name); err != nil {
-				framework.Failf("Pod did not start running: %v", err)
-			}
+			f.PodClient().CreateSync(pod)
 			defer func() {
 				logs, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 				if err != nil {
@@ -222,12 +217,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 		It("should support a client that connects, sends data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("abc", "10", "10", "100")
-			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
-				framework.Failf("Couldn't create pod: %v", err)
-			}
-			if err := f.WaitForPodRunning(pod.Name); err != nil {
-				framework.Failf("Pod did not start running: %v", err)
-			}
+			f.PodClient().CreateSync(pod)
 			defer func() {
 				logs, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 				if err != nil {
@@ -290,12 +280,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 		It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("", "10", "10", "100")
-			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
-				framework.Failf("Couldn't create pod: %v", err)
-			}
-			if err := f.WaitForPodRunning(pod.Name); err != nil {
-				framework.Failf("Pod did not start running: %v", err)
-			}
+			f.PodClient().CreateSync(pod)
 			defer func() {
 				logs, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 				if err != nil {

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -150,9 +150,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		requests := api.ResourceList{}
 		requests[api.ResourceCPU] = resource.MustParse("500m")
 		requests[api.ResourceMemory] = resource.MustParse("252Mi")
-		pod := newTestPodForQuota(f, podName, requests, api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod := f.PodClient().Create(newTestPodForQuota(f, podName, requests, api.ResourceList{}))
 		podToUpdate := pod
 
 		By("Ensuring ResourceQuota status captures the pod usage")
@@ -167,9 +165,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		requests = api.ResourceList{}
 		requests[api.ResourceCPU] = resource.MustParse("600m")
 		requests[api.ResourceMemory] = resource.MustParse("100Mi")
-		pod = newTestPodForQuota(f, "fail-pod", requests, api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).To(HaveOccurred())
+		pod = f.PodClient().Create(newTestPodForQuota(f, "fail-pod", requests, api.ResourceList{}))
 
 		By("Ensuring a pod cannot update its resource requirements")
 		// a pod cannot dynamically update its resource requirements.
@@ -334,9 +330,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		limits := api.ResourceList{}
 		limits[api.ResourceCPU] = resource.MustParse("1")
 		limits[api.ResourceMemory] = resource.MustParse("400Mi")
-		pod := newTestPodForQuota(f, podName, requests, limits)
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod := f.PodClient().Create(newTestPodForQuota(f, podName, requests, limits))
 
 		By("Ensuring resource quota with not terminating scope captures the pod usage")
 		usedResources[api.ResourcePods] = resource.MustParse("1")
@@ -374,8 +368,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		pod = newTestPodForQuota(f, podName, requests, limits)
 		activeDeadlineSeconds := int64(3600)
 		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 
 		By("Ensuring resource quota with terminating scope captures the pod usage")
 		usedResources[api.ResourcePods] = resource.MustParse("1")
@@ -430,8 +423,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 
 		By("Creating a best-effort pod")
 		pod := newTestPodForQuota(f, podName, api.ResourceList{}, api.ResourceList{})
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod = f.PodClient().Create(pod)
 
 		By("Ensuring resource quota with best effort scope captures the pod usage")
 		usedResources[api.ResourcePods] = resource.MustParse("1")
@@ -459,9 +451,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		limits := api.ResourceList{}
 		limits[api.ResourceCPU] = resource.MustParse("1")
 		limits[api.ResourceMemory] = resource.MustParse("400Mi")
-		pod = newTestPodForQuota(f, "burstable-pod", requests, limits)
-		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
-		Expect(err).NotTo(HaveOccurred())
+		pod = f.PodClient().Create(newTestPodForQuota(f, "burstable-pod", requests, limits))
 
 		By("Ensuring resource quota with not best effort scope captures the pod usage")
 		usedResources[api.ResourcePods] = resource.MustParse("1")

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -128,19 +128,19 @@ var _ = framework.KubeDescribe("Services", func() {
 		name1 := "pod1"
 		name2 := "pod2"
 
-		createPodOrFail(c, ns, name1, labels, []api.ContainerPort{{ContainerPort: 80}})
+		createPodOrFail(f, name1, labels, []api.ContainerPort{{ContainerPort: 80}})
 		names[name1] = true
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{name1: {80}})
 
-		createPodOrFail(c, ns, name2, labels, []api.ContainerPort{{ContainerPort: 80}})
+		createPodOrFail(f, name2, labels, []api.ContainerPort{{ContainerPort: 80}})
 		names[name2] = true
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{name1: {80}, name2: {80}})
 
-		deletePodOrFail(c, ns, name1)
+		deletePodOrFail(f, name1)
 		delete(names, name1)
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{name2: {80}})
 
-		deletePodOrFail(c, ns, name2)
+		deletePodOrFail(f, name2)
 		delete(names, name2)
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{})
 	})
@@ -212,19 +212,19 @@ var _ = framework.KubeDescribe("Services", func() {
 		podname1 := "pod1"
 		podname2 := "pod2"
 
-		createPodOrFail(c, ns, podname1, labels, containerPorts1)
+		createPodOrFail(f, podname1, labels, containerPorts1)
 		names[podname1] = true
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{podname1: {port1}})
 
-		createPodOrFail(c, ns, podname2, labels, containerPorts2)
+		createPodOrFail(f, podname2, labels, containerPorts2)
 		names[podname2] = true
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{podname1: {port1}, podname2: {port2}})
 
-		deletePodOrFail(c, ns, podname1)
+		deletePodOrFail(f, podname1)
 		delete(names, podname1)
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{podname2: {port2}})
 
-		deletePodOrFail(c, ns, podname2)
+		deletePodOrFail(f, podname2)
 		delete(names, podname2)
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{})
 	})
@@ -303,10 +303,10 @@ var _ = framework.KubeDescribe("Services", func() {
 		host := hosts[0]
 
 		By("verifying service1 is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
 
 		By("verifying service2 is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 
 		// Stop service 1 and make sure it is gone.
 		By("stopping service1")
@@ -315,7 +315,7 @@ var _ = framework.KubeDescribe("Services", func() {
 		By("verifying service1 is not up")
 		framework.ExpectNoError(verifyServeHostnameServiceDown(c, host, svc1IP, servicePort))
 		By("verifying service2 is still up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 
 		// Start another service and verify both are up.
 		By("creating service3 in namespace " + ns)
@@ -327,10 +327,10 @@ var _ = framework.KubeDescribe("Services", func() {
 		}
 
 		By("verifying service2 is still up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 
 		By("verifying service3 is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames3, svc3IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames3, svc3IP, servicePort))
 	})
 
 	It("should work after restarting kube-proxy [Disruptive]", func() {
@@ -362,15 +362,15 @@ var _ = framework.KubeDescribe("Services", func() {
 		}
 		host := hosts[0]
 
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 
 		By(fmt.Sprintf("Restarting kube-proxy on %v", host))
 		if err := framework.RestartKubeProxy(host); err != nil {
 			framework.Failf("error restarting kube-proxy: %v", err)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 
 		By("Removing iptable rules")
 		result, err := framework.SSH(`
@@ -381,8 +381,8 @@ var _ = framework.KubeDescribe("Services", func() {
 			framework.LogSSHResult(result)
 			framework.Failf("couldn't remove iptable rules: %v", err)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 	})
 
 	It("should work after restarting apiserver [Disruptive]", func() {
@@ -403,7 +403,7 @@ var _ = framework.KubeDescribe("Services", func() {
 		}
 		host := hosts[0]
 
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
 
 		// Restart apiserver
 		By("Restarting apiserver")
@@ -414,7 +414,7 @@ var _ = framework.KubeDescribe("Services", func() {
 		if err := framework.WaitForApiserverUp(c); err != nil {
 			framework.Failf("error while waiting for apiserver up: %v", err)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
 
 		// Create a new service and check if it's not reusing IP.
 		defer func() { framework.ExpectNoError(stopServeHostnameService(c, f.ClientSet, ns, "service2")) }()
@@ -424,8 +424,8 @@ var _ = framework.KubeDescribe("Services", func() {
 		if svc1IP == svc2IP {
 			framework.Failf("VIPs conflict: %v", svc1IP)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f, host, podNames2, svc2IP, servicePort))
 	})
 
 	// TODO: Run this test against the userspace proxy and nodes
@@ -1055,7 +1055,7 @@ var _ = framework.KubeDescribe("Services", func() {
 		svcName := fmt.Sprintf("%v.%v", serviceName, f.Namespace.Name)
 		By("waiting for endpoints of Service with DNS name " + svcName)
 
-		execPodName := createExecPodOrFail(f.Client, f.Namespace.Name, "execpod-")
+		execPodName := createExecPodOrFail(f, "execpod-")
 		cmd := fmt.Sprintf("wget -qO- %v", svcName)
 		var stdout string
 		if pollErr := wait.PollImmediate(framework.Poll, kubeProxyLagTimeout, func() (bool, error) {
@@ -1304,43 +1304,25 @@ func newExecPodSpec(ns, generateName string) *api.Pod {
 // createExecPodOrFail creates a simple busybox pod in a sleep loop used as a
 // vessel for kubectl exec commands.
 // Returns the name of the created pod.
-func createExecPodOrFail(client *client.Client, ns, generateName string) string {
+func createExecPodOrFail(f *framework.Framework, generateName string) string {
 	framework.Logf("Creating new exec pod")
-	execPod := newExecPodSpec(ns, generateName)
-	created, err := client.Pods(ns).Create(execPod)
-	Expect(err).NotTo(HaveOccurred())
-	err = wait.PollImmediate(framework.Poll, 5*time.Minute, func() (bool, error) {
-		retrievedPod, err := client.Pods(execPod.Namespace).Get(created.Name)
-		if err != nil {
-			return false, nil
-		}
-		return retrievedPod.Status.Phase == api.PodRunning, nil
-	})
-	Expect(err).NotTo(HaveOccurred())
-	return created.Name
+	execPod := newExecPodSpec(f.Namespace.Name, generateName)
+	pod := f.PodClient().CreateSync(execPod)
+	return pod.Name
 }
 
 // createExecPodOnNode launches a exec pod in the given namespace and node
 // waits until it's Running, created pod name would be returned
-func createExecPodOnNode(client *client.Client, ns, nodeName, generateName string) string {
-	framework.Logf("Creating exec pod %q in namespace %q", generateName, ns)
-	execPod := newExecPodSpec(ns, generateName)
+func createExecPodOnNode(f *framework.Framework, nodeName, generateName string) string {
+	framework.Logf("Creating exec pod %q in namespace %q", generateName, f.Namespace.Name)
+	execPod := newExecPodSpec(f.Namespace.Name, generateName)
 	execPod.Spec.NodeName = nodeName
-	created, err := client.Pods(ns).Create(execPod)
-	Expect(err).NotTo(HaveOccurred())
-	err = wait.PollImmediate(framework.Poll, 5*time.Minute, func() (bool, error) {
-		retrievedPod, err := client.Pods(execPod.Namespace).Get(created.Name)
-		if err != nil {
-			return false, nil
-		}
-		return retrievedPod.Status.Phase == api.PodRunning, nil
-	})
-	Expect(err).NotTo(HaveOccurred())
-	return created.Name
+	pod := f.PodClient().CreateSync(execPod)
+	return pod.Name
 }
 
-func createPodOrFail(c *client.Client, ns, name string, labels map[string]string, containerPorts []api.ContainerPort) {
-	By(fmt.Sprintf("creating pod %s in namespace %s", name, ns))
+func createPodOrFail(f *framework.Framework, name string, labels map[string]string, containerPorts []api.ContainerPort) {
+	By(fmt.Sprintf("creating pod %s in namespace %s", name, f.Namespace.Name))
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
@@ -1350,7 +1332,7 @@ func createPodOrFail(c *client.Client, ns, name string, labels map[string]string
 			Containers: []api.Container{
 				{
 					Name:  "pause",
-					Image: framework.GetPauseImageName(c),
+					Image: framework.GetPauseImageName(f.Client),
 					Ports: containerPorts,
 					// Add a dummy environment variable to work around a docker issue.
 					// https://github.com/docker/docker/issues/14203
@@ -1359,14 +1341,12 @@ func createPodOrFail(c *client.Client, ns, name string, labels map[string]string
 			},
 		},
 	}
-	_, err := c.Pods(ns).Create(pod)
-	Expect(err).NotTo(HaveOccurred())
+	f.PodClient().CreateSync(pod)
 }
 
-func deletePodOrFail(c *client.Client, ns, name string) {
-	By(fmt.Sprintf("deleting pod %s in namespace %s", name, ns))
-	err := c.Pods(ns).Delete(name, nil)
-	Expect(err).NotTo(HaveOccurred())
+func deletePodOrFail(f *framework.Framework, name string) {
+	By(fmt.Sprintf("deleting pod %s in namespace %s", name, f.Namespace.Name))
+	f.PodClient().DeleteSync(name, nil, 2*time.Minute)
 }
 
 func collectAddresses(nodes *api.NodeList, addressType api.NodeAddressType) []string {
@@ -1654,11 +1634,12 @@ func stopServeHostnameService(c *client.Client, clientset internalclientset.Inte
 // given host and from within a pod. The host is expected to be an SSH-able node
 // in the cluster. Each pod in the service is expected to echo its name. These
 // names are compared with the given expectedPods list after a sort | uniq.
-func verifyServeHostnameServiceUp(c *client.Client, ns, host string, expectedPods []string, serviceIP string, servicePort int) error {
-	execPodName := createExecPodOrFail(c, ns, "execpod-")
+func verifyServeHostnameServiceUp(f *framework.Framework, host string, expectedPods []string, serviceIP string, servicePort int) error {
+	execPodName := createExecPodOrFail(f, "execpod-")
 	defer func() {
-		deletePodOrFail(c, ns, execPodName)
+		deletePodOrFail(f, execPodName)
 	}()
+	ns := f.Namespace.Name
 
 	// Loop a bunch of times - the proxy is randomized, so we want a good
 	// chance of hitting each backend at least once.
@@ -2307,7 +2288,7 @@ func (j *ServiceTestJig) launchEchoserverPodOnNode(f *framework.Framework, nodeN
 
 func execSourceipTest(f *framework.Framework, c *client.Client, ns, nodeName, serviceIp string, servicePort int) (string, string) {
 	framework.Logf("Creating an exec pod on the same node")
-	execPodName := createExecPodOnNode(f.Client, ns, nodeName, fmt.Sprintf("execpod-sourceip-%s", nodeName))
+	execPodName := createExecPodOnNode(f, nodeName, fmt.Sprintf("execpod-sourceip-%s", nodeName))
 	defer func() {
 		framework.Logf("Cleaning up the exec pod")
 		err := c.Pods(ns).Delete(execPodName, nil)


### PR DESCRIPTION
Mostly a straight refactor, but with a couple changes:
- several calls were changed to wait for pods to be running (`CreateSync`)
- several calls converted to use `CreateBatch`

Hopefully this will take down a couple flakes, and make future changes simpler.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34576)

<!-- Reviewable:end -->
