### PR TITLE
remove testapi.GroupVersion()

### DIFF
--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
@@ -34,12 +35,14 @@ import (
 )
 
 var testHelper testapi.TestGroup
+var testGroupMeta *apimachinery.GroupMeta
 
 func init() {
 	if _, found := testapi.Groups[testgroup.SchemeGroupVersion.Group]; found {
 		return
 	}
-	externalGroupVersion := registered.GroupOrDie(testgroup.SchemeGroupVersion.Group).GroupVersion
+	testGroupMeta = registered.GroupOrDie(testgroup.SchemeGroupVersion.Group)
+	externalGroupVersion := testGroupMeta.GroupVersion
 	testapi.Groups[testgroup.SchemeGroupVersion.Group] = testapi.NewTestGroup(
 		externalGroupVersion,
 		testgroup.SchemeGroupVersion,
@@ -209,7 +212,7 @@ func TestListTestTypes(t *testing.T) {
 
 func TestListTestTypesLabels(t *testing.T) {
 	ns := api.NamespaceDefault
-	labelSelectorQueryParamName := unversioned.LabelSelectorQueryParam(testHelper.GroupVersion().String())
+	labelSelectorQueryParamName := unversioned.LabelSelectorQueryParam(testGroupMeta.GroupVersion.String())
 	c := DecoratedSimpleClient{
 		simpleClient: simple.Client{
 			Request: simple.Request{

--- a/federation/pkg/federation-controller/cluster/clustercontroller_test.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller_test.go
@@ -26,9 +26,9 @@ import (
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	controller_util "k8s.io/kubernetes/federation/pkg/federation-controller/util"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -37,7 +37,7 @@ import (
 
 func newCluster(clusterName string, serverUrl string) *federation_v1beta1.Cluster {
 	cluster := federation_v1beta1.Cluster{
-		TypeMeta: unversioned.TypeMeta{APIVersion: testapi.Federation.GroupVersion().String()},
+		TypeMeta: unversioned.TypeMeta{APIVersion: registered.GroupOrDie(federation_v1beta1.GroupName).GroupVersion.String()},
 		ObjectMeta: v1.ObjectMeta{
 			UID:  uuid.NewUUID(),
 			Name: clusterName,
@@ -56,7 +56,7 @@ func newCluster(clusterName string, serverUrl string) *federation_v1beta1.Cluste
 
 func newClusterList(cluster *federation_v1beta1.Cluster) *federation_v1beta1.ClusterList {
 	clusterList := federation_v1beta1.ClusterList{
-		TypeMeta: unversioned.TypeMeta{APIVersion: testapi.Federation.GroupVersion().String()},
+		TypeMeta: unversioned.TypeMeta{APIVersion: registered.GroupOrDie(federation_v1beta1.GroupName).GroupVersion.String()},
 		ListMeta: unversioned.ListMeta{
 			SelfLink: "foobar",
 		},

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -312,7 +312,7 @@ for (( i=0; i<${apiVersionsCount}; i++ )); do
   apiVersion=${apiVersions[i]}
   echo "Running tests for APIVersion: $apiVersion"
   # KUBE_TEST_API sets the version of each group to be tested.
-  KUBE_TEST_API="${apiVersion}" runTests "$@"
+  KUBE_TEST_API="${apiVersion}" KUBE_API_VERSIONS="${apiVersion}" runTests "$@"
 done
 
 # We might run the tests for multiple versions, but we want to report only

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -272,7 +272,7 @@ func init() {
 }
 
 func (g TestGroup) ContentConfig() (string, *unversioned.GroupVersion, runtime.Codec) {
-	return "application/json", g.GroupVersion(), g.Codec()
+	return "application/json", &g.externalGroupVersion, g.Codec()
 }
 
 // InternalGroupVersion returns the group,version used to identify the internal
@@ -294,10 +294,14 @@ func (g TestGroup) ExternalTypes() map[string]reflect.Type {
 // Codec returns the codec for the API version to test against, as set by the
 // KUBE_TEST_API_TYPE env var.
 func (g TestGroup) Codec() runtime.Codec {
+	return Codec(g.externalGroupVersion)
+}
+
+func Codec(version unversioned.GroupVersion) runtime.Codec {
 	if serializer.Serializer == nil {
-		return api.Codecs.LegacyCodec(g.externalGroupVersion)
+		return api.Codecs.LegacyCodec(version)
 	}
-	return api.Codecs.CodecForVersions(serializer, api.Codecs.UniversalDeserializer(), unversioned.GroupVersions{g.externalGroupVersion}, nil)
+	return api.Codecs.CodecForVersions(serializer, api.Codecs.UniversalDeserializer(), unversioned.GroupVersions{version}, nil)
 }
 
 // NegotiatedSerializer returns the negotiated serializer for the server.
@@ -412,8 +416,7 @@ func (g TestGroup) RESTMapper() meta.RESTMapper {
 func ExternalGroupVersions() unversioned.GroupVersions {
 	versions := []unversioned.GroupVersion{}
 	for _, g := range Groups {
-		gv := g.GroupVersion()
-		versions = append(versions, *gv)
+		versions = append(versions, g.externalGroupVersion)
 	}
 	return versions
 }
@@ -427,7 +430,7 @@ func GetCodecForObject(obj runtime.Object) (runtime.Codec, error) {
 	kind := kinds[0]
 
 	for _, group := range Groups {
-		if group.GroupVersion().Group != kind.Group {
+		if group.externalGroupVersion.Group != kind.Group {
 			continue
 		}
 

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -275,11 +275,6 @@ func (g TestGroup) ContentConfig() (string, *unversioned.GroupVersion, runtime.C
 	return "application/json", g.GroupVersion(), g.Codec()
 }
 
-func (g TestGroup) GroupVersion() *unversioned.GroupVersion {
-	copyOfGroupVersion := g.externalGroupVersion
-	return &copyOfGroupVersion
-}
-
 // InternalGroupVersion returns the group,version used to identify the internal
 // types for this API
 func (g TestGroup) InternalGroupVersion() unversioned.GroupVersion {

--- a/pkg/api/testapi/testapi_test.go
+++ b/pkg/api/testapi/testapi_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -35,11 +36,11 @@ func TestResourcePathWithPrefix(t *testing.T) {
 		name      string
 		expected  string
 	}{
-		{"prefix", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource/myresource"},
-		{"prefix", "resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/resource/myresource"},
-		{"prefix", "resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource"},
-		{"prefix", "resource", "", "", "/api/" + Default.GroupVersion().Version + "/prefix/resource"},
-		{"", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "myresource", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/prefix/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "", "myresource", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/prefix/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/prefix/namespaces/mynamespace/resource"},
+		{"prefix", "resource", "", "", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/prefix/resource"},
+		{"", "resource", "mynamespace", "myresource", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testCases {
 		if actual := Default.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
@@ -55,10 +56,10 @@ func TestResourcePath(t *testing.T) {
 		name      string
 		expected  string
 	}{
-		{"resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource"},
-		{"resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/resource/myresource"},
-		{"resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource"},
-		{"resource", "", "", "/api/" + Default.GroupVersion().Version + "/resource"},
+		{"resource", "mynamespace", "myresource", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{"resource", "", "myresource", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/resource/myresource"},
+		{"resource", "mynamespace", "", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/namespaces/mynamespace/resource"},
+		{"resource", "", "", "/api/" + registered.GroupOrDie("").GroupVersion.Version + "/resource"},
 	}
 	for _, item := range testCases {
 		if actual := Default.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -362,8 +363,8 @@ func FuzzerFor(t *testing.T, version unversioned.GroupVersion, src rand.Source) 
 				ev.ValueFrom.FieldRef = &api.ObjectFieldSelector{}
 
 				var versions []unversioned.GroupVersion
-				for _, testGroup := range testapi.Groups {
-					versions = append(versions, *testGroup.GroupVersion())
+				for _, groupVersion := range registered.EnabledVersions() {
+					versions = append(versions, groupVersion)
 				}
 
 				ev.ValueFrom.FieldRef.APIVersion = versions[c.Rand.Intn(len(versions))].String()

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -27,8 +27,11 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/runtime"
 	k8syaml "k8s.io/kubernetes/pkg/util/yaml"
 
@@ -44,16 +47,16 @@ func readPod(filename string) ([]byte, error) {
 }
 
 func readSwaggerFile() ([]byte, error) {
-	return readSwaggerApiFile(testapi.Default)
+	return readSwaggerApiFile(apiv1.SchemeGroupVersion)
 }
 
-func readSwaggerApiFile(group testapi.TestGroup) ([]byte, error) {
+func readSwaggerApiFile(version unversioned.GroupVersion) ([]byte, error) {
 	// TODO: Figure out a better way of finding these files
 	var pathToSwaggerSpec string
-	if group.GroupVersion().Group == "" {
-		pathToSwaggerSpec = "../../../api/swagger-spec/" + group.GroupVersion().Version + ".json"
+	if version.Group == "" {
+		pathToSwaggerSpec = "../../../api/swagger-spec/" + version.Version + ".json"
 	} else {
-		pathToSwaggerSpec = "../../../api/swagger-spec/" + group.GroupVersion().Group + "_" + group.GroupVersion().Version + ".json"
+		pathToSwaggerSpec = "../../../api/swagger-spec/" + version.Group + "_" + version.Version + ".json"
 	}
 
 	return ioutil.ReadFile(pathToSwaggerSpec)
@@ -103,8 +106,8 @@ func loadSchemaForTest() (Schema, error) {
 	return NewSwaggerSchemaFromBytes(data, nil)
 }
 
-func loadSchemaForTestWithFactory(group testapi.TestGroup, factory Schema) (Schema, error) {
-	data, err := readSwaggerApiFile(group)
+func loadSchemaForTestWithFactory(version unversioned.GroupVersion, factory Schema) (Schema, error) {
+	data, err := readSwaggerApiFile(version)
 	if err != nil {
 		return nil, err
 	}
@@ -113,12 +116,12 @@ func loadSchemaForTestWithFactory(group testapi.TestGroup, factory Schema) (Sche
 
 func NewFactory() (*Factory, error) {
 	f := &Factory{}
-	defaultSchema, err := loadSchemaForTestWithFactory(testapi.Default, f)
+	defaultSchema, err := loadSchemaForTestWithFactory(apiv1.SchemeGroupVersion, f)
 	if err != nil {
 		return nil, err
 	}
 	f.defaultSchema = defaultSchema
-	extensionSchema, err := loadSchemaForTestWithFactory(testapi.Extensions, f)
+	extensionSchema, err := loadSchemaForTestWithFactory(extensionsv1beta1.SchemeGroupVersion, f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apimachinery/registered/registered.go
+++ b/pkg/apimachinery/registered/registered.go
@@ -111,6 +111,7 @@ var (
 	IsRegisteredVersion           = DefaultAPIRegistrationManager.IsRegisteredVersion
 	IsRegistered                  = DefaultAPIRegistrationManager.IsRegistered
 	Group                         = DefaultAPIRegistrationManager.Group
+	EnabledGroups                 = DefaultAPIRegistrationManager.EnabledGroups
 	EnabledVersionsForGroup       = DefaultAPIRegistrationManager.EnabledVersionsForGroup
 	EnabledVersions               = DefaultAPIRegistrationManager.EnabledVersions
 	IsEnabledVersion              = DefaultAPIRegistrationManager.IsEnabledVersion
@@ -174,6 +175,25 @@ func (m *APIRegistrationManager) IsAllowedVersion(v unversioned.GroupVersion) bo
 func (m *APIRegistrationManager) IsEnabledVersion(v unversioned.GroupVersion) bool {
 	_, found := m.enabledVersions[v]
 	return found
+}
+
+// EnabledGroups returns all enabled groups.
+func (m *APIRegistrationManager) EnabledGroups() []*apimachinery.GroupMeta {
+	ret := []*apimachinery.GroupMeta{}
+	for _, groupMeta := range m.groupMetaMap {
+		enabled := false
+		for _, version := range groupMeta.GroupVersions {
+			if m.IsEnabledVersion(version) {
+				enabled = true
+				break
+			}
+		}
+
+		if enabled {
+			ret = append(ret, groupMeta)
+		}
+	}
+	return ret
 }
 
 // EnabledVersions returns all enabled versions.  Groups are randomly ordered, but versions within groups

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 	"k8s.io/kubernetes/pkg/labels"
@@ -183,7 +184,7 @@ func TestDeploymentWatch(t *testing.T) {
 
 func TestListDeploymentsLabels(t *testing.T) {
 	ns := api.NamespaceDefault
-	labelSelectorQueryParamName := unversioned.LabelSelectorQueryParam(testapi.Extensions.GroupVersion().String())
+	labelSelectorQueryParamName := unversioned.LabelSelectorQueryParam(registered.GroupOrDie(extensions.GroupName).GroupVersion.String())
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",

--- a/pkg/client/unversioned/scheduledjobs_test.go
+++ b/pkg/client/unversioned/scheduledjobs_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
@@ -32,7 +33,7 @@ func getScheduledJobsResource() string {
 
 func TestListScheduledJob(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -73,7 +74,7 @@ func TestListScheduledJob(t *testing.T) {
 
 func TestGetScheduledJob(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -112,7 +113,7 @@ func TestGetScheduledJob(t *testing.T) {
 
 func TestUpdateScheduledJob(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -158,7 +159,7 @@ func TestUpdateScheduledJob(t *testing.T) {
 
 func TestUpdateScheduledJobStatus(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -208,7 +209,7 @@ func TestUpdateScheduledJobStatus(t *testing.T) {
 
 func TestDeleteScheduledJob(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -229,7 +230,7 @@ func TestDeleteScheduledJob(t *testing.T) {
 
 func TestCreateScheduledJob(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 

--- a/pkg/client/unversioned/testclient/simple/simple_testclient.go
+++ b/pkg/client/unversioned/testclient/simple/simple_testclient.go
@@ -92,23 +92,23 @@ func (c *Client) Setup(t *testing.T) *Client {
 		// We will fix this by supporting multiple group versions in Config
 		c.AutoscalingClient = client.NewAutoscalingOrDie(&restclient.Config{
 			Host:          c.server.URL,
-			ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Autoscaling.GroupVersion()},
+			ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie("autoscaling").GroupVersion},
 		})
 		c.BatchClient = client.NewBatchOrDie(&restclient.Config{
 			Host:          c.server.URL,
-			ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Batch.GroupVersion()},
+			ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie("batch").GroupVersion},
 		})
 		c.ExtensionsClient = client.NewExtensionsOrDie(&restclient.Config{
 			Host:          c.server.URL,
-			ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Extensions.GroupVersion()},
+			ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie("extensions").GroupVersion},
 		})
 		c.RbacClient = client.NewRbacOrDie(&restclient.Config{
 			Host:          c.server.URL,
-			ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Rbac.GroupVersion()},
+			ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie("rbac.authorization.k8s.io").GroupVersion},
 		})
 		c.StorageClient = client.NewStorageOrDie(&restclient.Config{
 			Host:          c.server.URL,
-			ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Storage.GroupVersion()},
+			ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie("storage.k8s.io").GroupVersion},
 		})
 
 		c.Clientset = clientset.NewForConfigOrDie(&restclient.Config{Host: c.server.URL})

--- a/pkg/controller/daemon/daemoncontroller_test.go
+++ b/pkg/controller/daemon/daemoncontroller_test.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -54,7 +53,7 @@ func getKey(ds *extensions.DaemonSet, t *testing.T) string {
 
 func newDaemonSet(name string) *extensions.DaemonSet {
 	return &extensions.DaemonSet{
-		TypeMeta: unversioned.TypeMeta{APIVersion: testapi.Extensions.GroupVersion().String()},
+		TypeMeta: unversioned.TypeMeta{APIVersion: registered.GroupOrDie(extensions.GroupName).GroupVersion.String()},
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,
 			Namespace: api.NamespaceDefault,

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -359,8 +359,8 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 	// Add a Group.
 	extensionsVersions := []unversioned.GroupVersionForDiscovery{
 		{
-			GroupVersion: testapi.Extensions.GroupVersion().String(),
-			Version:      testapi.Extensions.GroupVersion().Version,
+			GroupVersion: registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
+			Version:      registered.GroupOrDie(extensions.GroupName).GroupVersion.Version,
 		},
 	}
 	extensionsPreferredVersion := unversioned.GroupVersionForDiscovery{

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -74,12 +74,12 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 
 	resourceEncoding := genericapiserver.NewDefaultResourceEncodingConfig()
 	resourceEncoding.SetVersionEncoding(api.GroupName, registered.GroupOrDie(api.GroupName).GroupVersion, unversioned.GroupVersion{Group: api.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(autoscaling.GroupName, *testapi.Autoscaling.GroupVersion(), unversioned.GroupVersion{Group: autoscaling.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(batch.GroupName, *testapi.Batch.GroupVersion(), unversioned.GroupVersion{Group: batch.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(apps.GroupName, *testapi.Apps.GroupVersion(), unversioned.GroupVersion{Group: apps.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(extensions.GroupName, *testapi.Extensions.GroupVersion(), unversioned.GroupVersion{Group: extensions.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(rbac.GroupName, *testapi.Rbac.GroupVersion(), unversioned.GroupVersion{Group: rbac.GroupName, Version: runtime.APIVersionInternal})
-	resourceEncoding.SetVersionEncoding(certificates.GroupName, *testapi.Certificates.GroupVersion(), unversioned.GroupVersion{Group: certificates.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(autoscaling.GroupName, registered.GroupOrDie(autoscaling.GroupName).GroupVersion, unversioned.GroupVersion{Group: autoscaling.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(batch.GroupName, registered.GroupOrDie(batch.GroupName).GroupVersion, unversioned.GroupVersion{Group: batch.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(apps.GroupName, registered.GroupOrDie(apps.GroupName).GroupVersion, unversioned.GroupVersion{Group: apps.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(extensions.GroupName, registered.GroupOrDie(extensions.GroupName).GroupVersion, unversioned.GroupVersion{Group: extensions.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(rbac.GroupName, registered.GroupOrDie(rbac.GroupName).GroupVersion, unversioned.GroupVersion{Group: rbac.GroupName, Version: runtime.APIVersionInternal})
+	resourceEncoding.SetVersionEncoding(certificates.GroupName, registered.GroupOrDie(certificates.GroupName).GroupVersion, unversioned.GroupVersion{Group: certificates.GroupName, Version: runtime.APIVersionInternal})
 	storageFactory := genericapiserver.NewDefaultStorageFactory(*storageConfig, testapi.StorageMediaType(), api.Codecs, resourceEncoding, DefaultAPIResourceConfigSource())
 
 	config.StorageFactory = storageFactory
@@ -393,8 +393,8 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 	expectVersions := map[string][]unversioned.GroupVersionForDiscovery{
 		autoscaling.GroupName: {
 			{
-				GroupVersion: testapi.Autoscaling.GroupVersion().String(),
-				Version:      testapi.Autoscaling.GroupVersion().Version,
+				GroupVersion: registered.GroupOrDie(autoscaling.GroupName).GroupVersion.String(),
+				Version:      registered.GroupOrDie(autoscaling.GroupName).GroupVersion.Version,
 			},
 		},
 		// batch is using its pkg/apis/batch/ types here since during installation
@@ -412,14 +412,14 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 		},
 		apps.GroupName: {
 			{
-				GroupVersion: testapi.Apps.GroupVersion().String(),
-				Version:      testapi.Apps.GroupVersion().Version,
+				GroupVersion: registered.GroupOrDie(apps.GroupName).GroupVersion.String(),
+				Version:      registered.GroupOrDie(apps.GroupName).GroupVersion.Version,
 			},
 		},
 		extensions.GroupName: {
 			{
-				GroupVersion: testapi.Extensions.GroupVersion().String(),
-				Version:      testapi.Extensions.GroupVersion().Version,
+				GroupVersion: registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
+				Version:      registered.GroupOrDie(extensions.GroupName).GroupVersion.Version,
 			},
 		},
 	}

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	_ "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Autoscaling.GroupVersion().String(),
+		registered.GroupOrDie(autoscaling.GroupName).GroupVersion.String(),
 		"Autoscaler",
 		AutoscalerToSelectableFields(&autoscaling.HorizontalPodAutoscaler{}),
 		nil,

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -223,7 +224,7 @@ func TestJobStatusStrategy(t *testing.T) {
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"Job",
 		JobToSelectableFields(&batch.Job{}),
 		nil,

--- a/pkg/registry/batch/scheduledjob/etcd/etcd_test.go
+++ b/pkg/registry/batch/scheduledjob/etcd/etcd_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
 	"k8s.io/kubernetes/pkg/fields"
@@ -64,7 +64,7 @@ func validNewScheduledJob() *batch.ScheduledJob {
 
 func TestCreate(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -86,7 +86,7 @@ func TestCreate(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -115,7 +115,7 @@ func TestUpdate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -128,7 +128,7 @@ func TestDelete(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -141,7 +141,7 @@ func TestGet(t *testing.T) {
 
 func TestList(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 
@@ -154,7 +154,7 @@ func TestList(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	// scheduled jobs should be tested only when batch/v2alpha1 is enabled
-	if *testapi.Batch.GroupVersion() != v2alpha1.SchemeGroupVersion {
+	if registered.GroupOrDie(batch.GroupName).GroupVersion != v2alpha1.SchemeGroupVersion {
 		return
 	}
 

--- a/pkg/registry/extensions/daemonset/strategy_test.go
+++ b/pkg/registry/extensions/daemonset/strategy_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	_ "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"DaemonSet",
 		DaemonSetToSelectableFields(&extensions.DaemonSet{}),
 		nil,

--- a/pkg/registry/extensions/deployment/strategy_test.go
+++ b/pkg/registry/extensions/deployment/strategy_test.go
@@ -21,15 +21,15 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"Deployment",
 		DeploymentToSelectableFields(&extensions.Deployment{}),
 		nil,

--- a/pkg/registry/extensions/ingress/strategy_test.go
+++ b/pkg/registry/extensions/ingress/strategy_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -133,7 +133,7 @@ func TestIngressStatusStrategy(t *testing.T) {
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"Ingress",
 		IngressToSelectableFields(&extensions.Ingress{}),
 		nil,

--- a/pkg/registry/extensions/thirdpartyresource/strategy_test.go
+++ b/pkg/registry/extensions/thirdpartyresource/strategy_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	_ "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"ThirdPartyResource",
 		SelectableFields(&extensions.ThirdPartyResource{}),
 		nil,

--- a/pkg/registry/extensions/thirdpartyresourcedata/strategy_test.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/strategy_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	_ "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Extensions.GroupVersion().String(),
+		registered.GroupOrDie(extensions.GroupName).GroupVersion.String(),
 		"ThirdPartyResourceData",
 		SelectableFields(&extensions.ThirdPartyResourceData{}),
 		nil,

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -164,7 +164,7 @@ func getCodec(obj runtime.Object) (runtime.Codec, error) {
 	var codec runtime.Codec
 	if api.Scheme.Recognizes(registered.GroupOrDie(api.GroupName).GroupVersion.WithKind(fqKind.Kind)) {
 		codec = testapi.Default.Codec()
-	} else if api.Scheme.Recognizes(testapi.Extensions.GroupVersion().WithKind(fqKind.Kind)) {
+	} else if api.Scheme.Recognizes(registered.GroupOrDie("extensions").GroupVersion.WithKind(fqKind.Kind)) {
 		codec = testapi.Extensions.Codec()
 	} else {
 		return nil, fmt.Errorf("unexpected kind: %v", fqKind)


### PR DESCRIPTION
This removes all references and then method for `testapi.GroupVersion()`.  I've got a separate commit with the non-mechanical changes involved.  The rest are straight forward.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34644)

<!-- Reviewable:end -->
