### PR TITLE
Make "Unschedulable" reason a constant in api

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1225,6 +1225,9 @@ const (
 	PodReady PodConditionType = "Ready"
 	// PodInitialized means that all init containers in the pod have started successfully.
 	PodInitialized PodConditionType = "Initialized"
+	// PodReasonUnschedulable reason in PodScheduled PodCondition means that the scheduler
+	// can't schedule the pod right now, for example due to insufficient resources in the cluster.
+	PodReasonUnschedulable = "Unschedulable"
 )
 
 type PodCondition struct {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1439,6 +1439,9 @@ const (
 	// PodReady means the pod is able to service requests and should be added to the
 	// load balancing pools of all matching services.
 	PodReady PodConditionType = "Ready"
+	// PodReasonUnschedulable reason in PodScheduled PodCondition means that the scheduler
+	// can't schedule the pod right now, for example due to insufficient resources in the cluster.
+	PodReasonUnschedulable = "Unschedulable"
 )
 
 // PodCondition contains details for the current condition of this pod.

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -100,7 +100,7 @@ func (s *Scheduler) scheduleOne() {
 		s.config.PodConditionUpdater.Update(pod, &api.PodCondition{
 			Type:   api.PodScheduled,
 			Status: api.ConditionFalse,
-			Reason: "Unschedulable",
+			Reason: api.PodReasonUnschedulable,
 		})
 		return
 	}


### PR DESCRIPTION
String "Unschedulable" is used in couple places in K8S:
- scheduler
- federation replicaset and deployment controllers
- cluster autoscaler
- rescheduler
  This PR makes the string a part of API so it not changed.

cc: @davidopp @fgrzadkowski @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34634)

<!-- Reviewable:end -->
