### PR TITLE
log-dump.sh: Fix kubemark log-dump.sh

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -96,7 +96,7 @@ function copy-logs-from-node() {
       scp -oLogLevel=quiet -oConnectTimeout=30 -oStrictHostKeyChecking=no -i "${LOG_DUMP_SSH_KEY}" "${LOG_DUMP_SSH_USER}@${node}:${scp_files}" "${dir}" > /dev/null || true
     else
       case "${KUBERNETES_PROVIDER}" in
-        gce|gke)
+        gce|gke|kubemark)
           gcloud compute copy-files --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
           ;;
         aws)
@@ -120,7 +120,7 @@ function save-logs() {
       fi
     else
       case "${KUBERNETES_PROVIDER}" in
-        gce|gke)
+        gce|gke|kubemark)
           files="${files} ${gce_logfiles}"
           ;;
         aws)


### PR DESCRIPTION
**What this PR does / why we need it**: Using `log-dump.sh` with the `kubemark` synthetic provider are broken.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #34446

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34647)

<!-- Reviewable:end -->
