### PR TITLE
Change link to official Ceph Kubernetes docs

### DIFF
--- a/examples/volumes/cephfs/README.md
+++ b/examples/volumes/cephfs/README.md
@@ -38,7 +38,7 @@ Install Ceph on the Kubernetes host. For example, on Fedora 21
 
     # yum -y install ceph
 
-If you don't have a Ceph cluster, you can set up a [containerized Ceph cluster](https://github.com/rootfs/ceph_docker)
+If you don't have a Ceph cluster, you can set up a [containerized Ceph cluster](https://github.com/ceph/ceph-docker/tree/master/examples/kubernetes)
 
 Then get the keyring from the Ceph cluster and copy it to */etc/ceph/keyring*.
 


### PR DESCRIPTION
@elsonrodriguez, @hunter, and @leseb have gotten Ceph to run almost entirely within Kubernetes. Also, the official Ceph Docker image is more likely to be kept updated.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35063)

<!-- Reviewable:end -->
