### PR TITLE
glog non-fatal, usually unimportant error instead of fmt

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful/swagger"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -337,7 +338,7 @@ func (f *factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 		// register third party resources with the api machinery groups.  This probably should be done, but
 		// its consistent with old code, so we'll start with it.
 		if err := registerThirdPartyResources(discoveryClient); err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to register third party resources: %v\n", err)
+			glog.V(1).Infof("Unable to register third party resources: %v", err)
 		}
 		// ThirdPartyResourceData is special.  It's not discoverable, but needed for thirdparty resource listing
 		// TODO eliminate this once we're truly generic.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/34977

This particular message isn't usually important, so demote it to glog.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34981)

<!-- Reviewable:end -->
