### PR TITLE
check_node_count falls out of use, clear from docs/devel/e2e-tests.md

### DIFF
--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -404,7 +404,7 @@ go run hack/e2e.go -v --test
 To control the tests that are run:
 
 ```sh
-go run hack/e2e.go -v --test --check_node_count=false --test_args="--ginkgo.focus="Secrets"
+go run hack/e2e.go -v --test --test_args="--ginkgo.focus=\"Secrets\""
 ```
 
 ### Version-skewed and upgrade testing


### PR DESCRIPTION
delete "--check_node_count " for testing against local clusters

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35085)

<!-- Reviewable:end -->
