### PR TITLE
Allow callers to bypass cmdutil.CheckError() logging

### DIFF
--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -79,8 +79,6 @@ var (
 		  kubectl edit svc/docker-registry --output-version=v1 -o json`)
 )
 
-var errExit = fmt.Errorf("exit directly")
-
 func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
@@ -102,9 +100,6 @@ func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		Example: fmt.Sprintf(editExample),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunEdit(f, out, errOut, cmd, args, options)
-			if err == errExit {
-				os.Exit(1)
-			}
 			cmdutil.CheckErr(err)
 		},
 		ValidArgs:  validArgs,
@@ -285,11 +280,11 @@ func RunEdit(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args 
 			// 3. invalid: retry those on the spot by looping ie. reloading the editor
 			if results.retryable > 0 {
 				fmt.Fprintf(errOut, "You can run `%s replace -f %s` to try this update again.\n", filepath.Base(os.Args[0]), file)
-				return errExit
+				return cmdutil.ErrExit
 			}
 			if results.notfound > 0 {
 				fmt.Fprintf(errOut, "The edits you made on deleted resources have been saved to %q\n", file)
-				return errExit
+				return cmdutil.ErrExit
 			}
 
 			if len(results.edit) == 0 {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -88,22 +88,25 @@ func DefaultBehaviorOnFatal() {
 	fatalErrHandler = fatal
 }
 
-// fatal prints the message if set and then exits. If V(2) or greater, glog.Fatal
-// is invoked for extended information.
+// fatal prints the message (if provided) and then exits. If V(2) or greater,
+// glog.Fatal is invoked for extended information.
 func fatal(msg string, code int) {
+	if glog.V(2) {
+		glog.FatalDepth(2, msg)
+	}
 	if len(msg) > 0 {
 		// add newline if needed
 		if !strings.HasSuffix(msg, "\n") {
 			msg += "\n"
 		}
-
-		if glog.V(2) {
-			glog.FatalDepth(2, msg)
-		}
 		fmt.Fprint(os.Stderr, msg)
 	}
 	os.Exit(code)
 }
+
+// ErrExit may be passed to CheckError to instruct it to output nothing but exit with
+// status code 1.
+var ErrExit = fmt.Errorf("exit")
 
 // CheckErr prints a user friendly error to STDERR and exits with a non-zero
 // exit code. Unrecognized errors will be printed with an "error: " prefix.
@@ -129,6 +132,9 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 
 	switch {
 	case err == nil:
+		return
+	case err == ErrExit:
+		handleErr("", DefaultErrorExitCode)
 		return
 	case kerrors.IsInvalid(err):
 		details := err.(*kerrors.StatusError).Status().Details


### PR DESCRIPTION
**Release note**:

``` release-note
release-note-none
```

This patch is originally from:
https://github.com/kubernetes/kubernetes/pull/25451 (https://github.com/kubernetes/kubernetes/pull/25451/commits/eedb67a30d3591bb609d649043a99f8fc46cd64a)

Simplifies code where clients are writing their own errors, and want to
terminate with an exit code.

cc @smarterclayton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34721)

<!-- Reviewable:end -->
