### PR TITLE
registry: remove redundant PDB deep-copy from eviction REST

### DIFF
--- a/pkg/registry/core/pod/etcd/eviction.go
+++ b/pkg/registry/core/pod/etcd/eviction.go
@@ -107,14 +107,8 @@ func (r *EvictionREST) checkAndDecrement(namespace string, pdb policy.PodDisrupt
 		return false, nil
 	}
 
-	copied, err := api.Scheme.DeepCopy(pdb)
-	if err != nil {
-		return false, err
-	}
-	newPDB := copied.(policy.PodDisruptionBudget)
-	newPDB.Status.PodDisruptionAllowed = false
-
-	if _, err := r.podDisruptionBudgetClient.PodDisruptionBudgets(namespace).Update(&newPDB); err != nil {
+	pdb.Status.PodDisruptionAllowed = false
+	if _, err := r.podDisruptionBudgetClient.PodDisruptionBudgets(namespace).Update(&pdb); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35098)

<!-- Reviewable:end -->
