### PR TITLE
Move the common test functions from cmd_test.go to cmd/testing/fake.go

### DIFF
--- a/pkg/kubectl/cmd/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -390,7 +391,7 @@ func TestAnnotateErrors(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		f, tf, _, _ := NewAPIFactory()
+		f, tf, _, _ := cmdtesting.NewAPIFactory()
 		tf.Printer = &testPrinter{}
 		tf.Namespace = "test"
 		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie(api.GroupName).GroupVersion}}
@@ -423,7 +424,7 @@ func TestAnnotateErrors(t *testing.T) {
 func TestAnnotateObject(t *testing.T) {
 	pods, _, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -473,7 +474,7 @@ func TestAnnotateObject(t *testing.T) {
 func TestAnnotateObjectFromFile(t *testing.T) {
 	pods, _, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -522,7 +523,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 }
 
 func TestAnnotateLocal(t *testing.T) {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -553,7 +554,7 @@ func TestAnnotateLocal(t *testing.T) {
 func TestAnnotateMultipleObjects(t *testing.T) {
 	pods, _, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -41,7 +42,7 @@ import (
 func TestApplyExtraArgsFail(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 	c := NewCmdApply(f, buf)
 	if validateApplyArgs(c, []string{"rc"}) == nil {
 		t.Fatalf("unexpected non-error")
@@ -181,7 +182,7 @@ func TestApplyObject(t *testing.T) {
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -223,7 +224,7 @@ func TestApplyRetry(t *testing.T) {
 	firstPatch := true
 	retry := false
 	getCount := 0
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -275,7 +276,7 @@ func TestApplyNonExistObject(t *testing.T) {
 	pathRC := "/namespaces/test/replicationcontrollers"
 	pathNameRC := pathRC + "/" + nameRC
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -324,7 +325,7 @@ func testApplyMultipleObjects(t *testing.T, asList bool) {
 	nameSVC, currentSVC := readAndAnnotateService(t, filenameSVC)
 	pathSVC := "/namespaces/test/services/" + nameSVC
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/util/term"
 )
 
@@ -96,7 +97,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f, tf, _, ns := NewAPIFactory()
+		f, tf, _, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client:               fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) { return nil, nil }),
@@ -162,7 +163,7 @@ func TestAttach(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -242,7 +243,7 @@ func TestAttachWarnings(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/kubectl/cmd/clusterinfo_dump_test.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump_test.go
@@ -22,13 +22,15 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestSetupOutputWriterNoOp(t *testing.T) {
 	tests := []string{"", "-"}
 	for _, test := range tests {
 		out := &bytes.Buffer{}
-		f, _, _, _ := NewAPIFactory()
+		f, _, _, _ := cmdtesting.NewAPIFactory()
 		cmd := NewCmdClusterInfoDump(f, os.Stdout)
 		cmd.Flag("output-directory").Value.Set(test)
 		writer := setupOutputWriter(cmd, out, "/some/file/that/should/be/ignored")
@@ -48,7 +50,7 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	out := &bytes.Buffer{}
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 	cmd := NewCmdClusterInfoDump(f, os.Stdout)
 	cmd.Flag("output-directory").Value.Set(dir)
 	writer := setupOutputWriter(cmd, out, file)

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,26 +27,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/emicklei/go-restful/swagger"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/client/typed/discovery"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/kubectl"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/util/strings"
 )
 
@@ -85,90 +73,6 @@ func defaultClientConfigForVersion(version *unversioned.GroupVersion) *restclien
 	}
 }
 
-type internalType struct {
-	Kind       string
-	APIVersion string
-
-	Name string
-}
-
-type externalType struct {
-	Kind       string `json:"kind"`
-	APIVersion string `json:"apiVersion"`
-
-	Name string `json:"name"`
-}
-
-type ExternalType2 struct {
-	Kind       string `json:"kind"`
-	APIVersion string `json:"apiVersion"`
-
-	Name string `json:"name"`
-}
-
-func (obj *internalType) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *internalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
-	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
-}
-func (obj *internalType) GroupVersionKind() unversioned.GroupVersionKind {
-	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
-}
-func (obj *externalType) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *externalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
-	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
-}
-func (obj *externalType) GroupVersionKind() unversioned.GroupVersionKind {
-	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
-}
-func (obj *ExternalType2) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *ExternalType2) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
-	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
-}
-func (obj *ExternalType2) GroupVersionKind() unversioned.GroupVersionKind {
-	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
-}
-
-var versionErr = errors.New("not a version")
-
-func versionErrIfFalse(b bool) error {
-	if b {
-		return nil
-	}
-	return versionErr
-}
-
-var validVersion = registered.GroupOrDie(api.GroupName).GroupVersion.Version
-var internalGV = unversioned.GroupVersion{Group: "apitest", Version: runtime.APIVersionInternal}
-var unlikelyGV = unversioned.GroupVersion{Group: "apitest", Version: "unlikelyversion"}
-var validVersionGV = unversioned.GroupVersion{Group: "apitest", Version: validVersion}
-
-func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName(internalGV.WithKind("Type"), &internalType{})
-	scheme.AddKnownTypeWithName(unlikelyGV.WithKind("Type"), &externalType{})
-	//This tests that kubectl will not confuse the external scheme with the internal scheme, even when they accidentally have versions of the same name.
-	scheme.AddKnownTypeWithName(validVersionGV.WithKind("Type"), &ExternalType2{})
-
-	codecs := serializer.NewCodecFactory(scheme)
-	codec := codecs.LegacyCodec(unlikelyGV)
-	mapper := meta.NewDefaultRESTMapper([]unversioned.GroupVersion{unlikelyGV, validVersionGV}, func(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
-		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: meta.NewAccessor(),
-		}, versionErrIfFalse(version == validVersionGV || version == unlikelyGV)
-	})
-	for _, gv := range []unversioned.GroupVersion{unlikelyGV, validVersionGV} {
-		for kind := range scheme.KnownTypes(gv) {
-			gvk := gv.WithKind(kind)
-
-			scope := meta.RESTScopeNamespace
-			mapper.Add(gvk, scope)
-		}
-	}
-
-	return scheme, mapper, codec
-}
-
 type testPrinter struct {
 	Objects []runtime.Object
 	Err     error
@@ -202,390 +106,6 @@ func (t *testDescriber) Describe(namespace, name string, describerSettings kubec
 	return t.Output, t.Err
 }
 
-type testFactory struct {
-	Mapper       meta.RESTMapper
-	Typer        runtime.ObjectTyper
-	Client       kubectl.RESTClient
-	Describer    kubectl.Describer
-	Printer      kubectl.ResourcePrinter
-	Validator    validation.Schema
-	Namespace    string
-	ClientConfig *restclient.Config
-	Err          error
-}
-
-type fakeFactory struct {
-	tf    *testFactory
-	Codec runtime.Codec
-}
-
-func NewTestFactory() (cmdutil.Factory, *testFactory, runtime.Codec, runtime.NegotiatedSerializer) {
-	scheme, mapper, codec := newExternalScheme()
-	t := &testFactory{
-		Validator: validation.NullSchema{},
-		Mapper:    mapper,
-		Typer:     scheme,
-	}
-	negotiatedSerializer := serializer.NegotiatedSerializerWrapper(
-		runtime.SerializerInfo{Serializer: codec},
-		runtime.StreamSerializerInfo{})
-	return &fakeFactory{
-		tf:    t,
-		Codec: codec,
-	}, t, codec, negotiatedSerializer
-}
-
-func (f *fakeFactory) FlagSet() *pflag.FlagSet {
-	return nil
-}
-
-func (f *fakeFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
-	priorityRESTMapper := meta.PriorityRESTMapper{
-		Delegate: f.tf.Mapper,
-		ResourcePriority: []unversioned.GroupVersionResource{
-			{Group: meta.AnyGroup, Version: "v1", Resource: meta.AnyResource},
-		},
-		KindPriority: []unversioned.GroupVersionKind{
-			{Group: meta.AnyGroup, Version: "v1", Kind: meta.AnyKind},
-		},
-	}
-	return priorityRESTMapper, f.tf.Typer
-}
-
-func (f *fakeFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
-	return nil, nil, nil
-}
-
-func (f *fakeFactory) Decoder(bool) runtime.Decoder {
-	return f.Codec
-}
-
-func (f *fakeFactory) JSONEncoder() runtime.Encoder {
-	return f.Codec
-}
-
-func (f *fakeFactory) RESTClient() (*restclient.RESTClient, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) ClientSet() (*internalclientset.Clientset, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) ClientConfig() (*restclient.Config, error) {
-	return f.tf.ClientConfig, f.tf.Err
-}
-
-func (f *fakeFactory) ClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
-	return f.tf.Client, f.tf.Err
-}
-
-func (f *fakeFactory) UnstructuredClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) Describer(*meta.RESTMapping) (kubectl.Describer, error) {
-	return f.tf.Describer, f.tf.Err
-}
-
-func (f *fakeFactory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
-	return f.tf.Printer, f.tf.Err
-}
-
-func (f *fakeFactory) Scaler(*meta.RESTMapping) (kubectl.Scaler, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) Reaper(*meta.RESTMapping) (kubectl.Reaper, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) HistoryViewer(*meta.RESTMapping) (kubectl.HistoryViewer, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) Rollbacker(*meta.RESTMapping) (kubectl.Rollbacker, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) StatusViewer(*meta.RESTMapping) (kubectl.StatusViewer, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) MapBasedSelectorForObject(runtime.Object) (string, error) {
-	return "", nil
-}
-
-func (f *fakeFactory) PortsForObject(runtime.Object) ([]string, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) ProtocolsForObject(runtime.Object) (map[string]string, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) LabelsForObject(runtime.Object) (map[string]string, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) PauseObject(runtime.Object) (bool, error) {
-	return false, nil
-}
-
-func (f *fakeFactory) ResumeObject(runtime.Object) (bool, error) {
-	return false, nil
-}
-
-func (f *fakeFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
-	return f.tf.Validator, f.tf.Err
-}
-
-func (f *fakeFactory) SwaggerSchema(unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) DefaultNamespace() (string, bool, error) {
-	return f.tf.Namespace, false, f.tf.Err
-}
-
-func (f *fakeFactory) Generators(string) map[string]kubectl.Generator {
-	return nil
-}
-
-func (f *fakeFactory) CanBeExposed(unversioned.GroupKind) error {
-	return nil
-}
-
-func (f *fakeFactory) CanBeAutoscaled(unversioned.GroupKind) error {
-	return nil
-}
-
-func (f *fakeFactory) AttachablePodForObject(ob runtime.Object) (*api.Pod, error) {
-	return nil, nil
-}
-
-func (f *fakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
-	return false, nil
-}
-
-func (f *fakeFactory) EditorEnvs() []string {
-	return nil
-}
-
-func (f *fakeFactory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
-}
-
-func (f *fakeFactory) Command() string {
-	return ""
-}
-
-func (f *fakeFactory) BindFlags(flags *pflag.FlagSet) {
-}
-
-func (f *fakeFactory) BindExternalFlags(flags *pflag.FlagSet) {
-}
-
-func (f *fakeFactory) PrintObject(cmd *cobra.Command, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
-	return nil
-}
-
-func (f *fakeFactory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (kubectl.ResourcePrinter, error) {
-	return f.tf.Printer, f.tf.Err
-}
-
-func (f *fakeFactory) NewBuilder() *resource.Builder {
-	return nil
-}
-
-func (f *fakeFactory) DefaultResourceFilterOptions(cmd *cobra.Command, withNamespace bool) *kubectl.PrintOptions {
-	return &kubectl.PrintOptions{}
-}
-
-func (f *fakeFactory) DefaultResourceFilterFunc() kubectl.Filters {
-	return nil
-}
-
-type fakeMixedFactory struct {
-	cmdutil.Factory
-	tf        *testFactory
-	apiClient resource.RESTClient
-}
-
-func (f *fakeMixedFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
-	var multiRESTMapper meta.MultiRESTMapper
-	multiRESTMapper = append(multiRESTMapper, f.tf.Mapper)
-	multiRESTMapper = append(multiRESTMapper, testapi.Default.RESTMapper())
-	priorityRESTMapper := meta.PriorityRESTMapper{
-		Delegate: multiRESTMapper,
-		ResourcePriority: []unversioned.GroupVersionResource{
-			{Group: meta.AnyGroup, Version: "v1", Resource: meta.AnyResource},
-		},
-		KindPriority: []unversioned.GroupVersionKind{
-			{Group: meta.AnyGroup, Version: "v1", Kind: meta.AnyKind},
-		},
-	}
-	return priorityRESTMapper, runtime.MultiObjectTyper{f.tf.Typer, api.Scheme}
-}
-
-func (f *fakeMixedFactory) ClientForMapping(m *meta.RESTMapping) (resource.RESTClient, error) {
-	if m.ObjectConvertor == api.Scheme {
-		return f.apiClient, f.tf.Err
-	}
-	return f.tf.Client, f.tf.Err
-}
-
-func NewMixedFactory(apiClient resource.RESTClient) (cmdutil.Factory, *testFactory, runtime.Codec) {
-	f, t, c, _ := NewTestFactory()
-	return &fakeMixedFactory{
-		Factory:   f,
-		tf:        t,
-		apiClient: apiClient,
-	}, t, c
-}
-
-type fakeAPIFactory struct {
-	cmdutil.Factory
-	tf *testFactory
-}
-
-func (f *fakeAPIFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
-	return testapi.Default.RESTMapper(), api.Scheme
-}
-
-func (f *fakeAPIFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
-	groupResources := testDynamicResources()
-	mapper := discovery.NewRESTMapper(groupResources, meta.InterfacesForUnstructured)
-	typer := discovery.NewUnstructuredObjectTyper(groupResources)
-
-	return cmdutil.NewShortcutExpander(mapper, nil), typer, nil
-}
-
-func (f *fakeAPIFactory) Decoder(bool) runtime.Decoder {
-	return testapi.Default.Codec()
-}
-
-func (f *fakeAPIFactory) JSONEncoder() runtime.Encoder {
-	return testapi.Default.Codec()
-}
-
-func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
-	// Swap out the HTTP client out of the client with the fake's version.
-	fakeClient := f.tf.Client.(*fake.RESTClient)
-	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
-	if err != nil {
-		panic(err)
-	}
-	restClient.Client = fakeClient.Client
-	return internalclientset.New(restClient), f.tf.Err
-}
-
-func (f *fakeAPIFactory) RESTClient() (*restclient.RESTClient, error) {
-	// Swap out the HTTP client out of the client with the fake's version.
-	fakeClient := f.tf.Client.(*fake.RESTClient)
-	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
-	if err != nil {
-		panic(err)
-	}
-	restClient.Client = fakeClient.Client
-	return restClient, f.tf.Err
-}
-
-func (f *fakeAPIFactory) ClientConfig() (*restclient.Config, error) {
-	return f.tf.ClientConfig, f.tf.Err
-}
-
-func (f *fakeAPIFactory) ClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
-	return f.tf.Client, f.tf.Err
-}
-
-func (f *fakeAPIFactory) UnstructuredClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
-	return f.tf.Client, f.tf.Err
-}
-
-func (f *fakeAPIFactory) Describer(*meta.RESTMapping) (kubectl.Describer, error) {
-	return f.tf.Describer, f.tf.Err
-}
-
-func (f *fakeAPIFactory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
-	return f.tf.Printer, f.tf.Err
-}
-
-func (f *fakeAPIFactory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
-	fakeClient := f.tf.Client.(*fake.RESTClient)
-	c := client.NewOrDie(f.tf.ClientConfig)
-	c.Client = fakeClient.Client
-
-	switch t := object.(type) {
-	case *api.Pod:
-		opts, ok := options.(*api.PodLogOptions)
-		if !ok {
-			return nil, errors.New("provided options object is not a PodLogOptions")
-		}
-		return c.Pods(f.tf.Namespace).GetLogs(t.Name, opts), nil
-	default:
-		fqKinds, _, err := api.Scheme.ObjectKinds(object)
-		if err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot get the logs from %v", fqKinds[0])
-	}
-}
-
-func (f *fakeAPIFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
-	return f.tf.Validator, f.tf.Err
-}
-
-func (f *fakeAPIFactory) DefaultNamespace() (string, bool, error) {
-	return f.tf.Namespace, false, f.tf.Err
-}
-
-func (f *fakeAPIFactory) Generators(cmdName string) map[string]kubectl.Generator {
-	return cmdutil.DefaultGenerators(cmdName)
-}
-
-func (f *fakeAPIFactory) PrintObject(cmd *cobra.Command, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
-	gvks, _, err := api.Scheme.ObjectKinds(obj)
-	if err != nil {
-		return err
-	}
-
-	mapping, err := mapper.RESTMapping(gvks[0].GroupKind())
-	if err != nil {
-		return err
-	}
-
-	printer, err := f.PrinterForMapping(cmd, mapping, false)
-	if err != nil {
-		return err
-	}
-	return printer.PrintObj(obj, out)
-}
-
-func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (kubectl.ResourcePrinter, error) {
-	return f.tf.Printer, f.tf.Err
-}
-
-func (f *fakeAPIFactory) NewBuilder() *resource.Builder {
-	mapper, typer := f.Object()
-
-	return resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
-}
-
-func NewAPIFactory() (cmdutil.Factory, *testFactory, runtime.Codec, runtime.NegotiatedSerializer) {
-	t := &testFactory{
-		Validator: validation.NullSchema{},
-	}
-	rf := cmdutil.NewFactory(nil)
-	return &fakeAPIFactory{
-		Factory: rf,
-		tf:      t,
-	}, t, testapi.Default.Codec(), testapi.Default.NegotiatedSerializer()
-}
-
 func objBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
 }
@@ -615,7 +135,7 @@ func stringBody(body string) io.ReadCloser {
 //}
 
 func Example_printReplicationControllerWithNamespace() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		WithNamespace: true,
 		ColumnLabels:  []string{},
@@ -665,7 +185,7 @@ func Example_printReplicationControllerWithNamespace() {
 }
 
 func Example_printMultiContainersReplicationControllerWithWide() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		Wide:         true,
 		ColumnLabels: []string{},
@@ -717,7 +237,7 @@ func Example_printMultiContainersReplicationControllerWithWide() {
 }
 
 func Example_printReplicationController() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		ColumnLabels: []string{},
 	})
