### PR TITLE
e2e: don't require minimum availability once scaling takes place

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -1166,8 +1166,6 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 	By(fmt.Sprintf("Waiting for deployment status to sync (current available: %d, minimum available: %d)", deployment.Status.AvailableReplicas, deploymentutil.MinAvailable(deployment)))
 	err = framework.WaitForDeploymentStatusValid(c, deployment)
 	Expect(err).NotTo(HaveOccurred())
-	err = framework.WaitForDeploymentStatus(c, deployment)
-	Expect(err).NotTo(HaveOccurred())
 
 	// Update the deployment with a non-existent image so that the new replica set will be blocked.
 	By(fmt.Sprintf("Updating deployment %q with a non-existent image", deploymentName))
@@ -1226,8 +1224,6 @@ func testScaledRolloutDeployment(f *framework.Framework) {
 
 	By(fmt.Sprintf("Waiting for deployment status to sync (current available: %d, minimum available: %d)", deployment.Status.AvailableReplicas, deploymentutil.MinAvailable(deployment)))
 	err = framework.WaitForDeploymentStatusValid(c, deployment)
-	Expect(err).NotTo(HaveOccurred())
-	err = framework.WaitForDeploymentStatus(c, deployment)
 	Expect(err).NotTo(HaveOccurred())
 }
 


### PR DESCRIPTION
This test shouldn't care about availability at all in the first place.

@mfojtik @kubernetes/deployment  ptal

Fixes https://github.com/kubernetes/kubernetes/issues/34717

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34724)

<!-- Reviewable:end -->
