### PR TITLE
filter out secrets of command for rollout

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -183,7 +183,7 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 		return err
 	}
 
-	changeCause := f.Command()
+	changeCause := f.Command(cmd, false)
 
 	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -242,7 +242,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			}
 
 			if cmdutil.ShouldRecord(cmd, info) {
-				if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
+				if err := cmdutil.RecordChangeCause(info.Object, f.Command(cmd, false)); err != nil {
 					return cmdutil.AddSourceToErr("creating", info.Source, err)
 				}
 			}
@@ -297,7 +297,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			}
 
 			if cmdutil.ShouldRecord(cmd, info) {
-				if patch, patchType, err := cmdutil.ChangeResourcePatch(info, f.Command()); err == nil {
+				if patch, patchType, err := cmdutil.ChangeResourcePatch(info, f.Command(cmd, true)); err == nil {
 					if _, err = helper.Patch(info.Namespace, info.Name, patchType, patch); err != nil {
 						glog.V(4).Infof("error recording reason: %v", err)
 					}

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -155,7 +155,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 			return err
 		}
 		if cmdutil.ShouldRecord(cmd, hpa) {
-			if err := cmdutil.RecordChangeCause(hpa.Object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(hpa.Object, f.Command(cmd, false)); err != nil {
 				return err
 			}
 			object = hpa.Object

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -151,7 +151,7 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		}
 
 		if cmdutil.ShouldRecord(cmd, info) {
-			if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(info.Object, f.Command(cmd, false)); err != nil {
 				return cmdutil.AddSourceToErr("creating", info.Source, err)
 			}
 		}

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -536,7 +536,7 @@ func visitAnnotation(cmd *cobra.Command, f cmdutil.Factory, updates *resource.In
 			return err
 		}
 		if cmdutil.ShouldRecord(cmd, info) {
-			if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(info.Object, f.Command(cmd, false)); err != nil {
 				return err
 			}
 		}

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -250,7 +250,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			return err
 		}
 		if cmdutil.ShouldRecord(cmd, info) {
-			if err := cmdutil.RecordChangeCause(object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(object, f.Command(cmd, false)); err != nil {
 				return err
 			}
 		}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -177,7 +177,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
-	changeCause := f.Command()
+	changeCause := f.Command(cmd, false)
 
 	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -188,7 +188,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 				infoCopy := *info
 				infoCopy.Object = patchedObj
 				infoCopy.VersionedObject = patchedObj
-				if patch, patchType, err := cmdutil.ChangeResourcePatch(&infoCopy, f.Command()); err == nil {
+				if patch, patchType, err := cmdutil.ChangeResourcePatch(&infoCopy, f.Command(cmd, true)); err == nil {
 					if _, err = helper.Patch(info.Namespace, info.Name, patchType, patch); err != nil {
 						glog.V(4).Infof("error recording reason: %v", err)
 					}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -150,7 +150,7 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		}
 
 		if cmdutil.ShouldRecord(cmd, info) {
-			if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(info.Object, f.Command(cmd, false)); err != nil {
 				return cmdutil.AddSourceToErr("replacing", info.Source, err)
 			}
 		}
@@ -271,7 +271,7 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		}
 
 		if cmdutil.ShouldRecord(cmd, info) {
-			if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
+			if err := cmdutil.RecordChangeCause(info.Object, f.Command(cmd, false)); err != nil {
 				return cmdutil.AddSourceToErr("replacing", info.Source, err)
 			}
 		}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -584,7 +584,7 @@ func createGeneratedObject(f cmdutil.Factory, cmd *cobra.Command, generator kube
 		return nil, "", nil, nil, err
 	}
 	if cmdutil.GetRecordFlag(cmd) || len(annotations[kubectl.ChangeCauseAnnotation]) > 0 {
-		if err := cmdutil.RecordChangeCause(obj, f.Command()); err != nil {
+		if err := cmdutil.RecordChangeCause(obj, f.Command(cmd, false)); err != nil {
 			return nil, "", nil, nil, err
 		}
 	}

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -163,7 +163,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			return err
 		}
 		if cmdutil.ShouldRecord(cmd, info) {
-			patchBytes, patchType, err := cmdutil.ChangeResourcePatch(info, f.Command())
+			patchBytes, patchType, err := cmdutil.ChangeResourcePatch(info, f.Command(cmd, true))
 			if err != nil {
 				return err
 			}

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -119,7 +119,7 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	o.Encoder = f.JSONEncoder()
 	o.ShortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
 	o.Record = cmdutil.GetRecordFlag(cmd)
-	o.ChangeCause = f.Command()
+	o.ChangeCause = f.Command(cmd, false)
 	o.PrintObject = f.PrintObject
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 	o.Output = cmdutil.GetFlagString(cmd, "output")

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -131,7 +131,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	o.Encoder = f.JSONEncoder()
 	o.ShortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
 	o.Record = cmdutil.GetRecordFlag(cmd)
-	o.ChangeCause = f.Command()
+	o.ChangeCause = f.Command(cmd, false)
 	o.PrintObject = f.PrintObject
 	o.Cmd = cmd
 

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -112,7 +112,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		return err
 	}
 
-	o.changeCause = f.Command()
+	o.changeCause = f.Command(cmd, false)
 	mapper, _ := f.Object()
 	o.mapper = mapper
 	o.encoder = f.JSONEncoder()

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -130,7 +130,7 @@ type ClientAccessFactory interface {
 	FlagSet() *pflag.FlagSet
 	// Command will stringify and return all environment arguments ie. a command run by a client
 	// using the factory.
-	Command() string
+	Command(cmd *cobra.Command, showSecret bool) string
 	// BindFlags adds any flags that are common to all kubectl sub commands.
 	BindFlags(flags *pflag.FlagSet)
 	// BindExternalFlags adds any flags defined by external projects (not part of pflags)

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -330,14 +330,34 @@ func (f *ring0Factory) FlagSet() *pflag.FlagSet {
 	return f.flags
 }
 
-// TODO: We need to filter out stuff like secrets.
-func (f *ring0Factory) Command() string {
+func (f *ring0Factory) Command(cmd *cobra.Command, showSecret bool) string {
 	if len(os.Args) == 0 {
 		return ""
 	}
+
+	got := []string{}
+	store := func(flag *pflag.Flag, value string) error {
+		got = append(got, "--"+flag.Name)
+		if len(value) > 0 {
+			// check the secret flag from help message
+			if !showSecret && strings.HasSuffix(flag.Usage, clientcmd.SecretDescription) {
+				got = append(got, "XXX")
+			} else {
+				got = append(got, value)
+			}
+		}
+		return nil
+	}
+
+	var err error
+	err = cmd.Flags().ParseAll(os.Args[1:], store)
+	if err != nil || !cmd.Flags().Parsed() {
+		return ""
+	}
+
 	base := filepath.Base(os.Args[0])
-	args := append([]string{base}, os.Args[1:]...)
-	return strings.Join(args, " ")
+	rawArgs := append([]string{base}, got[0:]...)
+	return strings.Join(rawArgs, " ")
 }
 
 func (f *ring0Factory) BindFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
this pr is used to hide user's secret information from "kubectl rollout histroy ..."

The current is someone create a pod specified the username and password, others can see the secrets.
for example:

```
ubuntu@kube-master:~$ kubectl create -f nginx.yaml --record -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --username=test --password=123456
deployment "my-nginx" created

ubuntu@kube-master:~$ kubectl rollout history deployment/my-nginx
deployments "my-nginx"
REVISION    CHANGE-CAUSE
1       kubectl create -f nginx.yaml --record -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --username=test--password=123456
```

username&password will be exposed
so we can hide token、username and password, such as:

use username/password

```

ubuntu@kube-master:~$ kubectl create -f nginx.yaml --record -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --username=test --password=123456
deployment "my-nginx" created

ubuntu@kube-master:~$ kubectl rollout history deployment/my-nginx
deployments "my-nginx"
REVISION    CHANGE-CAUSE
1       kubectl create -f nginx.yaml --record -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --username=****** --password=******

```

use token

```
ubuntu@kube-master:~$ kubectl edit deployment/my-nginx  -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --token=123456
deployment "my-nginx" edited

ubuntu@kube-master:~$ kubectl rollout history deployment/my-nginx
deployments "my-nginx"
REVISION    CHANGE-CAUSE
1       kubectl create -f nginx.yaml --record -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --username=****** --password=******
2       kubectl edit deployment/my-nginx -s https://127.0.0.1:6443 --insecure-skip-tls-verify=true --token=******
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35030)

<!-- Reviewable:end -->