@@ -768,7 +288,7 @@ func Example_printReplicationController() {
 }
 
 func Example_printPodWithWideFormat() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		Wide:         true,
 		ColumnLabels: []string{},
@@ -808,7 +328,7 @@ func Example_printPodWithWideFormat() {
 }
 
 func Example_printPodWithShowLabels() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		ShowLabels:   true,
 		ColumnLabels: []string{},
@@ -943,7 +463,7 @@ func newAllPhasePodList() *api.PodList {
 }
 
 func Example_printPodHideTerminated() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		ColumnLabels: []string{},
 	})
@@ -975,7 +495,7 @@ func Example_printPodHideTerminated() {
 }
 
 func Example_printPodShowAll() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		ShowAll:      true,
 		ColumnLabels: []string{},
@@ -1001,7 +521,7 @@ func Example_printPodShowAll() {
 }
 
 func Example_printServiceWithNamespacesAndLabels() {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = kubectl.NewHumanReadablePrinter(kubectl.PrintOptions{
 		WithNamespace: true,
 		ColumnLabels:  []string{"l1"},

--- a/pkg/kubectl/cmd/create_configmap_test.go
+++ b/pkg/kubectl/cmd/create_configmap_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateConfigMap(t *testing.T) {
 	configMap := &api.ConfigMap{}
 	configMap.Name = "my-configmap"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/create_deployment_test.go
+++ b/pkg/kubectl/cmd/create_deployment_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateDeployment(t *testing.T) {
 	depName := "jonny-dep"
-	f, tf, _, _ := NewAPIFactory()
+	f, tf, _, _ := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
@@ -42,7 +44,7 @@ func TestCreateDeployment(t *testing.T) {
 
 func TestCreateDeploymentNoImage(t *testing.T) {
 	depName := "jonny-dep"
-	f, tf, _, _ := NewAPIFactory()
+	f, tf, _, _ := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})

--- a/pkg/kubectl/cmd/create_namespace_test.go
+++ b/pkg/kubectl/cmd/create_namespace_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateNamespace(t *testing.T) {
 	namespaceObject := &api.Namespace{}
 	namespaceObject.Name = "my-namespace"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/create_quota_test.go
+++ b/pkg/kubectl/cmd/create_quota_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateQuota(t *testing.T) {
 	resourceQuotaObject := &api.ResourceQuota{}
 	resourceQuotaObject.Name = "my-quota"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/create_secret_test.go
+++ b/pkg/kubectl/cmd/create_secret_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateSecretGeneric(t *testing.T) {
 	secretObject := &api.Secret{}
 	secretObject.Name = "my-secret"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -56,7 +57,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 func TestCreateSecretDockerRegistry(t *testing.T) {
 	secretObject := &api.Secret{}
 	secretObject.Name = "my-secret"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/create_service_test.go
+++ b/pkg/kubectl/cmd/create_service_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateService(t *testing.T) {
 	service := &api.Service{}
 	service.Name = "my-service"
-	f, tf, codec, negSer := NewAPIFactory()
+	f, tf, codec, negSer := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: negSer,

--- a/pkg/kubectl/cmd/create_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/create_serviceaccount_test.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestCreateServiceAccount(t *testing.T) {
 	serviceAccountObject := &api.ServiceAccount{}
 	serviceAccountObject.Name = "my-service-account"
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/create_test.go
+++ b/pkg/kubectl/cmd/create_test.go
@@ -23,13 +23,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestExtraArgsFail(t *testing.T) {
 	initTestErrorHandler(t)
 	buf := bytes.NewBuffer([]byte{})
 
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 	c := NewCmdCreate(f, buf)
 	if ValidateArgs(c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
@@ -41,7 +42,7 @@ func TestCreateObject(t *testing.T) {
 	_, _, rc := testData()
 	rc.Items[0].Name = "redis-master-controller"
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
@@ -74,7 +75,7 @@ func TestCreateMultipleObject(t *testing.T) {
 	initTestErrorHandler(t)
 	_, svc, rc := testData()
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
@@ -111,7 +112,7 @@ func TestCreateDirectory(t *testing.T) {
 	_, _, rc := testData()
 	rc.Items[0].Name = "name"
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -28,13 +28,14 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 func TestDeleteObjectByTuple(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -66,7 +67,7 @@ func TestDeleteObjectByTuple(t *testing.T) {
 func TestDeleteNamedObject(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -98,7 +99,7 @@ func TestDeleteNamedObject(t *testing.T) {
 func TestDeleteObject(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -128,7 +129,7 @@ func TestDeleteObject(t *testing.T) {
 }
 
 func TestDeleteObjectNotFound(t *testing.T) {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -157,7 +158,7 @@ func TestDeleteObjectNotFound(t *testing.T) {
 }
 
 func TestDeleteObjectIgnoreNotFound(t *testing.T) {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -189,7 +190,7 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 func TestDeleteAllNotFound(t *testing.T) {
 	_, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 
 	// Add an item to the list which will result in a 404 on delete
 	svc.Items = append(svc.Items, api.Service{ObjectMeta: api.ObjectMeta{Name: "foo"}})
@@ -231,7 +232,7 @@ func TestDeleteAllNotFound(t *testing.T) {
 func TestDeleteAllIgnoreNotFound(t *testing.T) {
 	_, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 
 	// Add an item to the list which will result in a 404 on delete
 	svc.Items = append(svc.Items, api.Service{ObjectMeta: api.ObjectMeta{Name: "foo"}})
@@ -271,7 +272,7 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 func TestDeleteMultipleObject(t *testing.T) {
 	_, svc, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -305,7 +306,7 @@ func TestDeleteMultipleObject(t *testing.T) {
 func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 	_, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -341,7 +342,7 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 
 func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 	_, svc, rc := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -377,7 +378,7 @@ func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 func TestDeleteDirectory(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -408,7 +409,7 @@ func TestDeleteDirectory(t *testing.T) {
 func TestDeleteMultipleSelector(t *testing.T) {
 	pods, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -473,7 +474,7 @@ func TestResourceErrors(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		f, tf, _, _ := NewAPIFactory()
+		f, tf, _, _ := cmdtesting.NewAPIFactory()
 		tf.Printer = &testPrinter{}
 		tf.Namespace = "test"
 		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie(api.GroupName).GroupVersion}}

--- a/pkg/kubectl/cmd/describe_test.go
+++ b/pkg/kubectl/cmd/describe_test.go
@@ -23,16 +23,17 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 // Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
 func TestDescribeUnknownSchemaObject(t *testing.T) {
 	d := &testDescriber{Output: "test output"}
-	f, tf, codec, ns := NewTestFactory()
+	f, tf, codec, ns := cmdtesting.NewTestFactory()
 	tf.Describer = d
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
-		Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &internalType{Name: "foo"})},
+		Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, cmdtesting.NewInternalType("", "", "foo"))},
 	}
 	tf.Namespace = "non-default"
 	buf := bytes.NewBuffer([]byte{})
@@ -51,7 +52,7 @@ func TestDescribeUnknownSchemaObject(t *testing.T) {
 
 func TestDescribeObject(t *testing.T) {
 	_, _, rc := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	d := &testDescriber{Output: "test output"}
 	tf.Describer = d
 	tf.Client = &fake.RESTClient{
@@ -84,7 +85,7 @@ func TestDescribeObject(t *testing.T) {
 
 func TestDescribeListObjects(t *testing.T) {
 	pods, _, _ := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	d := &testDescriber{Output: "test output"}
 	tf.Describer = d
 	tf.Client = &fake.RESTClient{
@@ -104,7 +105,7 @@ func TestDescribeListObjects(t *testing.T) {
 
 func TestDescribeObjectShowEvents(t *testing.T) {
 	pods, _, _ := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	d := &testDescriber{Output: "test output"}
 	tf.Describer = d
 	tf.Client = &fake.RESTClient{
@@ -125,7 +126,7 @@ func TestDescribeObjectShowEvents(t *testing.T) {
 
 func TestDescribeObjectSkipEvents(t *testing.T) {
 	pods, _, _ := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	d := &testDescriber{Output: "test output"}
 	tf.Describer = d
 	tf.Client = &fake.RESTClient{

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/conversion"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -132,7 +133,7 @@ func TestCordon(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		new_node := &api.Node{}
 		updated := false
 		tf.Client = &fake.RESTClient{
@@ -459,7 +460,7 @@ func TestDrain(t *testing.T) {
 	for _, test := range tests {
 		new_node := &api.Node{}
 		deleted := false
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
@@ -567,7 +568,7 @@ func refJson(t *testing.T, o runtime.Object) string {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, _, codec, _ := NewAPIFactory()
+	_, _, codec, _ := cmdtesting.NewAPIFactory()
 	json, err := runtime.Encode(codec, &api.SerializedReference{Reference: *ref})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/util/term"
 )
 
@@ -126,7 +127,7 @@ func TestPodAndContainer(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, tf, _, ns := NewAPIFactory()
+		f, tf, _, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client:               fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) { return nil, nil }),
@@ -180,7 +181,7 @@ func TestExec(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/kubectl"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -431,7 +432,7 @@ func TestRunExposeService(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Printer = &kubectl.JSONPrinter{}
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -311,7 +312,7 @@ func TestLabelErrors(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		f, tf, _, _ := NewAPIFactory()
+		f, tf, _, _ := cmdtesting.NewAPIFactory()
 		tf.Printer = &testPrinter{}
 		tf.Namespace = "test"
 		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie(api.GroupName).GroupVersion}}
@@ -346,7 +347,7 @@ func TestLabelErrors(t *testing.T) {
 
 func TestLabelForResourceFromFile(t *testing.T) {
 	pods, _, _ := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -396,7 +397,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 }
 
 func TestLabelLocal(t *testing.T) {
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -429,7 +430,7 @@ func TestLabelLocal(t *testing.T) {
 
 func TestLabelMultipleObjects(t *testing.T) {
 	pods, _, _ := testData()
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestLog(t *testing.T) {
@@ -47,7 +48,7 @@ func TestLog(t *testing.T) {
 	}
 	for _, test := range tests {
 		logContent := "test log content"
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -95,7 +96,7 @@ func testPod() *api.Pod {
 }
 
 func TestValidateLogFlags(t *testing.T) {
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 
 	tests := []struct {
 		name     string

--- a/pkg/kubectl/cmd/patch_test.go
+++ b/pkg/kubectl/cmd/patch_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestPatchObject(t *testing.T) {
 	_, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -59,7 +60,7 @@ func TestPatchObject(t *testing.T) {
 func TestPatchObjectFromFile(t *testing.T) {
 	_, svc, _ := testData()
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 type fakePortForwarder struct {
@@ -67,7 +68,7 @@ func testPortForward(t *testing.T, flags map[string]string, args []string) {
 	}
 	for _, test := range tests {
 		var err error
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/kubectl/cmd/replace_test.go
+++ b/pkg/kubectl/cmd/replace_test.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestReplaceObject(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	deleted := false
@@ -86,7 +87,7 @@ func TestReplaceObject(t *testing.T) {
 func TestReplaceMultipleObject(t *testing.T) {
 	_, svc, rc := testData()
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	redisMasterDeleted := false
@@ -156,7 +157,7 @@ func TestReplaceMultipleObject(t *testing.T) {
 func TestReplaceDirectory(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	created := map[string]bool{}
@@ -213,7 +214,7 @@ func TestReplaceDirectory(t *testing.T) {
 func TestForceReplaceObjectNotFound(t *testing.T) {
 	_, _, rc := testData()
 
-	f, tf, codec, _ := NewAPIFactory()
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{

--- a/pkg/kubectl/cmd/rollingupdate_test.go
+++ b/pkg/kubectl/cmd/rollingupdate_test.go
@@ -19,10 +19,12 @@ package cmd
 import (
 	"bytes"
 	"testing"
+
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
 func TestValidateArgs(t *testing.T) {
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 
 	tests := []struct {
 		flags     map[string]string

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -149,7 +150,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -264,7 +265,7 @@ func TestGenerateService(t *testing.T) {
 	}
 	for _, test := range tests {
 		sawPOST := false
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie(api.GroupName).GroupVersion}}
 		tf.Printer = &testPrinter{}
 		tf.Client = &fake.RESTClient{

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+func TestImageLocal(t *testing.T) {
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
+			return nil, nil
+		}),
+	}
+	tf.Namespace = "test"
+	tf.ClientConfig = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &registered.GroupOrDie(api.GroupName).GroupVersion}}
+
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdImage(f, buf, buf)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("output", "name")
+	tf.Printer, _, _ = cmdutil.PrinterForCommand(cmd)
+
+	opts := ImageOptions{FilenameOptions: resource.FilenameOptions{
+		Filenames: []string{"../../../../examples/storage/cassandra/cassandra-controller.yaml"}},
+		Out:   buf,
+		Local: true}
+	err := opts.Complete(f, cmd, []string{"cassandra=thingy"})
+	if err == nil {
+		err = opts.Validate()
+	}
+	if err == nil {
+		err = opts.Run()
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "replicationcontroller/cassandra") {
+		t.Errorf("did not set image: %s", buf.String())
+	}
+}

--- a/pkg/kubectl/cmd/taint_test.go
+++ b/pkg/kubectl/cmd/taint_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/conversion"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -254,7 +255,7 @@ func TestTaint(t *testing.T) {
 
 		new_node := &api.Node{}
 		tainted := false
-		f, tf, codec, ns := NewAPIFactory()
+		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 
 		tf.Client = &fake.RESTClient{
 			NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -1,0 +1,539 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/emicklei/go-restful/swagger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/serializer"
+)
+
+type InternalType struct {
+	Kind       string
+	APIVersion string
+
+	Name string
+}
+
+type ExternalType struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+
+	Name string `json:"name"`
+}
+
+type ExternalType2 struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+
+	Name string `json:"name"`
+}
+
+func (obj *InternalType) GetObjectKind() unversioned.ObjectKind { return obj }
+func (obj *InternalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
+	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
+}
+func (obj *InternalType) GroupVersionKind() unversioned.GroupVersionKind {
+	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+}
+func (obj *ExternalType) GetObjectKind() unversioned.ObjectKind { return obj }
+func (obj *ExternalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
+	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
+}
+func (obj *ExternalType) GroupVersionKind() unversioned.GroupVersionKind {
+	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+}
+func (obj *ExternalType2) GetObjectKind() unversioned.ObjectKind { return obj }
+func (obj *ExternalType2) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
+	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
+}
+func (obj *ExternalType2) GroupVersionKind() unversioned.GroupVersionKind {
+	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+}
+
+func NewInternalType(kind, apiversion, name string) *InternalType {
+	item := InternalType{Kind: kind,
+		APIVersion: apiversion,
+		Name:       name}
+	return &item
+}
+
+var versionErr = errors.New("not a version")
+
+func versionErrIfFalse(b bool) error {
+	if b {
+		return nil
+	}
+	return versionErr
+}
+
+var ValidVersion = registered.GroupOrDie(api.GroupName).GroupVersion.Version
+var InternalGV = unversioned.GroupVersion{Group: "apitest", Version: runtime.APIVersionInternal}
+var UnlikelyGV = unversioned.GroupVersion{Group: "apitest", Version: "unlikelyversion"}
+var ValidVersionGV = unversioned.GroupVersion{Group: "apitest", Version: ValidVersion}
+
+func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(InternalGV.WithKind("Type"), &InternalType{})
+	scheme.AddKnownTypeWithName(UnlikelyGV.WithKind("Type"), &ExternalType{})
+	//This tests that kubectl will not confuse the external scheme with the internal scheme, even when they accidentally have versions of the same name.
+	scheme.AddKnownTypeWithName(ValidVersionGV.WithKind("Type"), &ExternalType2{})
+
+	codecs := serializer.NewCodecFactory(scheme)
+	codec := codecs.LegacyCodec(UnlikelyGV)
+	mapper := meta.NewDefaultRESTMapper([]unversioned.GroupVersion{UnlikelyGV, ValidVersionGV}, func(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
+		return &meta.VersionInterfaces{
+			ObjectConvertor:  scheme,
+			MetadataAccessor: meta.NewAccessor(),
+		}, versionErrIfFalse(version == ValidVersionGV || version == UnlikelyGV)
+	})
+	for _, gv := range []unversioned.GroupVersion{UnlikelyGV, ValidVersionGV} {
+		for kind := range scheme.KnownTypes(gv) {
+			gvk := gv.WithKind(kind)
+
+			scope := meta.RESTScopeNamespace
+			mapper.Add(gvk, scope)
+		}
+	}
+
+	return scheme, mapper, codec
+}
+
+type TestFactory struct {
+	Mapper       meta.RESTMapper
+	Typer        runtime.ObjectTyper
+	Client       kubectl.RESTClient
+	Describer    kubectl.Describer
+	Printer      kubectl.ResourcePrinter
+	Validator    validation.Schema
+	Namespace    string
+	ClientConfig *restclient.Config
+	Err          error
+}
+
+type FakeFactory struct {
+	tf    *TestFactory
+	Codec runtime.Codec
+}
+
+func NewTestFactory() (cmdutil.Factory, *TestFactory, runtime.Codec, runtime.NegotiatedSerializer) {
+	scheme, mapper, codec := newExternalScheme()
+	t := &TestFactory{
+		Validator: validation.NullSchema{},
+		Mapper:    mapper,
+		Typer:     scheme,
+	}
+	negotiatedSerializer := serializer.NegotiatedSerializerWrapper(
+		runtime.SerializerInfo{Serializer: codec},
+		runtime.StreamSerializerInfo{})
+	return &FakeFactory{
+		tf:    t,
+		Codec: codec,
+	}, t, codec, negotiatedSerializer
+}
+
+func (f *FakeFactory) FlagSet() *pflag.FlagSet {
+	return nil
+}
+
+func (f *FakeFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
+	priorityRESTMapper := meta.PriorityRESTMapper{
+		Delegate: f.tf.Mapper,
+		ResourcePriority: []unversioned.GroupVersionResource{
+			{Group: meta.AnyGroup, Version: "v1", Resource: meta.AnyResource},
+		},
+		KindPriority: []unversioned.GroupVersionKind{
+			{Group: meta.AnyGroup, Version: "v1", Kind: meta.AnyKind},
+		},
+	}
+	return priorityRESTMapper, f.tf.Typer
+}
+
+func (f *FakeFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+	return nil, nil, nil
+}
+
+func (f *FakeFactory) Decoder(bool) runtime.Decoder {
+	return f.Codec
+}
+
+func (f *FakeFactory) JSONEncoder() runtime.Encoder {
+	return f.Codec
+}
+
+func (f *FakeFactory) RESTClient() (*restclient.RESTClient, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) ClientSet() (*internalclientset.Clientset, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) ClientConfig() (*restclient.Config, error) {
+	return f.tf.ClientConfig, f.tf.Err
+}
+
+func (f *FakeFactory) ClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
+	return f.tf.Client, f.tf.Err
+}
+
+func (f *FakeFactory) UnstructuredClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) Describer(*meta.RESTMapping) (kubectl.Describer, error) {
+	return f.tf.Describer, f.tf.Err
+}
+
+func (f *FakeFactory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
+}
+
+func (f *FakeFactory) Scaler(*meta.RESTMapping) (kubectl.Scaler, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) Reaper(*meta.RESTMapping) (kubectl.Reaper, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) HistoryViewer(*meta.RESTMapping) (kubectl.HistoryViewer, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) Rollbacker(*meta.RESTMapping) (kubectl.Rollbacker, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) StatusViewer(*meta.RESTMapping) (kubectl.StatusViewer, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) MapBasedSelectorForObject(runtime.Object) (string, error) {
+	return "", nil
+}
+
+func (f *FakeFactory) PortsForObject(runtime.Object) ([]string, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) ProtocolsForObject(runtime.Object) (map[string]string, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) LabelsForObject(runtime.Object) (map[string]string, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) PauseObject(runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (f *FakeFactory) ResumeObject(runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (f *FakeFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
+	return f.tf.Validator, f.tf.Err
+}
+
+func (f *FakeFactory) SwaggerSchema(unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) DefaultNamespace() (string, bool, error) {
+	return f.tf.Namespace, false, f.tf.Err
+}
+
+func (f *FakeFactory) Generators(string) map[string]kubectl.Generator {
+	return nil
+}
+
+func (f *FakeFactory) CanBeExposed(unversioned.GroupKind) error {
+	return nil
+}
+
+func (f *FakeFactory) CanBeAutoscaled(unversioned.GroupKind) error {
+	return nil
+}
+
+func (f *FakeFactory) AttachablePodForObject(ob runtime.Object) (*api.Pod, error) {
+	return nil, nil
+}
+
+func (f *FakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
+	return false, nil
+}
+
+func (f *FakeFactory) EditorEnvs() []string {
+	return nil
+}
+
+func (f *FakeFactory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
+}
+
+func (f *FakeFactory) Command() string {
+	return ""
+}
+
+func (f *FakeFactory) BindFlags(flags *pflag.FlagSet) {
+}
+
+func (f *FakeFactory) BindExternalFlags(flags *pflag.FlagSet) {
+}
+
+func (f *FakeFactory) PrintObject(cmd *cobra.Command, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
+	return nil
+}
+
+func (f *FakeFactory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (kubectl.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
+}
+
+func (f *FakeFactory) NewBuilder() *resource.Builder {
+	return nil
+}
+
+func (f *FakeFactory) DefaultResourceFilterOptions(cmd *cobra.Command, withNamespace bool) *kubectl.PrintOptions {
+	return &kubectl.PrintOptions{}
+}
+
+func (f *FakeFactory) DefaultResourceFilterFunc() kubectl.Filters {
+	return nil
+}
+
+type fakeMixedFactory struct {
+	cmdutil.Factory
+	tf        *TestFactory
+	apiClient resource.RESTClient
+}
+
+func (f *fakeMixedFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
+	var multiRESTMapper meta.MultiRESTMapper
+	multiRESTMapper = append(multiRESTMapper, f.tf.Mapper)
+	multiRESTMapper = append(multiRESTMapper, testapi.Default.RESTMapper())
+	priorityRESTMapper := meta.PriorityRESTMapper{
+		Delegate: multiRESTMapper,
+		ResourcePriority: []unversioned.GroupVersionResource{
+			{Group: meta.AnyGroup, Version: "v1", Resource: meta.AnyResource},
+		},
+		KindPriority: []unversioned.GroupVersionKind{
+			{Group: meta.AnyGroup, Version: "v1", Kind: meta.AnyKind},
+		},
+	}
+	return priorityRESTMapper, runtime.MultiObjectTyper{f.tf.Typer, api.Scheme}
+}
+
+func (f *fakeMixedFactory) ClientForMapping(m *meta.RESTMapping) (resource.RESTClient, error) {
+	if m.ObjectConvertor == api.Scheme {
+		return f.apiClient, f.tf.Err
+	}
+	return f.tf.Client, f.tf.Err
+}
+
+func NewMixedFactory(apiClient resource.RESTClient) (cmdutil.Factory, *TestFactory, runtime.Codec) {
+	f, t, c, _ := NewTestFactory()
+	return &fakeMixedFactory{
+		Factory:   f,
+		tf:        t,
+		apiClient: apiClient,
+	}, t, c
+}
+
+type fakeAPIFactory struct {
+	cmdutil.Factory
+	tf *TestFactory
+}
+
+func (f *fakeAPIFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
+	return testapi.Default.RESTMapper(), api.Scheme
+}
+
+func (f *fakeAPIFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+	groupResources := testDynamicResources()
+	mapper := discovery.NewRESTMapper(groupResources, meta.InterfacesForUnstructured)
+	typer := discovery.NewUnstructuredObjectTyper(groupResources)
+
+	return cmdutil.NewShortcutExpander(mapper, nil), typer, nil
+}
+
+func (f *fakeAPIFactory) Decoder(bool) runtime.Decoder {
+	return testapi.Default.Codec()
+}
+
+func (f *fakeAPIFactory) JSONEncoder() runtime.Encoder {
+	return testapi.Default.Codec()
+}
+
+func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
+	// Swap out the HTTP client out of the client with the fake's version.
+	fakeClient := f.tf.Client.(*fake.RESTClient)
+	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
+	if err != nil {
+		panic(err)
+	}
+	restClient.Client = fakeClient.Client
+	return internalclientset.New(restClient), f.tf.Err
+}
+
+func (f *fakeAPIFactory) RESTClient() (*restclient.RESTClient, error) {
+	// Swap out the HTTP client out of the client with the fake's version.
+	fakeClient := f.tf.Client.(*fake.RESTClient)
+	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
+	if err != nil {
+		panic(err)
+	}
+	restClient.Client = fakeClient.Client
+	return restClient, f.tf.Err
+}
+
+func (f *fakeAPIFactory) ClientConfig() (*restclient.Config, error) {
+	return f.tf.ClientConfig, f.tf.Err
+}
+
+func (f *fakeAPIFactory) ClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
+	return f.tf.Client, f.tf.Err
+}
+
+func (f *fakeAPIFactory) UnstructuredClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
+	return f.tf.Client, f.tf.Err
+}
+
+func (f *fakeAPIFactory) Describer(*meta.RESTMapping) (kubectl.Describer, error) {
+	return f.tf.Describer, f.tf.Err
+}
+
+func (f *fakeAPIFactory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
+}
+
+func (f *fakeAPIFactory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
+	fakeClient := f.tf.Client.(*fake.RESTClient)
+	c := client.NewOrDie(f.tf.ClientConfig)
+	c.Client = fakeClient.Client
+
+	switch t := object.(type) {
+	case *api.Pod:
+		opts, ok := options.(*api.PodLogOptions)
+		if !ok {
+			return nil, errors.New("provided options object is not a PodLogOptions")
+		}
+		return c.Pods(f.tf.Namespace).GetLogs(t.Name, opts), nil
+	default:
+		fqKinds, _, err := api.Scheme.ObjectKinds(object)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("cannot get the logs from %v", fqKinds[0])
+	}
+}
+
+func (f *fakeAPIFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
+	return f.tf.Validator, f.tf.Err
+}
+
+func (f *fakeAPIFactory) DefaultNamespace() (string, bool, error) {
+	return f.tf.Namespace, false, f.tf.Err
+}
+
+func (f *fakeAPIFactory) Generators(cmdName string) map[string]kubectl.Generator {
+	return cmdutil.DefaultGenerators(cmdName)
+}
+
+func (f *fakeAPIFactory) PrintObject(cmd *cobra.Command, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
+	gvks, _, err := api.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return err
+	}
+
+	mapping, err := mapper.RESTMapping(gvks[0].GroupKind())
+	if err != nil {
+		return err
+	}
+
+	printer, err := f.PrinterForMapping(cmd, mapping, false)
+	if err != nil {
+		return err
+	}
+	return printer.PrintObj(obj, out)
+}
+
+func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (kubectl.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
+}
+
+func (f *fakeAPIFactory) NewBuilder() *resource.Builder {
+	mapper, typer := f.Object()
+
+	return resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
+}
+
+func NewAPIFactory() (cmdutil.Factory, *TestFactory, runtime.Codec, runtime.NegotiatedSerializer) {
+	t := &TestFactory{
+		Validator: validation.NullSchema{},
+	}
+	rf := cmdutil.NewFactory(nil)
+	return &fakeAPIFactory{
+		Factory: rf,
+		tf:      t,
+	}, t, testapi.Default.Codec(), testapi.Default.NegotiatedSerializer()
+}
+
+func testDynamicResources() []*discovery.APIGroupResources {
+	return []*discovery.APIGroupResources{
+		{
+			Group: unversioned.APIGroup{
+				Versions: []unversioned.GroupVersionForDiscovery{
+					{Version: "v1"},
+				},
+				PreferredVersion: unversioned.GroupVersionForDiscovery{Version: "v1"},
+			},
+			VersionedResources: map[string][]unversioned.APIResource{
+				"v1": {
+					{Name: "pods", Namespaced: true, Kind: "Pod"},
+					{Name: "services", Namespaced: true, Kind: "Service"},
+					{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/kubectl/cmd/top_node_test.go
+++ b/pkg/kubectl/cmd/top_node_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/heapster/metrics/apis/metrics/v1alpha1"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"net/url"
 )
 
@@ -40,7 +41,7 @@ func TestTopNodeAllMetrics(t *testing.T) {
 	expectedMetricsPath := fmt.Sprintf("%s/%s/nodes", baseMetricsAddress, metricsApiVersion)
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -88,7 +89,7 @@ func TestTopNodeWithNameMetrics(t *testing.T) {
 	expectedPath := fmt.Sprintf("%s/%s/nodes/%s", baseMetricsAddress, metricsApiVersion, expectedMetrics.Name)
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -147,7 +148,7 @@ func TestTopNodeWithLabelSelectorMetrics(t *testing.T) {
 	expectedQuery := fmt.Sprintf("labelSelector=%s", url.QueryEscape(label))
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-	f, tf, codec, ns := NewAPIFactory()
+	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/top_pod_test.go
+++ b/pkg/kubectl/cmd/top_pod_test.go
@@ -25,6 +25,7 @@ import (
 
 	metrics_api "k8s.io/heapster/metrics/apis/metrics/v1alpha1"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"net/url"
 )
 
@@ -40,7 +41,7 @@ func TestTopPodAllNamespacesMetrics(t *testing.T) {
 
 	expectedPath := fmt.Sprintf("%s/%s/pods", baseMetricsAddress, metricsApiVersion)
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -99,7 +100,7 @@ func TestTopPodAllInNamespaceMetrics(t *testing.T) {
 	}
 	expectedPath := fmt.Sprintf("%s/%s/namespaces/%s/pods", baseMetricsAddress, metricsApiVersion, testNamespace)
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -150,7 +151,7 @@ func TestTopPodWithNameMetrics(t *testing.T) {
 	expectedMetrics.Namespace = testNamespace
 	expectedPath := fmt.Sprintf("%s/%s/namespaces/%s/pods/%s", baseMetricsAddress, metricsApiVersion, testNamespace, expectedMetrics.Name)
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -203,7 +204,7 @@ func TestTopPodWithLabelSelectorMetrics(t *testing.T) {
 	expectedPath := fmt.Sprintf("%s/%s/namespaces/%s/pods", baseMetricsAddress, metricsApiVersion, testNamespace)
 	expectedQuery := fmt.Sprintf("labelSelector=%s", url.QueryEscape(label))
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -255,7 +256,7 @@ func TestTopPodWithContainersMetrics(t *testing.T) {
 	expectedMetrics.Namespace = testNamespace
 	expectedPath := fmt.Sprintf("%s/%s/namespaces/%s/pods/%s", baseMetricsAddress, metricsApiVersion, testNamespace, expectedMetrics.Name)
 
-	f, tf, _, ns := NewAPIFactory()
+	f, tf, _, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,

--- a/pkg/kubectl/cmd/top_test.go
+++ b/pkg/kubectl/cmd/top_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"testing"
 )
 
@@ -40,7 +41,7 @@ const (
 func TestTopSubcommandsExist(t *testing.T) {
 	initTestErrorHandler(t)
 
-	f, _, _, _ := NewAPIFactory()
+	f, _, _, _ := cmdtesting.NewAPIFactory()
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := NewCmdTop(f, buf)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is so that we can use NewAPIFactory() from cmd/set/*test.go
Up until now we would get a import loop error.

This commit also adds a basic unit test case for cmd/set/set_image.go

**Which issue this PR fixes**
partial #34592

**Special notes for your reviewer**:
None

**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34683)

<!-- Reviewable:end -->
