### PR TITLE
Added validation of generated object after merging with override json string for commands `run` and `expose`

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -99,6 +99,7 @@ func NewCmdRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *co
 	}
 	cmdutil.AddPrinterFlags(cmd)
 	addRunFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -604,12 +605,15 @@ func createGeneratedObject(f cmdutil.Factory, cmd *cobra.Command, generator kube
 
 	if len(overrides) > 0 {
 		codec := runtime.NewCodec(f.JSONEncoder(), f.Decoder(true))
-		obj, err = cmdutil.Merge(codec, obj, overrides, groupVersionKind.Kind)
+		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"), cmdutil.GetFlagString(cmd, "schema-cache-dir"))
+		if err != nil {
+			return nil, "", nil, nil, err
+		}
+		obj, err = cmdutil.Merge(codec, obj, overrides, schema)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}
 	}
-
 	mapping, err := mapper.RESTMapping(groupVersionKind.GroupKind(), groupVersionKind.Version)
 	if err != nil {
 		return nil, "", nil, nil, err

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -189,7 +189,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		out, err := Merge(testapi.Default.Codec(), test.obj, test.fragment, test.kind)
+		out, err := Merge(testapi.Default.Codec(), test.obj, test.fragment, nil)
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("testcase[%d], unexpected error: %v", i, err)


### PR DESCRIPTION
fixes #26804 

Output example:

```
# _output/local/go/bin/kubectl run -i --rm --tty ubuntu --overrides='{ "apiVersion":"batch/v1", "spec": {"containers": {"image": "ubuntu:14.04", "volumeMounts": {"mountPath": "/home/store", "name":"store"}}, "volumes":{"name":"store", "emptyDir":{}}}}' --image=ubuntu:14.04 --restart=OnFailure -- bash
error: error validating resource json after merging with override string: {"apiVersion":"batch/v1","kind":"Job","metadata":{"name":"ubuntu","creationTimestamp":null,"labels":{"run":"ubuntu"}},"spec":{"containers":{"image":"ubuntu:14.04","volumeMounts":{"mountPath":"/home/store","name":"store"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"run":"ubuntu"}},"spec":{"containers":[{"name":"ubuntu","image":"ubuntu:14.04","args":["bash"],"resources":{},"stdin":true,"stdinOnce":true,"tty":true}],"restartPolicy":"OnFailure"}},"volumes":{"emptyDir":{},"name":"store"}},"status":{}}
error validating data: [found invalid field containers for v1.JobSpec, found invalid field volumes for v1.JobSpec]; if you choose to ignore these errors, turn validation off with --validate=false
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34771)

<!-- Reviewable:end -->
