### PR TITLE
Added description to metadata to better describe resource

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -169,6 +169,10 @@ type ObjectMeta struct {
 	// This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
 	// +optional
 	ClusterName string `json:"clusterName,omitempty"`
+
+	// Description is an optional field that allows user to give a description of the resource.
+	// This is set by the creator of the resource to better identify to other users what the resource is used for.
+	Description string `json:"description,omitempty"`
 }
 
 const (

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -249,6 +249,7 @@ func newStorageClass() *storage.StorageClass {
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: "fast",
+			Description: "fast service used by gold members",
 		},
 		Provisioner: pluginName,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added "Description field to metadata object for resources such as storage classes, PVs, PVCs so the creator of said resources can put a more descriptive definition of what the resource is for. 

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #
N/A

**Special notes for your reviewer**:

**Release note**:

``` release-note
```

…source is to be used for

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35139)

<!-- Reviewable:end -->
