### PR TITLE
Revert "Add e2e tests for storageclass"

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -2562,21 +2562,6 @@ func (gce *GCECloud) GetAutoLabelsForPD(name string, zone string) (map[string]st
 	return labels, nil
 }
 
-// TestDisk checks that a disk has given type. It should be used only for
-// testing!
-func (gce *GCECloud) TestDisk(diskName, volumeType string) error {
-	disk, err := gce.getDiskByNameUnknownZone(diskName)
-	if err != nil {
-		return err
-	}
-
-	if strings.HasSuffix(disk.Type, volumeType) {
-		return nil
-	}
-
-	return fmt.Errorf("unexpected disk type %q, expected suffix %q", disk.Type, volumeType)
-}
-
 func (gce *GCECloud) AttachDisk(diskName string, nodeName types.NodeName, readOnly bool) error {
 	instanceName := mapNodeNameToInstanceName(nodeName)
 	instance, err := gce.getInstanceByName(instanceName)
@@ -2660,7 +2645,6 @@ func (gce *GCECloud) findDiskByName(diskName string, zone string) (*gceDisk, err
 			Zone: lastComponent(disk.Zone),
 			Name: disk.Name,
 			Kind: disk.Kind,
-			Type: disk.Type,
 		}
 		return d, nil
 	}
@@ -2781,7 +2765,6 @@ type gceDisk struct {
 	Zone string
 	Name string
 	Kind string
-	Type string
 }
 
 // Gets the named instances, returning cloudprovider.InstanceNotFound if any instance is not found


### PR DESCRIPTION
Reverts kubernetes/kubernetes#32485

This PR broke the multizone tests on GCE/GKE, and broke the AWS tests, e.g.:
- https://k8s-testgrid.appspot.com/google-aws
- https://k8s-testgrid.appspot.com/google-gke#gke-multizone
- https://k8s-testgrid.appspot.com/google-gke#gci-gke-multizone
  Suggest revert. 

Fixes #34794

cc @k8s-oncall

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34961)

<!-- Reviewable:end -->
