### PR TITLE
kubeadm: fix preflight checks

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -73,7 +73,7 @@ func RunJoin(out io.Writer, cmd *cobra.Command, args []string, s *kubeadmapi.Nod
 		fmt.Println("Running pre-flight checks")
 		err := preflight.RunJoinNodeChecks()
 		if err != nil {
-			return err
+			return &preflight.PreFlightError{Msg: err.Error()}
 		}
 	} else {
 		fmt.Println("Skipping pre-flight checks")


### PR DESCRIPTION
This PR fixes a couple issues cause by some bad rebases:
- When a pre-flight check returned errors, `kubeadm` would exit with error code `1` instead of `2` as the original pre-flight PR meant. This would also cause the output of `kubeadm` to include some stuff that was not supposed to be there.
- Duplicated `k8s.io/kubernetes/cmd/kubeadm/app/util` import.

I also took the freedom to do some output clean-up based on the input from the original pre-flight PR.

/cc @dmmcquay @dgoodwin @luxas

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34834)

<!-- Reviewable:end -->
