### PR TITLE
Allow kuberuntime to get network namespace for not ready sandboxes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -941,9 +941,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namesp
 // TODO: Rename param name to sandboxID in kubecontainer.Runtime.GetNetNS().
 // TODO: Remove GetNetNS after networking is delegated to the container runtime.
 func (m *kubeGenericRuntimeManager) GetNetNS(sandboxID kubecontainer.ContainerID) (string, error) {
-	readyState := runtimeApi.PodSandBoxState_READY
 	filter := &runtimeApi.PodSandboxFilter{
-		State:         &readyState,
 		Id:            &sandboxID.ID,
 		LabelSelector: map[string]string{kubernetesManagedLabel: "true"},
 	}


### PR DESCRIPTION
Kubelet calls TearDownPod to clean up the network resources for a pod sandbox.
TearDownPod relies on GetNetNS to retrieve network namespace, and the current
implementation makes this impossible for not-ready sandboxes. This change
removes the unnecessary filter to fix this issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34669)

<!-- Reviewable:end -->
