### PR TITLE
Add option to get-kube-binaries.sh to download and extract tests

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -77,7 +77,7 @@ function download_kube_binaries {
 }
 
 function create_cluster {
-  if [[ -n "${KUBERNETES_SKIP_CREATE_CLUSTER}" ]]; then
+  if [[ -n "${KUBERNETES_SKIP_CREATE_CLUSTER-}" ]]; then
     exit 0
   fi
   echo "Creating a kubernetes on ${KUBERNETES_PROVIDER:-gce}..."


### PR DESCRIPTION
A follow-on to #33701.

My goal is to use `cluster/get-kube.sh` and `cluster/get-kube-binaries.sh` instead of the custom download/extraction logic in `e2e-runner.sh`. In addition to simplifying the logic, it'll also allow me to properly test removing the arch-specific binaries from `kubernetes.tar.gz`.

Anyone on @kubernetes/test-infra-maintainers want to take a look?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35060)

<!-- Reviewable:end -->
