### PR TITLE
CRI: Add legacy container log path support.

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -58,6 +58,7 @@ func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot str
 	return &dockerService{
 		seccompProfileRoot: seccompProfileRoot,
 		client:             dockertools.NewInstrumentedDockerInterface(client),
+		os:                 kubecontainer.RealOS{},
 		podSandboxImage:    podSandboxImage,
 	}
 }
@@ -81,6 +82,7 @@ type DockerLegacyService interface {
 type dockerService struct {
 	seccompProfileRoot string
 	client             dockertools.DockerInterface
+	os                 kubecontainer.OSInterface
 	podSandboxImage    string
 }
 

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -19,6 +19,7 @@ package dockershim
 import (
 	"time"
 
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/util/clock"
 )
@@ -26,5 +27,5 @@ import (
 func newTestDockerService() (*dockerService, *dockertools.FakeDockerClient, *clock.FakeClock) {
 	fakeClock := clock.NewFakeClock(time.Time{})
 	c := dockertools.NewFakeDockerClientWithClock(fakeClock)
-	return &dockerService{client: c}, c, fakeClock
+	return &dockerService{client: c, os: &containertest.FakeOS{}}, c, fakeClock
 }


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kubernetes/issues/33189#issuecomment-253262462.

This PR creates the old container log symlink to make cloud logging work properly. 

@yujuhong @feiskyer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34663)

<!-- Reviewable:end -->
