### PR TITLE
Add secret e2e test for keys mapping

### DIFF
--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -189,12 +189,6 @@ func doSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32) {
 	)
 
 	By(fmt.Sprintf("Creating secret with name %s", secret.Name))
-	defer func() {
-		By("Cleaning up the secret")
-		if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-			framework.Failf("unable to delete secret %v: %v", secret.Name, err)
-		}
-	}()
 	var err error
 	if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
 		framework.Failf("unable to create test secret %s: %v", secret.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a basic e2e test missing in secrets

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_:

**Special notes for your reviewer**:

**Release note**:

``` NONE
```

This patch adds a secret e2e test. While configmap e2e tests are far
more complete, this patch makes secret e2e tests one step closer.

Also, now is more easy to add more tests without code duplication (as I
did in earlier patches :-/), because of the functions created, and is
more easy to make it similar to confimap e2e in the future, that is
really complete.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34653)

<!-- Reviewable:end -->
