### PR TITLE
Add CoreDNS as Federation DNS provider

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1549,6 +1549,11 @@
 			"Rev": "45c8b08e9af666add36a6f93ff8c1c75812367b0"
 		},
 		{
+			"ImportPath": "github.com/miekg/coredns/middleware/etcd/msg",
+			"Comment": "v003",
+			"Rev": "20e25559d5eada5a68a0720816a6e947b94860ce"
+		},
+		{
 			"ImportPath": "github.com/miekg/dns",
 			"Rev": "5d001d020961ae1c184f9f8152fdc73810481677"
 		},

--- a/federation/cmd/federation-controller-manager/app/BUILD
+++ b/federation/cmd/federation-controller-manager/app/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//federation/cmd/federation-controller-manager/app/options:go_default_library",
         "//federation/pkg/dnsprovider:go_default_library",
         "//federation/pkg/dnsprovider/providers/aws/route53:go_default_library",
+        "//federation/pkg/dnsprovider/providers/coredns:go_default_library",
         "//federation/pkg/dnsprovider/providers/google/clouddns:go_default_library",
         "//federation/pkg/federation-controller/cluster:go_default_library",
         "//federation/pkg/federation-controller/configmap:go_default_library",

--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -52,6 +52,8 @@ type Zone interface {
 type ResourceRecordSets interface {
 	// List returns the ResourceRecordSets of the Zone, or an error if the list operation failed.
 	List() ([]ResourceRecordSet, error)
+	// Get returns the ResourceRecordSet with the name in the Zone. if the named resource record set does not exist, but no error occurred, the returned set, and error, are both nil.
+	Get(name string) (ResourceRecordSet, error)
 	// New allocates a new ResourceRecordSet, which can then be passed to ResourceRecordChangeset Add() or Remove()
 	// Arguments are as per the ResourceRecordSet interface below.
 	New(name string, rrdatas []string, ttl int64, rrstype rrstype.RrsType) ResourceRecordSet

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrsets.go
@@ -48,6 +48,21 @@ func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error)
 	return list, nil
 }
 
+func (rrsets ResourceRecordSets) Get(name string) (dnsprovider.ResourceRecordSet, error) {
+	var newRrset dnsprovider.ResourceRecordSet
+	rrsetList, err := rrsets.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, rrset := range rrsetList {
+		if rrset.Name() == name {
+			newRrset = rrset
+			break
+		}
+	}
+	return newRrset, nil
+}
+
 func (r ResourceRecordSets) StartChangeset() dnsprovider.ResourceRecordChangeset {
 	return &ResourceRecordChangeset{
 		zone:   r.zone,

--- a/federation/pkg/dnsprovider/providers/coredns/BUILD
+++ b/federation/pkg/dnsprovider/providers/coredns/BUILD
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+    "cgo_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "coredns.go",
+        "interface.go",
+        "rrchangeset.go",
+        "rrset.go",
+        "rrsets.go",
+        "zone.go",
+        "zones.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//federation/pkg/dnsprovider:go_default_library",
+        "//federation/pkg/dnsprovider/providers/coredns/stubs:go_default_library",
+        "//federation/pkg/dnsprovider/rrstype:go_default_library",
+        "//vendor:github.com/coreos/etcd/client",
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/miekg/coredns/middleware/etcd/msg",
+        "//vendor:golang.org/x/net/context",
+        "//vendor:gopkg.in/gcfg.v1",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["coredns_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//federation/pkg/dnsprovider:go_default_library",
+        "//federation/pkg/dnsprovider/providers/coredns/stubs:go_default_library",
+        "//federation/pkg/dnsprovider/rrstype:go_default_library",
+        "//federation/pkg/dnsprovider/tests:go_default_library",
+    ],
+)

--- a/federation/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coredns is the implementation of pkg/dnsprovider interface for CoreDNS
+package coredns
+
+import (
+	"fmt"
+	etcdc "github.com/coreos/etcd/client"
+	"github.com/golang/glog"
+	"gopkg.in/gcfg.v1"
+	"io"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"strconv"
+	"strings"
+)
+
+// "coredns" should be used to use this DNS provider
+const (
+	ProviderName = "coredns"
+)
+
+// Config to override defaults
+type Config struct {
+	Global struct {
+		EtcdEndpoints string `gcfg:"etcd-endpoints"`
+		DNSZones      string `gcfg:"zones"`
+	}
+}
+
+func init() {
+	dnsprovider.RegisterDnsProvider(ProviderName, func(config io.Reader) (dnsprovider.Interface, error) {
+		return newCoreDNSProviderInterface(config)
+	})
+}
+
+// newCoreDnsProviderInterface creates a new instance of an CoreDNS DNS Interface.
+func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
+	etcdEndpoints := "http://federation-dns-server-etcd:2379"
+	etcdPathPrefix := "skydns"
+	dnsZones := ""
+
+	// Possibly override defaults with config below
+	if config != nil {
+		var cfg Config
+		if err := gcfg.ReadInto(&cfg, config); err != nil {
+			glog.Errorf("Couldn't read config: %v", err)
+			return nil, err
+		}
+		etcdEndpoints = cfg.Global.EtcdEndpoints
+		dnsZones = cfg.Global.DNSZones
+	}
+	glog.Infof("Using CoreDNS DNS provider")
+
+	if dnsZones == "" {
+		return nil, fmt.Errorf("Need to provide at least one DNS Zone")
+	}
+
+	etcdCfg := etcdc.Config{
+		Endpoints: strings.Split(etcdEndpoints, ","),
+		Transport: etcdc.DefaultTransport,
+	}
+
+	c, err := etcdc.New(etcdCfg)
+	if err != nil {
+		return nil, fmt.Errorf("Create etcd client from the config failed")
+	}
+	etcdKeysAPI := etcdc.NewKeysAPI(c)
+
+	intf := newInterfaceWithStub(etcdKeysAPI)
+	intf.etcdPathPrefix = etcdPathPrefix
+	zoneList := strings.Split(dnsZones, ",")
+
+	intf.zones = Zones{intf: intf}
+	for index, zoneName := range zoneList {
+		zone := Zone{domain: zoneName, id: strconv.Itoa(index), zones: &intf.zones}
+		intf.zones.zoneList = append(intf.zones.zoneList, zone)
+	}
+
+	return intf, nil
+}

