### PR TITLE
Add ShmSize support

### DIFF
--- a/api/swagger-spec/apps_v1alpha1.json
+++ b/api/swagger-spec/apps_v1alpha1.json
@@ -1328,6 +1328,10 @@
      "subdomain": {
       "type": "string",
       "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
+     },
+     "shmSize": {
+      "type": "string",
+      "description": "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated"
      }
     }
    },

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1333,6 +1333,10 @@
      "subdomain": {
       "type": "string",
       "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
+     },
+     "shmSize": {
+      "type": "string",
+      "description": "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated"
      }
     }
    },

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -7942,6 +7942,10 @@
      "subdomain": {
       "type": "string",
       "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
+     },
+     "shmSize": {
+      "type": "string",
+      "description": "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated"
      }
     }
    },

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -17939,6 +17939,10 @@
      "subdomain": {
       "type": "string",
       "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
+     },
+     "shmSize": {
+      "type": "string",
+      "description": "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated"
      }
     }
    },

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1566,6 +1566,11 @@ type PodSpec struct {
 	// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
 	// If not specified, the pod will not have a domainname at all.
 	Subdomain string `json:"subdomain,omitempty"`
+	//Optional: Docker "--shm-size" support. Defines the size of /dev/shm in the IPC namespace of the pod.
+	//If not defined here Docker uses a default value.
+	//Omitted if HostIPC is true.
+	//Cannot be updated
+	ShmSize *resource.Quantity `json:"shmSize,omitempty"`
 }
 
 // Sysctl defines a kernel parameter to be set

--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -2217,6 +2217,12 @@ message PodSpec {
   // If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
   // If not specified, the pod will not have a domainname at all.
   optional string subdomain = 17;
+
+  // Optional: Docker "--shm-size" support. Defines the size of /dev/shm in the IPC namespace of the pod.
+  // If not defined here Docker uses a default value.
+  // Omitted if HostIPC is true.
+  // Cannot be updated
+  optional k8s.io.kubernetes.pkg.api.resource.Quantity shmsize = 18;
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1853,6 +1853,11 @@ type PodSpec struct {
 	// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
 	// If not specified, the pod will not have a domainname at all.
 	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,17,opt,name=subdomain"`
+	//Optional: Docker "--shm-size" support. Defines the size of /dev/shm in the IPC namespace of the pod.
+	//If not defined here Docker uses a default value.
+	//Omitted if HostIPC is true.
+	//Cannot be updated
+	ShmSize *resource.Quantity `json:"shmSize,omitempty" protobuf:"bytes,18,opt,name=shmsize"`
 }
 
 // PodSecurityContext holds pod-level security attributes and common container settings.

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -1286,6 +1286,7 @@ var map_PodSpec = map[string]string{
 	"imagePullSecrets":              "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
 	"hostname":                      "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
 	"subdomain":                     "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+	"shmSize":                       "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated",
 }
 
 func (PodSpec) SwaggerDoc() map[string]string {

--- a/pkg/api/v1/zz_generated.conversion.go
+++ b/pkg/api/v1/zz_generated.conversion.go
@@ -5051,6 +5051,7 @@ func autoConvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	}
 	out.Hostname = in.Hostname
 	out.Subdomain = in.Subdomain
+	out.ShmSize = in.ShmSize
 	return nil
 }
 
@@ -5117,6 +5118,7 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	}
 	out.Hostname = in.Hostname
 	out.Subdomain = in.Subdomain
+	out.ShmSize = in.ShmSize
 	return nil
 }
 

--- a/pkg/api/v1/zz_generated.deepcopy.go
+++ b/pkg/api/v1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	resource "k8s.io/kubernetes/pkg/api/resource"
 	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
@@ -2655,6 +2656,13 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		}
 		out.Hostname = in.Hostname
 		out.Subdomain = in.Subdomain
+		if in.ShmSize != nil {
+			in, out := &in.ShmSize, &out.ShmSize
+			*out = new(resource.Quantity)
+			**out = (*in).DeepCopy()
+		} else {
+			out.ShmSize = nil
+		}
 		return nil
 	}
 }

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1851,6 +1851,7 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabels(spec.NodeSelector, fldPath.Child("nodeSelector"))...)
 	allErrs = append(allErrs, ValidatePodSecurityContext(spec.SecurityContext, spec, fldPath, fldPath.Child("securityContext"))...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets, fldPath.Child("imagePullSecrets"))...)
