### PR TITLE
Fix kube vsphere.kerneltime

### DIFF
--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -70,5 +70,5 @@ EOF
 #
 # -M installs the master
 set +x
-curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X stable 2016.3.2
 set -x

--- a/cluster/vsphere/templates/salt-minion.sh
+++ b/cluster/vsphere/templates/salt-minion.sh
@@ -65,4 +65,4 @@ EOF
 #
 # We specify -X to avoid a race condition that can cause minion failure to
 # install.  See https://github.com/saltstack/salt-bootstrap/issues/270
-curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X stable 2016.3.2

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -252,7 +252,7 @@ func readInstance(cfg *VSphereConfig) (string, string, error) {
 		var rp mo.ResourcePool
 		err = s.Properties(ctx, *vm.ResourcePool, []string{"parent"}, &rp)
 		if err == nil {
-			var ccr mo.ClusterComputeResource
+			var ccr mo.ComputeResource
 			err = s.Properties(ctx, *rp.Parent, []string{"name"}, &ccr)
 			if err == nil {
 				cluster = ccr.Name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This fixes kube-up to correctly install and configure on vSphere and avoid panics when only a single ESX(hypervisor) is used instead of a cluster.

**Which issue this PR fixes** 
fixes #34992
fixes #34847

``` release-note
Fix kube vsphere.kerneltime
```

**Special notes for your reviewer**:

We plan to cherry pick this into 1.4 release branch as well Ref: https://github.com/kubernetes/kubernetes/pull/34993

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/34997)

<!-- Reviewable:end -->
