### PR TITLE
Speed up some networking tests in large clusters

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -52,7 +52,7 @@ const (
 	// because we verify iptables statistical rr loadbalancing.
 	testTries = 30
 	// Maximum number of pods in a test, to make test work in large clusters.
-	maxNetProxyPodsCount = 20
+	maxNetProxyPodsCount = 10
 )
 
 // NewNetworkingTestConfig creates and sets up a new test config helper.
@@ -219,7 +219,9 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, containerIP, tar
 func (config *NetworkingTestConfig) DialFromNode(protocol, targetIP string, targetPort, maxTries, minTries int, expectedEps sets.String) {
 	var cmd string
 	if protocol == "udp" {
-		cmd = fmt.Sprintf("echo 'hostName' | timeout -t 3 nc -w 1 -u %s %d", targetIP, targetPort)
+		// TODO: It would be enough to pass 1s+epsilon to timeout, but unfortunately
+		// busybox timeout doesn't support non-integer values.
+		cmd = fmt.Sprintf("echo 'hostName' | timeout -t 2 nc -w 1 -u %s %d", targetIP, targetPort)
 	} else {
 		cmd = fmt.Sprintf("curl -q -s --connect-timeout 1 http://%s:%d/hostName", targetIP, targetPort)
 	}
@@ -486,8 +488,8 @@ func (config *NetworkingTestConfig) createNetProxyPods(podName string, selector 
 	nodeList := GetReadySchedulableNodesOrDie(config.f.Client)
 
 	// To make this test work reasonably fast in large clusters,
-	// we limit the number of NetProxyPods to no more than 100 ones
-	// on random nodes.
+	// we limit the number of NetProxyPods to no more than
+	// maxNetProxyPodsCount on random nodes.
 	nodes := shuffleNodes(nodeList.Items)
 	if len(nodes) > maxNetProxyPodsCount {
 		nodes = nodes[:maxNetProxyPodsCount]


### PR DESCRIPTION
Since we are getting towards testing larger and larger clusters (hopefully 5000-node ones soon-ish), I'm trying to limit the amount of super long tests to minimum.

This should significantly reduce amount of time used by those from test/e2e/networking.go.

@gmarek

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35114)

<!-- Reviewable:end -->
