### PR TITLE
Moved ViperizeFlags to test context

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,13 +18,7 @@ package e2e
 
 import (
 	"testing"
-
-	"k8s.io/kubernetes/test/e2e/framework"
 )
-
-func init() {
-	framework.ViperizeFlags()
-}
 
 func TestE2E(t *testing.T) {
 	RunE2ETests(t)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -132,6 +132,10 @@ type CloudConfig struct {
 var TestContext TestContextType
 var federatedKubeContext string
 
+func init() {
+	ViperizeFlags()
+}
+
 // Register flags common to all e2e test suites.
 func RegisterCommonFlags() {
 	// Turn on verbose by default to get spec names


### PR DESCRIPTION
**What this PR does / why we need it**:
Parses viper configuration earlier, so that the parameters are available when tests are defined rather than just during test execution.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #34735(,#34735,)

**Special notes for your reviewer**:
Minor code change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35042)

<!-- Reviewable:end -->