--- a/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	corednstesting "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns/stubs"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/tests"
+	"strings"
+)
+
+func newTestInterface() (dnsprovider.Interface, error) {
+	// Use this to test the real cloud service.
+	// return dnsprovider.GetDnsProvider(ProviderName, strings.NewReader("\n[global]\nproject-id = federation0-cluster00"))
+	return newFakeInterface() // Use this to stub out the entire cloud service
+}
+
+func newFakeInterface() (dnsprovider.Interface, error) {
+	var service corednstesting.EtcdKeysAPI
+	service = corednstesting.NewEtcdKeysAPIStub()
+	intf := newInterfaceWithStub(service)
+	intf.etcdPathPrefix = "skydns"
+
+	zoneList := strings.Split("example.com,federation.io", ",")
+	intf.zones = Zones{intf: intf}
+	for index, zoneName := range zoneList {
+		zone := Zone{domain: zoneName, id: strconv.Itoa(index), zones: &intf.zones}
+		intf.zones.zoneList = append(intf.zones.zoneList, zone)
+	}
+
+	return intf, nil
+}
+
+var intf dnsprovider.Interface
+
+func TestMain(m *testing.M) {
+	fmt.Printf("Parsing flags.\n")
+	flag.Parse()
+	var err error
+	fmt.Printf("Getting new test interface.\n")
+	intf, err = newTestInterface()
+	if err != nil {
+		fmt.Printf("Error creating interface: %v", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Running tests...\n")
+	os.Exit(m.Run())
+}
+
+// zones returns the zones interface for the configured dns provider account/project,
+// or fails if it can't be found
+func zones(t *testing.T) dnsprovider.Zones {
+	zonesInterface, supported := intf.Zones()
+	if !supported {
+		t.Fatalf("Zones interface not supported by interface %v", intf)
+	} else {
+		t.Logf("Got zones %v\n", zonesInterface)
+	}
+	return zonesInterface
+}
+
+// firstZone returns the first zone for the configured dns provider account/project,
+// or fails if it can't be found
+func firstZone(t *testing.T) dnsprovider.Zone {
+	t.Logf("Getting zones")
+	z := zones(t)
+	zones, err := z.List()
+	if err != nil {
+		t.Fatalf("Failed to list zones: %v", err)
+	} else {
+		t.Logf("Got zone list: %v\n", zones)
+	}
+	if len(zones) < 1 {
+		t.Fatalf("Zone listing returned %d, expected >= %d", len(zones), 1)
+	} else {
+		t.Logf("Got at least 1 zone in list:%v\n", zones[0])
+	}
+	return zones[0]
+}
+
+/* rrs returns the ResourceRecordSets interface for a given zone */
+func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets) {
+	rrsets, supported := zone.ResourceRecordSets()
+	if !supported {
+		t.Fatalf("ResourceRecordSets interface not supported by zone %v", zone)
+		return r
+	}
+	return rrsets
+}
+
+func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
+	rrset, err := rrsets.List()
+	if err != nil {
+		t.Fatalf("Failed to list recordsets: %v", err)
+	} else {
+		if len(rrset) < 0 {
+			t.Fatalf("Record set length=%d, expected >=0", len(rrset))
+		} else {
+			t.Logf("Got %d recordsets: %v", len(rrset), rrset)
+		}
+	}
+	return rrset
+}
+
+func getRrOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, name string) dnsprovider.ResourceRecordSet {
+	rrset, err := rrsets.Get(name)
+	if err != nil {
+		t.Fatalf("Failed to get recordset: %v", err)
+	} else if rrset == nil {
+		t.Logf("Did not Get recordset: %v", name)
+	} else {
+		t.Logf("Got recordset: %v", rrset.Name())
+	}
+	return rrset
+}
+
+func getExampleRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
+	rrsets, _ := zone.ResourceRecordSets()
+	return rrsets.New("www11."+zone.Name(), []string{"10.10.10.10", "169.20.20.20"}, 180, rrstype.A)
+}
+
+func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) {
+	err := rrsets.StartChangeset().Add(rrset).Apply()
+	if err != nil {
+		t.Fatalf("Failed to add recordsets: %v", err)
+	}
+}
+
+/* TestZonesList verifies that listing of zones succeeds */
+func TestZonesList(t *testing.T) {
+	firstZone(t)
+}
+
+/* TestZonesID verifies that the id of the zone is unique */
+func TestZonesID(t *testing.T) {
+	zone := firstZone(t)
+
+	zoneID := zone.ID()
+	if zoneID != "0" {
+		t.Fatalf("Unexpected zone id: %q", zoneID)
+	}
+}
+
+/* TestResourceRecordSetsGet verifies that getting of RRS succeeds */
+func TestResourceRecordSetsGet(t *testing.T) {
+	getRrOrFail(t, rrs(t, firstZone(t)), "example.com")
+}
+
+/* TestResourceRecordSetsAddSuccess verifies that addition of a valid RRS succeeds */
+func TestResourceRecordSetsAddSuccess(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	set := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, set)
+	defer sets.StartChangeset().Remove(set).Apply()
+	t.Logf("Successfully added resource record set: %v", set)
+}
+
+/* TestResourceRecordSetsAdditionVisible verifies that added RRS is visible after addition */
+func TestResourceRecordSetsAdditionVisible(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, rrset)
+	defer sets.StartChangeset().Remove(rrset).Apply()
+	t.Logf("Successfully added resource record set: %v", rrset)
+
+	record := getRrOrFail(t, sets, rrset.Name())
+	if record == nil {
+		t.Errorf("Failed to find added resource record set %s", rrset.Name())
+	}
+}
+
+/* TestResourceRecordSetsAddDuplicateFail verifies that addition of a duplicate RRS fails */
+func TestResourceRecordSetsAddDuplicateFail(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, rrset)
+	defer sets.StartChangeset().Remove(rrset).Apply()
+	t.Logf("Successfully added resource record set: %v", rrset)
+	// Try to add it again, and verify that the call fails.
+	err := sets.StartChangeset().Add(rrset).Apply()
+	if err == nil {
+		defer sets.StartChangeset().Remove(rrset).Apply()
+		t.Errorf("Should have failed to add duplicate resource record %v, but succeeded instead.", rrset)
+	} else {
+		t.Logf("Correctly failed to add duplicate resource record %v: %v", rrset, err)
+	}
+}
+
+/* TestResourceRecordSetsRemove verifies that the removal of an existing RRS succeeds */
+func TestResourceRecordSetsRemove(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, rrset)
+	err := sets.StartChangeset().Remove(rrset).Apply()
+	if err != nil {
+		// Try again to clean up.
+		defer sets.StartChangeset().Remove(rrset).Apply()
+		t.Errorf("Failed to remove resource record set %v after adding", rrset)
+	} else {
+		t.Logf("Successfully removed resource set %v after adding", rrset)
+	}
+}
+
+/* TestResourceRecordSetsRemoveGone verifies that a removed RRS no longer exists */
+func TestResourceRecordSetsRemoveGone(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, rrset)
+	err := sets.StartChangeset().Remove(rrset).Apply()
+	if err != nil {
+		// Try again to clean up.
+		defer sets.StartChangeset().Remove(rrset).Apply()
+		t.Errorf("Failed to remove resource record set %v after adding", rrset)
+	} else {
+		t.Logf("Successfully removed resource set %v after adding", rrset)
+	}
+
+	record := getRrOrFail(t, sets, rrset.Name())
+	if record != nil {
+		t.Errorf("Deleted resource record set %v is still present", rrset)
+	}
+}
+
+/* TestResourceRecordSetsReplace verifies that replacing an RRS works */
+func TestResourceRecordSetsReplace(t *testing.T) {
+	zone := firstZone(t)
+	tests.CommonTestResourceRecordSetsReplace(t, zone)
+}
+
+/* TestResourceRecordSetsReplaceAll verifies that we can remove an RRS and create one with a different name*/
+func TestResourceRecordSetsReplaceAll(t *testing.T) {
+	zone := firstZone(t)
+	tests.CommonTestResourceRecordSetsReplaceAll(t, zone)
+}

