### PR TITLE
[WIP] Add kubeadm to hyperkube

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -75,7 +75,8 @@ RUN ln -s /hyperkube /apiserver \
  && ln -s /hyperkube /kubectl \
  && ln -s /hyperkube /kubelet \
  && ln -s /hyperkube /proxy \
- && ln -s /hyperkube /scheduler
+ && ln -s /hyperkube /scheduler \
+ && ln -s /hyperkube /kubeadm
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube


### PR DESCRIPTION
Allow users to invoke the kubeadm tool from hyperkube w/o need to install kubelet, kubectl and other dependencies from packages.

Fixes https://github.com/kubernetes/kubernetes/issues/35041

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35130)

<!-- Reviewable:end -->
