### PR TITLE
WIP: Create apiserver cert w/ separate root-ca using cfssl

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -323,6 +323,11 @@
 			"Rev": "db0d0650b6496bfe8061ec56a92edd32d8e75c30"
 		},
 		{
+			"ImportPath": "github.com/cloudflare/cfssl/initca",
+			"Comment": "1.2.0",
+			"Rev": "db0d0650b6496bfe8061ec56a92edd32d8e75c30"
+		},
+		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
 			"Comment": "1.2.0",
 			"Rev": "db0d0650b6496bfe8061ec56a92edd32d8e75c30"

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -35,7 +35,6 @@ go_library(
         "//pkg/generated/openapi:go_default_library",
         "//pkg/genericapiserver:go_default_library",
         "//pkg/genericapiserver/authorizer:go_default_library",
-        "//pkg/genericapiserver/options:go_default_library",
         "//pkg/master:go_default_library",
         "//pkg/registry/cachesize:go_default_library",
         "//pkg/runtime/schema:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -21,6 +21,7 @@ package app
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -49,7 +50,6 @@ import (
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/authorizer"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/runtime/schema"
@@ -85,20 +85,20 @@ func Run(s *options.ServerRunOptions) error {
 		return err
 	}
 
-	genericapiserver.DefaultAndValidateRunOptions(s.GenericServerRunOptions)
-	genericConfig := genericapiserver.NewConfig(). // create the new config
-							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
-							ApplySecureServingOptions(s.SecureServing).
-							ApplyInsecureServingOptions(s.InsecureServing).
-							ApplyAuthenticationOptions(s.Authentication).
-							ApplyRBACSuperUser(s.Authorization.RBACSuperUser)
-
 	serviceIPRange, apiServerServiceIP, err := genericapiserver.DefaultServiceIPRange(s.GenericServerRunOptions.ServiceClusterIPRange)
 	if err != nil {
 		glog.Fatalf("Error determining service IP ranges: %v", err)
 	}
-	if err := genericConfig.MaybeGenerateServingCerts(apiServerServiceIP); err != nil {
-		glog.Fatalf("Failed to generate service certificate: %v", err)
+
+	genericapiserver.DefaultAndValidateRunOptions(s.GenericServerRunOptions)
+	genericConfig, err := genericapiserver.NewConfig(). // create the new config
+								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
+								ApplyInsecureServingOptions(s.InsecureServing).
+								ApplyAuthenticationOptions(s.Authentication).
+								ApplyRBACSuperUser(s.Authorization.RBACSuperUser).
+								ApplySecureServingOptions(s.SecureServing, s.GenericServerRunOptions.AdvertiseAddress.String(), apiServerServiceIP)
+	if err != nil {
+		return fmt.Errorf("failed to configure https: %s", err)
 	}
 
 	capabilities.Initialize(capabilities.Capabilities{
@@ -232,7 +232,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	privilegedLoopbackToken := uuid.NewRandom().String()
-	selfClientConfig, err := genericoptions.NewSelfClientConfig(s.SecureServing, s.InsecureServing, privilegedLoopbackToken)
+	selfClientConfig, err := genericapiserver.NewSelfClientConfig(genericConfig.SecureServingInfo, genericConfig.InsecureServingInfo, privilegedLoopbackToken)
 	if err != nil {
 		glog.Fatalf("Failed to create clientset: %v", err)
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -18,7 +18,6 @@ limitations under the License.
 package app
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -63,7 +62,6 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
-	"k8s.io/kubernetes/pkg/util/cert"
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	"k8s.io/kubernetes/pkg/util/configz"
@@ -526,12 +524,12 @@ func InitializeTLS(kc *componentconfig.KubeletConfiguration) (*server.TLSOptions
 			return nil, err
 		}
 		if !canReadCertAndKey {
-			cert, key, err := certutil.GenerateSelfSignedCertKey(nodeutil.GetHostname(kc.HostnameOverride), nil, nil)
+			caCert, _, cert, key, err := certutil.GenerateSelfSignedCertKey(nodeutil.GetHostname(kc.HostnameOverride), nil, nil)
 			if err != nil {
 				return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
 			}
 
-			if err := certutil.WriteCert(kc.TLSCertFile, cert); err != nil {
+			if err := certutil.WriteCert(kc.TLSCertFile, cert, caCert); err != nil {
 				return nil, err
 			}
 

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -42,7 +42,6 @@ go_library(
         "//pkg/generated/openapi:go_default_library",
         "//pkg/genericapiserver:go_default_library",
         "//pkg/genericapiserver/authorizer:go_default_library",
-        "//pkg/genericapiserver/options:go_default_library",
         "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/configmap/etcd:go_default_library",
         "//pkg/registry/core/event/etcd:go_default_library",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -37,7 +38,6 @@ import (
 	"k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/authorizer"
-	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
@@ -74,15 +74,14 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	genericapiserver.DefaultAndValidateRunOptions(s.GenericServerRunOptions)
-	genericConfig := genericapiserver.NewConfig(). // create the new config
-							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
-							ApplySecureServingOptions(s.SecureServing).
-							ApplyInsecureServingOptions(s.InsecureServing).
-							ApplyAuthenticationOptions(s.Authentication).
-							ApplyRBACSuperUser(s.Authorization.RBACSuperUser)
-
-	if err := genericConfig.MaybeGenerateServingCerts(); err != nil {
-		glog.Fatalf("Failed to generate service certificate: %v", err)
+	genericConfig, err := genericapiserver.NewConfig(). // create the new config
+								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
+								ApplyInsecureServingOptions(s.InsecureServing).
+								ApplyAuthenticationOptions(s.Authentication).
+								ApplyRBACSuperUser(s.Authorization.RBACSuperUser).
+								ApplySecureServingOptions(s.SecureServing, s.GenericServerRunOptions.AdvertiseAddress.String())
+	if err != nil {
+		return fmt.Errorf("failed to configure https: %s", err)
 	}
 
 	// TODO: register cluster federation resources here.
@@ -130,7 +129,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	privilegedLoopbackToken := uuid.NewRandom().String()
-	selfClientConfig, err := genericoptions.NewSelfClientConfig(s.SecureServing, s.InsecureServing, privilegedLoopbackToken)
+	selfClientConfig, err := genericapiserver.NewSelfClientConfig(genericConfig.SecureServingInfo, genericConfig.InsecureServingInfo, privilegedLoopbackToken)
 	if err != nil {
 		glog.Fatalf("Failed to create clientset: %v", err)
 	}

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -459,7 +459,6 @@ EOF
       --admission-control="${ADMISSION_CONTROL}" \
       --bind-address="${API_BIND_ADDR}" \
       --secure-port="${API_SECURE_PORT}" \
-      --tls-ca-file="${ROOT_CA_FILE}" \
       --insecure-bind-address="${API_HOST_IP}" \
       --insecure-port="${API_PORT}" \
       --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
@@ -473,6 +472,10 @@ EOF
     # Wait for kube-apiserver to come up before launching the rest of the components.
     echo "Waiting for apiserver to come up"
     kube::util::wait_for_url "https://${API_HOST}:${API_SECURE_PORT}/version" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
+
+    # extract root-ca from certificate chain created by the apiserver
+    openssl crl2pkcs7 -nocrl -certfile "${CERT_DIR}/apiserver.crt" | openssl pkcs7 -print_certs | \
+        sudo /bin/bash -c "awk '/subject.*CN=127.0.0.1@ca-/,/END CERTIFICATE/' > \"${ROOT_CA_FILE}\""
 
     # Create kubeconfigs for all components, using client certs
     write_client_kubeconfig kubelet

--- a/pkg/genericapiserver/BUILD
+++ b/pkg/genericapiserver/BUILD
@@ -14,6 +14,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "config_selfclient.go",
         "default_storage_factory_builder.go",
         "discovery.go",
         "doc.go",
@@ -118,6 +119,7 @@ go_test(
         "//pkg/storage/storagebackend:go_default_library",
         "//pkg/util/cert:go_default_library",
         "//pkg/util/clock:go_default_library",
+        "//pkg/util/config:go_default_library",
         "//pkg/util/net:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/version:go_default_library",

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -17,8 +17,11 @@ limitations under the License.
 package genericapiserver
 
 import (
+	"crypto/tls"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -166,33 +169,19 @@ type ServingInfo struct {
 type SecureServingInfo struct {
 	ServingInfo
 
-	// ServerCert is the TLS cert info for serving secure traffic
-	ServerCert GeneratableKeyCert
-	// SNICerts are named CertKeys for serving secure traffic with SNI support.
-	SNICerts []NamedCertKey
+	// Cert is the main server cert which is used if SNI does not match. Cert must be non-nil and is
+	// allowed to be in SNICerts.
+	Cert *tls.Certificate
+
+	// CACert is an optional certificate authority used for the loopback connection of the Admission controllers.
+	// If this is nil, the certificate authority is extracted from Cert or a matching SNI certificate.
+	CACert *tls.Certificate
+
+	// SNICerts are the TLS certificates by name used for SNI.
+	SNICerts map[string]*tls.Certificate
+
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string
-}
-
-type CertKey struct {
-	// CertFile is a file containing a PEM-encoded certificate
-	CertFile string
-	// KeyFile is a file containing a PEM-encoded private key for the certificate specified by CertFile
-	KeyFile string
-}
-
-type NamedCertKey struct {
-	CertKey
-
-	// Names is a list of domain patterns: fully qualified domain names, possibly prefixed with
-	// wildcard segments.
-	Names []string
-}
-
-type GeneratableKeyCert struct {
-	CertKey
-	// Generate indicates that the cert/key pair should be generated if its not present.
-	Generate bool
 }
 
 // NewConfig returns a Config struct with the default values
@@ -235,45 +224,98 @@ func NewConfig() *Config {
 	return config.ApplyOptions(defaultOptions)
 }
 
-func (c *Config) ApplySecureServingOptions(secureServing *options.SecureServingOptions) *Config {
+func (c *Config) ApplySecureServingOptions(secureServing *options.SecureServingOptions, publicAddress string, alternateIPs ...net.IP) (*Config, error) {
 	if secureServing == nil || secureServing.ServingOptions.BindPort <= 0 {
-		return c
+		return c, nil
 	}
 
 	secureServingInfo := &SecureServingInfo{
 		ServingInfo: ServingInfo{
 			BindAddress: net.JoinHostPort(secureServing.ServingOptions.BindAddress.String(), strconv.Itoa(secureServing.ServingOptions.BindPort)),
 		},
-		ServerCert: GeneratableKeyCert{
-			CertKey: CertKey{
-				CertFile: secureServing.ServerCert.CertKey.CertFile,
-				KeyFile:  secureServing.ServerCert.CertKey.KeyFile,
-			},
-		},
-		SNICerts: []NamedCertKey{},
 		ClientCA: secureServing.ClientCA,
 	}
-	if secureServing.ServerCert.CertKey.CertFile == "" && secureServing.ServerCert.CertKey.KeyFile == "" {
-		secureServingInfo.ServerCert.Generate = true
-		secureServingInfo.ServerCert.CertFile = path.Join(secureServing.ServerCert.CertDirectory, secureServing.ServerCert.PairName+".crt")
-		secureServingInfo.ServerCert.KeyFile = path.Join(secureServing.ServerCert.CertDirectory, secureServing.ServerCert.PairName+".key")
+
+	serverCertFile, serverKeyFile := secureServing.ServerCert.CertKey.CertFile, secureServing.ServerCert.CertKey.KeyFile
+
+	// possibly self-signed cert and key
+	if len(serverCertFile) == 0 && len(serverKeyFile) == 0 {
+		serverCertFile = path.Join(secureServing.ServerCert.CertDirectory, secureServing.ServerCert.PairName+".crt")
+		serverKeyFile = path.Join(secureServing.ServerCert.CertDirectory, secureServing.ServerCert.PairName+".key")
+
+		canReadCertAndKey, err := certutil.CanReadCertAndKey(serverCertFile, serverKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		if !canReadCertAndKey {
+			// TODO: It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
+			// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
+			// TODO (cjcullen): Is ClusterIP the right address to sign a cert with?
+			alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}
+			if cert, key, err := certutil.GenerateSelfSignedCertKey(publicAddress, alternateIPs, alternateDNS); err != nil {
+				return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
+			} else {
+				if err := certutil.WriteCert(serverCertFile, cert); err != nil {
+					return nil, err
+				}
+
+				if err := certutil.WriteKey(serverKeyFile, key); err != nil {
+					return nil, err
+				}
+				glog.Infof("Generated self-signed cert (%s, %s)", serverCertFile, serverKeyFile)
+			}
+		}
 	}
 
-	secureServingInfo.SNICerts = nil
-	for _, nkc := range secureServing.SNICertKeys {
-		secureServingInfo.SNICerts = append(secureServingInfo.SNICerts, NamedCertKey{
-			CertKey: CertKey{
-				KeyFile:  nkc.KeyFile,
-				CertFile: nkc.CertFile,
-			},
-			Names: nkc.Names,
+	// load main cert
+	if len(serverCertFile) != 0 || len(serverKeyFile) != 0 {
+		tlsCert, err := tls.LoadX509KeyPair(serverCertFile, serverKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load server certificate: %v", err)
+		}
+		secureServingInfo.Cert = &tlsCert
+	}
+
+	// optionally load CA cert
+	if len(secureServing.ServerCert.CaCertFile) != 0 {
+		pemData, err := ioutil.ReadFile(secureServing.ServerCert.CaCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificate authority from %q: %v", secureServing.ServerCert.CaCertFile, err)
+		}
+		block, pemData := pem.Decode(pemData)
+		if block == nil {
+			return nil, fmt.Errorf("no certificate found in certificate authority file %q", secureServing.ServerCert.CaCertFile)
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("expected CERTIFICATE block in certiticate authority file %q, found: %s", secureServing.ServerCert.CaCertFile, block.Type)
+		}
+		secureServingInfo.CACert = &tls.Certificate{
+			Certificate: [][]byte{block.Bytes},
+		}
+	}
+
+	// load SNI certs
+	namedTlsCerts := make([]namedTlsCert, 0, len(secureServing.SNICertKeys))
+	for _, nck := range secureServing.SNICertKeys {
+		tlsCert, err := tls.LoadX509KeyPair(nck.CertFile, nck.KeyFile)
+		namedTlsCerts = append(namedTlsCerts, namedTlsCert{
+			tlsCert: tlsCert,
+			names:   nck.Names,
 		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load SNI cert and key: %v", err)
+		}
+	}
+	var err error
+	secureServingInfo.SNICerts, err = getNamedCertificateMap(namedTlsCerts)
+	if err != nil {
+		return nil, err
 	}
 
 	c.SecureServingInfo = secureServingInfo
 	c.ReadWritePort = secureServing.ServingOptions.BindPort
 
-	return c
+	return c, nil
 }
 
 func (c *Config) ApplyInsecureServingOptions(insecureServing *options.ServingOptions) *Config {
@@ -450,38 +492,6 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	s.Handler, s.InsecureHandler = c.BuildHandlerChainsFunc(s.HandlerContainer.ServeMux, c.Config)
 
 	return s, nil
-}
-
-// MaybeGenerateServingCerts generates serving certificates if requested and needed.
-func (c *Config) MaybeGenerateServingCerts(alternateIPs ...net.IP) error {
-	// It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
-	// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
-	if c.SecureServingInfo != nil && c.SecureServingInfo.ServerCert.Generate {
-		canReadCertAndKey, err := certutil.CanReadCertAndKey(c.SecureServingInfo.ServerCert.CertFile, c.SecureServingInfo.ServerCert.KeyFile)
-		if err != nil {
-			return err
-		}
-		if canReadCertAndKey {
-			return nil
-		}
-		// TODO (cjcullen): Is ClusterIP the right address to sign a cert with?
-		alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}
-
-		if cert, key, err := certutil.GenerateSelfSignedCertKey(c.PublicAddress.String(), alternateIPs, alternateDNS); err != nil {
-			return fmt.Errorf("unable to generate self signed cert: %v", err)
-		} else {
-			if err := certutil.WriteCert(c.SecureServingInfo.ServerCert.CertFile, cert); err != nil {
-				return err
-			}
-
-			if err := certutil.WriteKey(c.SecureServingInfo.ServerCert.KeyFile, key); err != nil {
-				return err
-			}
-			glog.Infof("Generated self-signed cert (%s, %s)", c.SecureServingInfo.ServerCert.CertFile, c.SecureServingInfo.ServerCert.KeyFile)
-		}
-	}
-
-	return nil
 }
 
 func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) (secure, insecure http.Handler) {

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -252,10 +252,10 @@ func (c *Config) ApplySecureServingOptions(secureServing *options.SecureServingO
 			// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
 			// TODO (cjcullen): Is ClusterIP the right address to sign a cert with?
 			alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}
-			if cert, key, err := certutil.GenerateSelfSignedCertKey(publicAddress, alternateIPs, alternateDNS); err != nil {
+			if caCert, _, cert, key, err := certutil.GenerateSelfSignedCertKey(publicAddress, alternateIPs, alternateDNS); err != nil {
 				return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
 			} else {
-				if err := certutil.WriteCert(serverCertFile, cert); err != nil {
+				if err := certutil.WriteCert(serverCertFile, cert, caCert); err != nil {
 					return nil, err
 				}
 

--- a/pkg/genericapiserver/config_selfclient.go
+++ b/pkg/genericapiserver/config_selfclient.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapiserver
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+// NewSelfClientConfig returns a clientconfig which can be used to talk to this apiserver.
+func NewSelfClientConfig(secureServingInfo *SecureServingInfo, insecureServingInfo *ServingInfo, token string) (*restclient.Config, error) {
+	if cfg, err := secureServingInfo.NewSelfClientConfig(token); err != nil || cfg != nil {
+		return cfg, err
+	}
+	if cfg, err := insecureServingInfo.NewSelfClientConfig(token); err != nil || cfg != nil {
+		return cfg, err
+	}
+
+	return nil, errors.New("Unable to set url for apiserver local client")
+}
+
+func (s *SecureServingInfo) NewSelfClientConfig(token string) (*restclient.Config, error) {
+	if s == nil || (s.Cert == nil && len(s.SNICerts) == 0) {
+		return nil, nil
+	}
+
+	host, port, err := net.SplitHostPort(s.ServingInfo.BindAddress)
+	if err != nil {
+		// should never happen
+		return nil, fmt.Errorf("invalid secure bind address: %q", s.ServingInfo.BindAddress)
+	}
+	if host == "0.0.0.0" {
+		host = "localhost"
+	}
+
+	clientConfig := &restclient.Config{
+		// Increase QPS limits. The client is currently passed to all admission plugins,
+		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
+		// for more details. Once #22422 is fixed, we may want to remove it.
+		QPS:         50,
+		Burst:       100,
+		Host:        "https://" + net.JoinHostPort(host, port),
+		BearerToken: token,
+	}
+
+	// find certificate for host: either explicitly given, from the server cert bundle or one of the SNI certs
+	var derCA []byte
+	if s.CACert != nil {
+		derCA = s.CACert.Certificate[0]
+	}
+	if derCA == nil && s.Cert != nil {
+		x509Cert, err := x509.ParseCertificate(s.Cert.Certificate[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse server certificate: %v", err)
+		}
+
+		if (net.ParseIP(host) != nil && certMatchesIP(x509Cert, host)) || certMatchesName(x509Cert, host) {
+			if len(s.Cert.Certificate) < 2 {
+				return nil, fmt.Errorf("missing certificate authority in certificate chain for %q", host)
+			}
+			derCA = s.Cert.Certificate[1]
+		}
+	}
+	if derCA == nil && net.ParseIP(host) == nil {
+		if cert, found := s.SNICerts[host]; found {
+			if len(cert.Certificate) < 2 {
+				return nil, fmt.Errorf("missing certificate authority in certificate chain for %q", host)
+			}
+			derCA = cert.Certificate[1]
+		}
+	}
+	if derCA == nil {
+		return nil, fmt.Errorf("failed to find certificate which matches %q", host)
+	}
+	pemCA := bytes.Buffer{}
+	if err := pem.Encode(&pemCA, &pem.Block{Type: "CERTIFICATE", Bytes: derCA}); err != nil {
+		return nil, err
+	}
+	clientConfig.CAData = pemCA.Bytes()
+
+	return clientConfig, nil
+}
+
+func (s *ServingInfo) NewSelfClientConfig(token string) (*restclient.Config, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return &restclient.Config{
+		Host: s.BindAddress,
+		// Increase QPS limits. The client is currently passed to all admission plugins,
+		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
+		// for more details. Once #22422 is fixed, we may want to remove it.
+		QPS:   50,
+		Burst: 100,
+	}, nil
+}
+
+func certMatchesName(cert *x509.Certificate, name string) bool {
+	for _, certName := range cert.DNSNames {
+		if certName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func certMatchesIP(cert *x509.Certificate, ip string) bool {
+	for _, certIP := range cert.IPAddresses {
+		if certIP.String() == ip {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/genericapiserver/options/BUILD
+++ b/pkg/genericapiserver/options/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//pkg/apiserver/authenticator:go_default_library",
         "//pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1:go_default_library",
-        "//pkg/client/restclient:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",
         "//pkg/controller/informers:go_default_library",
         "//pkg/genericapiserver/authorizer:go_default_library",

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -74,7 +74,6 @@ type ServerRunOptions struct {
 	// for testing). This is not actually exposed as a flag.
 	DefaultStorageVersions string
 	TargetRAMMB            int
-	TLSCAFile              string
 	WatchCacheSizes        []string
 }
 

--- a/pkg/genericapiserver/options/serving.go
+++ b/pkg/genericapiserver/options/serving.go
@@ -17,14 +17,11 @@ limitations under the License.
 package options
 
 import (
-	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/spf13/pflag"
 
-	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/util/config"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
@@ -43,14 +40,10 @@ type SecureServingOptions struct {
 	SNICertKeys []config.NamedCertKey
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string
-
-	// ServerCA is the certificate bundle for the signer of your serving certificate.  Used for building a loopback
-	// connection to the API server for admission.
-	ServerCA string
 }
 
 type CertKey struct {
-	// CertFile is a file containing a PEM-encoded certificate
+	// CertFile is a file containing a PEM-encoded certificate, and possibly the complete certificate chain
 	CertFile string
 	// KeyFile is a file containing a PEM-encoded private key for the certificate specified by CertFile
 	KeyFile string
@@ -59,6 +52,8 @@ type CertKey struct {
 type GeneratableKeyCert struct {
 	CertKey CertKey
 
+	// CaCertFile is an optional file containing the certificate chain for CertKey.CertFile
+	CaCertFile string
 	// CertDirectory is a directory that will contain the certificates.  If the cert and key aren't specifically set
 	// this will be used to derive a match with the "pair-name"
 	CertDirectory string
@@ -78,31 +73,6 @@ func NewSecureServingOptions() *SecureServingOptions {
 			CertDirectory: "/var/run/kubernetes",
 		},
 	}
-}
-
-func (s *SecureServingOptions) NewSelfClientConfig(token string) *restclient.Config {
-	if s == nil || s.ServingOptions.BindPort <= 0 || len(s.ServerCA) == 0 {
-		return nil
-	}
-
-	clientConfig := &restclient.Config{
-		// Increase QPS limits. The client is currently passed to all admission plugins,
-		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
-		// for more details. Once #22422 is fixed, we may want to remove it.
-		QPS:   50,
-		Burst: 100,
-	}
-
-	// Use secure port if the ServerCA is specified
-	host := s.ServingOptions.BindAddress.String()
-	if host == "0.0.0.0" {
-		host = "localhost"
-	}
-	clientConfig.Host = "https://" + net.JoinHostPort(host, strconv.Itoa(s.ServingOptions.BindPort))
-	clientConfig.CAFile = s.ServerCA
-	clientConfig.BearerToken = token
-
-	return clientConfig
 }
 
 func (s *SecureServingOptions) Validate() []error {
@@ -138,6 +108,11 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServerCert.CertKey.KeyFile, "tls-private-key-file", s.ServerCert.CertKey.KeyFile,
 		"File containing the default x509 private key matching --tls-cert-file.")
 
+	fs.StringVar(&s.ServerCert.CaCertFile, "tls-ca-file", s.ServerCert.CaCertFile, "If set, this "+
+		"certificate authority will used for secure access from Admission "+
+		"Controllers. This must be a valid PEM-encoded CA bundle. Altneratively, the certificate authority "+
+		"can be appended to the certificate provided by --tls-cert-file.")
+
 	fs.Var(config.NewNamedCertKeyArray(&s.SNICertKeys), "tls-sni-cert-key", ""+
 		"A pair of x509 certificate and private key file paths, optionally suffixed with a list of "+
 		"domain patterns which are fully qualified domain names, possibly with prefixed wildcard "+
@@ -151,18 +126,12 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"If set, any request presenting a client certificate signed by one of "+
 		"the authorities in the client-ca-file is authenticated with an identity "+
 		"corresponding to the CommonName of the client certificate.")
-
-	fs.StringVar(&s.ServerCA, "tls-ca-file", s.ServerCA, "If set, this "+
-		"certificate authority will used for secure access from Admission "+
-		"Controllers. This must be a valid PEM-encoded CA bundle.")
-
 }
 
 func (s *SecureServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {
 	fs.IPVar(&s.ServingOptions.BindAddress, "public-address-override", s.ServingOptions.BindAddress,
 		"DEPRECATED: see --bind-address instead.")
 	fs.MarkDeprecated("public-address-override", "see --bind-address instead.")
-
 }
 
 func NewInsecureServingOptions() *ServingOptions {
@@ -180,23 +149,6 @@ func (s ServingOptions) Validate(portArg string) []error {
 	}
 
 	return errors
-}
-
-func (s *ServingOptions) NewSelfClientConfig(token string) *restclient.Config {
-	if s == nil || s.BindPort <= 0 {
-		return nil
-	}
-	clientConfig := &restclient.Config{
-		// Increase QPS limits. The client is currently passed to all admission plugins,
-		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
-		// for more details. Once #22422 is fixed, we may want to remove it.
-		QPS:   50,
-		Burst: 100,
-	}
-
-	clientConfig.Host = net.JoinHostPort(s.BindAddress.String(), strconv.Itoa(s.BindPort))
-
-	return clientConfig
 }
 
 func (s *ServingOptions) DefaultExternalAddress() (net.IP, error) {
@@ -222,16 +174,4 @@ func (s *ServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&s.BindPort, "port", s.BindPort, "DEPRECATED: see --insecure-port instead.")
 	fs.MarkDeprecated("port", "see --insecure-port instead.")
-}
-
-// Returns a clientconfig which can be used to talk to this apiserver.
-func NewSelfClientConfig(secureServingOptions *SecureServingOptions, insecureServingOptions *ServingOptions, token string) (*restclient.Config, error) {
-	if cfg := secureServingOptions.NewSelfClientConfig(token); cfg != nil {
-		return cfg, nil
-	}
-	if cfg := insecureServingOptions.NewSelfClientConfig(token); cfg != nil {
-		return cfg, nil
-	}
-
-	return nil, errors.New("Unable to set url for apiserver local client")
 }

--- a/pkg/genericapiserver/serve_test.go
+++ b/pkg/genericapiserver/serve_test.go
@@ -20,15 +20,18 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"testing"
 
-	utilcert "k8s.io/kubernetes/pkg/util/cert"
-
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/kubernetes/pkg/genericapiserver/options"
+	utilcert "k8s.io/kubernetes/pkg/util/cert"
+	"k8s.io/kubernetes/pkg/util/config"
 )
 
 type TestCertSpec struct {
@@ -39,47 +42,6 @@ type TestCertSpec struct {
 type NamedTestCertSpec struct {
 	TestCertSpec
 	explicitNames []string // as --tls-sni-cert-key explicit names
-}
-
-func createTestCerts(spec TestCertSpec) (certFilePath, keyFilePath string, err error) {
-	var ips []net.IP
-	for _, ip := range spec.ips {
-		ips = append(ips, net.ParseIP(ip))
-	}
-
-	certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, ips, spec.names)
-	if err != nil {
-		return "", "", err
-	}
-
-	certFile, err := ioutil.TempFile(os.TempDir(), "cert")
-	if err != nil {
-		return "", "", err
-	}
-
-	keyFile, err := ioutil.TempFile(os.TempDir(), "key")
-	if err != nil {
-		os.Remove(certFile.Name())
-		return "", "", err
-	}
-
-	_, err = certFile.Write(certPem)
-	if err != nil {
-		os.Remove(certFile.Name())
-		os.Remove(keyFile.Name())
-		return "", "", err
-	}
-	certFile.Close()
-
-	_, err = keyFile.Write(keyPem)
-	if err != nil {
-		os.Remove(certFile.Name())
-		os.Remove(keyFile.Name())
-		return "", "", err
-	}
-	keyFile.Close()
-
-	return certFile.Name(), keyFile.Name(), nil
 }
 
 func TestGetNamedCertificateMap(t *testing.T) {
@@ -225,26 +187,21 @@ func TestGetNamedCertificateMap(t *testing.T) {
 
 NextTest:
 	for i, test := range tests {
-		var namedCertKeys []NamedCertKey
+		var namedTLSCerts []namedTlsCert
 		bySignature := map[string]int{} // index in test.certs by cert signature
 		for j, c := range test.certs {
-			certFile, keyFile, err := createTestCerts(c.TestCertSpec)
+			cert, err := createTestTLSCerts(c.TestCertSpec)
 			if err != nil {
 				t.Errorf("%d - failed to create cert %d: %v", i, j, err)
 				continue NextTest
 			}
-			defer os.Remove(certFile)
-			defer os.Remove(keyFile)
 
-			namedCertKeys = append(namedCertKeys, NamedCertKey{
-				CertKey: CertKey{
-					KeyFile:  keyFile,
-					CertFile: certFile,
-				},
-				Names: c.explicitNames,
+			namedTLSCerts = append(namedTLSCerts, namedTlsCert{
+				tlsCert: cert,
+				names:   c.explicitNames,
 			})
 
-			sig, err := certFileSignature(certFile, keyFile)
+			sig, err := certSignature(cert)
 			if err != nil {
 				t.Errorf("%d - failed to get signature for %d: %v", i, j, err)
 				continue NextTest
@@ -252,7 +209,7 @@ NextTest:
 			bySignature[sig] = j
 		}
 
-		certMap, err := getNamedCertificateMap(namedCertKeys)
+		certMap, err := getNamedCertificateMap(namedTLSCerts)
 		if err == nil && len(test.errorString) != 0 {
 			t.Errorf("%d - expected no error, got: %v", i, err)
 		} else if err != nil && err.Error() != test.errorString {
@@ -363,19 +320,30 @@ func TestServerRunWithSNI(t *testing.T) {
 		},
 	}
 
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
 NextTest:
 	for i, test := range tests {
 		// create server cert
-		serverCertFile, serverKeyFile, err := createTestCerts(test.Cert)
+		serverCertBundleFile, serverKeyFile, err := createTestCertFiles(tempDir, test.Cert)
 		if err != nil {
 			t.Errorf("%d - failed to create server cert: %v", i, err)
+			continue NextTest
 		}
-		defer os.Remove(serverCertFile)
-		defer os.Remove(serverKeyFile)
+		ca, err := caCertFromBundle(serverCertBundleFile)
+		if err != nil {
+			t.Errorf("%d - failed to extract ca cert from server cert bundle: %v", i, err)
+			continue NextTest
+		}
+		caCerts := []*x509.Certificate{ca}
 
 		// create SNI certs
-		var namedCertKeys []NamedCertKey
-		serverSig, err := certFileSignature(serverCertFile, serverKeyFile)
+		var namedCertKeys []config.NamedCertKey
+		serverSig, err := certFileSignature(serverCertBundleFile, serverKeyFile)
 		if err != nil {
 			t.Errorf("%d - failed to get server cert signature: %v", i, err)
 			continue NextTest
@@ -384,24 +352,27 @@ NextTest:
 			serverSig: -1,
 		}
 		for j, c := range test.SNICerts {
-			certFile, keyFile, err := createTestCerts(c.TestCertSpec)
+			certBundleFile, keyFile, err := createTestCertFiles(tempDir, c.TestCertSpec)
 			if err != nil {
 				t.Errorf("%d - failed to create SNI cert %d: %v", i, j, err)
 				continue NextTest
 			}
-			defer os.Remove(certFile)
-			defer os.Remove(keyFile)
 
-			namedCertKeys = append(namedCertKeys, NamedCertKey{
-				CertKey: CertKey{
-					KeyFile:  keyFile,
-					CertFile: certFile,
-				},
-				Names: c.explicitNames,
+			namedCertKeys = append(namedCertKeys, config.NamedCertKey{
+				KeyFile:  keyFile,
+				CertFile: certBundleFile,
+				Names:    c.explicitNames,
 			})
 
+			ca, err := caCertFromBundle(certBundleFile)
+			if err != nil {
+				t.Errorf("%d - failed to extract ca cert from SNI cert bundle %s: %v", i, j, err)
+				continue NextTest
+			}
+			caCerts = append(caCerts, ca)
+
 			// store index in namedCertKeys with the signature as the key
-			sig, err := certFileSignature(certFile, keyFile)
+			sig, err := certFileSignature(certBundleFile, keyFile)
 			if err != nil {
 				t.Errorf("%d - failed get SNI cert %d signature: %v", i, j, err)
 				continue NextTest
@@ -416,17 +387,22 @@ NextTest:
 		defer etcdserver.Terminate(t)
 
 		config.EnableIndex = true
-		config.SecureServingInfo = &SecureServingInfo{
-			ServingInfo: ServingInfo{
-				BindAddress: "localhost:0",
+		_, err = config.ApplySecureServingOptions(&options.SecureServingOptions{
+			ServingOptions: options.ServingOptions{
+				BindAddress: net.ParseIP("127.0.0.1"),
+				BindPort:    6443,
 			},
-			ServerCert: GeneratableKeyCert{
-				CertKey: CertKey{
-					CertFile: serverCertFile,
+			ServerCert: options.GeneratableKeyCert{
+				CertKey: options.CertKey{
+					CertFile: serverCertBundleFile,
 					KeyFile:  serverKeyFile,
 				},
 			},
-			SNICerts: namedCertKeys,
+			SNICertKeys: namedCertKeys,
+		}, "1.2.3.4")
+		if err != nil {
+			t.Errorf("%d - failed applying the SecureServingOptions: %v", i, err)
+			continue NextTest
 		}
 		config.InsecureServingInfo = nil
 
@@ -436,27 +412,18 @@ NextTest:
 			continue NextTest
 		}
 
+		// patch in a 0-port to enable auto port allocation
+		s.SecureServingInfo.BindAddress = "127.0.0.1:0"
+
 		if err := s.serveSecurely(stopCh); err != nil {
 			t.Errorf("%d - failed running the server: %v", i, err)
 			continue NextTest
 		}
 
-		// load certificates into a pool
+		// load ca certificates into a pool
 		roots := x509.NewCertPool()
-		certFiles := []string{serverCertFile}
-		for _, c := range namedCertKeys {
-			certFiles = append(certFiles, c.CertFile)
-		}
-		for _, certFile := range certFiles {
-			bs, err := ioutil.ReadFile(certFile)
-			if err != nil {
-				t.Errorf("%d - error reading %q: %v", i, certFile, err)
-				continue NextTest
-			}
-			if ok := roots.AppendCertsFromPEM(bs); !ok {
-				t.Errorf("%d - error adding cert %q to the pool", i, certFile)
-				continue NextTest
-			}
+		for _, caCert := range caCerts {
+			roots.AddCert(caCert)
 		}
 
 		// try to dial
@@ -485,6 +452,77 @@ NextTest:
 	}
 }
 
+func parseIPList(ips []string) []net.IP {
+	var netIPs []net.IP
+	for _, ip := range ips {
+		netIPs = append(netIPs, net.ParseIP(ip))
+	}
+	return netIPs
+}
+
+func createTestTLSCerts(spec TestCertSpec) (tlsCert tls.Certificate, err error) {
+	certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
+	if err != nil {
+		return tlsCert, err
+	}
+
+	tlsCert, err = tls.X509KeyPair(certPem, keyPem)
+	return tlsCert, err
+}
+
+func createTestCertFiles(dir string, spec TestCertSpec) (certFilePath, keyFilePath string, err error) {
+	certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
+	if err != nil {
+		return "", "", err
+	}
+
+	certFile, err := ioutil.TempFile(dir, "cert")
+	if err != nil {
+		return "", "", err
+	}
+
+	keyFile, err := ioutil.TempFile(dir, "key")
+	if err != nil {
+		return "", "", err
+	}
+
+	_, err = certFile.Write(certPem)
+	if err != nil {
+		return "", "", err
+	}
+	certFile.Close()
+
+	_, err = keyFile.Write(keyPem)
+	if err != nil {
+		return "", "", err
+	}
+	keyFile.Close()
+
+	return certFile.Name(), keyFile.Name(), nil
+}
+
+func caCertFromBundle(bundlePath string) (*x509.Certificate, error) {
+	pemData, err := ioutil.ReadFile(bundlePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch last block
+	var block *pem.Block
+	for {
+		var nextBlock *pem.Block
+		nextBlock, pemData = pem.Decode(pemData)
+		if nextBlock == nil {
+			if block == nil {
+				return nil, fmt.Errorf("no certificate found in %q", bundlePath)
+
+			}
+			return x509.ParseCertificate(block.Bytes)
+		}
+		block = nextBlock
+	}
+}
+
 func x509CertSignature(cert *x509.Certificate) string {
 	return base64.StdEncoding.EncodeToString(cert.Signature)
 }
@@ -494,13 +532,13 @@ func certFileSignature(certFile, keyFile string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return certSignature(cert)
+}
 
+func certSignature(cert tls.Certificate) (string, error) {
 	x509Certs, err := x509.ParseCertificates(cert.Certificate[0])
 	if err != nil {
 		return "", err
-	}
-	if len(x509Certs) == 0 {
-		return "", fmt.Errorf("expected at least one cert after reparsing cert %q", certFile)
 	}
 	return x509CertSignature(x509Certs[0]), nil
 }

--- a/pkg/genericapiserver/serve_test.go
+++ b/pkg/genericapiserver/serve_test.go
@@ -461,7 +461,7 @@ func parseIPList(ips []string) []net.IP {
 }
 
 func createTestTLSCerts(spec TestCertSpec) (tlsCert tls.Certificate, err error) {
-	certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
+	_, _, certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
 	if err != nil {
 		return tlsCert, err
 	}
@@ -471,7 +471,7 @@ func createTestTLSCerts(spec TestCertSpec) (tlsCert tls.Certificate, err error) 
 }
 
 func createTestCertFiles(dir string, spec TestCertSpec) (certFilePath, keyFilePath string, err error) {
-	certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
+	caCertPem, _, certPem, keyPem, err := utilcert.GenerateSelfSignedCertKey(spec.host, parseIPList(spec.ips), spec.names)
 	if err != nil {
 		return "", "", err
 	}
@@ -486,7 +486,7 @@ func createTestCertFiles(dir string, spec TestCertSpec) (certFilePath, keyFilePa
 		return "", "", err
 	}
 
-	_, err = certFile.Write(certPem)
+	_, err = certFile.Write(append(certPem, caCertPem...))
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/util/cert/BUILD
+++ b/pkg/util/cert/BUILD
@@ -22,6 +22,13 @@ go_library(
     deps = [
         "//pkg/apis/certificates:go_default_library",
         "//pkg/apis/certificates/v1alpha1:go_default_library",
+        "//vendor:github.com/cloudflare/cfssl/config",
+        "//vendor:github.com/cloudflare/cfssl/csr",
+        "//vendor:github.com/cloudflare/cfssl/helpers",
+        "//vendor:github.com/cloudflare/cfssl/initca",
+        "//vendor:github.com/cloudflare/cfssl/signer",
+        "//vendor:github.com/cloudflare/cfssl/signer/local",
+        "//vendor:github.com/golang/glog",
     ],
 )
 

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cert
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
@@ -30,6 +29,15 @@ import (
 	"math/big"
 	"net"
 	"time"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/initca"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+
+	"github.com/golang/glog"
 )
 
 const (
@@ -126,56 +134,84 @@ func MakeEllipticPrivateKeyPEM() ([]byte, error) {
 	return pem.EncodeToMemory(privateKeyPemBlock), nil
 }
 
-// GenerateSelfSignedCertKey creates a self-signed certificate and key for the given host.
-// Host may be an IP or a DNS name
-// You may also specify additional subject alt names (either ip or dns names) for the certificate
-func GenerateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS []string) ([]byte, []byte, error) {
-	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
+// GenerateSelfSignedCertKey creates a self-signed CA, a server key and certificate signed
+// with the CA. Host may be an IP or a DNS name. You may also specify additional subject
+// alt names (either ip or dns names) for the certificate.
+func GenerateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS []string) (caCertPem []byte, caKeyPem []byte, certPem []byte, keyPem []byte, err error) {
+	// create root CA
+	glog.Infof("Creating root certificate authority")
+	rootCAReq := csr.CertificateRequest{
+		CN: fmt.Sprintf("%s@ca-%d", host, time.Now().Unix()),
+		KeyRequest: &csr.BasicKeyRequest{
+			A: "rsa",
+			S: 2048,
 		},
-		NotBefore: time.Now(),
-		NotAfter:  time.Now().Add(time.Hour * 24 * 365),
-
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IsCA: true,
+		CA: &csr.CAConfig{
+			Expiry: fmt.Sprintf("%dh", 24*365*1),
+		},
 	}
-
-	if ip := net.ParseIP(host); ip != nil {
-		template.IPAddresses = append(template.IPAddresses, ip)
-	} else {
-		template.DNSNames = append(template.DNSNames, host)
-	}
-
-	template.IPAddresses = append(template.IPAddresses, alternateIPs...)
-	template.DNSNames = append(template.DNSNames, alternateDNS...)
-
-	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &priv.PublicKey, priv)
+	caCertPem, _, caKeyPem, err = initca.New(&rootCAReq)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, nil, fmt.Errorf("error creating root certificate authority: %v", err)
 	}
 
-	// Generate cert
-	certBuffer := bytes.Buffer{}
-	if err := pem.Encode(&certBuffer, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return nil, nil, err
+	// create key and csr
+	glog.Infof("Creating signing request for apiserver key")
+	hosts := []string{host}
+	for _, ip := range alternateIPs {
+		hosts = append(hosts, ip.String())
+	}
+	hosts = append(hosts, alternateDNS...)
+	req := csr.CertificateRequest{
+		CN: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
+		KeyRequest: &csr.BasicKeyRequest{
+			A: "rsa",
+			S: 2048,
+		},
+		CA: &csr.CAConfig{
+			Expiry: fmt.Sprintf("%dh", 24*365*1),
+		},
+		Hosts: hosts,
 	}
 
-	// Generate key
-	keyBuffer := bytes.Buffer{}
-	if err := pem.Encode(&keyBuffer, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
-		return nil, nil, err
+	glog.Infof("Creating apiserver key and certificate signing request")
+	gen := csr.Generator{
+		Validator: func(req *csr.CertificateRequest) error {
+			return nil
+		},
+	}
+	keyCSR, keyPem, err := gen.ProcessRequest(&req)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("error creating key and certificate signing request: %v", err)
 	}
 
-	return certBuffer.Bytes(), keyBuffer.Bytes(), nil
+	// sign key with root CA
+	caKey, err := helpers.ParsePrivateKeyPEM(caKeyPem)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to parse private certificate authority key: %v", err)
+	}
+	caCert, err := helpers.ParseCertificatePEM(caCertPem)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to parse root certificate authority certificate: %v", err)
+	}
+	glog.Infof("Signing apiserver certificate with root certificate authority")
+	policy := config.Signing{
+		Profiles: map[string]*config.SigningProfile{},
+		Default:  config.DefaultConfig(),
+	}
+	policy.Default.ExpiryString = fmt.Sprintf("%dh", 24*365*1)
+	s, err := local.NewSigner(caKey, caCert, signer.DefaultSigAlgo(caKey), &policy)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("error creating signer: %v", err)
+	}
+	certPem, err = s.Sign(signer.SignRequest{
+		Request: string(keyCSR),
+	})
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("error signing apiserver certificate: %v", err)
+	}
+
+	return caCertPem, caKeyPem, certPem, keyPem, nil
 }
 
 // FormatBytesCert receives byte array certificate and formats in human-readable format

--- a/pkg/util/cert/io.go
+++ b/pkg/util/cert/io.go
@@ -59,13 +59,17 @@ func canReadFile(path string) bool {
 	return true
 }
 
-// WriteCert writes the pem-encoded certificate data to certPath.
+// WriteCert writes the pem-encoded certificates to certPath.
 // The certificate file will be created with file mode 0644.
 // If the certificate file already exists, it will be overwritten.
 // The parent directory of the certPath will be created as needed with file mode 0755.
-func WriteCert(certPath string, data []byte) error {
+func WriteCert(certPath string, certs ...[]byte) error {
 	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
 		return err
+	}
+	data := make([]byte, 0)
+	for _, c := range certs {
+		data = append(data, c...)
 	}
 	if err := ioutil.WriteFile(certPath, data, os.FileMode(0644)); err != nil {
 		return err

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -11785,3 +11785,18 @@ go_library(
     tags = ["automanaged"],
     deps = ["//vendor:github.com/gogo/protobuf/proto"],
 )
+
+go_library(
+    name = "github.com/cloudflare/cfssl/initca",
+    srcs = ["github.com/cloudflare/cfssl/initca/initca.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/cloudflare/cfssl/config",
+        "//vendor:github.com/cloudflare/cfssl/csr",
+        "//vendor:github.com/cloudflare/cfssl/errors",
+        "//vendor:github.com/cloudflare/cfssl/helpers",
+        "//vendor:github.com/cloudflare/cfssl/log",
+        "//vendor:github.com/cloudflare/cfssl/signer",
+        "//vendor:github.com/cloudflare/cfssl/signer/local",
+    ],
+)

--- a/vendor/github.com/cloudflare/cfssl/initca/initca.go
+++ b/vendor/github.com/cloudflare/cfssl/initca/initca.go
@@ -1,0 +1,278 @@
+// Package initca contains code to initialise a certificate authority,
+// generating a new root key and certificate.
+package initca
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"net"
+	"time"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+)
+
+// validator contains the default validation logic for certificate
+// authority certificates. The only requirement here is that the
+// certificate have a non-empty subject field.
+func validator(req *csr.CertificateRequest) error {
+	if req.CN != "" {
+		return nil
+	}
+
+	if len(req.Names) == 0 {
+		return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing subject information"))
+	}
+
+	for i := range req.Names {
+		if csr.IsNameEmpty(req.Names[i]) {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing subject information"))
+		}
+	}
+
+	return nil
+}
+
+// New creates a new root certificate from the certificate request.
+func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			CAPolicy.Default.ExpiryString = req.CA.Expiry
+			CAPolicy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+		}
+
+		if req.CA.PathLength != 0 {
+			signer.MaxPathLen = req.CA.PathLength
+		}
+	}
+
+	g := &csr.Generator{Validator: validator}
+	csrPEM, key, err = g.ProcessRequest(req)
+	if err != nil {
+		log.Errorf("failed to process request: %v", err)
+		key = nil
+		return
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(key)
+	if err != nil {
+		log.Errorf("failed to parse private key: %v", err)
+		return
+	}
+
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), nil)
+	if err != nil {
+		log.Errorf("failed to create signer: %v", err)
+		return
+	}
+	s.SetPolicy(CAPolicy)
+
+	signReq := signer.SignRequest{Hosts: req.Hosts, Request: string(csrPEM)}
+	cert, err = s.Sign(signReq)
+
+	return
+
+}
+
+// NewFromPEM creates a new root certificate from the key file passed in.
+func NewFromPEM(req *csr.CertificateRequest, keyFile string) (cert, csrPEM []byte, err error) {
+	privData, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(privData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewFromSigner(req, priv)
+}
+
+// RenewFromPEM re-creates a root certificate from the CA cert and key
+// files. The resulting root certificate will have the input CA certificate
+// as the template and have the same expiry length. E.g. the exsiting CA
+// is valid for a year from Jan 01 2015 to Jan 01 2016, the renewed certificate
+// will be valid from now and expire in one year as well.
+func RenewFromPEM(caFile, keyFile string) ([]byte, error) {
+	caBytes, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ca, err := helpers.ParseCertificatePEM(caBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	keyBytes, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := helpers.ParsePrivateKeyPEM(keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return RenewFromSigner(ca, key)
+
+}
+
+// NewFromSigner creates a new root certificate from a crypto.Signer.
+func NewFromSigner(req *csr.CertificateRequest, priv crypto.Signer) (cert, csrPEM []byte, err error) {
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			CAPolicy.Default.ExpiryString = req.CA.Expiry
+			CAPolicy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if req.CA.PathLength != 0 {
+			signer.MaxPathLen = req.CA.PathLength
+		}
+	}
+
+	var sigAlgo x509.SignatureAlgorithm
+	switch pub := priv.Public().(type) {
+	case *rsa.PublicKey:
+		bitLength := pub.N.BitLen()
+		switch {
+		case bitLength >= 4096:
+			sigAlgo = x509.SHA512WithRSA
+		case bitLength >= 3072:
+			sigAlgo = x509.SHA384WithRSA
+		case bitLength >= 2048:
+			sigAlgo = x509.SHA256WithRSA
+		default:
+			sigAlgo = x509.SHA1WithRSA
+		}
+	case *ecdsa.PublicKey:
+		switch pub.Curve {
+		case elliptic.P521():
+			sigAlgo = x509.ECDSAWithSHA512
+		case elliptic.P384():
+			sigAlgo = x509.ECDSAWithSHA384
+		case elliptic.P256():
+			sigAlgo = x509.ECDSAWithSHA256
+		default:
+			sigAlgo = x509.ECDSAWithSHA1
+		}
+	default:
+		sigAlgo = x509.UnknownSignatureAlgorithm
+	}
+
+	var tpl = x509.CertificateRequest{
+		Subject:            req.Name(),
+		SignatureAlgorithm: sigAlgo,
+	}
+
+	for i := range req.Hosts {
+		if ip := net.ParseIP(req.Hosts[i]); ip != nil {
+			tpl.IPAddresses = append(tpl.IPAddresses, ip)
+		} else {
+			tpl.DNSNames = append(tpl.DNSNames, req.Hosts[i])
+		}
+	}
+
+	return signWithCSR(&tpl, priv)
+}
+
+// signWithCSR creates a new root certificate from signing a X509.CertificateRequest
+// by a crypto.Signer.
+func signWithCSR(tpl *x509.CertificateRequest, priv crypto.Signer) (cert, csrPEM []byte, err error) {
+	csrPEM, err = x509.CreateCertificateRequest(rand.Reader, tpl, priv)
+	if err != nil {
+		log.Errorf("failed to generate a CSR: %v", err)
+		// The use of CertificateError was a matter of some
+		// debate; it is the one edge case in which a new
+		// error category specifically for CSRs might be
+		// useful, but it was deemed that one edge case did
+		// not a new category justify.
+		err = cferr.Wrap(cferr.CertificateError, cferr.BadRequest, err)
+		return
+	}
+
+	p := &pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrPEM,
+	}
+	csrPEM = pem.EncodeToMemory(p)
+
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), nil)
+	if err != nil {
+		log.Errorf("failed to create signer: %v", err)
+		return
+	}
+	s.SetPolicy(CAPolicy)
+
+	signReq := signer.SignRequest{Request: string(csrPEM)}
+	cert, err = s.Sign(signReq)
+	return
+}
+
+// RenewFromSigner re-creates a root certificate from the CA cert and crypto.Signer.
+// The resulting root certificate will have ca certificate
+// as the template and have the same expiry length. E.g. the exsiting CA
+// is valid for a year from Jan 01 2015 to Jan 01 2016, the renewed certificate
+// will be valid from now and expire in one year as well.
+func RenewFromSigner(ca *x509.Certificate, priv crypto.Signer) ([]byte, error) {
+	if !ca.IsCA {
+		return nil, errors.New("input certificate is not a CA cert")
+	}
+
+	// matching certificate public key vs private key
+	switch {
+	case ca.PublicKeyAlgorithm == x509.RSA:
+
+		var rsaPublicKey *rsa.PublicKey
+		var ok bool
+		if rsaPublicKey, ok = priv.Public().(*rsa.PublicKey); !ok {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+		if ca.PublicKey.(*rsa.PublicKey).N.Cmp(rsaPublicKey.N) != 0 {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+	case ca.PublicKeyAlgorithm == x509.ECDSA:
+		var ecdsaPublicKey *ecdsa.PublicKey
+		var ok bool
+		if ecdsaPublicKey, ok = priv.Public().(*ecdsa.PublicKey); !ok {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+		if ca.PublicKey.(*ecdsa.PublicKey).X.Cmp(ecdsaPublicKey.X) != 0 {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+	default:
+		return nil, cferr.New(cferr.PrivateKeyError, cferr.NotRSAOrECC)
+	}
+
+	req := csr.ExtractCertificateRequest(ca)
+
+	cert, _, err := NewFromSigner(req, priv)
+	return cert, err
+
+}
+
+// CAPolicy contains the CA issuing policy as default policy.
+var CAPolicy = &config.Signing{
+	Default: &config.SigningProfile{
+		Usage:        []string{"cert sign", "crl sign"},
+		ExpiryString: "43800h",
+		Expiry:       5 * helpers.OneYear,
+		CA:           true,
+	},
+}


### PR DESCRIPTION
**Based on** https://github.com/kubernetes/kubernetes/pull/37830

- use cfssl to create apiserver self-signed certs with separate root-ca, appended to the actual cert in `apiserver.crt`
- ~~find root-ca for loopback client via `--tls-ca-file`, appended to the server cert or appended to a matching SNI cert~~ also part of https://github.com/kubernetes/kubernetes/pull/39022
- extract root-ca from `apiserver.crt` and write to kubeconfig in `local-cluster-up.sh`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35143)
<!-- Reviewable:end -->