--- a/federation/pkg/dnsprovider/providers/coredns/interface.go
+++ b/federation/pkg/dnsprovider/providers/coredns/interface.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns/stubs"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.Interface = Interface{}
+
+type Interface struct {
+	etcdKeysAPI    stubs.EtcdKeysAPI
+	etcdPathPrefix string
+	zones          Zones
+}
+
+// newInterfaceWithStub facilitates stubbing out the underlying etcd
+// library for testing purposes.  It returns an provider-independent interface.
+func newInterfaceWithStub(etcdKeysAPI stubs.EtcdKeysAPI) *Interface {
+	return &Interface{etcdKeysAPI: etcdKeysAPI}
+}
+
+func (i Interface) Zones() (dnsprovider.Zones, bool) {
+	return i.zones, true
+}

--- a/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"encoding/json"
+	"fmt"
+	etcdc "github.com/coreos/etcd/client"
+	dnsmsg "github.com/miekg/coredns/middleware/etcd/msg"
+	"golang.org/x/net/context"
+	"hash/fnv"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.ResourceRecordChangeset = &ResourceRecordChangeset{}
+
+type ChangeSetType string
+
+const (
+	ADDITION = ChangeSetType("ADDITION")
+	DELETION = ChangeSetType("DELETION")
+)
+
+type ChangeSet struct {
+	cstype ChangeSetType
+	rrset  dnsprovider.ResourceRecordSet
+}
+
+type ResourceRecordChangeset struct {
+	zone   *Zone
+	rrsets *ResourceRecordSets
+
+	changeset []ChangeSet
+}
+
+func (c *ResourceRecordChangeset) Add(rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordChangeset {
+	c.changeset = append(c.changeset, ChangeSet{cstype: ADDITION, rrset: rrset})
+	return c
+}
+
+func (c *ResourceRecordChangeset) Remove(rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordChangeset {
+	c.changeset = append(c.changeset, ChangeSet{cstype: DELETION, rrset: rrset})
+	return c
+}
+
+func (c *ResourceRecordChangeset) Apply() error {
+	ctx := context.Background()
+	etcdPathPrefix := c.zone.zones.intf.etcdPathPrefix
+	getOpts := &etcdc.GetOptions{}
+	setOpts := &etcdc.SetOptions{}
+	deleteOpts := &etcdc.DeleteOptions{
+		Recursive: true,
+	}
+
+	for _, changeset := range c.changeset {
+		switch changeset.cstype {
+		case ADDITION:
+			for _, rrdata := range changeset.rrset.Rrdatas() {
+				b, err := json.Marshal(&dnsmsg.Service{Host: rrdata, TTL: uint32(changeset.rrset.Ttl()), Group: changeset.rrset.Name()})
+				if err != nil {
+					return err
+				}
+				recordValue := string(b)
+				recordLabel := getHash(rrdata)
+				recordKey := buildDNSNameString(changeset.rrset.Name(), recordLabel)
+
+				response, err := c.zone.zones.intf.etcdKeysAPI.Get(ctx, dnsmsg.Path(recordKey, etcdPathPrefix), getOpts)
+				if err == nil && response != nil {
+					return fmt.Errorf("Key already exist, key: %v", recordKey)
+				}
+
+				_, err = c.zone.zones.intf.etcdKeysAPI.Set(ctx, dnsmsg.Path(recordKey, etcdPathPrefix), recordValue, setOpts)
+				if err != nil {
+					return err
+				}
+			}
+		case DELETION:
+			for _, rrdata := range changeset.rrset.Rrdatas() {
+				recordLabel := getHash(rrdata)
+				recordKey := buildDNSNameString(changeset.rrset.Name(), recordLabel)
+				_, err := c.zone.zones.intf.etcdKeysAPI.Delete(ctx, dnsmsg.Path(recordKey, etcdPathPrefix), deleteOpts)
+				if err != nil {
+					return err
+				}
+			}
+			// TODO: We need to cleanup empty dirs in etcd
+		}
+	}
+	return nil
+}
+
+func getHash(text string) string {
+	h := fnv.New32a()
+	h.Write([]byte(text))
+	return fmt.Sprintf("%x", h.Sum32())
+}
+
+func buildDNSNameString(labels ...string) string {
+	var res string
+	for _, label := range labels {
+		if res == "" {
+			res = label
+		} else {
+			res = fmt.Sprintf("%s.%s", label, res)
+		}
+	}
+	return res
+}

--- a/federation/pkg/dnsprovider/providers/coredns/rrset.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrset.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.ResourceRecordSet = ResourceRecordSet{}
+
+type ResourceRecordSet struct {
+	name    string
+	rrdatas []string
+	ttl     int64
+	rrsType rrstype.RrsType
+	rrsets  *ResourceRecordSets
+}
+
+func (rrset ResourceRecordSet) Name() string {
+	return rrset.name
+}
+
+func (rrset ResourceRecordSet) Rrdatas() []string {
+	return rrset.rrdatas
+}
+
+func (rrset ResourceRecordSet) Ttl() int64 {
+	return rrset.ttl
+}
+
+func (rrset ResourceRecordSet) Type() rrstype.RrsType {
+	return rrset.rrsType
+}

--- a/federation/pkg/dnsprovider/providers/coredns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrsets.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"encoding/json"
+	"fmt"
+	etcdc "github.com/coreos/etcd/client"
+	"github.com/golang/glog"
+	dnsmsg "github.com/miekg/coredns/middleware/etcd/msg"
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+	"net"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.ResourceRecordSets = ResourceRecordSets{}
+
+type ResourceRecordSets struct {
+	zone *Zone
+}
+
+func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error) {
+	var list []dnsprovider.ResourceRecordSet
+	return list, fmt.Errorf("OperationNotSupported")
+}
+
+func (rrsets ResourceRecordSets) Get(name string) (dnsprovider.ResourceRecordSet, error) {
+	getOpts := &etcdc.GetOptions{
+		Recursive: true,
+	}
+	etcdPathPrefix := rrsets.zone.zones.intf.etcdPathPrefix
+	response, err := rrsets.zone.zones.intf.etcdKeysAPI.Get(context.Background(), dnsmsg.Path(name, etcdPathPrefix), getOpts)
+	if err != nil {
+		if etcdc.IsKeyNotFound(err) {
+			glog.V(2).Infof("Subdomain %q does not exist", name)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Failed to get service from etcd, err: %v", err)
+	}
+	if emptyResponse(response) {
+		glog.V(2).Infof("Subdomain %q does not exist in etcd", name)
+		return nil, nil
+	}
+
+	rrset := ResourceRecordSet{name: name, rrdatas: []string{}, rrsets: &rrsets}
+	found := false
+	for _, node := range response.Node.Nodes {
+		found = true
+		service := dnsmsg.Service{}
+		err = json.Unmarshal([]byte(node.Value), &service)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to unmarshall json data, err: %v", err)
+		}
+
+		// assuming all rrdatas in a rrset will have same type
+		ip := net.ParseIP(service.Host)
+		switch {
+		case ip == nil:
+			rrset.rrsType = rrstype.CNAME
+		case ip.To4() != nil:
+			rrset.rrsType = rrstype.A
+		}
+		rrset.rrdatas = append(rrset.rrdatas, service.Host)
+		rrset.ttl = int64(service.TTL)
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	return rrset, nil
+}
+
+func (rrsets ResourceRecordSets) StartChangeset() dnsprovider.ResourceRecordChangeset {
+	return &ResourceRecordChangeset{
+		zone:   rrsets.zone,
+		rrsets: &rrsets,
+	}
+}
+
+func (rrsets ResourceRecordSets) New(name string, rrdatas []string, ttl int64, rrsType rrstype.RrsType) dnsprovider.ResourceRecordSet {
+	return ResourceRecordSet{
+		name:    name,
+		rrdatas: rrdatas,
+		ttl:     ttl,
+		rrsType: rrsType,
+		rrsets:  &rrsets,
+	}
+}
+
+func emptyResponse(resp *etcdc.Response) bool {
+	return resp == nil || resp.Node == nil || (len(resp.Node.Value) == 0 && len(resp.Node.Nodes) == 0)
+}

--- a/federation/pkg/dnsprovider/providers/coredns/stubs/BUILD
+++ b/federation/pkg/dnsprovider/providers/coredns/stubs/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+    "cgo_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["corednsapi.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/coreos/etcd/client",
+        "//vendor:golang.org/x/net/context",
+    ],
+)

