### PR TITLE
improve controller test debuggability

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/util/clock"
+	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/util/uuid"
@@ -273,7 +274,7 @@ func TestCreatePods(t *testing.T) {
 	}
 	if !api.Semantic.DeepDerivative(&expectedPod, actualPod) {
 		t.Logf("Body: %s", fakeHandler.RequestBody)
-		t.Errorf("Unexpected mismatch.  Expected\n %#v,\n Got:\n %#v", &expectedPod, actualPod)
+		t.Errorf("Unexpected mismatch: %s", diff.ObjectDiff(&expectedPod, actualPod))
 	}
 }
 
@@ -374,7 +375,7 @@ func TestSortingActivePods(t *testing.T) {
 		actual := getOrder(randomizedPods)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("expected %v, got %v", expected, actual)
+			t.Errorf("Unexpected mismatch: %s", diff.ObjectDiff(expected, actual))
 		}
 	}
 }

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/informers"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
+	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/util/uuid"
@@ -539,7 +540,7 @@ func TestWatchControllers(t *testing.T) {
 		}
 		rsSpec := *obj.(*extensions.ReplicaSet)
 		if !api.Semantic.DeepDerivative(rsSpec, testRSSpec) {
-			t.Errorf("Expected %#v, but got %#v", testRSSpec, rsSpec)
+			t.Errorf("Unexpected mismatch: %s", diff.ObjectDiff(testRSSpec, rsSpec))
 		}
 		close(received)
 		return nil
@@ -581,7 +582,7 @@ func TestWatchPods(t *testing.T) {
 		}
 		rsSpec := obj.(*extensions.ReplicaSet)
 		if !api.Semantic.DeepDerivative(rsSpec, testRSSpec) {
-			t.Errorf("\nExpected %#v,\nbut got %#v", testRSSpec, rsSpec)
+			t.Errorf("Unexpected mismatch: %s", diff.ObjectDiff(testRSSpec, rsSpec))
 		}
 		close(received)
 		return nil

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
+	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/util/uuid"
@@ -464,7 +465,7 @@ func TestWatchControllers(t *testing.T) {
 		}
 		controllerSpec := *obj.(*api.ReplicationController)
 		if !api.Semantic.DeepDerivative(controllerSpec, testControllerSpec) {
-			t.Errorf("Expected %#v, but got %#v", testControllerSpec, controllerSpec)
+			t.Errorf("Unexpected mismatch: %s", diff.ObjectDiff(testControllerSpec, controllerSpec))
 		}
 		close(received)
 		return nil
@@ -507,7 +508,7 @@ func TestWatchPods(t *testing.T) {
 		}
 		controllerSpec := obj.(*api.ReplicationController)
 		if !api.Semantic.DeepDerivative(controllerSpec, testControllerSpec) {
-			t.Errorf("\nExpected %#v,\nbut got %#v", testControllerSpec, controllerSpec)
+			t.Errorf("UnExpected mismatch: %s", diff.ObjectDiff(testControllerSpec, controllerSpec))
 		}
 		close(received)
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

use `diff.ObjectDiff(a, b)` output two objects difference to improve `controller_utils_test.go` debuggablity.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35170)

<!-- Reviewable:end -->
