### PR TITLE
[CRI] Migrate Network Logic into runtime

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -112,6 +112,8 @@ type Runtime interface {
 	GetContainerLogs(pod *api.Pod, containerID ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error)
 	// Delete a container. If the container is still running, an error is returned.
 	DeleteContainer(containerID ContainerID) error
+	// UpdatePodCIDR allows kubelet to update pod CIDR
+	UpdatePodCIDR(podCIDR string) error
 	// ContainerCommandRunner encapsulates the command runner interfaces for testability.
 	ContainerCommandRunner
 	// ContainerAttach encapsulates the attaching to containers for testability

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -400,3 +400,7 @@ func (f *FakeRuntime) ImageStats() (*ImageStats, error) {
 	f.CalledFunctions = append(f.CalledFunctions, "ImageStats")
 	return nil, f.Err
 }
+
+func (f *FakeRuntime) UpdatePodCIDR(podCIDR string) error {
+	return nil
+}

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -153,3 +153,7 @@ func (r *Mock) ImageStats() (*ImageStats, error) {
 	args := r.Called()
 	return args.Get(0).(*ImageStats), args.Error(1)
 }
+
+func (f *Mock) UpdatePodCIDR(podCIDR string) error {
+	return nil
+}

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -20,11 +20,12 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/util/clock"
 )
 
 func newTestDockerService() (*dockerService, *dockertools.FakeDockerClient, *clock.FakeClock) {
 	fakeClock := clock.NewFakeClock(time.Time{})
 	c := dockertools.NewFakeDockerClientWithClock(fakeClock)
-	return &dockerService{client: c}, c, fakeClock
+	return &dockerService{client: c, networkPlugin: &network.NoopNetworkPlugin{}}, c, fakeClock
 }

--- a/pkg/kubelet/dockershim/network.go
+++ b/pkg/kubelet/dockershim/network.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import "k8s.io/kubernetes/pkg/kubelet/network/hostport"
+
+// Exports required functions from dockershim for use by network plugins
+type DockerNetworkHost struct {
+	ds *dockerService
+}
+
+func (nh *DockerNetworkHost) GetPodSandboxNetNS(podSandboxID string) (string, error) {
+	return nh.ds.GetPodSandboxNetNS(podSandboxID)
+}
+
+func (nh *DockerNetworkHost) GetPodHostportMapping() ([]*hostport.PodPortMapping, error) {
+	return nh.ds.GetPodHostportMapping()
+}
+
+func (nh *DockerNetworkHost) GetPodAnnotations(namespace, name, podSandboxID string) (map[string]string, error) {
+	return nh.ds.GetPodAnnotations(namespace, name, podSandboxID)
+}

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -2631,6 +2631,10 @@ func (dm *DockerManager) getVersionInfo() (versionInfo, error) {
 	}, nil
 }
 
+func (dm *DockerManager) UpdatePodCIDR(podCIDR string) error {
+	return nil
+}
+
 // Truncate the message if it exceeds max length.
 func truncateMsg(msg string, max int) string {
 	if len(msg) <= max {

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -132,7 +132,7 @@ func createTestDockerManager(fakeHTTPClient *fakeHTTP, fakeDocker *FakeDockerCli
 	networkPlugin, _ := network.InitNetworkPlugin(
 		[]network.NetworkPlugin{},
 		"",
-		nettest.NewFakeHost(nil),
+		nettest.NewFakeHost(nil, nil, nil),
 		componentconfig.HairpinNone,
 		"10.0.0.0/8",
 		network.UseDefaultMTU)

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2284,7 +2284,7 @@ func TestGetPodStatusFromNetworkPlugin(t *testing.T) {
 		if test.fakePodIP != "" {
 			podNetworkStatus = &network.PodNetworkStatus{IP: net.ParseIP(test.fakePodIP)}
 		}
-		fnp.EXPECT().GetPodNetworkStatus(test.pod.Namespace, test.pod.Name, kubecontainer.DockerID(test.infraContainerID).ContainerID()).Return(podNetworkStatus, test.networkStatusError)
+		fnp.EXPECT().GetPodNetworkStatus(test.pod.Namespace, test.pod.Name, test.infraContainerID).Return(podNetworkStatus, test.networkStatusError)
 
 		podStatus, err := dm.GetPodStatus(test.pod.UID, test.pod.Name, test.pod.Namespace)
 		if err != nil {

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -885,7 +885,7 @@ func TestFindContainersByPod(t *testing.T) {
 		},
 	}
 	fakeClient := NewFakeDockerClient()
-	np, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	np, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	// image back-off is set to nil, this test should not pull images
 	containerManager := NewFakeDockerManager(fakeClient, &record.FakeRecorder{}, nil, nil, &cadvisorapi.MachineInfo{}, "", 0, 0, "", &containertest.FakeOS{}, np, nil, nil, nil)
 	for i, test := range tests {

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -269,6 +269,10 @@ func (kl *Kubelet) updatePodCIDR(cidr string) {
 		details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = cidr
 		kl.networkPlugin.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
 	}
+
+	if err := kl.GetRuntime().UpdatePodCIDR(cidr); err != nil {
+		glog.Errorf("Failed to update pod cidr in runtime: %v", err)
+	}
 }
 
 // shapingEnabled returns whether traffic shaping is enabled.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -131,7 +131,7 @@ func newTestKubeletWithImageList(
 	kubelet.nodeName = types.NodeName(testKubeletHostname)
 	kubelet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	kubelet.runtimeState.setNetworkState(nil)
-	kubelet.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, kubelet.nonMasqueradeCIDR, 1440)
+	kubelet.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, kubelet.nonMasqueradeCIDR, 1440)
 	if tempDir, err := ioutil.TempDir("/tmp", "kubelet_test."); err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	} else {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -639,39 +639,19 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *api.Pod, _ api.PodStatus, podSt
 			glog.Errorf("createPodSandbox for pod %q failed: %v", format.Pod(pod), err)
 			return
 		}
-
-		setupNetworkResult := kubecontainer.NewSyncResult(kubecontainer.SetupNetwork, podSandboxID)
-		result.AddSyncResult(setupNetworkResult)
-		if !kubecontainer.IsHostNetworkPod(pod) {
-			glog.V(3).Infof("Calling network plugin %s to setup pod for %s", m.networkPlugin.Name(), format.Pod(pod))
-			// Setup pod network plugin with sandbox id
-			// TODO: rename the last param to sandboxID
-			err = m.networkPlugin.SetUpPod(pod.Namespace, pod.Name, podSandboxID)
-			if err != nil {
-				message := fmt.Sprintf("Failed to setup network for pod %q using network plugins %q: %v", format.Pod(pod), m.networkPlugin.Name(), err)
-				setupNetworkResult.Fail(kubecontainer.ErrSetupNetwork, message)
-				glog.Error(message)
-
-				killPodSandboxResult := kubecontainer.NewSyncResult(kubecontainer.KillPodSandbox, format.Pod(pod))
-				result.AddSyncResult(killPodSandboxResult)
-				if err := m.runtimeService.StopPodSandbox(podSandboxID); err != nil {
-					killPodSandboxResult.Fail(kubecontainer.ErrKillPodSandbox, err.Error())
-					glog.Errorf("Kill sandbox %q failed for pod %q: %v", podSandboxID, format.Pod(pod), err)
-				}
-				return
-			}
-
-			podSandboxStatus, err := m.runtimeService.PodSandboxStatus(podSandboxID)
-			if err != nil {
-				glog.Errorf("Failed to get pod sandbox status: %v; Skipping pod %q", err, format.Pod(pod))
-				result.Fail(err)
-				return
-			}
-
-			// Overwrite the podIP passed in the pod status, since we just started the infra container.
-			podIP = m.determinePodSandboxIP(pod.Namespace, pod.Name, podSandboxStatus)
-			glog.V(4).Infof("Determined the ip %q for pod %q after sandbox changed", podIP, format.Pod(pod))
+		podSandboxStatus, err := m.runtimeService.PodSandboxStatus(podSandboxID)
+		if err != nil {
+			glog.Errorf("Failed to get pod sandbox status: %v; Skipping pod %q", err, format.Pod(pod))
+			result.Fail(err)
+			return
 		}
+		podIP, err = m.determinePodSandboxIP(podSandboxStatus)
+		if err != nil {
+			glog.Errorf("Could not retrieve pod IP after creating PodSandbox. Skipping pod %q", format.Pod(pod))
+			result.Fail(err)
+			return
+		}
+		glog.V(4).Infof("Determined the ip %q for pod %q after sandbox changed", podIP, format.Pod(pod))
 	}
 
 	// Get podSandboxConfig for containers to start.
@@ -811,30 +791,6 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(pod *api.Pod, runningP
 		result.AddSyncResult(containerResult)
 	}
 
-	// Teardown network plugin
-	if len(runningPod.Sandboxes) == 0 {
-		glog.V(4).Infof("Can not find pod sandbox by UID %q, assuming already removed.", runningPod.ID)
-		return
-	}
-
-	sandboxID := runningPod.Sandboxes[0].ID.ID
-	isHostNetwork, err := m.isHostNetwork(sandboxID, pod)
-	if err != nil {
-		result.Fail(err)
-		return
-	}
-	if !isHostNetwork {
-		teardownNetworkResult := kubecontainer.NewSyncResult(kubecontainer.TeardownNetwork, runningPod.ID)
-		result.AddSyncResult(teardownNetworkResult)
-		// Tear down network plugin with sandbox id
-		if err := m.networkPlugin.TearDownPod(runningPod.Namespace, runningPod.Name, sandboxID); err != nil {
-			message := fmt.Sprintf("Failed to teardown network for pod %s_%s(%s) using network plugins %q: %v",
-				runningPod.Name, runningPod.Namespace, runningPod.ID, m.networkPlugin.Name(), err)
-			teardownNetworkResult.Fail(kubecontainer.ErrTeardownNetwork, message)
-			glog.Error(message)
-		}
-	}
-
 	// stop sandbox, the sandbox will be removed in GarbageCollect
 	killSandboxResult := kubecontainer.NewSyncResult(kubecontainer.KillPodSandbox, runningPod.ID)
 	result.AddSyncResult(killSandboxResult)
@@ -911,7 +867,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namesp
 
 		// Only get pod IP from latest sandbox
 		if idx == 0 && podSandboxStatus.GetState() == runtimeApi.PodSandBoxState_READY {
-			podIP = m.determinePodSandboxIP(namespace, name, podSandboxStatus)
+			podIP, _ = m.determinePodSandboxIP(podSandboxStatus)
 		}
 	}
 
