### PR TITLE
Remove reference from addon-manager dockerfile

### DIFF
--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -21,7 +21,6 @@ CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 RUN pip install pyyaml
 
 ADD kube-addons.sh /opt/
-ADD kube-addon-update.sh /opt/
 ADD namespace.yaml /opt/
 ADD kubectl /usr/local/bin/
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Removes a reference to nonexisting file in the dockerfile for the addon-manager

This file was deleted with #34513

cc @mikedanese @MrHohn 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35147)

<!-- Reviewable:end -->
