### PR TITLE
WIP: Allow multiple api group prefixes

### DIFF
--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -102,7 +102,7 @@ func Run(serverOptions *genericoptions.ServerRunOptions) error {
 		Scheme:               api.Scheme,
 		NegotiatedSerializer: api.Codecs,
 	}
-	if err := s.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := s.InstallAPIGroup(config.APIGroupPrefixes[0], &apiGroupInfo); err != nil {
 		return fmt.Errorf("Error in installing API: %v", err)
 	}
 	s.Run()

--- a/federation/cmd/federation-apiserver/app/extensions.go
+++ b/federation/cmd/federation-apiserver/app/extensions.go
@@ -60,7 +60,7 @@ func installExtensionsAPIs(g *genericapiserver.GenericAPIServer, restOptionsFact
 		ParameterCodec:         api.ParameterCodec,
 		NegotiatedSerializer:   api.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallAPIGroup("/apis", &apiGroupInfo); err != nil {
 		glog.Fatalf("Error in registering group versions: %v", err)
 	}
 }

--- a/federation/cmd/federation-apiserver/app/federation.go
+++ b/federation/cmd/federation-apiserver/app/federation.go
@@ -46,7 +46,7 @@ func installFederationAPIs(g *genericapiserver.GenericAPIServer, restOptionsFact
 		ParameterCodec:         api.ParameterCodec,
 		NegotiatedSerializer:   api.Codecs,
 	}
