### PR TITLE
log info on invalid --output-version

### DIFF
--- a/pkg/kubectl/resource/BUILD
+++ b/pkg/kubectl/resource/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//pkg/api/validation:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/client/restclient:go_default_library",
+        "//vendor:github.com/golang/glog",
         "//vendor:golang.org/x/text/encoding/unicode",
         "//vendor:golang.org/x/text/transform",
         "//vendor:k8s.io/apimachinery/pkg/api/meta",

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,6 +230,15 @@ func AsVersionedObject(infos []*Info, forceList bool, version schema.GroupVersio
 			return nil, err
 		}
 		object = converted
+	}
+
+	actualVersion := object.GetObjectKind().GroupVersionKind()
+	if actualVersion.Version != version.Version {
+		defaultVersionInfo := ""
+		if len(actualVersion.Version) > 0 {
+			defaultVersionInfo = fmt.Sprintf("Defaulting to %q", actualVersion.Version)
+		}
+		glog.V(1).Infof("info: the output version specified is invalid. %s\n", defaultVersionInfo)
 	}
 	return object, nil
 }


### PR DESCRIPTION
**Release note**:

``` release-note
release-note-none
```

Object versions default to the current version (v1) when a specified
`--output-version` is invalid. This patch logs a warning when this is
the case. Cases affected are all commands with the `--output-version`
option, and anywhere runtime objects are converted to versioned objects.

**Example**

```
$ kubectl get pod <mypod> -o json --output-version=invalid
W1013 17:24:16.810278   26719 result.go:238]  info: the output version
specified (invalid) is invalid, defaulting to v1
{
        "kind": "Pod",
            "apiVersion": "v1",
                "metadata": {
                            "name": "mypod",
                                    "namespace": "test",
...
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34763)

<!-- Reviewable:end -->
