### PR TITLE
Set non-always RestartPolicy for write-pod in pv e2e

### DIFF
--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -649,6 +649,7 @@ func makeWritePod(ns string, pvcName string) *api.Pod {
 					},
 				},
 			},
+			RestartPolicy: api.RestartPolicyOnFailure,
 			Volumes: []api.Volume{
 				{
 					Name: "nfs-pvc",


### PR DESCRIPTION
Due to https://github.com/kubernetes/kubernetes/pull/34632 the RestartPolicy can't be Always (& it shouldn't be anyway)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35131)

<!-- Reviewable:end -->
