### PR TITLE
Fix federated-image.tag written with empty string

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -40,6 +40,8 @@ if [[ $KUBE_RELEASE_RUN_TESTS =~ ^[yY]$ ]]; then
   kube::build::run_build_command make test-integration
 fi
 
+kube::build::copy_output
+
 if [[ "${FEDERATION:-}" == "true" ]];then
     (
 	source "${KUBE_ROOT}/build/util.sh"
@@ -48,6 +50,5 @@ if [[ "${FEDERATION:-}" == "true" ]];then
     )
 fi
 
-kube::build::copy_output
 kube::release::package_tarballs
 kube::release::package_hyperkube


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Fix federation-up

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #34575

**Special notes for your reviewer**: This issue is happening because there is no kubectl available now when we are trying to write federated-image.tag file. Instead of using kubectl we can use KUBE_GIT_VERSION to get the version.

**Release note**: `NONE`

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

@nikhiljindal @madhusudancs @colhom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34898)

<!-- Reviewable:end -->