--- a/federation/pkg/dnsprovider/providers/coredns/stubs/corednsapi.go
+++ b/federation/pkg/dnsprovider/providers/coredns/stubs/corednsapi.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package stubs implements a stub for the EtcdKeysAPI, used primarily for unit testing purposes
+package stubs
+
+import (
+	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+	"strings"
+)
+
+// Compile time check for interface conformance
+var _ EtcdKeysAPI = &EtcdKeysAPIStub{}
+
+type EtcdKeysAPI interface {
+	Set(context context.Context, key, value string, options *etcd.SetOptions) (*etcd.Response, error)
+	Get(context context.Context, key string, options *etcd.GetOptions) (*etcd.Response, error)
+	Delete(context context.Context, key string, options *etcd.DeleteOptions) (*etcd.Response, error)
+}
+
+type EtcdKeysAPIStub struct {
+	writes map[string]string
+}
+
+// NewEtcdKeysAPIStub returns an initialized EtcdKeysAPIStub
+func NewEtcdKeysAPIStub() *EtcdKeysAPIStub {
+	return &EtcdKeysAPIStub{make(map[string]string)}
+}
+
+func (ec *EtcdKeysAPIStub) Set(context context.Context, key, value string, options *etcd.SetOptions) (*etcd.Response, error) {
+	ec.writes[key] = value
+	return nil, nil
+}
+
+func (ec *EtcdKeysAPIStub) Delete(context context.Context, key string, options *etcd.DeleteOptions) (*etcd.Response, error) {
+	for p := range ec.writes {
+		if (options.Recursive && strings.HasPrefix(p, key)) || (!options.Recursive && p == key) {
+			delete(ec.writes, p)
+		}
+	}
+	return nil, nil
+}
+
+func (ec *EtcdKeysAPIStub) Get(context context.Context, key string, options *etcd.GetOptions) (*etcd.Response, error) {
+	nodes := ec.GetAll(key)
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+	if len(nodes) == 1 && nodes[key] != "" {
+		return &etcd.Response{Node: &etcd.Node{Key: key, Value: nodes[key], Dir: false}}, nil
+	}
+
+	node := &etcd.Node{Key: key, Dir: true, Nodes: etcd.Nodes{}}
+	for k, v := range nodes {
+		n := &etcd.Node{Key: k, Value: v}
+		node.Nodes = append(node.Nodes, n)
+	}
+	return &etcd.Response{Node: node}, nil
+}
+
+func (ec *EtcdKeysAPIStub) GetAll(key string) map[string]string {
+	nodes := make(map[string]string)
+	key = strings.ToLower(key)
+	for path := range ec.writes {
+		if strings.HasPrefix(path, key) {
+			nodes[path] = ec.writes[path]
+		}
+	}
+	return nodes
+}