+	allErrs = append(allErrs, ValidateShmSize(spec.ShmSize, fldPath.Child("shmSize"))...)
 	if len(spec.ServiceAccountName) > 0 {
 		for _, msg := range ValidateServiceAccountName(spec.ServiceAccountName, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccountName"), spec.ServiceAccountName, msg))
@@ -3637,4 +3638,13 @@ func sysctlIntersection(a []api.Sysctl, b []api.Sysctl) []string {
 		}
 	}
 	return result
+}
+
+// ValidateShmSize tests the shmSize field of Pod
+func ValidateShmSize(shmSize *resource.Quantity, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if shmSize != nil && !(shmSize.Cmp(resource.Quantity{}) > 0) {
+		allErrs = append(allErrs, field.Invalid(fldPath, shmSize.Value(), "must be greater than 0"))
+	}
+	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3123,6 +3123,8 @@ func TestValidatePodSpec(t *testing.T) {
 	activeDeadlineSeconds := int64(30)
 	minID := int64(0)
 	maxID := int64(2147483647)
+	shmSizePositive := resource.MustParse("128M")
+	shmSizeNegative := resource.MustParse("-1G")
 	successCases := []api.PodSpec{
 		{ // Populate basic fields, leave defaults for most.
 			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
@@ -3200,6 +3202,13 @@ func TestValidatePodSpec(t *testing.T) {
 			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
+		},
+		{ // Populate ShmSize.
+			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
+			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+			ShmSize:       &shmSizePositive,
 		},
 	}
 	for i := range successCases {
@@ -3334,6 +3343,13 @@ func TestValidatePodSpec(t *testing.T) {
 			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
+		},
+		"bad shmSize": {
+			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
+			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+			ShmSize:       &shmSizeNegative,
 		},
 	}
 	for k, v := range failureCases {

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package api
 
 import (
+	resource "k8s.io/kubernetes/pkg/api/resource"
 	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	fields "k8s.io/kubernetes/pkg/fields"
@@ -2713,6 +2714,13 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 		}
 		out.Hostname = in.Hostname
 		out.Subdomain = in.Subdomain
+		if in.ShmSize != nil {
+			in, out := &in.ShmSize, &out.ShmSize
+			*out = new(resource.Quantity)
+			**out = (*in).DeepCopy()
+		} else {
+			out.ShmSize = nil
+		}
 		return nil
 	}
 }

--- a/pkg/apis/apps/types.generated.go
+++ b/pkg/apis/apps/types.generated.go
@@ -1547,7 +1547,7 @@ func (x codecSelfer1234) decSlicePetSet(v *[]PetSet, d *codec1978.Decoder) {
 
 			yyrg127 := len(yyv127) > 0
 			yyv2127 := yyv127
-			yyrl127, yyrt127 = z.DecInferLen(yyl127, z.DecBasicHandle().MaxInitLen, 776)
+			yyrl127, yyrt127 = z.DecInferLen(yyl127, z.DecBasicHandle().MaxInitLen, 784)
 			if yyrt127 {
 				if yyrl127 <= cap(yyv127) {
 					yyv127 = yyv127[:yyrl127]

--- a/pkg/apis/apps/v1alpha1/types.generated.go
+++ b/pkg/apis/apps/v1alpha1/types.generated.go
@@ -1577,7 +1577,7 @@ func (x codecSelfer1234) decSlicePetSet(v *[]PetSet, d *codec1978.Decoder) {
 
 			yyrg131 := len(yyv131) > 0
 			yyv2131 := yyv131
-			yyrl131, yyrt131 = z.DecInferLen(yyl131, z.DecBasicHandle().MaxInitLen, 800)
+			yyrl131, yyrt131 = z.DecInferLen(yyl131, z.DecBasicHandle().MaxInitLen, 808)
 			if yyrt131 {
 				if yyrl131 <= cap(yyv131) {
 					yyv131 = yyv131[:yyrl131]

--- a/pkg/apis/batch/types.generated.go
+++ b/pkg/apis/batch/types.generated.go
@@ -4247,7 +4247,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 			yyrg370 := len(yyv370) > 0
 			yyv2370 := yyv370
-			yyrl370, yyrt370 = z.DecInferLen(yyl370, z.DecBasicHandle().MaxInitLen, 800)
+			yyrl370, yyrt370 = z.DecInferLen(yyl370, z.DecBasicHandle().MaxInitLen, 808)
 			if yyrt370 {
 				if yyrl370 <= cap(yyv370) {
 					yyv370 = yyv370[:yyrl370]
@@ -4479,7 +4479,7 @@ func (x codecSelfer1234) decSliceScheduledJob(v *[]ScheduledJob, d *codec1978.De
 
 			yyrg382 := len(yyv382) > 0
 			yyv2382 := yyv382
-			yyrl382, yyrt382 = z.DecInferLen(yyl382, z.DecBasicHandle().MaxInitLen, 1048)
+			yyrl382, yyrt382 = z.DecInferLen(yyl382, z.DecBasicHandle().MaxInitLen, 1056)
 			if yyrt382 {
 				if yyrl382 <= cap(yyv382) {
 					yyv382 = yyv382[:yyrl382]

--- a/pkg/apis/batch/v1/types.generated.go
+++ b/pkg/apis/batch/v1/types.generated.go
@@ -2872,7 +2872,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 			yyrg245 := len(yyv245) > 0
 			yyv2245 := yyv245
-			yyrl245, yyrt245 = z.DecInferLen(yyl245, z.DecBasicHandle().MaxInitLen, 824)
+			yyrl245, yyrt245 = z.DecInferLen(yyl245, z.DecBasicHandle().MaxInitLen, 832)
 			if yyrt245 {
 				if yyrl245 <= cap(yyv245) {
 					yyv245 = yyv245[:yyrl245]

--- a/pkg/apis/batch/v2alpha1/types.generated.go
+++ b/pkg/apis/batch/v2alpha1/types.generated.go
@@ -4767,7 +4767,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 			yyrg409 := len(yyv409) > 0
 			yyv2409 := yyv409
-			yyrl409, yyrt409 = z.DecInferLen(yyl409, z.DecBasicHandle().MaxInitLen, 824)
+			yyrl409, yyrt409 = z.DecInferLen(yyl409, z.DecBasicHandle().MaxInitLen, 832)
 			if yyrt409 {
 				if yyrl409 <= cap(yyv409) {
 					yyv409 = yyv409[:yyrl409]
@@ -4999,7 +4999,7 @@ func (x codecSelfer1234) decSliceScheduledJob(v *[]ScheduledJob, d *codec1978.De
 
 			yyrg421 := len(yyv421) > 0
 			yyv2421 := yyv421
-			yyrl421, yyrt421 = z.DecInferLen(yyl421, z.DecBasicHandle().MaxInitLen, 1072)
+			yyrl421, yyrt421 = z.DecInferLen(yyl421, z.DecBasicHandle().MaxInitLen, 1080)
 			if yyrt421 {
 				if yyrl421 <= cap(yyv421) {
 					yyv421 = yyv421[:yyrl421]

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -11090,12 +11090,18 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+					"shmSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional: Docker \"--shm-size\" support. Defines the size of /dev/shm in the IPC namespace of the pod. If not defined here Docker uses a default value. Omitted if HostIPC is true. Cannot be updated",
+							Ref:         spec.MustCreateRef("#/definitions/resource.Quantity"),
+						},
+					},
 				},
 				Required: []string{"containers"},
 			},
 		},
 		Dependencies: []string{
-			"v1.Container", "v1.LocalObjectReference", "v1.PodSecurityContext", "v1.Volume"},
+			"resource.Quantity", "v1.Container", "v1.LocalObjectReference", "v1.PodSecurityContext", "v1.Volume"},
 	},
 	"v1.PodStatus": {
 		Schema: spec.Schema{

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -737,6 +737,14 @@ func (dm *DockerManager) runContainer(
 		setInfraContainerNetworkConfig(pod, netMode, opts, &dockerOpts)
 	}
 
+	//Set IPC Shm size for the infra-container as this IPC Shm is used by
+	//all containers in the pod
+	if container.Name == PodInfraContainerName {
+		if pod.Spec.ShmSize != nil && !pod.Spec.SecurityContext.HostIPC {
+			hc.ShmSize = pod.Spec.ShmSize.Value()
+		}
+	}
+
 	setEntrypointAndCommand(container, opts, dockerOpts)
 
 	glog.V(3).Infof("Container %v/%v/%v: setting entrypoint \"%v\" and command \"%v\"", pod.Namespace, pod.Name, container.Name, dockerOpts.Config.Entrypoint, dockerOpts.Config.Cmd)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Support for defining the size of /dev/shm in the pod's IPC namespace

**Which issue this PR fixes** : fixes #28272

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34928)

<!-- Reviewable:end -->
