### PR TITLE
Add sysctls for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -122,6 +122,13 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeApi
 		Privileged:     config.GetPrivileged(),
 	}
 
+	// Set sysctls if requested
+	sysctls, err := getSysctlsFromAnnotations(config.Annotations)
+	if err != nil {
+		return "", fmt.Errorf("failed to get sysctls from annotations %v for container %q: %v", config.Annotations, config.Metadata.GetName(), err)
+	}
+	hc.Sysctls = sysctls
+
 	// Apply options derived from the sandbox config.
 	if lc := sandboxConfig.GetLinux(); lc != nil {
 		// Apply Cgroup options.
@@ -166,7 +173,6 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeApi
 		// Note: ShmSize is handled in kube_docker_client.go
 	}
 
-	var err error
 	hc.SecurityOpt, err = getContainerSecurityOpts(config.Metadata.GetName(), sandboxConfig, ds.seccompProfileRoot)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate container security options for container %q: %v", config.Metadata.GetName(), err)

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -147,3 +147,43 @@ func TestGetSandboxSecurityOpts(t *testing.T) {
 		}
 	}
 }
+
+// TestGetSystclsFromAnnotations tests the logic of getting sysctls from annotations.
+func TestGetSystclsFromAnnotations(t *testing.T) {
+	tests := []struct {
+		annotations     map[string]string
+		expectedSysctls map[string]string
+	}{{
+		annotations: map[string]string{
+			api.SysctlsPodAnnotationKey:       "kernel.shmmni=32768,kernel.shmmax=1000000000",
+			api.UnsafeSysctlsPodAnnotationKey: "knet.ipv4.route.min_pmtu=1000",
+		},
+		expectedSysctls: map[string]string{
+			"kernel.shmmni":            "32768",
+			"kernel.shmmax":            "1000000000",
+			"knet.ipv4.route.min_pmtu": "1000",
+		},
+	}, {
+		annotations: map[string]string{
+			api.SysctlsPodAnnotationKey: "kernel.shmmni=32768,kernel.shmmax=1000000000",
+		},
+		expectedSysctls: map[string]string{
+			"kernel.shmmni": "32768",
+			"kernel.shmmax": "1000000000",
+		},
+	}, {
+		annotations: map[string]string{
+			api.UnsafeSysctlsPodAnnotationKey: "knet.ipv4.route.min_pmtu=1000",
+		},
+		expectedSysctls: map[string]string{
+			"knet.ipv4.route.min_pmtu": "1000",
+		},
+	}}
+
+	for i, test := range tests {
+		actual, err := getSysctlsFromAnnotations(test.annotations)
+		assert.NoError(t, err, "TestCase[%d]", i)
+		assert.Len(t, actual, len(test.expectedSysctls), "TestCase[%d]", i)
+		assert.Equal(t, test.expectedSysctls, actual, "TestCase[%d]", i)
+	}
+}


### PR DESCRIPTION
This PR adds sysctls support for dockershim. All sysctls e2e tests are passed in my local settings.

Note that sysctls runtimeAdmit is not included in this PR, it is addressed in #32803.

cc/ @yujuhong @Random-Liu

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34830)

<!-- Reviewable:end -->
