### PR TITLE
Don't overwrite FLANNEL_OTHER_NET_CONFIG in ubuntu config

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -64,7 +64,7 @@ export FLANNEL_NET=${FLANNEL_NET:-172.16.0.0/16}
 # FLANNEL_OTHER_NET_CONFIG=', "SubnetMin": "172.16.10.0", "SubnetMax": "172.16.90.0"'
 
 export FLANNEL_OTHER_NET_CONFIG
-FLANNEL_OTHER_NET_CONFIG=''
+FLANNEL_OTHER_NET_CONFIG=${FLANNEL_OTHER_NET_CONFIG:-""}
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incrementing quota usage prematurely.


### PR DESCRIPTION
Make it easier to pass options to flannel through environment variables.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34908)

<!-- Reviewable:end -->
