### PR TITLE
Only delete GKE clusters that exist

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -401,6 +401,8 @@ function test-teardown() {
 function kube-down() {
   echo "... in gke:kube-down()" >&2
   detect-project >&2
-  "${GCLOUD}" ${CMD_GROUP:-} container clusters delete --project="${PROJECT}" \
-    --zone="${ZONE}" "${CLUSTER_NAME}" --quiet
+  if "${GCLOUD}" ${CMD_GROUP:-} container clusters describe --project="${PROJECT}" --zone="${ZONE}" "${CLUSER_NAME}" --quiet &>/dev/null; then
+    "${GCLOUD}" ${CMD_GROUP:-} container clusters delete --project="${PROJECT}" \
+      --zone="${ZONE}" "${CLUSTER_NAME}" --quiet
+  fi
 }


### PR DESCRIPTION
This matches the gce pattern: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/util.sh#L1197

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35167)

<!-- Reviewable:end -->
