### PR TITLE
Add import restriction to clientset

### DIFF
--- a/pkg/client/clientset_generated/.import-restrictions
+++ b/pkg/client/clientset_generated/.import-restrictions
@@ -1,0 +1,11 @@
+{
+  "Rules": [
+    {
+      "SelectorRegexp": "k8s[.]io/kubernetes/pkg/client/unversioned",
+      "AllowedPrefixes": [
+        "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
This prevents clientset from import more packages in pkg/client/unversioned, because we want to deprecate pkg/client/unversioned.

cc @ingvagabund

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35148)

<!-- Reviewable:end -->
