### PR TITLE
Remove duplicate --etcd-servers arguments in kubeadm

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -225,7 +225,6 @@ func getComponentCommand(component string, s *kubeadmapi.MasterConfiguration) (c
 	baseFlags := map[string][]string{
 		apiServer: {
 			"--insecure-bind-address=127.0.0.1",
-			"--etcd-servers=http://127.0.0.1:2379",
 			"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
 			"--service-cluster-ip-range=" + s.Networking.ServiceSubnet,
 			"--service-account-key-file=" + pkiDir + "/apiserver-key.pem",


### PR DESCRIPTION
fixes: #34900

@pires @errordeveloper

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34907)

<!-- Reviewable:end -->
