### PR TITLE
Fix the typo of fPrintf in hyperkube.go

### DIFF
--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -178,7 +178,7 @@ func (hk *HyperKube) Run(args []string) error {
 
 	err = s.Run(s, s.Flags().Args())
 	if err != nil {
-		hk.Println("Error:", err)
+		hk.Printf("Error: %v\n\n", err)
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the typo of fPrintf in hyperkube.go

Signed-off-by: YuPengZTE yu.peng36@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34929)

<!-- Reviewable:end -->
