### PR TITLE
Wait until all shared informers have synced state before starting con…

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -227,6 +227,9 @@ func StartControllers(s *options.CMServer, kubeconfig *restclient.Config, rootCl
 	discoveryClient := client("controller-discovery").Discovery()
 	sharedInformers := informers.NewSharedInformerFactory(client("shared-informers"), ResyncPeriod(s)())
 
+	sharedInformers.Start(stop)
+	sharedInformers.WaitForSync()
+
 	// always start the SA token controller first using a full-power client, since it needs to mint tokens for the rest
 	if len(s.ServiceAccountKeyFile) > 0 {
 		privateKey, err := serviceaccount.ReadPrivateKey(s.ServiceAccountKeyFile)
@@ -557,8 +560,6 @@ func StartControllers(s *options.CMServer, kubeconfig *restclient.Config, rootCl
 			go garbageCollector.Run(workers, wait.NeverStop)
 		}
 	}
-
-	sharedInformers.Start(stop)
 
 	select {}
 }


### PR DESCRIPTION
I have no idea if we can start informers before registering handlers, but we probably should do this to avoid races at startup.

cc @wojtek-t @dchen1107 @davidopp

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34741)

<!-- Reviewable:end -->
