### PR TITLE
Eliminate half-baked multi-architecture support

### DIFF
--- a/cmd/kubeadm/app/master/addons.go
+++ b/cmd/kubeadm/app/master/addons.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"path"
-	"runtime"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
@@ -31,15 +30,11 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
-// TODO(phase1+): kube-proxy should be a daemonset, three different daemonsets should not be here
-func createKubeProxyPodSpec(cfg *kubeadmapi.MasterConfiguration, architecture string) api.PodSpec {
+func createKubeProxyPodSpec(cfg *kubeadmapi.MasterConfiguration) api.PodSpec {
 	envParams := kubeadmapi.GetEnvParams()
 	privilegedTrue := true
 	return api.PodSpec{
 		SecurityContext: &api.PodSecurityContext{HostNetwork: true},
-		NodeSelector: map[string]string{
-			"beta.kubernetes.io/arch": architecture,
-		},
 		Containers: []api.Container{{
 			Name:            kubeProxy,
 			Image:           images.GetCoreImage(images.KubeProxyImage, cfg, envParams["hyperkube_image"]),
@@ -108,9 +103,6 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) api.PodSpec {
 	)
 
 	return api.PodSpec{
-		NodeSelector: map[string]string{
-			"beta.kubernetes.io/arch": runtime.GOARCH,
-		},
 		Containers: []api.Container{
 			// DNS server
 			{
@@ -237,21 +229,19 @@ func createKubeDNSServiceSpec(cfg *kubeadmapi.MasterConfiguration) (*api.Service
 }
 
 func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
-	arches := [3]string{"amd64", "arm", "arm64"}
+	kubeProxyDaemonSet := NewDaemonSet(kubeProxy, createKubeProxyPodSpec(cfg))
+	SetMasterTaintTolerations(&kubeProxyDaemonSet.Spec.Template.ObjectMeta)
+	SetNodeAffinity(&kubeProxyDaemonSet.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
-	for _, arch := range arches {
-		kubeProxyDaemonSet := NewDaemonSet(kubeProxy+"-"+arch, createKubeProxyPodSpec(cfg, arch))
-		SetMasterTaintTolerations(&kubeProxyDaemonSet.Spec.Template.ObjectMeta)
-
-		if _, err := client.Extensions().DaemonSets(api.NamespaceSystem).Create(kubeProxyDaemonSet); err != nil {
-			return fmt.Errorf("<master/addons> failed creating essential kube-proxy addon [%v]", err)
-		}
+	if _, err := client.Extensions().DaemonSets(api.NamespaceSystem).Create(kubeProxyDaemonSet); err != nil {
+		return fmt.Errorf("<master/addons> failed creating essential kube-proxy addon [%v]", err)
 	}
 
 	fmt.Println("<master/addons> created essential addon: kube-proxy")
 
 	kubeDNSDeployment := NewDeployment("kube-dns", 1, createKubeDNSPodSpec(cfg))
 	SetMasterTaintTolerations(&kubeDNSDeployment.Spec.Template.ObjectMeta)
+	SetNodeAffinity(&kubeDNSDeployment.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
 	if _, err := client.Extensions().Deployments(api.NamespaceSystem).Create(kubeDNSDeployment); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-dns addon [%v]", err)

--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -112,7 +112,7 @@ func newKubeDiscovery(cfg *kubeadmapi.MasterConfiguration, caCert *x509.Certific
 	}
 
 	SetMasterTaintTolerations(&kd.Deployment.Spec.Template.ObjectMeta)
-	SetMasterNodeAffinity(&kd.Deployment.Spec.Template.ObjectMeta)
+	SetNodeAffinity(&kd.Deployment.Spec.Template.ObjectMeta, MasterNodeAffinity(), NativeArchitectureNodeAffinity())
 
 	return kd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We have release `kubeadm` with half-baked support for clusters with nodes of different CPU architectures. The problem with the code as it stand is that user will notice pending daemonsets of `kube-proxy` for machines with architectures that they don't have. At the same time, the code as it stand did not pick up correct images for architectures it wanted to allow. Additionally, it only treated `kube-proxy` in such a way, but didn't do anything about `kube-dns`. This removes multiple daemonesets, but ensures that whichever resources we deploy have node affinity set to the architecture native to the master. Users wishing to use mixed architectures can still create extra daemonsets via the API.

**Which issue this PR fixes**: fixes #33916

**Release note**:

``` release-note
Remove support for multi-architecture code in `kubeadm`, which was released untested.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35124)

<!-- Reviewable:end -->
