### PR TITLE
If token validation fails, give the user the expected format.

### DIFF
--- a/cmd/kubeadm/app/util/tokens.go
+++ b/cmd/kubeadm/app/util/tokens.go
@@ -68,7 +68,7 @@ func UseGivenTokenIfValid(s *kubeadmapi.Secrets) (bool, error) {
 	givenToken := strings.Split(strings.ToLower(s.GivenToken), ".")
 	// TODO(phase1+) print desired format
 	// TODO(phase1+) could also print more specific messages in each case
-	invalidErr := "<util/tokens> provided token is invalid - %s"
+	invalidErr := "<util/tokens> provided token does not match expected <6 characters>.<16 characters> format - %s"
 	if len(givenToken) != 2 {
 		return false, fmt.Errorf(invalidErr, "not in 2-part dot-separated format")
 	}

--- a/cmd/kubeadm/app/util/tokens_test.go
+++ b/cmd/kubeadm/app/util/tokens_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
+)
+
+func TestUsingEmptyTokenFails(t *testing.T) {
+	// Simulates what happens when you omit --token on the CLI
+	config := newConfigWithToken("")
+
+	ok, err := UseGivenTokenIfValid(config)
+	assert.False(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestTokenValidationFailures(t *testing.T) {
+	invalidTokens := []string{
+		"1234567890123456789012",
+		"12345.1234567890123456",
+		".1234567890123456",
+		"123456.1234567890.123456",
+	}
+
+	for _, token := range(invalidTokens) {
+		config := newConfigWithToken(token)
+		ok, err := UseGivenTokenIfValid(config)
+
+		assert.False(t, ok, "expected invalid token to return ok = false: [%s]", token)
+		assert.Error(t, err, "expected invalid token to return an error: [%s]", token)
+		assert.Contains(t, err.Error(), "<6 characters>.<16 characters>", "expected better validation failure message")
+	}
+}
+
+func TestValidTokenPopulatesSecrets(t *testing.T) {
+	config := newConfigWithToken("123456.0123456789AbCdEf")
+
+	ok, err := UseGivenTokenIfValid(config)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "123456", config.Secrets.TokenID)
+	assert.Equal(t, "0123456789abcdef", config.Secrets.BearerToken)
+	assert.Equal(t, []byte("0123456789abcdef"), config.Secrets.Token)
+}
+
+func newConfigWithToken(token string) *kubeadmapi.KubeadmConfig {
+	config := new(kubeadmapi.KubeadmConfig)
+	config.Secrets.GivenToken = token
+	return config
+}

--- a/cmd/kubeadm/app/util/tokens_test.go
+++ b/cmd/kubeadm/app/util/tokens_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 func TestUsingEmptyTokenFails(t *testing.T) {
 	// Simulates what happens when you omit --token on the CLI
-	config := newConfigWithToken("")
+	s := newSecretsWithToken("")
 
-	ok, err := UseGivenTokenIfValid(config)
+	ok, err := UseGivenTokenIfValid(s)
 	assert.False(t, ok)
 	assert.NoError(t, err)
 }
@@ -41,8 +41,8 @@ func TestTokenValidationFailures(t *testing.T) {
 	}
 
 	for _, token := range(invalidTokens) {
-		config := newConfigWithToken(token)
-		ok, err := UseGivenTokenIfValid(config)
+		s := newSecretsWithToken(token)
+		ok, err := UseGivenTokenIfValid(s)
 
 		assert.False(t, ok, "expected invalid token to return ok = false: [%s]", token)
 		assert.Error(t, err, "expected invalid token to return an error: [%s]", token)
@@ -51,19 +51,19 @@ func TestTokenValidationFailures(t *testing.T) {
 }
 
 func TestValidTokenPopulatesSecrets(t *testing.T) {
-	config := newConfigWithToken("123456.0123456789AbCdEf")
+	s := newSecretsWithToken("123456.0123456789AbCdEf")
 
-	ok, err := UseGivenTokenIfValid(config)
+	ok, err := UseGivenTokenIfValid(s)
 	assert.True(t, ok)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "123456", config.Secrets.TokenID)
-	assert.Equal(t, "0123456789abcdef", config.Secrets.BearerToken)
-	assert.Equal(t, []byte("0123456789abcdef"), config.Secrets.Token)
+	assert.Equal(t, "123456", s.TokenID)
+	assert.Equal(t, "0123456789abcdef", s.BearerToken)
+	assert.Equal(t, []byte("0123456789abcdef"), s.Token)
 }
 
-func newConfigWithToken(token string) *kubeadmapi.KubeadmConfig {
-	config := new(kubeadmapi.KubeadmConfig)
-	config.Secrets.GivenToken = token
-	return config
+func newSecretsWithToken(token string) *kubeadmapi.Secrets {
+	s := new(kubeadmapi.Secrets)
+	s.GivenToken = token
+	return s
 }


### PR DESCRIPTION
If a user specifies their own token to kubeadm, and it fails validation, the error they currently receive isn't the friendliest. This first change adds messaging for the expected token format, with more improvements to follow as part of #33930. It also adds some unit tests to document the behavior we have currently.

CC: @mikedanese, @krousey, @kubernetes/sig-cluster-lifecycle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35072)

<!-- Reviewable:end -->
