### PR TITLE
make version an explicit choice so zero config and customized work

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 	authenticatorunion "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
 )
 
@@ -293,6 +294,8 @@ func Run(s *options.APIServer) error {
 		glog.Fatalf("Failed to initialize plugins: %v", err)
 	}
 
+	kubeVersion := version.Get()
+	genericConfig.Version = &kubeVersion
 	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/routes"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 	authenticatorunion "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
 )
 
@@ -183,6 +184,9 @@ func Run(s *options.ServerRunOptions) error {
 	if err != nil {
 		glog.Fatalf("Failed to initialize plugins: %v", err)
 	}
+
+	kubeVersion := version.Get()
+	genericConfig.Version = &kubeVersion
 	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.SupportsBasicAuth = len(s.BasicAuthFile) > 0

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -55,6 +55,7 @@ import (
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/version"
 )
 
 const (
@@ -77,11 +78,12 @@ type Config struct {
 	// allow downstream consumers to disable the index route
 	EnableIndex             bool
 	EnableProfiling         bool
-	EnableVersion           bool
 	EnableGarbageCollection bool
-	APIGroupPrefix          string
-	CorsAllowedOriginList   []string
-	Authenticator           authenticator.Request
+
+	Version               *version.Info
+	APIGroupPrefix        string
+	CorsAllowedOriginList []string
+	Authenticator         authenticator.Request
 	// TODO(roberthbailey): Remove once the server no longer supports http basic auth.
 	SupportsBasicAuth      bool
 	Authorizer             authorizer.Authorizer
@@ -213,7 +215,6 @@ func NewConfig() *Config {
 
 		EnableIndex:          true,
 		EnableSwaggerSupport: true,
-		EnableVersion:        true,
 		OpenAPIConfig: &common.Config{
 			ProtocolList:   []string{"https"},
 			IgnorePrefixes: []string{"/swaggerapi"},
@@ -471,9 +472,7 @@ func (s *GenericAPIServer) installAPI(c *Config) {
 	if c.EnableProfiling {
 		routes.Profiling{}.Install(s.HandlerContainer)
 	}
-	if c.EnableVersion {
-		routes.Version{}.Install(s.HandlerContainer)
-	}
+	routes.Version{Version: c.Version}.Install(s.HandlerContainer)
 	s.HandlerContainer.Add(s.DynamicApisDiscovery())
 }
 

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -42,6 +42,7 @@ import (
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/version"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -230,7 +231,9 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 	config.EnableIndex = true
 	config.EnableProfiling = true
 	config.EnableSwaggerSupport = true
-	config.EnableVersion = true
+
+	kubeVersion := version.Get()
+	config.Version = &kubeVersion
 
 	s, err := config.SkipComplete().New()
 	if err != nil {

--- a/pkg/genericapiserver/routes/version.go
+++ b/pkg/genericapiserver/routes/version.go
@@ -27,16 +27,22 @@ import (
 )
 
 // Version provides a webservice with version information.
-type Version struct{}
+type Version struct {
+	Version *version.Info
+}
 
 // Install registers the APIServer's `/version` handler.
 func (v Version) Install(c *mux.APIContainer) {
+	if v.Version == nil {
+		return
+	}
+
 	// Set up a service to return the git code version.
 	versionWS := new(restful.WebService)
 	versionWS.Path("/version")
 	versionWS.Doc("git code version from which this is built")
 	versionWS.Route(
-		versionWS.GET("/").To(handleVersion).
+		versionWS.GET("/").To(v.handleVersion).
 			Doc("get the code version").
 			Operation("getCodeVersion").
 			Produces(restful.MIME_JSON).
@@ -47,6 +53,6 @@ func (v Version) Install(c *mux.APIContainer) {
 }
 
 // handleVersion writes the server's version information.
-func handleVersion(req *restful.Request, resp *restful.Response) {
-	apiserver.WriteRawJSON(http.StatusOK, version.Get(), resp.ResponseWriter)
+func (v Version) handleVersion(req *restful.Request, resp *restful.Response) {
+	apiserver.WriteRawJSON(http.StatusOK, *v.Version, resp.ResponseWriter)
 }

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -83,6 +83,8 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	resourceEncoding.SetVersionEncoding(certificates.GroupName, *testapi.Certificates.GroupVersion(), unversioned.GroupVersion{Group: certificates.GroupName, Version: runtime.APIVersionInternal})
 	storageFactory := genericapiserver.NewDefaultStorageFactory(*storageConfig, testapi.StorageMediaType(), api.Codecs, resourceEncoding, DefaultAPIResourceConfigSource())
 
+	kubeVersion := version.Get()
+	config.GenericConfig.Version = &kubeVersion
 	config.StorageFactory = storageFactory
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
@@ -94,7 +96,6 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
 	config.GenericConfig.ProxyTLSClientConfig = &tls.Config{}
 	config.GenericConfig.RequestContextMapper = api.NewRequestContextMapper()
-	config.GenericConfig.EnableVersion = true
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.EnableCoreControllers = false
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/watch"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	authenticatorunion "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
@@ -344,6 +345,8 @@ func NewMasterConfig() *master.Config {
 		NewSingleContentTypeSerializer(api.Scheme, testapi.Storage.Codec(), runtime.ContentTypeJSON))
 
 	genericConfig := genericapiserver.NewConfig()
+	kubeVersion := version.Get()
+	genericConfig.Version = &kubeVersion
 	genericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
 	genericConfig.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
 	genericConfig.AdmissionControl = admit.NewAlwaysAdmit()


### PR DESCRIPTION
Makes `/version` key off of setting the version.  This allows composers to add a version that is correct.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34967)

<!-- Reviewable:end -->
