### PR TITLE
Avoid unnecessary allocation

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -192,13 +192,12 @@ func NodeNameTriggerFunc(obj runtime.Object) []storage.MatchValue {
 // PodToSelectableFields returns a field set that represents the object
 // TODO: fields are not labels, and the validation rules for them do not apply.
 func PodToSelectableFields(pod *api.Pod) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&pod.ObjectMeta, true)
 	podSpecificFieldsSet := fields.Set{
 		"spec.nodeName":      pod.Spec.NodeName,
 		"spec.restartPolicy": string(pod.Spec.RestartPolicy),
 		"status.phase":       string(pod.Status.Phase),
 	}
-	return generic.MergeFieldsSets(objectMetaFieldsSet, podSpecificFieldsSet)
+	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
 }
 
 // ResourceGetter is an interface for retrieving resources by ResourceLocation.

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -192,11 +192,14 @@ func NodeNameTriggerFunc(obj runtime.Object) []storage.MatchValue {
 // PodToSelectableFields returns a field set that represents the object
 // TODO: fields are not labels, and the validation rules for them do not apply.
 func PodToSelectableFields(pod *api.Pod) fields.Set {
-	podSpecificFieldsSet := fields.Set{
-		"spec.nodeName":      pod.Spec.NodeName,
-		"spec.restartPolicy": string(pod.Spec.RestartPolicy),
-		"status.phase":       string(pod.Status.Phase),
-	}
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	podSpecificFieldsSet := make(fields.Set, 5)
+	podSpecificFieldsSet["spec.nodeName"] = pod.Spec.NodeName
+	podSpecificFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
+	podSpecificFieldsSet["status.phase"] = string(pod.Status.Phase)
 	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
 }
 

--- a/pkg/registry/generic/matcher.go
+++ b/pkg/registry/generic/matcher.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 )
 
-// ObjectMetaFieldsSet returns a fields that represents the ObjectMeta.
+// ObjectMetaFieldsSet returns a fields that represent the ObjectMeta.
 func ObjectMetaFieldsSet(objectMeta *api.ObjectMeta, hasNamespaceField bool) fields.Set {
 	if !hasNamespaceField {
 		return fields.Set{
@@ -32,6 +32,15 @@ func ObjectMetaFieldsSet(objectMeta *api.ObjectMeta, hasNamespaceField bool) fie
 		"metadata.name":      objectMeta.Name,
 		"metadata.namespace": objectMeta.Namespace,
 	}
+}
+
+// AdObjectMetaField add fields that represent the ObjectMeta to source.
+func AddObjectMetaFieldsSet(source fields.Set, objectMeta *api.ObjectMeta, hasNamespaceField bool) fields.Set {
+	source["metadata.name"] = objectMeta.Name
+	if hasNamespaceField {
+		source["metadata.namespace"] = objectMeta.Namespace
+	}
+	return source
 }
 
 // MergeFieldsSets merges a fields'set from fragment into the source.


### PR DESCRIPTION
This is supposed to avoid unnecessary memory allocations.

PodToSelectableFields seems to be the biggest contributor to memory allocations:

```
Showing top 10 nodes out of 247 (cum >= 83166442)
      flat  flat%   sum%        cum   cum%
1796823715 31.09% 31.09% 1796823715 31.09%  k8s.io/kubernetes/pkg/registry/core/pod.PodToSelectableFields
 530856268  9.19% 40.28%  530856268  9.19%  k8s.io/kubernetes/pkg/storage.NamespaceKeyFunc
 241505351  4.18% 44.46%  241505351  4.18%  reflect.unsafe_New
...
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34948)

<!-- Reviewable:end -->
