### PR TITLE
In the CENTOS system experiment, found that there is no binding IPV4 …

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1329,7 +1329,13 @@ func openLocalPort(lp *localPort) (closeable, error) {
 	var socket closeable
 	switch lp.protocol {
 	case "tcp":
-		listener, err := net.Listen("tcp", net.JoinHostPort(lp.ip, strconv.Itoa(lp.port)))
+		var protocolV string
+		if net.ParseIP(lp.ip).To16() != nil && net.ParseIP(lp.ip).To4() == nil {
+			protocolV = "tcp6"
+		} else {
+			protocolV = "tcp4"
+		}
+		listener, err := net.Listen(protocolV, net.JoinHostPort(lp.ip, strconv.Itoa(lp.port)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The deployment of K8S in CENTOS system, found that the use of the IPV4 address can not access, netstat view, found that only monitored the address of the IPV6.
tracking code,Found in the function syncProxyRules, call function openLocalPort ip="", this time openLocalPort will be bound to the IPV6 address on the listener, while

Test the ip= "0.0.0.0", is also bound to the IPV6 address on the listener; can not be accessed through the IPV4 address. In view of the current situation is also the case of IPV4,

Modify the openLocalPort code, for IP is not the case of IPV6 address, the default listener IPV4 address.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35005)

<!-- Reviewable:end -->
