### PR TITLE
Add comment for why EndpointsStore doesn't have DeleteFunc

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -225,6 +225,8 @@ func (kd *KubeDNS) setEndpointsStore() {
 				// TODO: Avoid unwanted updates.
 				kd.handleEndpointAdd(newObj)
 			},
+			// No DeleteFunc for EndpointsStore because endpoint object will be deleted
+			// when corresponding service is deleted.
 		},
 	)
 }


### PR DESCRIPTION
I was confused about why EndpointsStore does not need to have the DeleteFunc. I think it would be helpful to have a comment here.

@bprashanth @bowei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35138)

<!-- Reviewable:end -->
