### PR TITLE
duplicate function call

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -154,7 +154,6 @@ type completedConfig struct {
 
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() completedConfig {
-	c.GenericConfig.Complete()
 
 	// enable swagger UI only if general UI support is on
 	c.GenericConfig.EnableSwaggerUI = c.GenericConfig.EnableSwaggerUI && c.EnableUISupport

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -70,7 +70,7 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	server, storageConfig := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 
 	config := &Config{
-		GenericConfig: genericapiserver.NewConfig(),
+		GenericConfig: genericapiserver.NewConfig().Complete().Config,
 	}
 
 	resourceEncoding := genericapiserver.NewDefaultResourceEncodingConfig()

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -344,7 +344,7 @@ func NewMasterConfig() *master.Config {
 		"",
 		NewSingleContentTypeSerializer(api.Scheme, testapi.Storage.Codec(), runtime.ContentTypeJSON))
 
-	genericConfig := genericapiserver.NewConfig()
+	genericConfig := genericapiserver.NewConfig().Complete().Config
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
 	genericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -228,6 +228,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	}
 
 	masterConfig.GenericConfig.LoopbackClientConfig.BearerToken = privilegedLoopbackToken
+	masterConfig.GenericConfig = masterConfig.GenericConfig.Complete().Config
 
 	m, err := masterConfig.Complete().New()
 	if err != nil {
@@ -344,7 +345,7 @@ func NewMasterConfig() *master.Config {
 		"",
 		NewSingleContentTypeSerializer(api.Scheme, testapi.Storage.Codec(), runtime.ContentTypeJSON))
 
-	genericConfig := genericapiserver.NewConfig().Complete().Config
+	genericConfig := genericapiserver.NewConfig()
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
 	genericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()


### PR DESCRIPTION
When we call the main function app.Run(s),at the beginning, we get the 'genericConfig' by "genericConfig := genericapiserver.NewConfig(). // create the new config
ApplyOptions(s.ServerRunOptions). // apply the options selected
Complete() "
here we call the function "(c *Config) Complete()", and then,we get the struct master by "m, err := config.Complete().New()",in the function config.Complete(),we also call "c.GenericConfig.Complete()".
Maybe we could remove the latter one, is my understanding right?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35095)

<!-- Reviewable:end -->
