### PR TITLE
build: Fix version generation.

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -56,7 +56,14 @@ kube::version::get_version_vars() {
       #
       # TODO: We continue calling this "git version" because so many
       # downstream consumers are expecting it there.
-      KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
+      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      fi
       if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,


### PR DESCRIPTION
This PR provides update to version string generation procedure to handle additional case - working on branch delivered from release tag, instead of working on `-(alpha|beta).no` suffixed tag.

Reason of it is that actually if someone would start working on branch forked from release tag (`v1.4.1` for example), will add some commits and then would try to build k8s/run conformance tests - will end up with broken version string in form similar to `v1.4.1.X+YYYY` where `X` is a distance/number of commits from base tag and `YYYY` will be first 14 characters from commit hash.
Such version - containing four dotted parts is rejected during conformance tests with error similar to:

```
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/kubectl.go:843
Oct 11 12:38:33.726: Failed to get server version: Unable to parse server version "v1.4.1.5+somecommithash": Invalid character(s) found in patch number "1.5"
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:413
```

This PR provides a cure for this situation creating version string in form `v1.4.1-X+YYYY` which then should be readable for version validation checks. 

Release note:

``` release-note
Fix version string generation for local version different from release and not based on `-alpha.no` or `-beta.no` suffixed tag.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34612)

<!-- Reviewable:end -->
