### PR TITLE
kubelet: Mark container with error state on CNI error

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -2220,8 +2220,7 @@ func TestGetPodStatusFromNetworkPlugin(t *testing.T) {
 		containerID        string
 		infraContainerID   string
 		networkStatusError error
-		expectRunning      bool
-		expectUnknown      bool
+		expectedState      kubecontainer.ContainerState
 	}{
 		{
 			pod: &api.Pod{
@@ -2238,8 +2237,7 @@ func TestGetPodStatusFromNetworkPlugin(t *testing.T) {
 			containerID:        "123",
 			infraContainerID:   "9876",
 			networkStatusError: nil,
-			expectRunning:      true,
-			expectUnknown:      false,
+			expectedState:      kubecontainer.ContainerStateRunning,
 		},
 		{
 			pod: &api.Pod{
@@ -2256,8 +2254,7 @@ func TestGetPodStatusFromNetworkPlugin(t *testing.T) {
 			containerID:        "123",
 			infraContainerID:   "9876",
 			networkStatusError: fmt.Errorf("CNI plugin error"),
-			expectRunning:      false,
-			expectUnknown:      true,
+			expectedState:      kubecontainer.ContainerStateExited,
 		},
 	}
 	for _, test := range cases {
@@ -2295,16 +2292,8 @@ func TestGetPodStatusFromNetworkPlugin(t *testing.T) {
 		}
 
 		expectedStatesCount := 0
-		var expectedState kubecontainer.ContainerState
-		if test.expectRunning {
-			expectedState = kubecontainer.ContainerStateRunning
-		} else if test.expectUnknown {
-			expectedState = kubecontainer.ContainerStateUnknown
-		} else {
-			t.Errorf("Some state has to be expected")
-		}
 		for _, containerStatus := range podStatus.ContainerStatuses {
-			if containerStatus.State == expectedState {
+			if containerStatus.State == test.expectedState {
 				expectedStatesCount++
 			}
 		}


### PR DESCRIPTION
In case of CNI plugin error, especially if that error appears due to lack of available IP addresses on the node, we want to mark container with error state and re-run it.

Fixes #34283

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34918)

<!-- Reviewable:end -->
