### PR TITLE
WIP: Pet finalizers to avoid pod deletion from nodecontroller

### DIFF
--- a/pkg/apis/apps/v1alpha1/defaults.go
+++ b/pkg/apis/apps/v1alpha1/defaults.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -43,4 +44,12 @@ func SetDefaults_PetSet(obj *PetSet) {
 		obj.Spec.Replicas = new(int32)
 		*obj.Spec.Replicas = 1
 	}
+
+	// set default safe-deletion flag.
+	finalizers := sets.NewString(obj.Spec.Template.Finalizers...)
+	if finalizers.Has("k8s.io/safe-delete") {
+		return
+	}
+	finalizers.Insert("k8s.io/safe-delete")
+	obj.Spec.Template.SetFinalizers(finalizers.List())
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -374,6 +374,12 @@ func getPodsLabelSet(template *api.PodTemplateSpec) labels.Set {
 	return desiredLabels
 }
 
+func getPodsFinalizers(template *api.PodTemplateSpec) []string {
+	desiredFinalizers := make([]string, len(template.Finalizers))
+	copy(desiredFinalizers, template.Finalizers)
+	return desiredFinalizers
+}
+
 func getPodsAnnotationSet(template *api.PodTemplateSpec, object runtime.Object) (labels.Set, error) {
 	desiredAnnotations := make(labels.Set)
 	for k, v := range template.Annotations {
@@ -439,6 +445,7 @@ func (r RealPodControl) PatchPod(namespace, name string, data []byte) error {
 
 func GetPodFromTemplate(template *api.PodTemplateSpec, parentObject runtime.Object, controllerRef *api.OwnerReference) (*api.Pod, error) {
 	desiredLabels := getPodsLabelSet(template)
+	desiredFinalizers := getPodsFinalizers(template)
 	desiredAnnotations, err := getPodsAnnotationSet(template, parentObject)
 	if err != nil {
 		return nil, err
@@ -454,6 +461,7 @@ func GetPodFromTemplate(template *api.PodTemplateSpec, parentObject runtime.Obje
 			Labels:       desiredLabels,
 			Annotations:  desiredAnnotations,
 			GenerateName: prefix,
+			Finalizers:   desiredFinalizers,
 		},
 	}
 	if controllerRef != nil {


### PR DESCRIPTION
- Commit 1 enables finalizers set on the PodTemplateSpec to be copied to each pod during creation. It is on its way to being merged in https://github.com/kubernetes/kubernetes/pull/34512 
- Commit 2 is WIP and adds the safe-delete finalizer in the petset defaulting code and clears it within the node controller prior to zero-grace removal from the apiserver.

TODO: Approach review, Tests

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34578)

<!-- Reviewable:end -->
