### PR TITLE
Register the kubeadm api group in cmd/kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/install/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/install/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import "k8s.io/kubernetes/pkg/api/unversioned"
 
 type MasterConfiguration struct {
-	unversioned.TypeMeta
+	unversioned.TypeMeta `json:",inline"`
 
 	Secrets           Secrets    `json:"secrets"`
 	API               API        `json:"api"`
@@ -55,7 +55,7 @@ type Secrets struct {
 }
 
 type NodeConfiguration struct {
-	unversioned.TypeMeta
+	unversioned.TypeMeta `json:",inline"`
 
 	MasterAddresses []string `json:"masterAddresses"`
 	Secrets         Secrets  `json:"secrets"`
@@ -63,7 +63,7 @@ type NodeConfiguration struct {
 
 // ClusterInfo TODO add description
 type ClusterInfo struct {
-	unversioned.TypeMeta
+	unversioned.TypeMeta `json:",inline"`
 	// TODO(phase1+) this may become simply `api.Config`
 	CertificateAuthorities []string `json:"certificateAuthorities"`
 	Endpoints              []string `json:"endpoints"`

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -99,7 +99,7 @@ func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, s
 	}
 
 	// TODO(phase1+) this we are missing args from the help text, there should be a way to tell cobra about it
-	if len(args) == 0 {
+	if len(args) == 0 && len(cfg.MasterAddresses) == 0 {
 		return nil, fmt.Errorf("must specify master IP address (see --help)")
 	}
 	cfg.MasterAddresses = append(cfg.MasterAddresses, args...)

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"


### PR DESCRIPTION
Fixes the issue mentioned in: https://github.com/kubernetes/kubernetes/pull/34885#issuecomment-253995383

My test config:

``` yaml
apiVersion: kubeadm.k8s.io/v1alpha1
kind: MasterConfiguration
kubernetesVersion: v1.4.2
networking:
  podSubnet: 10.244.0.0/16
  dnsDomain: k8s.somecompany.com
  serviceSubnet: 10.16.0.0/12
api:
  externalDNSNames:
   - myawesomek8snode
secrets:
  givenToken: 92f7e2.3685fe2e01f799f3
```

``` console
# kubeadm init --config kubeadm.yaml
```

@kubernetes/sig-cluster-lifecycle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34891)

<!-- Reviewable:end -->
