### PR TITLE
Get rid of output line that break automated usage of `kubectl set image`

### DIFF
--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -199,7 +199,6 @@ func (o *ImageOptions) Run() error {
 		}
 
 		if o.Local {
-			fmt.Fprintln(o.Out, "running in local mode...")
 			return o.PrintObject(o.Cmd, o.Mapper, info.Object, o.Out)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**: fixes #35105

**Special notes for your reviewer**: We could consider printing it to stderr, or using `IsTerminal()`, but I went for the simplest thing first.

**Release note**:

``` release-note
Make `kubectl set image` easier to script
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35112)

<!-- Reviewable:end -->
