### PR TITLE
Set message for kubectl cordon or drain

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -473,6 +473,7 @@ mesos-master
 mesos-sandbox-overlay
 mesos-user
 metrics-path
+message
 min-available
 minimum-container-ttl-duration
 minimum-image-ttl-duration

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -70,6 +70,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/annotations:go_default_library",
         "//pkg/api/helper:go_default_library",
+        "//pkg/api/ref:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/api/v1/helper:go_default_library",
         "//pkg/api/validation:go_default_library",
@@ -142,6 +143,7 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
+        "//vendor/k8s.io/client-go/util/clock:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -35,7 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/clock"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/ref"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -57,6 +61,7 @@ type DrainOptions struct {
 	backOff            clockwork.Clock
 	DeleteLocalData    bool
 	mapper             meta.RESTMapper
+	message            string
 	nodeInfo           *resource.Info
 	Out                io.Writer
 	ErrOut             io.Writer
@@ -92,7 +97,11 @@ var (
 
 	cordon_example = templates.Examples(i18n.T(`
 		# Mark node "foo" as unschedulable.
-		kubectl cordon foo`))
+		kubectl cordon foo
+
+		# Mark node "foo" as unschedulable and set event message.
+		kubectl cordon foo --message="cordon for foo"
+		`))
 )
 
 func NewCmdCordon(f cmdutil.Factory, out io.Writer) *cobra.Command {
@@ -108,6 +117,7 @@ func NewCmdCordon(f cmdutil.Factory, out io.Writer) *cobra.Command {
 			cmdutil.CheckErr(options.RunCordonOrUncordon(true))
 		},
 	}
+	cmd.Flags().StringVar(&options.message, "message", "", "Set event message to describe why this node was cordoned")
 	return cmd
 }
 
@@ -117,7 +127,10 @@ var (
 
 	uncordon_example = templates.Examples(i18n.T(`
 		# Mark node "foo" as schedulable.
-		$ kubectl uncordon foo`))
+		$ kubectl uncordon foo
+
+		# Mark node "foo" as schedulable and set event message.
+		kubectl uncordon foo --message="uncordon for foo"`))
 )
 
 func NewCmdUncordon(f cmdutil.Factory, out io.Writer) *cobra.Command {
@@ -133,6 +146,7 @@ func NewCmdUncordon(f cmdutil.Factory, out io.Writer) *cobra.Command {
 			cmdutil.CheckErr(options.RunCordonOrUncordon(false))
 		},
 	}
+	cmd.Flags().StringVar(&options.message, "message", "", "Set event message to describe why this node was uncordoned")
 	return cmd
 }
 
@@ -188,6 +202,7 @@ func NewCmdDrain(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.DeleteLocalData, "delete-local-data", false, "Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).")
 	cmd.Flags().IntVar(&options.GracePeriodSeconds, "grace-period", -1, "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
 	cmd.Flags().DurationVar(&options.Timeout, "timeout", 0, "The length of time to wait before giving up, zero means infinite")
+	cmd.Flags().StringVar(&options.message, "message", "", "Set event message to describe why this node was drained")
 	return cmd
 }
 
@@ -646,6 +661,7 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 			if err != nil {
 				return err
 			}
+			o.sendEventWithMessage(desired)
 			cmdutil.PrintSuccess(o.mapper, false, o.Out, o.nodeInfo.Mapping.Resource, o.nodeInfo.Name, false, changed(desired))
 		}
 	} else {
@@ -669,4 +685,48 @@ func changed(desired bool) string {
 		return "cordoned"
 	}
 	return "uncordoned"
+}
+
+func (o *DrainOptions) sendEventWithMessage(desired bool) {
+	reason := "NodeUncordoned"
+	if desired {
+		reason = "NodeCordoned"
+	}
+
+	t := metav1.Time{Time: clock.RealClock{}.Now()}
+	namespace := o.nodeInfo.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+
+	ref, err := ref.GetReference(api.Scheme, o.nodeInfo.Object)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get reference: %v\n", err)
+		return
+	}
+
+	event := &api.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", o.nodeInfo.Name, t.UnixNano()),
+			Namespace: namespace,
+		},
+		InvolvedObject: *ref,
+		Source: api.EventSource{
+			Component: "kubectl",
+			Host:      o.nodeInfo.Name,
+		},
+		Reason:         reason,
+		Message:        fmt.Sprintf("Node %s: %s", o.nodeInfo.Name, o.message),
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           v1.EventTypeNormal,
+	}
+
+	_, err = o.client.Core().Events(namespace).Create(event)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to send event: %v\n", err)
+	}
 }


### PR DESCRIPTION
Add new flag `--set-message` for `kubectl cordon` or `kubectl drain`

For example:
`kubectl drain K8S_NODENAME --set-message "disabled due to docker maintenance"`
or
`kubectl cordon K8S_NODENAME --set-message "disabled due to docker maintenance"`

The message is visible as node condition message field

```
$ kubectl describe node
...
...
Conditions:
  Type          Status  LastHeartbeatTime           LastTransitionTime          Reason              Message
  ----          ------  -----------------           ------------------          ------              -------
  Ready         False   Wed, 19 Oct 2016 14:12:58 +0200     Wed, 19 Oct 2016 14:12:58 +0200     SchedulingDisabled      disable due to Docker maintenance 

...
...
```

This PR fixes: https://github.com/kubernetes/kubernetes/issues/30586

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35113)

<!-- Reviewable:end -->
