### PR TITLE
Fix the GCL cluster logging test

### DIFF
--- a/test/e2e/cluster_logging_utils.go
+++ b/test/e2e/cluster_logging_utils.go
@@ -45,6 +45,7 @@ func createSynthLogger(f *framework.Framework, linesCount int) {
 			Namespace: f.Namespace.Name,
 		},
 		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyOnFailure,
 			Containers: []api.Container{
 				{
 					Name:  synthLoggerPodName,


### PR DESCRIPTION
Because the test wait for the synthlogger pod should have a restart policy of
"OnFailure" or "Never" in order to reach a termianted state.

Also fix the framework to check the pod phase directly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34630)

<!-- Reviewable:end -->
