### PR TITLE
Append first address from `--api-advertise-addresses` to `kube-apiserver` flags

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -266,6 +266,10 @@ func getComponentCommand(component string, s *kubeadmapi.MasterConfiguration) (c
 	command = append(command, baseFlags[component]...)
 
 	if component == apiServer {
+		// Use first address we are given
+		if len(s.API.AdvertiseAddresses) > 0 {
+			command = append(command, fmt.Sprintf("--advertise-address=%s", s.API.AdvertiseAddresses[0]))
+		}
 		// Check if the user decided to use an external etcd cluster
 		if len(s.Etcd.Endpoints) > 0 {
 			command = append(command, fmt.Sprintf("--etcd-servers=%s", strings.Join(s.Etcd.Endpoints, ",")))


### PR DESCRIPTION
**What this PR does / why we need it**:

We have `--api-advertise-addresses` already, but it's only used for SANs in server certificates we generate. Currently setting this flag doesn't affect what address API server advertises, and this PR fixes that. In particular, this has been an issue for VirtualBox users (see #34101).

**Which issue this PR fixes**: fixes #34101

**Release note**:

``` release-note
Make `kubeadm` append first address from `--api-advertise-addresses` to `kube-apiserver` flags as `--advertise-address`
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34607)

<!-- Reviewable:end -->
