### PR TITLE
Set the dns policy for pods in node e2e tests

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -125,6 +125,10 @@ func (c *PodClient) mungeSpec(pod *api.Pod) {
 	if TestContext.NodeName != "" {
 		Expect(pod.Spec.NodeName).To(Or(BeZero(), Equal(TestContext.NodeName)), "Test misconfigured")
 		pod.Spec.NodeName = TestContext.NodeName
+		// Node e2e does not support the default DNSClusterFirst policy. Set
+		// the policy to DNSDefault, which is configured per node.
+		pod.Spec.DNSPolicy = api.DNSDefault
+
 		if !TestContext.PrepullImages {
 			return
 		}


### PR DESCRIPTION
This change stops kubelet from sending MissingClusterDNS events for every pod.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34642)

<!-- Reviewable:end -->
