### PR TITLE
you can be authorized and have a failure

### DIFF
--- a/pkg/apiserver/filters/authorization.go
+++ b/pkg/apiserver/filters/authorization.go
@@ -40,16 +40,17 @@ func WithAuthorization(handler http.Handler, getAttribs RequestAttributeGetter, 
 			return
 		}
 		authorized, reason, err := a.Authorize(attrs)
+		if authorized {
+			handler.ServeHTTP(w, req)
+			return
+		}
 		if err != nil {
 			internalError(w, req, err)
 			return
 		}
-		if !authorized {
-			glog.V(4).Infof("Forbidden: %#v, Reason: %s", req.RequestURI, reason)
-			forbidden(w, req)
-			return
-		}
-		handler.ServeHTTP(w, req)
+
+		glog.V(4).Infof("Forbidden: %#v, Reason: %s", req.RequestURI, reason)
+		forbidden(w, req)
 	})
 }
 


### PR DESCRIPTION
Fix the authorization filter to allow you through and to avoid showing internal errors to users when authorization failed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34848)

<!-- Reviewable:end -->
