### PR TITLE
move proxytransport config out of the genericapiserver

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package genericapiserver
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -36,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/apiserver"
 	apiserverfilters "k8s.io/kubernetes/pkg/apiserver/filters"
 	"k8s.io/kubernetes/pkg/apiserver/request"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
@@ -138,10 +136,6 @@ type Config struct {
 
 	// The range of ports to be assigned to services with type=NodePort or greater
 	ServiceNodePortRange utilnet.PortRange
-
-	// Used to customize default proxy dial/tls options
-	ProxyDialer          apiserver.ProxyDialerFunc
-	ProxyTLSClientConfig *tls.Config
 
 	// Additional ports to be exposed on the GenericAPIServer service
 	// extraServicePorts is injectable in the event that more ports
@@ -398,13 +392,6 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	}
 
 	s.HandlerContainer = mux.NewAPIContainer(http.NewServeMux(), c.Serializer)
-
-	if c.ProxyDialer != nil || c.ProxyTLSClientConfig != nil {
-		s.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{
-			Dial:            c.ProxyDialer,
-			TLSClientConfig: c.ProxyTLSClientConfig,
-		})
-	}
 
 	s.installAPI(c.Config)
 

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -132,9 +132,6 @@ type GenericAPIServer struct {
 	Handler         http.Handler
 	InsecureHandler http.Handler
 
-	// Used for custom proxy dialing, and proxy TLS options
-	ProxyTransport http.RoundTripper
-
 	// Map storing information about all groups to be exposed in discovery response.
 	// The map is from name to the group.
 	apiGroupsForDiscoveryLock sync.RWMutex

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -19,6 +19,7 @@ package master
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -99,6 +100,7 @@ type Config struct {
 	Tunneler          genericapiserver.Tunneler
 	EnableUISupport   bool
 	EnableLogsSupport bool
+	ProxyTransport    http.RoundTripper
 }
 
 // EndpointReconcilerConfig holds the endpoint reconciler and endpoint reconciliation interval to be
@@ -197,7 +199,7 @@ func (c completedConfig) New() (*Master, error) {
 	if c.GenericConfig.APIResourceConfigSource.AnyResourcesForVersionEnabled(apiv1.SchemeGroupVersion) {
 		legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
 			StorageFactory:            c.StorageFactory,
-			ProxyTransport:            s.ProxyTransport,
+			ProxyTransport:            c.ProxyTransport,
 			KubeletClientConfig:       c.KubeletClientConfig,
 			EventTTL:                  c.EventTTL,
 			ServiceClusterIPRange:     c.GenericConfig.ServiceClusterIPRange,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -19,7 +19,6 @@ package master
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -91,12 +90,14 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
-	config.GenericConfig.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
-	config.GenericConfig.ProxyTLSClientConfig = &tls.Config{}
 	config.GenericConfig.RequestContextMapper = api.NewRequestContextMapper()
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.EnableCoreControllers = false
 	config.KubeletClientConfig = kubeletclient.KubeletClientConfig{Port: 10250}
+	config.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{
+		Dial:            func(network, addr string) (net.Conn, error) { return nil, nil },
+		TLSClientConfig: &tls.Config{},
+	})
 
 	master, err := config.Complete().New()
 	if err != nil {
@@ -149,7 +150,7 @@ func newLimitedMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Confi
 // TestNew verifies that the New function returns a Master
 // using the configuration properly.
 func TestNew(t *testing.T) {
-	master, etcdserver, config, assert := newMaster(t)
+	master, etcdserver, _, assert := newMaster(t)
 	defer etcdserver.Terminate(t)
 
 	// these values get defaulted
@@ -157,14 +158,6 @@ func TestNew(t *testing.T) {
 	serviceReadWriteIP, _ := ipallocator.GetIndexedIP(serviceClusterIPRange, 1)
 	assert.Equal(master.GenericAPIServer.MasterCount, 1)
 	assert.Equal(master.GenericAPIServer.ServiceReadWriteIP, serviceReadWriteIP)
-
-	// These functions should point to the same memory location
-	masterDialer, _ := utilnet.Dialer(master.GenericAPIServer.ProxyTransport)
-	masterDialerFunc := fmt.Sprintf("%p", masterDialer)
-	configDialerFunc := fmt.Sprintf("%p", config.GenericConfig.ProxyDialer)
-	assert.Equal(masterDialerFunc, configDialerFunc)
-
-	assert.Equal(master.GenericAPIServer.ProxyTransport.(*http.Transport).TLSClientConfig, config.GenericConfig.ProxyTLSClientConfig)
 }
 
 // TestVersion tests /version


### PR DESCRIPTION
Proxy transport is not generic. This moves it to the master config where it is used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34973)

<!-- Reviewable:end -->
