### PR TITLE
vSphere cloud provider: re-use session for vCenter logins

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -118,11 +118,11 @@ func TestVSphereLogin(t *testing.T) {
 	defer cancel()
 
 	// Create vSphere client
-	c, err := vsphereLogin(vs.cfg, ctx)
+	err = vSphereLogin(vs, ctx)
 	if err != nil {
 		t.Errorf("Failed to create vSpere client: %s", err)
 	}
-	defer c.Logout(ctx)
+	defer vs.client.Logout(ctx)
 }
 
 func TestZones(t *testing.T) {


### PR DESCRIPTION
This change allows for the re-use of a vCenter client session.  Addresses #34491

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34892)

<!-- Reviewable:end -->
