### PR TITLE
default serializer

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -303,7 +303,6 @@ func Run(s *options.APIServer) error {
 	genericConfig.MasterServiceNamespace = s.MasterServiceNamespace
 	genericConfig.ProxyDialer = proxyDialerFn
 	genericConfig.ProxyTLSClientConfig = proxyTLSClientConfig
-	genericConfig.Serializer = api.Codecs
 	genericConfig.OpenAPIConfig.Info.Title = "Kubernetes"
 	genericConfig.OpenAPIConfig.Definitions = generatedopenapi.OpenAPIDefinitions
 	genericConfig.OpenAPIConfig.GetOperationID = openapi.GetOperationID

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -74,7 +74,6 @@ func Run(serverOptions *genericoptions.ServerRunOptions) error {
 	}
 
 	config.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
-	config.Serializer = api.Codecs
 	s, err := config.New()
 	if err != nil {
 		return fmt.Errorf("Error in bringing up the server: %v", err)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -191,7 +191,6 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig.AdmissionControl = admissionController
 	genericConfig.APIResourceConfigSource = storageFactory.APIResourceConfigSource
 	genericConfig.MasterServiceNamespace = s.MasterServiceNamespace
-	genericConfig.Serializer = api.Codecs
 	genericConfig.OpenAPIConfig.Definitions = openapi.OpenAPIDefinitions
 	// Reusing api-server's GetOperationID function. if federation and api-server spec diverge and
 	// this method does not provide good operation IDs for federation, we should create federation's own GetOperationID.

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -202,6 +202,7 @@ func NewConfig() *Config {
 	longRunningRE := regexp.MustCompile(options.DefaultLongRunningRequestRE)
 
 	config := &Config{
+		Serializer:             api.Codecs,
 		MasterCount:            1,
 		ReadWritePort:          6443,
 		ServiceReadWritePort:   443,

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -55,7 +55,6 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.RequestContextMapper = api.NewRequestContextMapper()
 	config.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
 	config.ProxyTLSClientConfig = &tls.Config{}
-	config.Serializer = api.Codecs
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.APIGroupPrefix = "/apis"
 
@@ -164,7 +163,6 @@ func TestCustomHandlerChain(t *testing.T) {
 
 	var protected, called bool
 
-	config.Serializer = api.Codecs
 	config.BuildHandlerChainsFunc = func(apiHandler http.Handler, c *Config) (secure, insecure http.Handler) {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				protected = true

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -87,7 +87,6 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
 	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
-	config.GenericConfig.Serializer = api.Codecs
 	config.KubeletClient = client.FakeKubeletClient{}
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.GenericConfig.APIGroupPrefix = "/apis"

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -347,7 +347,6 @@ func NewMasterConfig() *master.Config {
 	genericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
 	genericConfig.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
 	genericConfig.AdmissionControl = admit.NewAlwaysAdmit()
-	genericConfig.Serializer = api.Codecs
 	genericConfig.EnableOpenAPISupport = true
 
 	return &master.Config{


### PR DESCRIPTION
Everyone uses the same serializer.  Set it as the default, but still allow someone to take control if they want.

Found while trying to use genericapiserver for composition.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34828)

<!-- Reviewable:end -->
