### PR TITLE
WIP: Federation: separate notion of zone-name & dns-suffix

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -179,7 +179,7 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 
 	glog.Infof("Loading client config for service controller %q", servicecontroller.UserAgentName)
 	scClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, servicecontroller.UserAgentName))
-	servicecontroller := servicecontroller.New(scClientset, dns, s.FederationName, s.ZoneName)
+	servicecontroller := servicecontroller.New(scClientset, dns, s.FederationName, s.FederationDnsSuffix, s.ZoneName, s.ZoneID)
 	glog.Infof("Running service controller")
 	if err := servicecontroller.Run(s.ConcurrentServiceSyncs, wait.NeverStop); err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -39,6 +39,10 @@ type ControllerManagerConfiguration struct {
 	FederationName string `json:"federationName"`
 	// zone name, like example.com.
 	ZoneName string `json:"zoneName"`
+	// zone id, for use when zoneName is ambiguous.
+	ZoneID string `json:"zoneID"`
+	// suffix to use for publishing federated services.
+	FederationDnsSuffix string `json:"federationDnsSuffix"`
 	// dnsProvider is the provider for dns services.
 	DnsProvider string `json:"dnsProvider"`
 	// dnsConfigFile is the path to the dns provider configuration file.
@@ -101,6 +105,8 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.StringVar(&s.FederationName, "federation-name", s.FederationName, "Federation name.")
 	fs.StringVar(&s.ZoneName, "zone-name", s.ZoneName, "Zone name, like example.com.")
+	fs.StringVar(&s.ZoneID, "zone-id", s.ZoneID, "Zone ID, for use with multiple zones with the same name.")
+	fs.StringVar(&s.FederationDnsSuffix, "federation-dns-suffix", s.FederationDnsSuffix, "DNS Suffix to use for federation domain names.")
 	fs.IntVar(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.IntVar(&s.ConcurrentReplicaSetSyncs, "concurrent-replicaset-syncs", s.ConcurrentReplicaSetSyncs, "The number of ReplicaSets syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.DurationVar(&s.ClusterMonitorPeriod.Duration, "cluster-monitor-period", s.ClusterMonitorPeriod.Duration, "The period for syncing ClusterStatus in ClusterController.")

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -19,6 +19,7 @@ package route53
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
 
@@ -79,6 +80,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 	}
 
 	if len(changes) == 0 {
+		glog.V(4).Infof("No changes in changeset; skipping apply")
 		return nil
 	}
 

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
@@ -19,6 +19,7 @@ package clouddns
 import (
 	"fmt"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
 )
@@ -54,6 +55,11 @@ func (c *ResourceRecordChangeset) Apply() error {
 	var deletions []interfaces.ResourceRecordSet
 	for _, r := range c.removals {
 		deletions = append(deletions, r.(ResourceRecordSet).impl)
+	}
+
+	if len(additions) == 0 && len(deletions) == 0 {
+		glog.V(4).Infof("No changes in changeset; skipping apply")
+		return nil
 	}
 
 	change := service.NewChange(additions, deletions)


### PR DESCRIPTION
WIP, but for discussion @quinton-hoole & @madhusudancs .  I think we will likely want to split into two or three PRs (suffix vs hosted-zone, match by id, bigger batches)

Basically untested at this point.

---

Also support specification of zone by ID, so that if we have a public &
private zone with the same name (common on AWS), we can still create
records.

Also use the changeset interface to be more efficient in updating DNS
records.  Again particularly important on AWS where requests must
complete before a second request can be made.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34901)

<!-- Reviewable:end -->
