### PR TITLE
convert TPR controller to posthook instead of disable flag

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -107,8 +107,6 @@ type Config struct {
 	Tunneler          genericapiserver.Tunneler
 	EnableUISupport   bool
 	EnableLogsSupport bool
-
-	disableThirdPartyControllerForTesting bool
 }
 
 // EndpointReconcilerConfig holds the endpoint reconciler and endpoint reconciliation interval to be
@@ -130,8 +128,6 @@ type Master struct {
 	thirdPartyResources map[string]*thirdPartyEntry
 	// protects the map
 	thirdPartyResourcesLock sync.RWMutex
-	// Useful for reliable testing.  Shouldn't be used otherwise.
-	disableThirdPartyControllerForTesting bool
 
 	// nodeClient is used to back the tunneler
 	nodeClient coreclient.NodeInterface
@@ -205,8 +201,6 @@ func (c completedConfig) New() (*Master, error) {
 		GenericAPIServer:        s,
 		deleteCollectionWorkers: c.DeleteCollectionWorkers,
 		nodeClient:              coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig).Nodes(),
-
-		disableThirdPartyControllerForTesting: c.disableThirdPartyControllerForTesting,
 	}
 
 	restOptionsFactory := restOptionsFactory{
@@ -246,10 +240,7 @@ func (c completedConfig) New() (*Master, error) {
 	c.RESTStorageProviders[autoscaling.GroupName] = autoscalingrest.RESTStorageProvider{}
 	c.RESTStorageProviders[batch.GroupName] = batchrest.RESTStorageProvider{}
 	c.RESTStorageProviders[certificates.GroupName] = certificatesrest.RESTStorageProvider{}
-	c.RESTStorageProviders[extensions.GroupName] = extensionsrest.RESTStorageProvider{
-		ResourceInterface:                     m,
-		DisableThirdPartyControllerForTesting: m.disableThirdPartyControllerForTesting,
-	}
+	c.RESTStorageProviders[extensions.GroupName] = extensionsrest.RESTStorageProvider{ResourceInterface: m}
 	c.RESTStorageProviders[policy.GroupName] = policyrest.RESTStorageProvider{}
 	c.RESTStorageProviders[rbac.GroupName] = &rbacrest.RESTStorageProvider{AuthorizerRBACSuperUser: c.GenericConfig.AuthorizerRBACSuperUser}
 	c.RESTStorageProviders[storage.GroupName] = storagerest.RESTStorageProvider{}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -98,14 +98,6 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.EnableCoreControllers = false
 
-	// TODO: this is kind of hacky.  The trouble is that the sync loop
-	// runs in a go-routine and there is no way to validate in the test
-	// that the sync routine has actually run.  The right answer here
-	// is probably to add some sort of callback that we can register
-	// to validate that it's actually been run, but for now we don't
-	// run the sync routine and register types manually.
-	config.disableThirdPartyControllerForTesting = true
-
 	master, err := config.Complete().New()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/registry/extensions/rest/thirdparty_controller.go
+++ b/pkg/registry/extensions/rest/thirdparty_controller.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	thirdpartyresourceetcd "k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresource/etcd"
+	extensionsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned"
 	"k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresourcedata"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -47,8 +47,8 @@ const thirdpartyprefix = "/apis"
 // ThirdPartyController is a control loop that knows how to synchronize ThirdPartyResource objects with
 // RESTful resources which are present in the API server.
 type ThirdPartyController struct {
-	master                     ResourceInterface
-	thirdPartyResourceRegistry *thirdpartyresourceetcd.REST
+	master ResourceInterface
+	client extensionsclient.ThirdPartyResourcesGetter
 }
 
 // SyncOneResource synchronizes a single resource with RESTful resources on the master
@@ -68,7 +68,7 @@ func (t *ThirdPartyController) SyncOneResource(rsrc *extensions.ThirdPartyResour
 
 // Synchronize all resources with RESTful resources on the master
 func (t *ThirdPartyController) SyncResources() error {
-	list, err := t.thirdPartyResourceRegistry.List(api.NewDefaultContext(), nil)
+	list, err := t.client.ThirdPartyResources().List(api.ListOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Converts the third party resource controller into a posthook using a loopback client instead going direct to etcd.  This let's us eliminate more flags and special-casing during initialization.  Also, using a client brings us closer to building this without side-effects for downstream composers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34979)

<!-- Reviewable:end -->
