### PR TITLE
Drop proxy environment variables from init and join commands

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -145,6 +145,9 @@ type Init struct {
 }
 
 func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight bool) (*Init, error) {
+	// Drop any proxy environment settings
+	kubeadmutil.UnsetProxyEnvironmentVariables()
+
 	if cfgPath != "" {
 		b, err := ioutil.ReadFile(cfgPath)
 		if err != nil {

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -88,6 +88,9 @@ type Join struct {
 }
 
 func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, skipPreFlight bool) (*Join, error) {
+	// Drop any proxy environment settings
+	kubeadmutil.UnsetProxyEnvironmentVariables()
+
 	if cfgPath != "" {
 		b, err := ioutil.ReadFile(cfgPath)
 		if err != nil {

--- a/cmd/kubeadm/app/util/proxy.go
+++ b/cmd/kubeadm/app/util/proxy.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+// UnsetProxyEnvironmentVariables removing all *_proxy variables from
+// environment. Helpful in situations where API clients must be forced
+// to work over direct connections.
+func UnsetProxyEnvironmentVariables() {
+	for _, envVar := range os.Environ() {
+		varName := strings.Split(envVar, "=")[0]
+		if strings.HasSuffix(strings.ToLower(varName), "_proxy") {
+			os.Unsetenv(varName)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of using kubeadm init/join in corporate environment, user often has http_proxy/https_proxy set.
Often user also has no_proxy set, but without taking into account of advertised API IP address.
This leads to situations where kubeadm tries to reach newly set API endpoints via corporate proxy and fails. This PR forcibly makes kubeadm to work directly with API endpoints, as all operations that it supposed to do are done on the same host.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #34695 

**Special notes for your reviewer**:
So far, I haven't found reasons why kubeadm for init/join command should go via proxy, thus it should be safe to have it by default like this. Recommendation where to put this function are more than welcome, if kubeadm utils is not the right place.

**Release note**:

``` release-note
```

kubeadm during initialization of master and slave nodes need to make
several API calls directly to the node where it is running.

Forcing http client to work directly by removing any potential
user settings.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35044)

<!-- Reviewable:end -->