@@ -998,4 +954,12 @@ func (m *kubeGenericRuntimeManager) PortForward(pod *kubecontainer.Pod, port uin
 	}
 
 	return fmt.Errorf("not implemented")
+}
+
+func (m *kubeGenericRuntimeManager) UpdatePodCIDR(podCIDR string) error {
+	err := m.runtimeService.UpdateRuntimeConfig(&runtimeApi.RuntimeConfig{NetworkConfig: &runtimeApi.NetworkConfig{PodCidr: &podCIDR}})
+	if err != nil {
+		return fmt.Errorf("Failed to update pod cidr: %v", err)
+	}
+	return nil
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -646,10 +646,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *api.Pod, _ api.PodStatus, podSt
 			glog.V(3).Infof("Calling network plugin %s to setup pod for %s", m.networkPlugin.Name(), format.Pod(pod))
 			// Setup pod network plugin with sandbox id
 			// TODO: rename the last param to sandboxID
-			err = m.networkPlugin.SetUpPod(pod.Namespace, pod.Name, kubecontainer.ContainerID{
-				Type: m.runtimeName,
-				ID:   podSandboxID,
-			})
+			err = m.networkPlugin.SetUpPod(pod.Namespace, pod.Name, podSandboxID)
 			if err != nil {
 				message := fmt.Sprintf("Failed to setup network for pod %q using network plugins %q: %v", format.Pod(pod), m.networkPlugin.Name(), err)
 				setupNetworkResult.Fail(kubecontainer.ErrSetupNetwork, message)
@@ -830,10 +827,7 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(pod *api.Pod, runningP
 		teardownNetworkResult := kubecontainer.NewSyncResult(kubecontainer.TeardownNetwork, runningPod.ID)
 		result.AddSyncResult(teardownNetworkResult)
 		// Tear down network plugin with sandbox id
-		if err := m.networkPlugin.TearDownPod(runningPod.Namespace, runningPod.Name, kubecontainer.ContainerID{
-			Type: m.runtimeName,
-			ID:   sandboxID,
-		}); err != nil {
+		if err := m.networkPlugin.TearDownPod(runningPod.Namespace, runningPod.Name, sandboxID); err != nil {
 			message := fmt.Sprintf("Failed to teardown network for pod %s_%s(%s) using network plugins %q: %v",
 				runningPod.Name, runningPod.Namespace, runningPod.ID, m.networkPlugin.Name(), err)
 			teardownNetworkResult.Fail(kubecontainer.ErrTeardownNetwork, message)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -50,7 +50,7 @@ func createTestRuntimeManager() (*apitest.FakeRuntimeService, *apitest.FakeImage
 	networkPlugin, _ := network.InitNetworkPlugin(
 		[]network.NetworkPlugin{},
 		"",
-		nettest.NewFakeHost(nil),
+		nettest.NewFakeHost(nil, nil, nil),
 		componentconfig.HairpinNone,
 		"10.0.0.0/8",
 		network.UseDefaultMTU,

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -179,10 +179,7 @@ func (m *kubeGenericRuntimeManager) determinePodSandboxIP(podNamespace, podName 
 
 	if m.networkPlugin.Name() != network.DefaultPluginName {
 		// TODO: podInfraContainerID in GetPodNetworkStatus() interface should be renamed to sandboxID
-		netStatus, err := m.networkPlugin.GetPodNetworkStatus(podNamespace, podName, kubecontainer.ContainerID{
-			Type: m.runtimeName,
-			ID:   podSandbox.GetId(),
-		})
+		netStatus, err := m.networkPlugin.GetPodNetworkStatus(podNamespace, podName, podSandbox.GetId())
 		if err != nil {
 			glog.Errorf("NetworkPlugin %s failed on the status hook for pod '%s' - %v", m.networkPlugin.Name(), kubecontainer.BuildPodFullName(podName, podNamespace), err)
 		} else if netStatus != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
+	"net"
 )
 
 // createPodSandbox creates a pod sandbox and returns (podSandBoxID, message, error).
@@ -169,25 +169,15 @@ func (m *kubeGenericRuntimeManager) getKubeletSandboxes(all bool) ([]*runtimeApi
 }
 
 // determinePodSandboxIP determines the IP address of the given pod sandbox.
-// TODO: remove determinePodSandboxIP after networking is delegated to the container runtime.
-func (m *kubeGenericRuntimeManager) determinePodSandboxIP(podNamespace, podName string, podSandbox *runtimeApi.PodSandboxStatus) string {
+func (m *kubeGenericRuntimeManager) determinePodSandboxIP(podSandbox *runtimeApi.PodSandboxStatus) (string, error) {
 	ip := ""
-
 	if podSandbox.Network != nil {
 		ip = podSandbox.Network.GetIp()
 	}
-
-	if m.networkPlugin.Name() != network.DefaultPluginName {
-		// TODO: podInfraContainerID in GetPodNetworkStatus() interface should be renamed to sandboxID
-		netStatus, err := m.networkPlugin.GetPodNetworkStatus(podNamespace, podName, podSandbox.GetId())
-		if err != nil {
-			glog.Errorf("NetworkPlugin %s failed on the status hook for pod '%s' - %v", m.networkPlugin.Name(), kubecontainer.BuildPodFullName(podName, podNamespace), err)
-		} else if netStatus != nil {
-			ip = netStatus.IP.String()
-		}
+	if net.ParseIP(ip) == nil {
+		return "", fmt.Errorf("Failed to retrieve IP from podSandboxStatus")
 	}
-
-	return ip
+	return ip, nil
 }
 
 // getPodSandboxID gets the sandbox id by podUID and returns ([]sandboxID, error).

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -193,7 +193,7 @@ func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubec
 	if err := plugin.checkInitialized(); err != nil {
 		return err
 	}
-	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
+	netnsPath, err := plugin.host.GetPodSandboxNetNS(id.ID)
 	if err != nil {
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
@@ -217,7 +217,7 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 	if err := plugin.checkInitialized(); err != nil {
 		return err
 	}
-	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
+	netnsPath, err := plugin.host.GetPodSandboxNetNS(id.ID)
 	if err != nil {
 		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
@@ -228,7 +228,7 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 // TODO: Use the addToNetwork function to obtain the IP of the Pod. That will assume idempotent ADD call to the plugin.
 // Also fix the runtime's call to Status function to be done only in the case that the IP is lost, no need to do periodic calls
 func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
-	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
+	netnsPath, err := plugin.host.GetPodSandboxNetNS(id.ID)
 	if err != nil {
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -29,16 +29,13 @@ import (
 	"testing"
 	"text/template"
 
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/cni/testing"
+	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
@@ -111,33 +108,6 @@ func tearDownPlugin(tmpDir string) {
 	}
 }
 
-type fakeNetworkHost struct {
-	kubeClient clientset.Interface
-	runtime    kubecontainer.Runtime
-}
-
-func NewFakeHost(kubeClient clientset.Interface, pods []*containertest.FakePod) *fakeNetworkHost {
-	host := &fakeNetworkHost{
-		kubeClient: kubeClient,
-		runtime: &containertest.FakeRuntime{
-			AllPodList: pods,
-		},
-	}
-	return host
-}
-
-func (fnh *fakeNetworkHost) GetPodByName(name, namespace string) (*api.Pod, bool) {
-	return nil, false
-}
-
-func (fnh *fakeNetworkHost) GetKubeClient() clientset.Interface {
-	return fnh.kubeClient
-}
-
-func (fnh *fakeNetworkHost) GetRuntime() kubecontainer.Runtime {
-	return fnh.runtime
-}
-
 func TestCNIPlugin(t *testing.T) {
 	// install some random plugin
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
@@ -174,14 +144,9 @@ func TestCNIPlugin(t *testing.T) {
 	installPluginUnderTest(t, testVendorCNIDirPrefix, testNetworkConfigPath, vendorName, pluginName)
 
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "test_infra_container"}
-	pods := []*containertest.FakePod{{
-		Pod: &kubecontainer.Pod{
-			Containers: []*kubecontainer.Container{
-				{ID: containerID},
-			},
-		},
-		NetnsPath: "/proc/12345/ns/net",
-	}}
+	netNSMap := map[string]string{
+		containerID.ID: "/proc/12345/ns/net",
+	}
 
 	plugins := probeNetworkPluginsWithVendorCNIDirPrefix(path.Join(testNetworkConfigPath, pluginName), "", testVendorCNIDirPrefix)
 	if len(plugins) != 1 {
@@ -200,7 +165,7 @@ func TestCNIPlugin(t *testing.T) {
 
 	mockLoCNI.On("AddNetwork", cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(&cnitypes.Result{IP4: &cnitypes.IPConfig{IP: net.IPNet{IP: []byte{127, 0, 0, 1}}}}, nil)
 
-	plug, err := network.InitNetworkPlugin(plugins, "cni", NewFakeHost(nil, pods), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(plugins, "cni", nettest.NewFakeHost(netNSMap, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err != nil {
 		t.Fatalf("Failed to select the desired plugin: %v", err)
 	}

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -171,7 +171,7 @@ func TestCNIPlugin(t *testing.T) {
 	}
 
 	// Set up the pod
-	err = plug.SetUpPod("podNamespace", "podName", containerID)
+	err = plug.SetUpPod("podNamespace", "podName", containerID.ID)
 	if err != nil {
 		t.Errorf("Expected nil: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestCNIPlugin(t *testing.T) {
 	}
 
 	// Get its IP address
-	status, err := plug.GetPodNetworkStatus("podNamespace", "podName", containerID)
+	status, err := plug.GetPodNetworkStatus("podNamespace", "podName", containerID.ID)
 	if err != nil {
 		t.Errorf("Failed to read pod network status: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestCNIPlugin(t *testing.T) {
 	}
 
 	// Tear it down
-	err = plug.TearDownPod("podNamespace", "podName", containerID)
+	err = plug.TearDownPod("podNamespace", "podName", containerID.ID)
 	if err != nil {
 		t.Errorf("Expected nil: %v", err)
 	}

--- a/pkg/kubelet/network/exec/exec.go
+++ b/pkg/kubelet/network/exec/exec.go
@@ -67,7 +67,6 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
 )
@@ -145,8 +144,8 @@ func (plugin *execNetworkPlugin) validate() error {
 	return nil
 }
 
-func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
-	out, err := utilexec.New().Command(plugin.getExecutable(), setUpCmd, namespace, name, id.ID).CombinedOutput()
+func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, podSandboxID string) error {
+	out, err := utilexec.New().Command(plugin.getExecutable(), setUpCmd, namespace, name, podSandboxID).CombinedOutput()
 	if err != nil {
 		glog.V(5).Infof("SetUpPod 'exec' network plugin output: %s, %v", string(out), err)
 	} else {
@@ -156,8 +155,8 @@ func (plugin *execNetworkPlugin) SetUpPod(namespace string, name string, id kube
 	return err
 }
 
-func (plugin *execNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.ContainerID) error {
-	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, id.ID).CombinedOutput()
+func (plugin *execNetworkPlugin) TearDownPod(namespace string, name string, podSandboxID string) error {
+	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, podSandboxID).CombinedOutput()
 	if err != nil {
 		glog.V(5).Infof("TearDownPod 'exec' network plugin output: %s, %v", string(out), err)
 	} else {
@@ -166,8 +165,9 @@ func (plugin *execNetworkPlugin) TearDownPod(namespace string, name string, id k
 	return err
 }
 
-func (plugin *execNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
-	out, err := utilexec.New().Command(plugin.getExecutable(), statusCmd, namespace, name, id.ID).CombinedOutput()
+func (plugin *execNetworkPlugin) GetPodNetworkStatus(namespace string, name string, podSandboxID string) (*network.PodNetworkStatus, error) {
+	out, err := utilexec.New().Command(plugin.getExecutable(), statusCmd, namespace, name, podSandboxID).CombinedOutput()
+	glog.V(5).Infof("Status 'exec' network plugin output: %s, %v", string(out), err)
 	if err != nil {
 		glog.V(5).Infof("Status 'exec' network plugin output: %s, %v", string(out), err)
 		return nil, err

--- a/pkg/kubelet/network/exec/exec_test.go
+++ b/pkg/kubelet/network/exec/exec_test.go
@@ -30,7 +30,6 @@ import (
 	"text/template"
 
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -226,7 +225,7 @@ func TestPluginSetupHook(t *testing.T) {
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
-	err = plug.SetUpPod("podNamespace", "podName", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
+	err = plug.SetUpPod("podNamespace", "podName", "dockerid2345")
 	if err != nil {
 		t.Errorf("Expected nil: %v", err)
 	}
@@ -254,7 +253,7 @@ func TestPluginTearDownHook(t *testing.T) {
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
-	err = plug.TearDownPod("podNamespace", "podName", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
+	err = plug.TearDownPod("podNamespace", "podName", "dockerid2345")
 	if err != nil {
 		t.Errorf("Expected nil")
 	}
@@ -282,7 +281,7 @@ func TestPluginStatusHook(t *testing.T) {
 
 	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
-	ip, err := plug.GetPodNetworkStatus("namespace", "name", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
+	ip, err := plug.GetPodNetworkStatus("namespace", "name", "dockerid2345")
 	if err != nil {
 		t.Errorf("Expected nil got %v", err)
 	}
@@ -321,7 +320,7 @@ func TestPluginStatusHookIPv6(t *testing.T) {
 		t.Errorf("InitNetworkPlugin() failed: %v", err)
 	}
 
-	ip, err := plug.GetPodNetworkStatus("namespace", "name", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
+	ip, err := plug.GetPodNetworkStatus("namespace", "name", "dockerid2345")
 	if err != nil {
 		t.Errorf("Status() failed: %v", err)
 	}

--- a/pkg/kubelet/network/exec/exec_test.go
+++ b/pkg/kubelet/network/exec/exec_test.go
@@ -135,7 +135,7 @@ func TestSelectPlugin(t *testing.T) {
 
 	installPluginUnderTest(t, "", testPluginPath, pluginName, nil)
 
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err != nil {
 		t.Errorf("Failed to select the desired plugin: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestSelectVendoredPlugin(t *testing.T) {
 	installPluginUnderTest(t, vendor, testPluginPath, pluginName, nil)
 
 	vendoredPluginName := fmt.Sprintf("%s/%s", vendor, pluginName)
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), vendoredPluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), vendoredPluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err != nil {
 		t.Errorf("Failed to select the desired plugin: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestSelectWrongPlugin(t *testing.T) {
 	installPluginUnderTest(t, "", testPluginPath, pluginName, nil)
 
 	wrongPlugin := "abcd"
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), wrongPlugin, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), wrongPlugin, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if plug != nil || err == nil {
 		t.Errorf("Expected to see an error. Wrong plugin selected.")
 	}
@@ -206,7 +206,7 @@ func TestPluginValidation(t *testing.T) {
 	}
 	f.Close()
 
-	_, err = network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	_, err = network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err == nil {
 		// we expected an error here because validation would have failed
 		t.Errorf("Expected non-nil value.")
@@ -224,7 +224,7 @@ func TestPluginSetupHook(t *testing.T) {
 
 	installPluginUnderTest(t, "", testPluginPath, pluginName, nil)
 
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
 	err = plug.SetUpPod("podNamespace", "podName", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
 	if err != nil {
@@ -252,7 +252,7 @@ func TestPluginTearDownHook(t *testing.T) {
 
 	installPluginUnderTest(t, "", testPluginPath, pluginName, nil)
 
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
 	err = plug.TearDownPod("podNamespace", "podName", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
 	if err != nil {
@@ -280,7 +280,7 @@ func TestPluginStatusHook(t *testing.T) {
 
 	installPluginUnderTest(t, "", testPluginPath, pluginName, nil)
 
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 
 	ip, err := plug.GetPodNetworkStatus("namespace", "name", kubecontainer.ContainerID{Type: "docker", ID: "dockerid2345"})
 	if err != nil {
@@ -316,7 +316,7 @@ func TestPluginStatusHookIPv6(t *testing.T) {
 	}
 	installPluginUnderTest(t, "", testPluginPath, pluginName, execTemplate)
 
-	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	plug, err := network.InitNetworkPlugin(ProbeNetworkPlugins(testPluginPath), pluginName, nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err != nil {
 		t.Errorf("InitNetworkPlugin() failed: %v", err)
 	}

--- a/pkg/kubelet/network/hostport/hostport.go
+++ b/pkg/kubelet/network/hostport/hostport.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
@@ -42,13 +42,26 @@ const (
 )
 
 type HostportHandler interface {
-	OpenPodHostportsAndSync(newPod *ActivePod, natInterfaceName string, activePods []*ActivePod) error
-	SyncHostports(natInterfaceName string, activePods []*ActivePod) error
+	SyncHostports(natInterfaceName string, activePortMapping []*PodPortMapping) error
+	OpenPodHostportsAndSync(newPortMapping *PodPortMapping, natInterfaceName string, activePortMapping []*PodPortMapping) error
 }
 
-type ActivePod struct {
-	Pod *api.Pod
-	IP  net.IP
+// PortMapping represents a network port in a single container
+type PortMapping struct {
+	Name          string
+	HostPort      int32
+	ContainerPort int32
+	Protocol      api.Protocol
+	HostIP        string
+}
+
+type PodPortMapping struct {
+	Namespace    string
+	Name         string
+	PodSandboxID string
+	PortMappings []PortMapping
+	HostNetwork  bool
+	IP           net.IP
 }
 
 type hostportOpener func(*hostport) (closeable, error)
@@ -87,35 +100,35 @@ func (hp *hostport) String() string {
 }
 
 //openPodHostports opens all hostport for pod and returns the map of hostport and socket
-func (h *handler) openHostports(pod *api.Pod) error {
+func (h *handler) openHostports(podHostportMapping *PodPortMapping) error {
 	var retErr error
 	ports := make(map[hostport]closeable)
-	for _, container := range pod.Spec.Containers {
-		for _, port := range container.Ports {
-			if port.HostPort <= 0 {
-				// Ignore
-				continue
-			}
-			hp := hostport{
-				port:     port.HostPort,
-				protocol: strings.ToLower(string(port.Protocol)),
-			}
-			socket, err := h.portOpener(&hp)
-			if err != nil {
-				retErr = fmt.Errorf("Cannot open hostport %d for pod %s: %v", port.HostPort, kubecontainer.GetPodFullName(pod), err)
-				break
-			}
-			ports[hp] = socket
+	for _, port := range podHostportMapping.PortMappings {
+		if port.HostPort <= 0 {
+			// Ignore
+			continue
 		}
+		hp := hostport{
+			port:     port.HostPort,
+			protocol: strings.ToLower(string(port.Protocol)),
+		}
+		socket, err := h.portOpener(&hp)
+		if err != nil {
+			retErr = fmt.Errorf("Cannot open hostport %d for pod %s: %v", port.HostPort, getPodFullName(podHostportMapping), err)
+			break
+		}
+		ports[hp] = socket
+
 		if retErr != nil {
 			break
 		}
 	}
+
 	// If encounter any error, close all hostports that just got opened.
 	if retErr != nil {
 		for hp, socket := range ports {
 			if err := socket.Close(); err != nil {
-				glog.Errorf("Cannot clean up hostport %d for pod %s: %v", hp.port, kubecontainer.GetPodFullName(pod), err)
+				glog.Errorf("Cannot clean up hostport %d for pod %s: %v", hp.port, getPodFullName(podHostportMapping), err)
 			}
 		}
 		return retErr
@@ -128,27 +141,28 @@ func (h *handler) openHostports(pod *api.Pod) error {
 	return nil
 }
 
+func getPodFullName(pod *PodPortMapping) string {
+	// Use underscore as the delimiter because it is not allowed in pod name
+	// (DNS subdomain format), while allowed in the container name format.
+	return pod.Name + "_" + pod.Namespace
+}
+
 // gatherAllHostports returns all hostports that should be presented on node,
 // given the list of pods running on that node and ignoring host network
 // pods (which don't need hostport <-> container port mapping).
-func gatherAllHostports(activePods []*ActivePod) (map[api.ContainerPort]targetPod, error) {
-	podHostportMap := make(map[api.ContainerPort]targetPod)
-	for _, r := range activePods {
-		if r.IP.To4() == nil {
-			return nil, fmt.Errorf("Invalid or missing pod %s IP", kubecontainer.GetPodFullName(r.Pod))
+func gatherAllHostports(activePortMapping []*PodPortMapping) (map[PortMapping]targetPod, error) {
+	podHostportMap := make(map[PortMapping]targetPod)
+	for _, pm := range activePortMapping {
+		if pm.IP.To4() == nil {
+			return nil, fmt.Errorf("Invalid or missing pod %s IP", getPodFullName(pm))
 		}
-
 		// should not handle hostports for hostnetwork pods
-		if r.Pod.Spec.SecurityContext != nil && r.Pod.Spec.SecurityContext.HostNetwork {
+		if pm.HostNetwork {
 			continue
 		}
 
-		for _, container := range r.Pod.Spec.Containers {
-			for _, port := range container.Ports {
-				if port.HostPort != 0 {
-					podHostportMap[port] = targetPod{podFullName: kubecontainer.GetPodFullName(r.Pod), podIP: r.IP.String()}
-				}
-			}
+		for _, port := range pm.PortMappings {
+			podHostportMap[port] = targetPod{podFullName: getPodFullName(pm), podIP: pm.IP.String()}
 		}
 	}
 	return podHostportMap, nil
@@ -164,8 +178,8 @@ func writeLine(buf *bytes.Buffer, words ...string) {
 // then encoding to base32 and truncating with the prefix "KUBE-SVC-".  We do
 // this because IPTables Chain Names must be <= 28 chars long, and the longer
 // they are the harder they are to read.
-func hostportChainName(cp api.ContainerPort, podFullName string) utiliptables.Chain {
-	hash := sha256.Sum256([]byte(string(cp.HostPort) + string(cp.Protocol) + podFullName))
+func hostportChainName(pm PortMapping, podFullName string) utiliptables.Chain {
+	hash := sha256.Sum256([]byte(string(pm.HostPort) + string(pm.Protocol) + podFullName))
 	encoded := base32.StdEncoding.EncodeToString(hash[:])
 	return utiliptables.Chain(kubeHostportChainPrefix + encoded[:16])
 }
@@ -173,35 +187,35 @@ func hostportChainName(cp api.ContainerPort, podFullName string) utiliptables.Ch
 // OpenPodHostportsAndSync opens hostports for a new pod, gathers all hostports on
 // node, sets up iptables rules enable them. And finally clean up stale hostports.
 // 'newPod' must also be present in 'activePods'.
-func (h *handler) OpenPodHostportsAndSync(newPod *ActivePod, natInterfaceName string, activePods []*ActivePod) error {
+func (h *handler) OpenPodHostportsAndSync(newPortMapping *PodPortMapping, natInterfaceName string, activePortMapping []*PodPortMapping) error {
 	// try to open pod host port if specified
-	if err := h.openHostports(newPod.Pod); err != nil {
+	if err := h.openHostports(newPortMapping); err != nil {
 		return err
 	}
 
 	// Add the new pod to active pods if it's not present.
 	var found bool
-	for _, p := range activePods {
-		if p.Pod.UID == newPod.Pod.UID {
+	for _, pm := range activePortMapping {
+		if pm.PodSandboxID == newPortMapping.PodSandboxID {
 			found = true
 			break
 		}
 	}
 	if !found {
-		activePods = append(activePods, newPod)
+		activePortMapping = append(activePortMapping, newPortMapping)
 	}
 
-	return h.SyncHostports(natInterfaceName, activePods)
+	return h.SyncHostports(natInterfaceName, activePortMapping)
 }
 
 // SyncHostports gathers all hostports on node and setup iptables rules enable them. And finally clean up stale hostports
-func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod) error {
+func (h *handler) SyncHostports(natInterfaceName string, activePortMapping []*PodPortMapping) error {
 	start := time.Now()
 	defer func() {
 		glog.V(4).Infof("syncHostportsRules took %v", time.Since(start))
 	}()
 
-	containerPortMap, err := gatherAllHostports(activePods)
+	hostportPodMap, err := gatherAllHostports(activePortMapping)
 	if err != nil {
 		return err
 	}
@@ -256,9 +270,9 @@ func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod
 	// Accumulate NAT chains to keep.
 	activeNATChains := map[utiliptables.Chain]bool{} // use a map as a set
 
-	for containerPort, target := range containerPortMap {
-		protocol := strings.ToLower(string(containerPort.Protocol))
-		hostportChain := hostportChainName(containerPort, target.podFullName)
+	for port, target := range hostportPodMap {
+		protocol := strings.ToLower(string(port.Protocol))
+		hostportChain := hostportChainName(port, target.podFullName)
 		if chain, ok := existingNATChains[hostportChain]; ok {
 			writeLine(natChains, chain)
 		} else {
@@ -270,9 +284,9 @@ func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod
 		// Redirect to hostport chain
 		args := []string{
 			"-A", string(kubeHostportsChain),
-			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, containerPort.HostPort),
+			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, port.HostPort),
 			"-m", protocol, "-p", protocol,
-			"--dport", fmt.Sprintf("%d", containerPort.HostPort),
+			"--dport", fmt.Sprintf("%d", port.HostPort),
 			"-j", string(hostportChain),
 		}
 		writeLine(natRules, args...)
@@ -281,7 +295,7 @@ func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod
 		// If the request comes from the pod that is serving the hostport, then SNAT
 		args = []string{
 			"-A", string(hostportChain),
-			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, containerPort.HostPort),
+			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, port.HostPort),
 			"-s", target.podIP, "-j", string(iptablesproxy.KubeMarkMasqChain),
 		}
 		writeLine(natRules, args...)
@@ -290,9 +304,9 @@ func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod
 		// IPTables will maintained the stats for this chain
 		args = []string{
 			"-A", string(hostportChain),
-			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, containerPort.HostPort),
+			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, port.HostPort),
 			"-m", protocol, "-p", protocol,
-			"-j", "DNAT", fmt.Sprintf("--to-destination=%s:%d", target.podIP, containerPort.ContainerPort),
+			"-j", "DNAT", fmt.Sprintf("--to-destination=%s:%d", target.podIP, port.ContainerPort),
 		}
 		writeLine(natRules, args...)
 	}
@@ -321,7 +335,7 @@ func (h *handler) SyncHostports(natInterfaceName string, activePods []*ActivePod
 		return fmt.Errorf("Failed to execute iptables-restore: %v", err)
 	}
 
-	h.cleanupHostportMap(containerPortMap)
+	h.cleanupHostportMap(hostportPodMap)
 	return nil
 }
 
@@ -364,7 +378,7 @@ func openLocalPort(hp *hostport) (closeable, error) {
 }
 
 // cleanupHostportMap closes obsolete hostports
-func (h *handler) cleanupHostportMap(containerPortMap map[api.ContainerPort]targetPod) {
+func (h *handler) cleanupHostportMap(containerPortMap map[PortMapping]targetPod) {
 	// compute hostports that are supposed to be open
 	currentHostports := make(map[hostport]bool)
 	for containerPort := range containerPortMap {

--- a/pkg/kubelet/network/hostport/testing/fake.go
+++ b/pkg/kubelet/network/hostport/testing/fake.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"fmt"
 
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
 )
 
@@ -29,16 +28,15 @@ func NewFakeHostportHandler() hostport.HostportHandler {
 	return &fakeHandler{}
 }
 
-func (h *fakeHandler) OpenPodHostportsAndSync(newPod *hostport.ActivePod, natInterfaceName string, activePods []*hostport.ActivePod) error {
-	return h.SyncHostports(natInterfaceName, activePods)
+func (h *fakeHandler) OpenPodHostportsAndSync(newPortMapping *hostport.PodPortMapping, natInterfaceName string, activePortMapping []*hostport.PodPortMapping) error {
+	return h.SyncHostports(natInterfaceName, activePortMapping)
 }
 
-func (h *fakeHandler) SyncHostports(natInterfaceName string, activePods []*hostport.ActivePod) error {
-	for _, r := range activePods {
+func (h *fakeHandler) SyncHostports(natInterfaceName string, activePortMapping []*hostport.PodPortMapping) error {
+	for _, r := range activePortMapping {
 		if r.IP.To4() == nil {
-			return fmt.Errorf("Invalid or missing pod %s IP", kubecontainer.GetPodFullName(r.Pod))
+			return fmt.Errorf("Invalid or missing pod %s/%s IP", r.Namespace, r.Name)
 		}
 	}
-
 	return nil
 }

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -418,10 +418,6 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, podS
 		glog.V(4).Infof("SetUpPod took %v for %s/%s", time.Since(start), namespace, name)
 	}()
 
-	//pod, ok := plugin.host.GetPodByName(namespace, name)
-	//if !ok {
-	//	return fmt.Errorf("pod %q cannot be found", name)
-	//}
 	podAnnotation, err := plugin.host.GetPodAnnotations(namespace, name, podSandboxID)
 	if err != nil {
 		return err
@@ -430,7 +426,6 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, podS
 	if err := plugin.Status(); err != nil {
 		return fmt.Errorf("Kubenet cannot SetUpPod: %v", err)
 	}
-
 	if err := plugin.setup(namespace, name, podSandboxID, podAnnotation); err != nil {
 		// Make sure everything gets cleaned up on errors
 		podIP, _ := plugin.podIPs[podSandboxID]

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -32,7 +32,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"io/ioutil"
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
@@ -83,7 +82,7 @@ type kubenetNetworkPlugin struct {
 	cniConfig       libcni.CNI
 	bandwidthShaper bandwidth.BandwidthShaper
 	mu              sync.Mutex //Mutex for protecting podIPs map, netConfig, and shaper initialization
-	podIPs          map[kubecontainer.ContainerID]string
+	podIPs          map[string]string
 	mtu             int
 	execer          utilexec.Interface
 	nsenterPath     string
@@ -107,7 +106,7 @@ func NewPlugin(networkPluginDir string) network.NetworkPlugin {
 	sysctl := utilsysctl.New()
 	iptInterface := utiliptables.New(execer, dbus, protocol)
 	return &kubenetNetworkPlugin{
-		podIPs:            make(map[kubecontainer.ContainerID]string),
+		podIPs:            make(map[string]string),
 		execer:            utilexec.New(),
 		iptables:          iptInterface,
 		sysctl:            sysctl,
@@ -329,7 +328,7 @@ func (plugin *kubenetNetworkPlugin) Capabilities() utilsets.Int {
 	return utilsets.NewInt(network.NET_PLUGIN_CAPABILITY_SHAPING)
 }
 
-func (plugin *kubenetNetworkPlugin) setup(namespace string, name string, id kubecontainer.ContainerID, pod *api.Pod) error {
+func (plugin *kubenetNetworkPlugin) setup(namespace string, name string, id kubecontainer.ContainerID, podAnnotation map[string]string) error {
 	// Bring up container loopback interface
 	if _, err := plugin.addContainerToNetwork(plugin.loConfig, "lo", namespace, name, id); err != nil {
 		return err
@@ -383,7 +382,7 @@ func (plugin *kubenetNetworkPlugin) setup(namespace string, name string, id kube
 	// initialization
 	shaper := plugin.shaper()
 
-	ingress, egress, err := bandwidth.ExtractPodBandwidthResources(pod.Annotations)
+	ingress, egress, err := bandwidth.ExtractPodBandwidthResources(podAnnotation)
 	if err != nil {
 		return fmt.Errorf("Error reading pod bandwidth annotations: %v", err)
 	}
@@ -392,20 +391,22 @@ func (plugin *kubenetNetworkPlugin) setup(namespace string, name string, id kube
 			return fmt.Errorf("Failed to add pod to shaper: %v", err)
 		}
 	}
+	plugin.podIPs[id.ID] = ip4.String()
 
-	plugin.podIPs[id] = ip4.String()
-
-	// Open any hostports the pod's containers want
-	activePods, err := plugin.getActivePods()
+	// Handle hostport if specified
+	activePodHostportMapping, err := plugin.getActivePodPortMapping()
 	if err != nil {
 		return err
 	}
-
-	newPod := &hostport.ActivePod{Pod: pod, IP: ip4}
-	if err := plugin.hostportHandler.OpenPodHostportsAndSync(newPod, BridgeName, activePods); err != nil {
-		return err
+	for _, phm := range activePodHostportMapping {
+		// Only sync hostport if the current pod has a hostport
+		if phm.Name == name && phm.Namespace == namespace {
+			if err := plugin.hostportHandler.OpenPodHostportsAndSync(phm, BridgeName, activePodHostportMapping); err != nil {
+				return err
+			}
+			break
+		}
 	}
-
 	return nil
 }
 
@@ -418,18 +419,22 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id k
 		glog.V(4).Infof("SetUpPod took %v for %s/%s", time.Since(start), namespace, name)
 	}()
 
-	pod, ok := plugin.host.GetPodByName(namespace, name)
-	if !ok {
-		return fmt.Errorf("pod %q cannot be found", name)
+	//pod, ok := plugin.host.GetPodByName(namespace, name)
+	//if !ok {
+	//	return fmt.Errorf("pod %q cannot be found", name)
+	//}
+	podAnnotation, err := plugin.host.GetPodAnnotations(namespace, name, id.ID)
+	if err != nil {
+		return err
 	}
 
 	if err := plugin.Status(); err != nil {
 		return fmt.Errorf("Kubenet cannot SetUpPod: %v", err)
 	}
 
-	if err := plugin.setup(namespace, name, id, pod); err != nil {
+	if err := plugin.setup(namespace, name, id, podAnnotation); err != nil {
 		// Make sure everything gets cleaned up on errors
-		podIP, _ := plugin.podIPs[id]
+		podIP, _ := plugin.podIPs[id.ID]
 		if err := plugin.teardown(namespace, name, id, podIP); err != nil {
 			// Not a hard error or warning
 			glog.V(4).Infof("Failed to clean up %s/%s after SetUpPod failure: %v", namespace, name, err)
@@ -458,7 +463,7 @@ func (plugin *kubenetNetworkPlugin) teardown(namespace string, name string, id k
 			glog.V(4).Infof("Failed to remove pod IP %s from shaper: %v", podIP, err)
 		}
 
-		delete(plugin.podIPs, id)
+		delete(plugin.podIPs, id.ID)
 	}
 
 	if err := plugin.delContainerFromNetwork(plugin.netConfig, network.DefaultInterfaceName, namespace, name, id); err != nil {
@@ -470,9 +475,9 @@ func (plugin *kubenetNetworkPlugin) teardown(namespace string, name string, id k
 		}
 	}
 
-	activePods, err := plugin.getActivePods()
+	activePodHostportMapping, err := plugin.getActivePodPortMapping()
 	if err == nil {
-		err = plugin.hostportHandler.SyncHostports(BridgeName, activePods)
+		err = plugin.hostportHandler.SyncHostports(BridgeName, activePodHostportMapping)
 	}
 	if err != nil {
 		errList = append(errList, err)
@@ -495,7 +500,7 @@ func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, i
 	}
 
 	// no cached IP is Ok during teardown
-	podIP, _ := plugin.podIPs[id]
+	podIP, _ := plugin.podIPs[id.ID]
 	if err := plugin.teardown(namespace, name, id, podIP); err != nil {
 		return err
 	}
@@ -514,11 +519,11 @@ func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name s
 	plugin.mu.Lock()
 	defer plugin.mu.Unlock()
 	// Assuming the ip of pod does not change. Try to retrieve ip from kubenet map first.
-	if podIP, ok := plugin.podIPs[id]; ok {
+	if podIP, ok := plugin.podIPs[id.ID]; ok {
 		return &network.PodNetworkStatus{IP: net.ParseIP(podIP)}, nil
 	}
 
-	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
+	netnsPath, err := plugin.host.GetPodSandboxNetNS(id.ID)
 	if err != nil {
 		return nil, fmt.Errorf("Kubenet failed to retrieve network namespace path: %v", err)
 	}
@@ -527,7 +532,7 @@ func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name s
 		return nil, err
 	}
 
-	plugin.podIPs[id] = ip.String()
+	plugin.podIPs[id.ID] = ip.String()
 	return &network.PodNetworkStatus{IP: ip}, nil
 }
 
@@ -572,59 +577,39 @@ func (plugin *kubenetNetworkPlugin) checkCNIPluginInDir(dir string) bool {
 	return true
 }
 
-// Returns a list of pods running or ready to run on this node and each pod's IP address.
-// Assumes PodSpecs retrieved from the runtime include the name and ID of containers in
-// each pod.
-func (plugin *kubenetNetworkPlugin) getActivePods() ([]*hostport.ActivePod, error) {
-	pods, err := plugin.host.GetRuntime().GetPods(true)
+// Returns a list of podPortMapping where pod is running or ready to run on this node and populate pod's IP address.
+// Assumes runtime will include pod details in GetPodHostportMapping
+func (plugin *kubenetNetworkPlugin) getActivePodPortMapping() ([]*hostport.PodPortMapping, error) {
+	podHostportMapping, err := plugin.host.GetPodHostportMapping()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve pods from runtime: %v", err)
+		return nil, fmt.Errorf("Failed to retrieve pod hostport mapping from runtime: %v", err)
 	}
-	activePods := make([]*hostport.ActivePod, 0)
-	for _, p := range pods {
-		if podIsExited(p) {
+	activePodHostportMapping := make([]*hostport.PodPortMapping, 0)
+	for _, phm := range podHostportMapping {
+		hasIP := false
+		if phm.IP.To4() != nil {
+			hasIP = true
+		} else {
+			ip, ok := plugin.podIPs[phm.PodSandboxID]
+			if ok {
+				phm.IP = net.ParseIP(ip)
+				if phm.IP != nil {
+					hasIP = true
+				}
+			}
+		}
+		// If pod does not have a IP, probably means either pod has not be properly setup yet.
+		if !hasIP {
 			continue
 		}
 
-		containerID, err := plugin.host.GetRuntime().GetPodContainerID(p)
-		if err != nil {
-			continue
-		}
-		ipString, ok := plugin.podIPs[containerID]
-		if !ok {
-			continue
-		}
-		podIP := net.ParseIP(ipString)
-		if podIP == nil {
-			continue
-		}
-		if pod, ok := plugin.host.GetPodByName(p.Namespace, p.Name); ok {
-			activePods = append(activePods, &hostport.ActivePod{
-				Pod: pod,
-				IP:  podIP,
-			})
-		}
+		activePodHostportMapping = append(activePodHostportMapping, phm)
 	}
-	return activePods, nil
-}
-
-// podIsExited returns true if the pod is exited (all containers inside are exited).
-func podIsExited(p *kubecontainer.Pod) bool {
-	for _, c := range p.Containers {
-		if c.State != kubecontainer.ContainerStateExited {
-			return false
-		}
-	}
-	for _, c := range p.Sandboxes {
-		if c.State != kubecontainer.ContainerStateExited {
-			return false
-		}
-	}
-	return true
+	return activePodHostportMapping, nil
 }
 
 func (plugin *kubenetNetworkPlugin) buildCNIRuntimeConf(ifName string, id kubecontainer.ContainerID) (*libcni.RuntimeConf, error) {
-	netnsPath, err := plugin.host.GetRuntime().GetNetNS(id)
+	netnsPath, err := plugin.host.GetPodSandboxNetNS(id.ID)
 	if err != nil {
 		return nil, fmt.Errorf("Kubenet failed to retrieve network namespace path: %v", err)
 	}

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/cni/testing"
 	hostporttest "k8s.io/kubernetes/pkg/kubelet/network/hostport/testing"
@@ -108,7 +107,7 @@ func TestGetPodNetworkStatus(t *testing.T) {
 	fakeKubenet := newFakeKubenetPlugin(podIPMap, &fexec, fhost)
 
 	for i, tc := range testCases {
-		out, err := fakeKubenet.GetPodNetworkStatus("", "", kubecontainer.ContainerID{ID: tc.id})
+		out, err := fakeKubenet.GetPodNetworkStatus("", "", tc.id)
 		if tc.expectError {
 			if err == nil {
 				t.Errorf("Test case %d expects error but got none", i)
@@ -149,8 +148,8 @@ func TestTeardownCallsShaper(t *testing.T) {
 	details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = "10.0.0.1/24"
 	kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
 
-	existingContainerID := kubecontainer.BuildContainerID("docker", "123")
-	kubenet.podIPs[existingContainerID.ID] = "10.0.0.1"
+	existingContainerID := "123"
+	kubenet.podIPs[existingContainerID] = "10.0.0.1"
 
 	if err := kubenet.TearDownPod("namespace", "name", existingContainerID); err != nil {
 		t.Fatalf("Unexpected error in TearDownPod: %v", err)

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -40,7 +40,7 @@ import (
 // test it fulfills the NetworkPlugin interface
 var _ network.NetworkPlugin = &kubenetNetworkPlugin{}
 
-func newFakeKubenetPlugin(initMap map[kubecontainer.ContainerID]string, execer exec.Interface, host network.Host) *kubenetNetworkPlugin {
+func newFakeKubenetPlugin(initMap map[string]string, execer exec.Interface, host network.Host) *kubenetNetworkPlugin {
 	return &kubenetNetworkPlugin{
 		podIPs: initMap,
 		execer: execer,
@@ -50,9 +50,9 @@ func newFakeKubenetPlugin(initMap map[kubecontainer.ContainerID]string, execer e
 }
 
 func TestGetPodNetworkStatus(t *testing.T) {
-	podIPMap := make(map[kubecontainer.ContainerID]string)
-	podIPMap[kubecontainer.ContainerID{ID: "1"}] = "10.245.0.2"
-	podIPMap[kubecontainer.ContainerID{ID: "2"}] = "10.245.0.3"
+	podIPMap := make(map[string]string)
+	podIPMap["1"] = "10.245.0.2"
+	podIPMap["2"] = "10.245.0.3"
 
 	testCases := []struct {
 		id          string
@@ -85,7 +85,7 @@ func TestGetPodNetworkStatus(t *testing.T) {
 		fCmd := exec.FakeCmd{
 			CombinedOutputScript: []exec.FakeCombinedOutputAction{
 				func() ([]byte, error) {
-					ip, ok := podIPMap[kubecontainer.ContainerID{ID: t.id}]
+					ip, ok := podIPMap[t.id]
 					if !ok {
 						return nil, fmt.Errorf("Pod IP %q not found", t.id)
 					}
@@ -104,7 +104,7 @@ func TestGetPodNetworkStatus(t *testing.T) {
 		},
 	}
 
-	fhost := nettest.NewFakeHost(nil)
+	fhost := nettest.NewFakeHost(nil, nil, nil)
 	fakeKubenet := newFakeKubenetPlugin(podIPMap, &fexec, fhost)
 
 	for i, tc := range testCases {
@@ -134,10 +134,10 @@ func TestTeardownCallsShaper(t *testing.T) {
 			return fmt.Sprintf("/fake-bin/%s", file), nil
 		},
 	}
-	fhost := nettest.NewFakeHost(nil)
+	fhost := nettest.NewFakeHost(nil, nil, nil)
 	fshaper := &bandwidth.FakeShaper{}
 	mockcni := &mock_cni.MockCNI{}
-	kubenet := newFakeKubenetPlugin(map[kubecontainer.ContainerID]string{}, fexec, fhost)
+	kubenet := newFakeKubenetPlugin(map[string]string{}, fexec, fhost)
 	kubenet.cniConfig = mockcni
 	kubenet.iptables = ipttest.NewFake()
 	kubenet.bandwidthShaper = fshaper
@@ -150,7 +150,7 @@ func TestTeardownCallsShaper(t *testing.T) {
 	kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
 
 	existingContainerID := kubecontainer.BuildContainerID("docker", "123")
-	kubenet.podIPs[existingContainerID] = "10.0.0.1"
+	kubenet.podIPs[existingContainerID.ID] = "10.0.0.1"
 
 	if err := kubenet.TearDownPod("namespace", "name", existingContainerID); err != nil {
 		t.Fatalf("Unexpected error in TearDownPod: %v", err)
@@ -184,15 +184,15 @@ func TestInit_MTU(t *testing.T) {
 		},
 	}
 
-	fhost := nettest.NewFakeHost(nil)
-	kubenet := newFakeKubenetPlugin(map[kubecontainer.ContainerID]string{}, fexec, fhost)
+	fhost := nettest.NewFakeHost(nil, nil, nil)
+	kubenet := newFakeKubenetPlugin(map[string]string{}, fexec, fhost)
 	kubenet.iptables = ipttest.NewFake()
 
 	sysctl := sysctltest.NewFake()
 	sysctl.Settings["net/bridge/bridge-nf-call-iptables"] = 0
 	kubenet.sysctl = sysctl
 
-	if err := kubenet.Init(nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", 1234); err != nil {
+	if err := kubenet.Init(nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", 1234); err != nil {
 		t.Fatalf("Unexpected error in Init: %v", err)
 	}
 	assert.Equal(t, 1234, kubenet.mtu, "kubenet.mtu should have been set")

--- a/pkg/kubelet/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/network/kubenet/kubenet_unsupported.go
@@ -42,14 +42,14 @@ func (plugin *kubenetNetworkPlugin) Name() string {
 	return "kubenet"
 }
 
-func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, podSandboxID string) error {
 	return fmt.Errorf("Kubenet is not supported in this build")
 }
 
-func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, podSandboxID string) error {
 	return fmt.Errorf("Kubenet is not supported in this build")
 }
 
-func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
+func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name string, podSandboxID string) (*network.PodNetworkStatus, error) {
 	return nil, fmt.Errorf("Kubenet is not supported in this build")
 }

--- a/pkg/kubelet/network/mock_network/network_plugins.go
+++ b/pkg/kubelet/network/mock_network/network_plugins.go
@@ -23,7 +23,6 @@ package mock_network
 import (
 	gomock "github.com/golang/mock/gomock"
 	componentconfig "k8s.io/kubernetes/pkg/apis/componentconfig"
-	container "k8s.io/kubernetes/pkg/kubelet/container"
 	network "k8s.io/kubernetes/pkg/kubelet/network"
 	sets "k8s.io/kubernetes/pkg/util/sets"
 )
@@ -67,7 +66,7 @@ func (_mr *_MockNetworkPluginRecorder) Event(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Event", arg0, arg1)
 }
 
-func (_m *MockNetworkPlugin) GetPodNetworkStatus(_param0 string, _param1 string, _param2 container.ContainerID) (*network.PodNetworkStatus, error) {
+func (_m *MockNetworkPlugin) GetPodNetworkStatus(_param0 string, _param1 string, _param2 string) (*network.PodNetworkStatus, error) {
 	ret := _m.ctrl.Call(_m, "GetPodNetworkStatus", _param0, _param1, _param2)
 	ret0, _ := ret[0].(*network.PodNetworkStatus)
 	ret1, _ := ret[1].(error)
@@ -98,7 +97,7 @@ func (_mr *_MockNetworkPluginRecorder) Name() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Name")
 }
 
-func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID) error {
+func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 string) error {
 	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -118,7 +117,7 @@ func (_mr *_MockNetworkPluginRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
-func (_m *MockNetworkPlugin) TearDownPod(_param0 string, _param1 string, _param2 container.ContainerID) error {
+func (_m *MockNetworkPlugin) TearDownPod(_param0 string, _param1 string, _param2 string) error {
 	ret := _m.ctrl.Call(_m, "TearDownPod", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -21,13 +21,11 @@ import (
 	"net"
 	"strings"
 
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
 	utilsets "k8s.io/kubernetes/pkg/util/sets"
@@ -95,16 +93,16 @@ type PodNetworkStatus struct {
 	IP net.IP `json:"ip" description:"Primary IP address of the pod"`
 }
 
-// Host is an interface that plugins can use to access the kubelet.
+// Host is an interface that plugins can use to access the kubelet or runtime shims.
 type Host interface {
-	// Get the pod structure by its name, namespace
-	GetPodByName(namespace, name string) (*api.Pod, bool)
+	// GetPodSandboxNetNS returns the path of pod sandbox's network namespace
+	GetPodSandboxNetNS(podSandboxID string) (string, error)
 
-	// GetKubeClient returns a client interface
-	GetKubeClient() clientset.Interface
+	// GetPodHostportMapping returns all active and ready to run pod hostport mapping
+	GetPodHostportMapping() ([]*hostport.PodPortMapping, error)
 
-	// GetContainerRuntime returns the container runtime that implements the containers (e.g. docker/rkt)
-	GetRuntime() kubecontainer.Runtime
+	// GetPodAnnotations returns the pod annotations
+	GetPodAnnotations(namespace, name, podSandboxID string) (map[string]string, error)
 }
 
 // InitNetworkPlugin inits the plugin that matches networkPluginName. Plugins must have unique names.

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -24,7 +24,6 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
@@ -66,16 +65,13 @@ type NetworkPlugin interface {
 	// SetUpPod is the method called after the infra container of
 	// the pod has been created but before the other containers of the
 	// pod are launched.
-	// TODO: rename podInfraContainerID to sandboxID
-	SetUpPod(namespace string, name string, podInfraContainerID kubecontainer.ContainerID) error
+	SetUpPod(namespace string, name string, podSandboxID string) error
 
 	// TearDownPod is the method called before a pod's infra container will be deleted
-	// TODO: rename podInfraContainerID to sandboxID
-	TearDownPod(namespace string, name string, podInfraContainerID kubecontainer.ContainerID) error
+	TearDownPod(namespace string, name string, podSandboxID string) error
 
 	// Status is the method called to obtain the ipv4 or ipv6 addresses of the container
-	// TODO: rename podInfraContainerID to sandboxID
-	GetPodNetworkStatus(namespace string, name string, podInfraContainerID kubecontainer.ContainerID) (*PodNetworkStatus, error)
+	GetPodNetworkStatus(namespace string, name string, podSandboxID string) (*PodNetworkStatus, error)
 
 	// NetworkStatus returns error if the network plugin is in error state
 	Status() error
@@ -185,15 +181,15 @@ func (plugin *NoopNetworkPlugin) Capabilities() utilsets.Int {
 	return utilsets.NewInt()
 }
 
-func (plugin *NoopNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *NoopNetworkPlugin) SetUpPod(namespace string, name string, podSandboxID string) error {
 	return nil
 }
 
-func (plugin *NoopNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.ContainerID) error {
+func (plugin *NoopNetworkPlugin) TearDownPod(namespace string, name string, podSandboxID string) error {
 	return nil
 }
 
-func (plugin *NoopNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*PodNetworkStatus, error) {
+func (plugin *NoopNetworkPlugin) GetPodNetworkStatus(namespace string, name string, podSandboxID string) (*PodNetworkStatus, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/network/plugins_test.go
+++ b/pkg/kubelet/network/plugins_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSelectDefaultPlugin(t *testing.T) {
 	all_plugins := []NetworkPlugin{}
-	plug, err := InitNetworkPlugin(all_plugins, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, "10.0.0.0/8", UseDefaultMTU)
+	plug, err := InitNetworkPlugin(all_plugins, "", nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, "10.0.0.0/8", UseDefaultMTU)
 	if err != nil {
 		t.Fatalf("Unexpected error in selecting default plugin: %v", err)
 	}

--- a/pkg/kubelet/networks.go
+++ b/pkg/kubelet/networks.go
@@ -17,9 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
 )
 
 // This just exports required functions from kubelet proper, for use by network
@@ -28,14 +26,14 @@ type networkHost struct {
 	kubelet *Kubelet
 }
 
-func (nh *networkHost) GetPodByName(name, namespace string) (*api.Pod, bool) {
-	return nh.kubelet.GetPodByName(name, namespace)
+func (nh *networkHost) GetPodSandboxNetNS(podSandboxID string) (string, error) {
+	return nh.kubelet.GetPodSandboxNetNS(podSandboxID)
 }
 
-func (nh *networkHost) GetKubeClient() clientset.Interface {
-	return nh.kubelet.kubeClient
+func (nh *networkHost) GetPodHostportMapping() ([]*hostport.PodPortMapping, error) {
+	return nh.kubelet.GetPodHostportMapping()
 }
 
-func (nh *networkHost) GetRuntime() kubecontainer.Runtime {
-	return nh.kubelet.GetRuntime()
+func (nh *networkHost) GetPodAnnotations(namespace, name, podSandboxID string) (map[string]string, error) {
+	return nh.kubelet.GetPodAnnotations(namespace, name, podSandboxID)
 }

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -2339,6 +2339,10 @@ func (r *Runtime) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kube
 	return podStatus, nil
 }
 
+func (r *Runtime) UpdatePodCIDR(podCIDR string) error {
+	return nil
+}
+
 // getOSReleaseInfo reads /etc/os-release and returns a map
 // that contains the key value pairs in that file.
 func getOSReleaseInfo() (map[string]string, error) {

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1046,7 +1046,7 @@ func (r *Runtime) cleanupPodNetwork(pod *api.Pod) error {
 
 	var teardownErr error
 	containerID := kubecontainer.ContainerID{ID: string(pod.UID)}
-	if err := r.networkPlugin.TearDownPod(pod.Namespace, pod.Name, containerID); err != nil {
+	if err := r.networkPlugin.TearDownPod(pod.Namespace, pod.Name, containerID.ID); err != nil {
 		teardownErr = fmt.Errorf("rkt: failed to tear down network for pod %s: %v", format.Pod(pod), err)
 		glog.Errorf("%v", teardownErr)
 	}
@@ -1274,11 +1274,11 @@ func (r *Runtime) setupPodNetwork(pod *api.Pod) (string, string, error) {
 	// Set up networking with the network plugin
 	glog.V(3).Infof("Calling network plugin %s to setup pod for %s", r.networkPlugin.Name(), format.Pod(pod))
 	containerID := kubecontainer.ContainerID{ID: string(pod.UID)}
-	err = r.networkPlugin.SetUpPod(pod.Namespace, pod.Name, containerID)
+	err = r.networkPlugin.SetUpPod(pod.Namespace, pod.Name, containerID.ID)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to set up pod network: %v", err)
 	}
-	status, err := r.networkPlugin.GetPodNetworkStatus(pod.Namespace, pod.Name, containerID)
+	status, err := r.networkPlugin.GetPodNetworkStatus(pod.Namespace, pod.Name, containerID.ID)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get status of pod network: %v", err)
 	}
@@ -2326,7 +2326,7 @@ func (r *Runtime) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kube
 		}
 	} else {
 		containerID := kubecontainer.ContainerID{ID: string(uid)}
-		status, err := r.networkPlugin.GetPodNetworkStatus(namespace, name, containerID)
+		status, err := r.networkPlugin.GetPodNetworkStatus(namespace, name, containerID.ID)
 		if err != nil {
 			glog.Warningf("rkt: Failed to get pod network status for pod (UID %q, name %q, namespace %q): %v", uid, name, namespace, err)
 		} else if status != nil {

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -797,7 +797,7 @@ func TestGetPodStatus(t *testing.T) {
 				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook", "42").
 					Return(&network.PodNetworkStatus{IP: net.ParseIP(tt.result.IP)}, nil)
 			} else {
-				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook","42").
+				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook", "42").
 					Return(nil, fmt.Errorf("no such network"))
 			}
 		}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -794,10 +794,10 @@ func TestGetPodStatus(t *testing.T) {
 
 		if tt.networkPluginName == kubenet.KubenetPluginName {
 			if tt.result.IP != "" {
-				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook", kubecontainer.ContainerID{ID: "42"}).
+				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook", "42").
 					Return(&network.PodNetworkStatus{IP: net.ParseIP(tt.result.IP)}, nil)
 			} else {
-				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook", kubecontainer.ContainerID{ID: "42"}).
+				fnp.EXPECT().GetPodNetworkStatus("default", "guestbook","42").
 					Return(nil, fmt.Errorf("no such network"))
 			}
 		}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -103,7 +103,7 @@ func TestRunOnce(t *testing.T) {
 		kb.getPodsDir(),
 		kb.recorder)
 
-	kb.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, kb.nonMasqueradeCIDR, network.UseDefaultMTU)
+	kb.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil, nil, nil), componentconfig.HairpinNone, kb.nonMasqueradeCIDR, network.UseDefaultMTU)
 	// TODO: Factor out "StatsProvider" from Kubelet so we don't have a cyclic dependency
 	volumeStatsAggPeriod := time.Second * 10
 	kb.resourceAnalyzer = stats.NewResourceAnalyzer(kb, volumeStatsAggPeriod, kb.containerRuntime)


### PR DESCRIPTION
1) Refactor network plugin framework, so that network plugins can be triggered by kubelet or shims. Aims to reuse most of the network code. 
- change network.`Host` interface to be more specific. 
- add UpdatePodCIDR interface for container.`Runtime` to allow kubelet to pass podCIDR to runtime manager.

2) Migrate network logic from `kuberuntime_manager` into `dockershim`. Assuming other shims will follow soon. 

**Not Covered in this PR:**
- Hostport handling for dockershim
- Network resource garbage collection 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34780)

<!-- Reviewable:end -->
