### PR TITLE
Fix the wait for pod success in test framework.

### DIFF
--- a/test/e2e/cluster_logging_es.go
+++ b/test/e2e/cluster_logging_es.go
@@ -53,7 +53,7 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 		By("Running synthetic logger")
 		createSynthLogger(f, expectedLinesCount)
 		defer f.PodClient().Delete(synthLoggerPodName, &api.DeleteOptions{})
-		err = framework.WaitForPodSuccessInNamespace(f.Client, synthLoggerPodName, synthLoggerPodName, f.Namespace.Name)
+		err = framework.WaitForPodSuccessInNamespace(f.Client, synthLoggerPodName, f.Namespace.Name)
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", synthLoggerPodName))
 
 		By("Waiting for logs to ingest")

--- a/test/e2e/cluster_logging_gcl.go
+++ b/test/e2e/cluster_logging_gcl.go
@@ -43,7 +43,7 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL", func() {
 		By("Running synthetic logger")
 		createSynthLogger(f, expectedLinesCount)
 		defer f.PodClient().Delete(synthLoggerPodName, &api.DeleteOptions{})
-		err := framework.WaitForPodSuccessInNamespace(f.Client, synthLoggerPodName, synthLoggerPodName, f.Namespace.Name)
+		err := framework.WaitForPodSuccessInNamespace(f.Client, synthLoggerPodName, f.Namespace.Name)
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", synthLoggerPodName))
 
 		By("Waiting for logs to ingest")

--- a/test/e2e/cluster_logging_utils.go
+++ b/test/e2e/cluster_logging_utils.go
@@ -45,6 +45,7 @@ func createSynthLogger(f *framework.Framework, linesCount int) {
 			Namespace: f.Namespace.Name,
 		},
 		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyOnFailure,
 			Containers: []api.Container{
 				{
 					Name:  synthLoggerPodName,

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -277,7 +277,7 @@ func testPodSuccessOrFail(f *framework.Framework, c *client.Client, ns string, p
 
 	By("Pod should terminate with exitcode 0 (success)")
 
-	err := framework.WaitForPodSuccessInNamespace(c, pod.Name, pod.Spec.Containers[0].Name, ns)
+	err := framework.WaitForPodSuccessInNamespace(c, pod.Name, ns)
 	if err != nil {
 		return fmt.Errorf("Pod %v returned non-zero exitcode: %+v", pod.Name, err)
 	}

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -228,7 +228,7 @@ func runInPodWithVolume(c *client.Client, ns, claimName, command string) {
 		framework.ExpectNoError(c.Pods(ns).Delete(pod.Name, nil))
 	}()
 	framework.ExpectNoError(err, "Failed to create pod: %v", err)
-	framework.ExpectNoError(framework.WaitForPodSuccessInNamespaceSlow(c, pod.Name, pod.Spec.Containers[0].Name, pod.Namespace))
+	framework.ExpectNoError(framework.WaitForPodSuccessInNamespaceSlow(c, pod.Name, pod.Namespace))
 }
 
 func newStorageClass() *storage.StorageClass {

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -319,7 +319,7 @@ func injectHtml(client *client.Client, config VolumeTestConfig, volume api.Volum
 
 	injectPod, err := podClient.Create(injectPod)
 	framework.ExpectNoError(err, "Failed to create injector pod: %v", err)
-	err = framework.WaitForPodSuccessInNamespace(client, injectPod.Name, injectPod.Spec.Containers[0].Name, injectPod.Namespace)
+	err = framework.WaitForPodSuccessInNamespace(client, injectPod.Name, injectPod.Namespace)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/e2e_node/cgroup_manager_test.go
+++ b/test/e2e_node/cgroup_manager_test.go
@@ -68,7 +68,7 @@ var _ = framework.KubeDescribe("Kubelet Cgroup Manager [Skip]", func() {
 				}
 				podClient := f.PodClient()
 				podClient.Create(pod)
-				err := framework.WaitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
+				err := framework.WaitForPodSuccessInNamespace(f.Client, podName, f.Namespace.Name)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/34623.
Addresses https://github.com/kubernetes/kubernetes/issues/33189#issuecomment-253282725.
Related to #34630.

This PR:
1) Changes `WaitForPodSuccessInNamespace` to use pod phase instead of container status because of https://github.com/kubernetes/kubernetes/issues/33189#issuecomment-253287397. The code was introduced because of https://github.com/kubernetes/kubernetes/issues/2632, which is never true now.
2) Fixes the cluster logging test to set the pod as `RestartOnFailure`.

@yujuhong @Crassirostris

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34632)

<!-- Reviewable:end -->
