### PR TITLE
Use LC_ALL=C with sort

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -39,12 +39,12 @@ array_contains () {
 
 # Check that the file is in alphabetical order
 linted_file="${KUBE_ROOT}/hack/.linted_packages"
-if ! diff -u "${linted_file}" <(LANG=C sort "${linted_file}"); then
+if ! diff -u "${linted_file}" <(LC_ALL=C sort "${linted_file}"); then
 	{
 		echo
 		echo "hack/.linted_packages is not in alphabetical order. Please sort it:"
 		echo
-		echo "  LANG=C sort -o hack/.linted_packages hack/.linted_packages"
+		echo "  LC_ALL=C sort -o hack/.linted_packages hack/.linted_packages"
 		echo
 	} >&2
 	false
@@ -104,7 +104,7 @@ else
 		for p in "${linted[@]}"; do
 			echo "  echo $p >> hack/.linted_packages"
 		done
-		echo "  LANG=C sort -o hack/.linted_packages hack/.linted_packages"
+		echo "  LC_ALL=C sort -o hack/.linted_packages hack/.linted_packages"
 		echo
 		echo 'You can test via this script and commit the result.'
 		echo


### PR DESCRIPTION
In some user env LANG=C might lose:

Wrong:

```
echo -e "test/images/port-forward-tester\ntest/images/porter" | LANG=C sort
test/images/porter
test/images/port-forward-tester
```

Right:

```
echo -e "test/images/port-forward-tester\ntest/images/porter" | LC_ALL=C sort
test/images/port-forward-tester
test/images/porter
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35120)

<!-- Reviewable:end -->