-	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err := g.InstallAPIGroup("/apis", &apiGroupInfo); err != nil {
 		glog.Fatalf("Error in registering group versions: %v", err)
 	}
 }

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -514,7 +514,7 @@ func (s *GenericAPIServer) DynamicApisDiscovery(prefix string) *restful.WebServi
 		}
 		sort.Strings(groupNames)
 		for _, groupName := range groupNames {
-			sortedGroups = append(sortedGroups, s.apiGroupsForDiscovery[groupName])
+			sortedGroups = append(sortedGroups, s.apiGroupsForDiscovery[prefix+"/"+groupName])
 		}
 
 		serverCIDR := s.getServerAddressByClientCIDRs(req.Request)

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -101,8 +101,8 @@ type GenericAPIServer struct {
 	// TODO eventually we should be able to factor this out to take place during initialization.
 	enableSwaggerSupport bool
 
-	// apiPrefix is the prefix where API groups live, usually /apis
-	apiPrefix string
+	// apiPrefixes are the prefixes where API groups live, usually only /apis
+	apiPrefixes []string
 
 	// legacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
 	// to InstallLegacyAPIGroup
@@ -139,7 +139,7 @@ type GenericAPIServer struct {
 	ProxyTransport http.RoundTripper
 
 	// Map storing information about all groups to be exposed in discovery response.
-	// The map is from name to the group.
+	// The map is from prefix/name to the group.
 	apiGroupsForDiscoveryLock sync.RWMutex
 	apiGroupsForDiscovery     map[string]unversioned.APIGroup
 
@@ -321,7 +321,7 @@ func (s *GenericAPIServer) InstallLegacyAPIGroup(apiPrefix string, apiGroupInfo 
 }
 
 // Exposes the given api group in the API.
-func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
+func (s *GenericAPIServer) InstallAPIGroup(prefix string, apiGroupInfo *APIGroupInfo) error {
 	// Do not register empty group or empty version.  Doing so claims /apis/ for the wrong entity to be returned.
 	// Catching these here places the error  much closer to its origin
 	if len(apiGroupInfo.GroupMeta.GroupVersion.Group) == 0 {
@@ -331,7 +331,18 @@ func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
 		return fmt.Errorf("cannot register handler with an empty version for %#v", *apiGroupInfo)
 	}
 
-	if err := s.installAPIResources(s.apiPrefix, apiGroupInfo); err != nil {
+	foundPrefix := false
+	for _, p := range s.apiPrefixes {
+		if p == prefix {
+			foundPrefix = true
+			break
+		}
+	}
+	if !foundPrefix {
+		return fmt.Errorf("cannot register handler with an unknown API prefix %q, known are %+v", prefix, s.apiPrefixes)
+	}
+
+	if err := s.installAPIResources(prefix, apiGroupInfo); err != nil {
 		return err
 	}
 
@@ -359,24 +370,24 @@ func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
 		PreferredVersion: preferedVersionForDiscovery,
 	}
 
-	s.AddAPIGroupForDiscovery(apiGroup)
-	s.HandlerContainer.Add(apiserver.NewGroupWebService(s.Serializer, s.apiPrefix+"/"+apiGroup.Name, apiGroup))
+	s.AddAPIGroupForDiscovery(prefix, apiGroup)
+	s.HandlerContainer.Add(apiserver.NewGroupWebService(s.Serializer, prefix+"/"+apiGroup.Name, apiGroup))
 
 	return nil
 }
 
-func (s *GenericAPIServer) AddAPIGroupForDiscovery(apiGroup unversioned.APIGroup) {
+func (s *GenericAPIServer) AddAPIGroupForDiscovery(prefix string, apiGroup unversioned.APIGroup) {
 	s.apiGroupsForDiscoveryLock.Lock()
 	defer s.apiGroupsForDiscoveryLock.Unlock()
 
-	s.apiGroupsForDiscovery[apiGroup.Name] = apiGroup
+	s.apiGroupsForDiscovery[prefix+"/"+apiGroup.Name] = apiGroup
 }
 
-func (s *GenericAPIServer) RemoveAPIGroupForDiscovery(groupName string) {
+func (s *GenericAPIServer) RemoveAPIGroupForDiscovery(prefix, groupName string) {
 	s.apiGroupsForDiscoveryLock.Lock()
 	defer s.apiGroupsForDiscoveryLock.Unlock()
 
-	delete(s.apiGroupsForDiscovery, groupName)
+	delete(s.apiGroupsForDiscovery, prefix+"/"+groupName)
 }
 
 func (s *GenericAPIServer) getServerAddressByClientCIDRs(req *http.Request) []unversioned.ServerAddressByClientCIDR {
@@ -484,17 +495,21 @@ func (s *GenericAPIServer) InstallOpenAPI() {
 	}
 }
 
-// DynamicApisDiscovery returns a webservice serving api group discovery.
+// DynamicApisDiscovery returns a webservice serving api group discovery for a given API prefix.
 // Note: during the server runtime apiGroupsForDiscovery might change.
-func (s *GenericAPIServer) DynamicApisDiscovery() *restful.WebService {
-	return apiserver.NewApisWebService(s.Serializer, s.apiPrefix, func(req *restful.Request) []unversioned.APIGroup {
+func (s *GenericAPIServer) DynamicApisDiscovery(prefix string) *restful.WebService {
+	return apiserver.NewApisWebService(s.Serializer, prefix, func(req *restful.Request) []unversioned.APIGroup {
 		s.apiGroupsForDiscoveryLock.RLock()
 		defer s.apiGroupsForDiscoveryLock.RUnlock()
 
 		// sort to have a deterministic order
 		sortedGroups := []unversioned.APIGroup{}
 		groupNames := make([]string, 0, len(s.apiGroupsForDiscovery))
-		for groupName := range s.apiGroupsForDiscovery {
+		for key := range s.apiGroupsForDiscovery {
+			if !strings.HasPrefix(key, prefix+"/") {
+				continue
+			}
+			groupName := key[len(prefix)+1:]
 			groupNames = append(groupNames, groupName)
 		}
 		sort.Strings(groupNames)

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -55,7 +55,7 @@ var AuthorizationModeChoices = []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABA
 
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
-	APIGroupPrefix             string
+	APIGroupPrefixes           []string
 	AdmissionControl           string
 	AdmissionControlConfigFile string
 	AdvertiseAddress           net.IP
@@ -123,7 +123,7 @@ type ServerRunOptions struct {
 
 func NewServerRunOptions() *ServerRunOptions {
 	return &ServerRunOptions{
-		APIGroupPrefix:                           "/apis",
+		APIGroupPrefixes:                         []string{"/apis"},
 		AdmissionControl:                         "AlwaysAdmit",
 		AnonymousAuth:                            true,
 		AuthorizationMode:                        "AlwaysAllow",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -344,7 +344,7 @@ func (m *Master) InstallAPIs(c *Config, restOptionsGetter genericapiserver.RESTO
 	}
 
 	for i := range apiGroupsInfo {
-		if err := m.GenericAPIServer.InstallAPIGroup(&apiGroupsInfo[i]); err != nil {
+		if err := m.GenericAPIServer.InstallAPIGroup("/apis", &apiGroupsInfo[i]); err != nil {
 			glog.Fatalf("Error in registering group versions: %v", err)
 		}
 	}
@@ -427,7 +427,7 @@ func (m *Master) removeThirdPartyStorage(path, resource string) error {
 	delete(entry.storage, resource)
 	if len(entry.storage) == 0 {
 		delete(m.thirdPartyResources, path)
-		m.GenericAPIServer.RemoveAPIGroupForDiscovery(extensionsrest.GetThirdPartyGroupName(path))
+		m.GenericAPIServer.RemoveAPIGroupForDiscovery("/apis", extensionsrest.GetThirdPartyGroupName(path))
 	} else {
 		m.thirdPartyResources[path] = entry
 	}
@@ -527,7 +527,7 @@ func (m *Master) addThirdPartyResourceStorage(path, resource string, storage *th
 	}
 	entry.storage[resource] = storage
 	if !found {
-		m.GenericAPIServer.AddAPIGroupForDiscovery(apiGroup)
+		m.GenericAPIServer.AddAPIGroupForDiscovery("/apis", apiGroup)
 	}
 }
 

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -89,7 +89,7 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	config.KubeletClient = client.FakeKubeletClient{}
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
-	config.GenericConfig.APIGroupPrefix = "/apis"
+	config.GenericConfig.APIGroupPrefixes = []string{"/apis"}
 	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
 	config.GenericConfig.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
 	config.GenericConfig.ProxyTLSClientConfig = &tls.Config{}


### PR DESCRIPTION
Needed for downstream, compare https://github.com/openshift/origin/pull/11192/files#r83795002.

TODO:
- [ ] add tests with multiple prefixes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35021)

<!-- Reviewable:end -->
