### PR TITLE
local-up: Add option to guess binary path

### DIFF
--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -102,6 +102,12 @@ hack/local-up-cluster.sh
 This will build and start a lightweight local cluster, consisting of a master
 and a single node. Type Control-C to shut it down.
 
+If you've already compiled the Kubernetes components, then you can avoid rebuilding them with this script by using the `-O` flag.
+
+```sh
+./hack/local-up-cluster.sh -O
+```
+
 You can use the cluster/kubectl.sh script to interact with the local cluster. hack/local-up-cluster.sh will
 print the commands to run to point kubectl at the local cluster.
 


### PR DESCRIPTION
This adds a `-O` flag which guesses the right output directory.

The reason for having two flags, not one, is because bash's `getopt` doesn't let you do optional arguments easily, so having both makes the code simpler.

I also removed the redundant empty check; the bash argument check meant that was never hit.

cc @jayunit100 and @jbeda (arbitrary people from the git log)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34958)

<!-- Reviewable:end -->