--- a/federation/pkg/dnsprovider/providers/coredns/zone.go
+++ b/federation/pkg/dnsprovider/providers/coredns/zone.go
@@ -14,14 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package coredns
 
-// This file exists to force the desired plugin implementations to be linked.
-// This should probably be part of some configuration fed into the build for a
-// given binary target.
 import (
-	// DNS providers
-	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
-	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
-	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
+
+// Compile time check for interface adherence
+var _ dnsprovider.Zone = Zone{}
+
+type Zone struct {
+	domain string
+	id     string
+	zones  *Zones
+}
+
+func (zone Zone) Name() string {
+	return zone.domain
+}
+
+func (zone Zone) ID() string {
+	return zone.id
+}
+
+func (zone Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {
+	return &ResourceRecordSets{zone: &zone}, true
+}

--- a/federation/pkg/dnsprovider/providers/coredns/zones.go
+++ b/federation/pkg/dnsprovider/providers/coredns/zones.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.Zones = Zones{}
+
+type Zones struct {
+	intf     *Interface
+	zoneList []Zone
+}
+
+func (zones Zones) List() ([]dnsprovider.Zone, error) {
+	var zoneList []dnsprovider.Zone
+	for _, zone := range zones.zoneList {
+		zoneList = append(zoneList, zone)
+	}
+	return zoneList, nil
+}
+
+func (zones Zones) Add(zone dnsprovider.Zone) (dnsprovider.Zone, error) {
+	return &Zone{}, fmt.Errorf("OperationNotSupported")
+}
+
+func (zones Zones) Remove(zone dnsprovider.Zone) error {
+	return fmt.Errorf("OperationNotSupported")
+}
+func (zones Zones) New(name string) (dnsprovider.Zone, error) {
+	return &Zone{}, fmt.Errorf("OperationNotSupported")
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
@@ -42,6 +42,21 @@ func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error)
 	return list, nil
 }
 
+func (rrsets ResourceRecordSets) Get(name string) (dnsprovider.ResourceRecordSet, error) {
+	var newRrset dnsprovider.ResourceRecordSet
+	rrsetList, err := rrsets.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, rrset := range rrsetList {
+		if rrset.Name() == name {
+			newRrset = rrset
+			break
+		}
+	}
+	return newRrset, nil
+}
+
 func (r ResourceRecordSets) StartChangeset() dnsprovider.ResourceRecordChangeset {
 	return &ResourceRecordChangeset{
 		rrsets: &r,

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -147,22 +147,9 @@ func getDnsZone(dnsZoneName string, dnsZoneID string, dnsZonesInterface dnsprovi
 	}
 }
 
-/* getRrset is a hack around the fact that dnsprovider.ResourceRecordSets interface does not yet include a Get() method, only a List() method.  TODO:  Fix that.
-   Note that if the named resource record set does not exist, but no error occurred, the returned set, and error, are both nil
-*/
+//   Note that if the named resource record set does not exist, but no error occurred, the returned set, and error, are both nil
 func getRrset(dnsName string, rrsetsInterface dnsprovider.ResourceRecordSets) (dnsprovider.ResourceRecordSet, error) {
-	var returnVal dnsprovider.ResourceRecordSet
-	rrsets, err := rrsetsInterface.List()
-	if err != nil {
-		return nil, err
-	}
-	for _, rrset := range rrsets {
-		if rrset.Name() == dnsName {
-			returnVal = rrset
-			break
-		}
-	}
-	return returnVal, nil
+	return rrsetsInterface.Get(dnsName)
 }
 
 /* getResolvedEndpoints performs DNS resolution on the provided slice of endpoints (which might be DNS names or IPv4 addresses)

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -11786,3 +11786,13 @@ go_library(
         "//vendor:k8s.io/client-go/pkg/selection",
     ],
 )
+
+go_library(
+    name = "github.com/miekg/coredns/middleware/etcd/msg",
+    srcs = [
+        "github.com/miekg/coredns/middleware/etcd/msg/path.go",
+        "github.com/miekg/coredns/middleware/etcd/msg/service.go",
+    ],
+    tags = ["automanaged"],
+    deps = ["//vendor:github.com/miekg/dns"],
+)

--- a/vendor/github.com/miekg/coredns/LICENSE
+++ b/vendor/github.com/miekg/coredns/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/miekg/coredns/middleware/etcd/msg/path.go
+++ b/vendor/github.com/miekg/coredns/middleware/etcd/msg/path.go
@@ -1,0 +1,46 @@
+package msg
+
+import (
+	"path"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// Path converts a domainname to an etcd path. If s looks like service.staging.skydns.local.,
+// the resulting key will be /skydns/local/skydns/staging/service .
+func Path(s, prefix string) string {
+	l := dns.SplitDomainName(s)
+	for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
+		l[i], l[j] = l[j], l[i]
+	}
+	return path.Join(append([]string{"/" + prefix + "/"}, l...)...)
+}
+
+// Domain is the opposite of Path.
+func Domain(s string) string {
+	l := strings.Split(s, "/")
+	// start with 1, to strip /skydns
+	for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
+		l[i], l[j] = l[j], l[i]
+	}
+	return dns.Fqdn(strings.Join(l[1:len(l)-1], "."))
+}
+
+// PathWithWildcard ascts as Path, but if a name contains wildcards (* or any), the name will be
+// chopped of before the (first) wildcard, and we do a highler evel search and
+// later find the matching names.  So service.*.skydns.local, will look for all
+// services under skydns.local and will later check for names that match
+// service.*.skydns.local.  If a wildcard is found the returned bool is true.
+func PathWithWildcard(s, prefix string) (string, bool) {
+	l := dns.SplitDomainName(s)
+	for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
+		l[i], l[j] = l[j], l[i]
+	}
+	for i, k := range l {
+		if k == "*" || k == "any" {
+			return path.Join(append([]string{"/" + prefix + "/"}, l[:i]...)...), true
+		}
+	}
+	return path.Join(append([]string{"/" + prefix + "/"}, l...)...), false
+}

--- a/vendor/github.com/miekg/coredns/middleware/etcd/msg/service.go
+++ b/vendor/github.com/miekg/coredns/middleware/etcd/msg/service.go
@@ -1,0 +1,203 @@
+// Package msg defines the Service structure which is used for service discovery.
+package msg
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// Service defines a discoverable service in etcd. It is the rdata from a SRV
+// record, but with a twist.  Host (Target in SRV) must be a domain name, but
+// if it looks like an IP address (4/6), we will treat it like an IP address.
+type Service struct {
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Weight   int    `json:"weight,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Mail     bool   `json:"mail,omitempty"` // Be an MX record. Priority becomes Preference.
+	TTL      uint32 `json:"ttl,omitempty"`
+
+	// When a SRV record with a "Host: IP-address" is added, we synthesize
+	// a srv.Target domain name.  Normally we convert the full Key where
+	// the record lives to a DNS name and use this as the srv.Target.  When
+	// TargetStrip > 0 we strip the left most TargetStrip labels from the
+	// DNS name.
+	TargetStrip int `json:"targetstrip,omitempty"`
+
+	// Group is used to group (or *not* to group) different services
+	// together. Services with an identical Group are returned in the same
+	// answer.
+	Group string `json:"group,omitempty"`
+
+	// Etcd key where we found this service and ignored from json un-/marshalling
+	Key string `json:"-"`
+}
+
+// RR returns an RR representation of s. It is in a condensed form to minimize space
+// when this is returned in a DNS message.
+// The RR will look like:
+//	1.rails.production.east.skydns.local. 300 CH TXT "service1.example.com:8080(10,0,,false)[0,]"
+//                      etcd Key              Ttl               Host:Port          <   see below   >
+// between parens: (Priority, Weight, Text (only first 200 bytes!), Mail)
+// between blockquotes: [TargetStrip,Group]
+// If the record is synthesised by CoreDNS (i.e. no lookup in etcd happened):
+//
+//	TODO(miek): what to put here?
+//
+func (s *Service) RR() *dns.TXT {
+	l := len(s.Text)
+	if l > 200 {
+		l = 200
+	}
+	t := new(dns.TXT)
+	t.Hdr.Class = dns.ClassCHAOS
+	t.Hdr.Ttl = s.TTL
+	t.Hdr.Rrtype = dns.TypeTXT
+	t.Hdr.Name = Domain(s.Key)
+
+	t.Txt = make([]string, 1)
+	t.Txt[0] = fmt.Sprintf("%s:%d(%d,%d,%s,%t)[%d,%s]",
+		s.Host, s.Port,
+		s.Priority, s.Weight, s.Text[:l], s.Mail,
+		s.TargetStrip, s.Group)
+	return t
+}
+
+// NewSRV returns a new SRV record based on the Service.
+func (s *Service) NewSRV(name string, weight uint16) *dns.SRV {
+	host := targetStrip(dns.Fqdn(s.Host), s.TargetStrip)
+
+	return &dns.SRV{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeSRV, Class: dns.ClassINET, Ttl: s.TTL},
+		Priority: uint16(s.Priority), Weight: weight, Port: uint16(s.Port), Target: dns.Fqdn(host)}
+}
+
+// NewMX returns a new MX record based on the Service.
+func (s *Service) NewMX(name string) *dns.MX {
+	host := targetStrip(dns.Fqdn(s.Host), s.TargetStrip)
+
+	return &dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: s.TTL},
+		Preference: uint16(s.Priority), Mx: host}
+}
+
+// NewA returns a new A record based on the Service.
+func (s *Service) NewA(name string, ip net.IP) *dns.A {
+	return &dns.A{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: s.TTL}, A: ip}
+}
+
+// NewAAAA returns a new AAAA record based on the Service.
+func (s *Service) NewAAAA(name string, ip net.IP) *dns.AAAA {
+	return &dns.AAAA{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: s.TTL}, AAAA: ip}
+}
+
+// NewCNAME returns a new CNAME record based on the Service.
+func (s *Service) NewCNAME(name string, target string) *dns.CNAME {
+	return &dns.CNAME{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: s.TTL}, Target: dns.Fqdn(target)}
+}
+
+// NewTXT returns a new TXT record based on the Service.
+func (s *Service) NewTXT(name string) *dns.TXT {
+	return &dns.TXT{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: s.TTL}, Txt: split255(s.Text)}
+}
+
+// NewPTR returns a new PTR record based on the Service.
+func (s *Service) NewPTR(name string, target string) *dns.PTR {
+	return &dns.PTR{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: s.TTL}, Ptr: dns.Fqdn(target)}
+}
+
+// NewNS returns a new NS record based on the Service.
+func (s *Service) NewNS(name string) *dns.NS {
+	host := targetStrip(dns.Fqdn(s.Host), s.TargetStrip)
+	return &dns.NS{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: s.TTL}, Ns: host}
+}
+
+// Group checks the services in sx, it looks for a Group attribute on the shortest
+// keys. If there are multiple shortest keys *and* the group attribute disagrees (and
+// is not empty), we don't consider it a group.
+// If a group is found, only services with *that* group (or no group) will be returned.
+func Group(sx []Service) []Service {
+	if len(sx) == 0 {
+		return sx
+	}
+
+	// Shortest key with group attribute sets the group for this set.
+	group := sx[0].Group
+	slashes := strings.Count(sx[0].Key, "/")
+	length := make([]int, len(sx))
+	for i, s := range sx {
+		x := strings.Count(s.Key, "/")
+		length[i] = x
+		if x < slashes {
+			if s.Group == "" {
+				break
+			}
+			slashes = x
+			group = s.Group
+		}
+	}
+
+	if group == "" {
+		return sx
+	}
+
+	ret := []Service{} // with slice-tricks in sx we can prolly save this allocation (TODO)
+
+	for i, s := range sx {
+		if s.Group == "" {
+			ret = append(ret, s)
+			continue
+		}
+
+		// Disagreement on the same level
+		if length[i] == slashes && s.Group != group {
+			return sx
+		}
+
+		if s.Group == group {
+			ret = append(ret, s)
+		}
+	}
+	return ret
+}
+
+// Split255 splits a string into 255 byte chunks.
+func split255(s string) []string {
+	if len(s) < 255 {
+		return []string{s}
+	}
+	sx := []string{}
+	p, i := 0, 255
+	for {
+		if i <= len(s) {
+			sx = append(sx, s[p:i])
+		} else {
+			sx = append(sx, s[p:])
+			break
+
+		}
+		p, i = p+255, i+255
+	}
+
+	return sx
+}
+
+// targetStrip strips "targetstrip" labels from the left side of the fully qualified name.
+func targetStrip(name string, targetStrip int) string {
+	if targetStrip == 0 {
+		return name
+	}
+
+	offset, end := 0, false
+	for i := 0; i < targetStrip; i++ {
+		offset, end = dns.NextLabel(name, offset)
+	}
+	if end {
+		// We overshot the name, use the orignal one.
+		offset = 0
+	}
+	name = name[offset:]
+	return name
+}


### PR DESCRIPTION
This PR contains following
1. DNS provider implementation for CoreDNS with etcd as backend
2. Script for optionally deploying CoreDNS in federation control plane

Still to do:
1. HA for CoreDNS service need to be handled, would be taken up in subsequent PR
2. Need to configure CoreDNS as fallback DNS to in-cluster KubeDNS(Manual Step). Need to consider automation.

Request for review: @quinton-hoole @madhusudancs @nikhiljindal @kshafiee @deepak-vij
cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35116)

<!-- Reviewable:end -->
