### PR TITLE
Fixed gcloud command in logs-generator makefile

### DIFF
--- a/test/images/logs-generator/Makefile
+++ b/test/images/logs-generator/Makefile
@@ -26,7 +26,7 @@ container:
 	docker build -t $(PREFIX)/logs-generator:$(TAG) .
 
 push:
-	gcloud docker push $(PREFIX)/logs-generator:$(TAG)
+	gcloud docker -- push $(PREFIX)/logs-generator:$(TAG)
 
 clean:
 	rm -f logs-generator


### PR DESCRIPTION
I grepped through the code looking for `gcloud` and `push` commands and only found one Makefile missing the `--`. I added it.

fixes #33765 :bug:

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35175)

<!-- Reviewable:end -->
