### PR TITLE
Update elasticsearch and kibana usage

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -20,8 +20,8 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: gcr.io/google_containers/elasticsearch:1.9
-        name: elasticsearch-logging         
+      - image: gcr.io/google_containers/elasticsearch:v2.4.1
+        name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: gcr.io/google_containers/kibana:1.3
+        image: gcr.io/google_containers/kibana:v4.6.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/fluentd-elasticsearch/es-controller.yaml
@@ -20,12 +20,12 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: gcr.io/google_containers/elasticsearch:1.9
-        name: elasticsearch-logging         
+      - image: gcr.io/google_containers/elasticsearch:v2.4.1
+        name: elasticsearch-logging
         resources:
-          # keep request = limit to keep this container in guaranteed class
+          # need more cpu upon initialization, therefore burstable class
           limits:
-            cpu: 100m
+            cpu: 1000m
           requests:
             cpu: 100m
         ports:

--- a/cluster/gce/coreos/kube-manifests/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: gcr.io/google_containers/kibana:1.3
+        image: gcr.io/google_containers/kibana:v4.6.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
``` release-note
Updated default Elasticsearch and Kibana used for elasticsearch logging destination to versions 2.4.1 and 4.6.1 respectively.
```

Updated controllers for elasticsearch and kibana to use newer versions of images. Fixed e2e test because of elasticsearch backward incompatible API changes.

Fixed out of sync elasticsearch controller for coreos.

@piosz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34969)

<!-- Reviewable:end -->
