### PR TITLE
Added option to specify the flannel backend, to cluster/ubuntu

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -57,6 +57,16 @@ CNI_KUBELET_TRIGGER=${CNI_KUBELET_TRIGGER:-networking}
 # drawn.
 export FLANNEL_NET=${FLANNEL_NET:-172.16.0.0/16}
 
+# If Flannel networking is used then the following variable can be
+# used to customize the Flannel backend.  The variable's value should
+# be a JSON object.  An empty string means to use the default, which
+# is `{"Type": "vxlan"}`.  See
+# https://github.com/coreos/flannel#configuration for details on
+# configuring Flannel.
+
+export FLANNEL_BACKEND
+FLANNEL_BACKEND=''
+
 # Optionally add other contents to the Flannel configuration JSON
 # object normally stored in etcd as /coreos.com/network/config.  Use
 # JSON syntax suitable for insertion into a JSON object constructor
@@ -66,9 +76,15 @@ export FLANNEL_NET=${FLANNEL_NET:-172.16.0.0/16}
 export FLANNEL_OTHER_NET_CONFIG
 FLANNEL_OTHER_NET_CONFIG=''
 
-# Admission Controllers to invoke prior to persisting objects in cluster
-# If we included ResourceQuota, we should keep it at the end of the list to prevent incrementing quota usage prematurely.
-export ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,DefaultStorageClass,ResourceQuota
+# Admission Controllers to invoke prior to persisting objects in
+# cluster.  If we included ResourceQuota, we should keep it at the end
+# of the list to prevent incrementing quota usage prematurely.  The
+# list below is what
+# http://kubernetes.io/docs/admin/admission-controllers/ recommends
+# for release >= 1.4.0; see that doc for the recommended settings for
+# earlier releases.
+
+export ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
 
 # Path to the config file or directory of files of kubelet
 export KUBELET_CONFIG=${KUBELET_CONFIG:-""}

--- a/cluster/ubuntu/reconfDocker.sh
+++ b/cluster/ubuntu/reconfDocker.sh
@@ -18,6 +18,10 @@
 
 source "$HOME/kube/${KUBE_CONFIG_FILE##*/}"
 
+if [[ -n "$DEBUG" ]] && [[ "$DEBUG" != false ]] && [[ "$DEBUG" != FALSE ]]; then
+	set -x
+fi
+
 if [[ "$(id -u)" != "0" ]]; then
   echo >&2 "Please run as root"
   exit 1
@@ -36,7 +40,7 @@ function config_etcd {
         exit 2
       fi
 
-      /opt/bin/etcdctl mk /coreos.com/network/config "{\"Network\":\"${FLANNEL_NET}\", \"Backend\": {\"Type\": \"vxlan\"}${FLANNEL_OTHER_NET_CONFIG}}"
+      /opt/bin/etcdctl mk /coreos.com/network/config "{\"Network\":\"${FLANNEL_NET}\", \"Backend\": ${FLANNEL_BACKEND:-"{\"Type\": \"vxlan\"}"}${FLANNEL_OTHER_NET_CONFIG}}"
       attempt=$((attempt+1))
       sleep 3
     fi

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -482,7 +482,7 @@ function provision-master() {
     create-kube-controller-manager-opts
     create-kube-scheduler-opts
     create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
-    FLANNEL_OTHER_NET_CONFIG='${FLANNEL_OTHER_NET_CONFIG}' sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
+    FLANNEL_BACKEND='${FLANNEL_BACKEND}' FLANNEL_OTHER_NET_CONFIG='${FLANNEL_OTHER_NET_CONFIG}' sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
       ${BASH_DEBUG_FLAGS}
 
       cp ~/kube/default/* /etc/default/
@@ -494,7 +494,7 @@ function provision-master() {
       mkdir -p /opt/bin/
       cp ~/kube/master/* /opt/bin/
       service etcd start
-      if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" ~/kube/reconfDocker.sh a; fi
+      if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" DEBUG=\"$DEBUG\" ~/kube/reconfDocker.sh a; fi
       '" || {
       echo "Deploying master on machine ${MASTER_IP} failed"
       exit 1
@@ -575,7 +575,7 @@ function provision-node() {
       mkdir -p /opt/bin/
       cp ~/kube/minion/* /opt/bin
       ${SERVICE_STARTS}
-      if ${NEED_RECONFIG_DOCKER}; then KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" ~/kube/reconfDocker.sh i; fi
+      if ${NEED_RECONFIG_DOCKER}; then KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" DEBUG=\"$DEBUG\" ~/kube/reconfDocker.sh i; fi
       '" || {
       echo "Deploying node on machine ${1#*@} failed"
       exit 1
@@ -669,7 +669,7 @@ function provision-masterandnode() {
       '${KUBE_PROXY_EXTRA_OPTS}'
     create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
 
-    FLANNEL_OTHER_NET_CONFIG='${FLANNEL_OTHER_NET_CONFIG}' sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
+    FLANNEL_BACKEND='${FLANNEL_BACKEND}' FLANNEL_OTHER_NET_CONFIG='${FLANNEL_OTHER_NET_CONFIG}' sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
       ${BASH_DEBUG_FLAGS}
       cp ~/kube/default/* /etc/default/
       cp ~/kube/init_conf/* /etc/init/
@@ -682,7 +682,7 @@ function provision-masterandnode() {
       cp ~/kube/minion/* /opt/bin/
 
       service etcd start
-      if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" ~/kube/reconfDocker.sh ai; fi
+      if ${NEED_RECONFIG_DOCKER}; then FLANNEL_NET=\"${FLANNEL_NET}\" KUBE_CONFIG_FILE=\"${KUBE_CONFIG_FILE}\" DOCKER_OPTS=\"${DOCKER_OPTS}\" DEBUG=\"$DEBUG\" ~/kube/reconfDocker.sh ai; fi
       '" || {
       echo "Deploying master and node on machine ${MASTER_IP} failed"
       exit 1


### PR DESCRIPTION
``` release-note
```

Generalized the cluster/ubuntu scripting so that there is a way to
specify the Flannel "backend" to use.

Also updated the default setting of ADMISSION_CONTROL, to match that
recommended for the latest release in
http://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-plug-ins-to-use,
and updated the comment on that setting to explain it.

Also made `cluster/ubuntu/reconfDocker.sh` sensitive to the `DEBUG` envar.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34876)

<!-- Reviewable:end -->
