### PR TITLE
auth duplicate detect

### DIFF
--- a/plugin/pkg/auth/authenticator/password/passwordfile/BUILD
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/BUILD
@@ -14,7 +14,10 @@ go_library(
     name = "go_default_library",
     srcs = ["passwordfile.go"],
     tags = ["automanaged"],
-    deps = ["//pkg/auth/user:go_default_library"],
+    deps = [
+        "//pkg/auth/user:go_default_library",
+        "//vendor:github.com/golang/glog",
+    ],
 )
 
 go_test(

--- a/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
@@ -43,6 +44,7 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 	}
 	defer file.Close()
 
+	recordNum := 0
 	users := make(map[string]*userPasswordInfo)
 	reader := csv.NewReader(file)
 	for {
@@ -59,6 +61,10 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 		obj := &userPasswordInfo{
 			info:     &user.DefaultInfo{Name: record[1], UID: record[2]},
 			password: record[0],
+		}
+		recordNum++
+		if _, exist := users[obj.info.Name]; exist {
+			glog.Warningf("duplicate username '%s' has been found in password file '%s', record number '%d'", obj.info.Name, path, recordNum)
 		}
 		users[obj.info.Name] = obj
 	}

--- a/plugin/pkg/auth/authenticator/token/tokenfile/BUILD
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/BUILD
@@ -14,7 +14,10 @@ go_library(
     name = "go_default_library",
     srcs = ["tokenfile.go"],
     tags = ["automanaged"],
-    deps = ["//pkg/auth/user:go_default_library"],
+    deps = [
+        "//pkg/auth/user:go_default_library",
+        "//vendor:github.com/golang/glog",
+    ],
 )
 
 go_test(

--- a/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
@@ -46,6 +47,7 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 	}
 	defer file.Close()
 
+	recordNum := 0
 	tokens := make(map[string]*user.DefaultInfo)
 	reader := csv.NewReader(file)
 	reader.FieldsPerRecord = -1
@@ -63,6 +65,10 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 		obj := &user.DefaultInfo{
 			Name: record[1],
 			UID:  record[2],
+		}
+		recordNum++
+		if _, exist := tokens[record[0]]; exist {
+			glog.Warningf("duplicate token has been found in token file '%s', record number '%d'", path, recordNum)
 		}
 		tokens[record[0]] = obj
 


### PR DESCRIPTION
I think we should not allow people set duplicate tokens in token file or set duplicate usernames in password file. because the default action overwriting the old data may let people misunderstand.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35101)

<!-- Reviewable:end -->
