### PR TITLE
Increase the limitRange Namespace deletion timeout

### DIFF
--- a/test/e2e/limit_range.go
+++ b/test/e2e/limit_range.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
@@ -29,6 +30,7 @@ import (
 
 var _ = framework.KubeDescribe("LimitRange", func() {
 	f := framework.NewDefaultFramework("limitrange")
+	f.NamespaceDeletionTimeout = 10 * time.Minute
 
 	It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		By("Creating a LimitRange")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a end-to-end test flake which happens because Namespace simply takes longer than default 5 minute to be deleted.

More investigation and details are here - https://github.com/openshift/origin/issues/11094

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34614)

<!-- Reviewable:end -->
