### PR TITLE
Fixing flakes caused by petset tests.

### DIFF
--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -57,6 +57,10 @@ const (
 	// Should the test restart petset clusters?
 	// TODO: enable when we've productionzed bringup of pets in this e2e.
 	restartCluster = false
+
+	// Timeout for reads from databases running on pets.
+	readTimeout = 60 * time.Second
+
 )
 
 // Time: 25m, slow by design.
@@ -805,15 +809,20 @@ func ExpectNoError(err error) {
 }
 
 func pollReadWithTimeout(pet petTester, petNumber int, key, expectedVal string) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+	err := wait.PollImmediate(time.Second, readTimeout, func() (bool, error) {
 		val := pet.read(petNumber, key)
 		if val == "" {
 			return false, nil
 		} else if val != expectedVal {
-			return false, fmt.Errorf("Expected value %v, found %v", expectedVal, val)
+			return false, fmt.Errorf("expected value %v, found %v", expectedVal, val)
 		}
 		return true, nil
 	})
+
+	if err == wait.ErrWaitTimeout {
+		return fmt.Errorf("timed out when trying to read value for key %v from pet %d", key, petNumber)
+	}
+	return err
 }
 
 func isInitialized(pod api.Pod) bool {

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -202,8 +202,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 
@@ -223,8 +223,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 
@@ -244,8 +244,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 	})
@@ -802,6 +802,18 @@ func deleteAllPetSets(c *client.Client, ns string) {
 
 func ExpectNoError(err error) {
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func pollReadWithTimeout(pet petTester, petNumber int, key, expectedVal string) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		val := pet.read(petNumber, key)
+		if val == "" {
+			return false, nil
+		} else if val != expectedVal {
+			return false, fmt.Errorf("Expected value %v, found %v", expectedVal, val)
+		}
+		return true, nil
+	})
 }
 
 func isInitialized(pod api.Pod) bool {

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -60,7 +60,6 @@ const (
 
 	// Timeout for reads from databases running on pets.
 	readTimeout = 60 * time.Second
-
 )
 
 // Time: 25m, slow by design.


### PR DESCRIPTION
**What this PR does / why we need it**: We should wait till the key/value has been replicated to database slaves before trying to read from them.

**Which issue this PR fixes** Fixes https://github.com/kubernetes/kubernetes/issues/33904, https://github.com/kubernetes/kubernetes/issues/33895

``` release-note
Fixed flakes caused by petset tests.
```

cc @kubernetes/sig-apps

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35158)

<!-- Reviewable:end -->
