### PR TITLE
Automated cherry pick of #33147 #34468 #34416 #34010 origin release 1.4

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -125,6 +125,7 @@ function wait-for-master() {
 function prepare-upgrade() {
   ensure-temp-dir
   detect-project
+  detect-node-names # sets INSTANCE_GROUPS
   write-cluster-name
   tars_from_version
 }
@@ -175,6 +176,16 @@ function upgrade-nodes() {
   do-node-upgrade
 }
 
+function setup-base-image() {
+  if [[ "${env_os_distro}" == "false" ]]; then
+    echo "== Ensuring that new Node base OS image matched the existing Node base OS image"
+    node_os_distribution=$(get-node-os "${NODE_NAMES[0]}")
+    source "${KUBE_ROOT}/cluster/gce/${node_os_distribution}/node-helper.sh"
+    # Reset the node image based on current os distro
+    set-node-image
+fi
+}
+
 # prepare-node-upgrade creates a new instance template suitable for upgrading
 # to KUBE_VERSION and echos a single line with the name of the new template.
 #
@@ -196,9 +207,9 @@ function upgrade-nodes() {
 #   KUBELET_KEY_BASE64
 function prepare-node-upgrade() {
   echo "== Preparing node upgrade (to ${KUBE_VERSION}). ==" >&2
-  SANITIZED_VERSION=$(echo ${KUBE_VERSION} | sed 's/[\.\+]/-/g')
+  setup-base-image
 
-  detect-node-names # sets INSTANCE_GROUPS
+  SANITIZED_VERSION=$(echo ${KUBE_VERSION} | sed 's/[\.\+]/-/g')
 
   # TODO(zmerlynn): Refactor setting scope flags.
   local scope_flags=
@@ -220,13 +231,6 @@ function prepare-node-upgrade() {
   # TODO(zmerlynn): How do we ensure kube-env is written in a ${version}-
   #                 compatible way?
   write-node-env
-
-  if [[ "${env_os_distro}" == "false" ]]; then
-    NODE_OS_DISTRIBUTION=$(get-node-os "${NODE_NAMES[0]}")
-    source "${KUBE_ROOT}/cluster/gce/${NODE_OS_DISTRIBUTION}/node-helper.sh"
-    # Reset the node image based on current os distro
-    set-node-image
-  fi
 
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
   #                 through all create-node-instance-template implementations).

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -179,8 +179,8 @@ function upgrade-nodes() {
 function setup-base-image() {
   if [[ "${env_os_distro}" == "false" ]]; then
     echo "== Ensuring that new Node base OS image matched the existing Node base OS image"
-    node_os_distribution=$(get-node-os "${NODE_NAMES[0]}")
-    source "${KUBE_ROOT}/cluster/gce/${node_os_distribution}/node-helper.sh"
+    NODE_OS_DISTRIBUTION=$(get-node-os "${NODE_NAMES[0]}")
+    source "${KUBE_ROOT}/cluster/gce/${NODE_OS_DISTRIBUTION}/node-helper.sh"
     # Reset the node image based on current os distro
     set-node-image
 fi

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -29,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     socat \
     git \
     nfs-common \
+    cifs-utils \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/pkg/api/unversioned/group_version_test.go
+++ b/pkg/api/unversioned/group_version_test.go
@@ -147,3 +147,47 @@ func TestGroupVersionMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestKindForGroupVersionKinds(t *testing.T) {
+	gvks := GroupVersions{
+		GroupVersion{Group: "batch", Version: "v1"},
+		GroupVersion{Group: "batch", Version: "v2alpha1"},
+		GroupVersion{Group: "policy", Version: "v1alpha1"},
+	}
+	cases := []struct {
+		input  []GroupVersionKind
+		target GroupVersionKind
+		ok     bool
+	}{
+		{
+			input:  []GroupVersionKind{{Group: "batch", Version: "v2alpha1", Kind: "ScheduledJob"}},
+			target: GroupVersionKind{Group: "batch", Version: "v2alpha1", Kind: "ScheduledJob"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "batch", Version: "v3alpha1", Kind: "CronJob"}},
+			target: GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "policy", Version: "v1alpha1", Kind: "PodDisruptionBudget"}},
+			target: GroupVersionKind{Group: "policy", Version: "v1alpha1", Kind: "PodDisruptionBudget"},
+			ok:     true,
+		},
+		{
+			input:  []GroupVersionKind{{Group: "apps", Version: "v1alpha1", Kind: "PetSet"}},
+			target: GroupVersionKind{},
+			ok:     false,
+		},
+	}
+
+	for i, c := range cases {
+		target, ok := gvks.KindForGroupVersionKinds(c.input)
+		if c.target != target {
+			t.Errorf("%d: unexpected target: %v, expected %v", i, target, c.target)
+		}
+		if c.ok != ok {
+			t.Errorf("%d: unexpected ok: %v, expected %v", i, ok, c.ok)
+		}
+	}
+}

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -602,12 +602,15 @@ func TestConvertToVersion(t *testing.T) {
 			gv:     unversioned.GroupVersion{Version: "__internal"},
 			out:    &TestType1{A: "test"},
 		},
-		// prefers the first group version in the list
+		// prefers the best match
 		{
 			scheme: GetTestScheme(),
 			in:     &ExternalTestType1{A: "test"},
 			gv:     unversioned.GroupVersions{{Version: "__internal"}, {Version: "v1"}},
-			out:    &TestType1{A: "test"},
+			out: &ExternalTestType1{
+				MyWeirdCustomEmbeddedVersionKindField: MyWeirdCustomEmbeddedVersionKindField{APIVersion: "v1", ObjectKind: "TestType1"},
+				A: "test",
+			},
 		},
 		// unversioned type returned as-is
 		{


### PR DESCRIPTION
Cherry pick of #33147 #34468 #34416 #34010 on release-1.4.
#33147: fix base image pinning during upgrades via
#34468: Fix upgrade.sh image setup
#34416: hyperkube image: add cifs-utils
#34010: Match GroupVersionKind against specific version

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34628)

<!-- Reviewable:end -->
