### PR TITLE
Change code of conduct to call CNCF CoC by reference

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,58 +1,5 @@
 ## Kubernetes Community Code of Conduct
 
-### Contributor Code of Conduct
-
-As contributors and maintainers of this project, and in the interest of fostering
-an open and welcoming community, we pledge to respect all people who contribute
-through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, and other activities.
-
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
-religion, or nationality.
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses,
- without explicit permission
-* Other unethical or unprofessional conduct.
-
-Project maintainers have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are not
-aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
-commit themselves to fairly and consistently applying these principles to every aspect
-of managing this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
-
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a Kubernetes maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
-
-This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.2.0, available at
-http://contributor-covenant.org/version/1/2/0/
-
-### Kubernetes Events Code of Conduct
-
-Kubernetes events are working conferences intended for professional networking and collaboration in the
-Kubernetes community. Attendees are expected to behave according to professional standards and in accordance
-with their employer's policies on appropriate workplace behavior.
-
-While at Kubernetes events or related social networking opportunities, attendees should not engage in
-discriminatory or offensive speech or actions regarding gender, sexuality, race, or religion. Speakers should
-be especially aware of these concerns.
-
-The Kubernetes team does not condone any statements by speakers contrary to these standards.  The Kubernetes
-team reserves the right to deny entrance and/or eject from an event (without refund) any individual found to
-be engaging in discriminatory or offensive speech or actions.
-
-Please bring any concerns to to the immediate attention of Kubernetes event staff
-
+Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/code-of-conduct.md?pixel)]()


### PR DESCRIPTION
**What this PR does / why we need it**:

Revises the Kubernetes Code of Conduct (CoC) to point to the CNCF CoC by reference. The CNCF CoC is nearly identical to the Kubernetes one. The only changes are replacing `Kubernetes` with `CNCF` and referencing the Linux Foundation events CoC.

Here is an exact diff of the changes between the Kubernetes CoC and the CNCF CoC: https://github.com/cncf/foundation/commit/9f3936e486806e4c2efffb25ebd3306dee203943

Note that this PR attempts to resolve https://github.com/cncf/foundation/issues/2 which is to have a standard CoC for all CNCF projects.

**Special notes for your reviewer**:

Cc @sarahnovotny @bgrant0607 @aronchick @caniszczyk @monadic

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35142)

<!-- Reviewable:end -->
