### PR TITLE
Clean up typos in links in README

### DIFF
--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -55,7 +55,7 @@ Demonstrated Kubernetes Concepts:
 * [Secrets](http://kubernetes.io/docs/user-guide/secrets/) to store sensitive
   passwords.
 
-## tl;dr Quickstart
+## Quickstart
 
 Put your desired mysql password in a file called `password.txt` with
 no trailing newline. The first `tr` command will remove the newline if
@@ -76,7 +76,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master
 <!-- BEGIN MUNGE: GENERATED_TOC -->
 
 - [Persistent Installation of MySQL and WordPress on Kubernetes](#persistent-installation-of-mysql-and-wordpress-on-kubernetes)
-  - [tl;dr Quickstart](#tldr-quickstart)
+  - [Quickstart](#quickstart)
   - [Table of Contents](#table-of-contents)
   - [Cluster Requirements](#cluster-requirements)
   - [Decide where you will store your data](#decide-where-you-will-store-your-data)

--- a/examples/volumes/nfs/README.md
+++ b/examples/volumes/nfs/README.md
@@ -55,7 +55,7 @@ Note, this example uses an NFS container that doesn't support NFSv4.
 [nfs pv example]: nfs-pv.png
 
 
-## tl;dr Quickstart
+## Quickstart
 
 ```console
 $ kubectl create -f examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Clean up the link in README for mysql-wordpress-pd and nfs

Signed-off-by: YuPengZTE yu.peng36@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34804)

<!-- Reviewable:end -->
