### PR TITLE
kubectl: commas in --from-literal on secret creation

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -85,7 +85,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, cmdOut io.Writer) *cobra.Comma
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.SecretV1GeneratorName)
 	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
-	cmd.Flags().StringSlice("from-literal", []string{}, "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)")
+	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)")
 	cmd.Flags().String("type", "", "The type of secret to create")
 	return cmd
 }
@@ -103,7 +103,7 @@ func CreateSecretGeneric(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command
 			Name:           name,
 			Type:           cmdutil.GetFlagString(cmd, "type"),
 			FileSources:    cmdutil.GetFlagStringSlice(cmd, "from-file"),
-			LiteralSources: cmdutil.GetFlagStringSlice(cmd, "from-literal"),
+			LiteralSources: cmdutil.GetFlagStringArray(cmd, "from-literal"),
 		}
 	default:
 		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not supported.", generatorName))

--- a/pkg/kubectl/cmd/create_secret_test.go
+++ b/pkg/kubectl/cmd/create_secret_test.go
@@ -27,7 +27,12 @@ import (
 )
 
 func TestCreateSecretGeneric(t *testing.T) {
-	secretObject := &api.Secret{}
+	secretObject := &api.Secret{
+		Data: map[string][]byte{
+			"password": []byte("includes,comma"),
+			"username": []byte("test_user"),
+		},
+	}
 	secretObject.Name = "my-secret"
 	f, tf, codec, ns := cmdtesting.NewAPIFactory()
 	tf.Printer = &testPrinter{}
@@ -47,6 +52,8 @@ func TestCreateSecretGeneric(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateSecretGeneric(f, buf)
 	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("from-literal", "password=includes,comma")
+	cmd.Flags().Set("from-literal", "username=test_user")
 	cmd.Run(cmd, []string{secretObject.Name})
 	expectedOutput := "secret/" + secretObject.Name + "\n"
 	if buf.String() != expectedOutput {


### PR DESCRIPTION
Closes #35185

``` release-note
Fixes an issue where commas were not accepted in --from-literal flags when creating secrets. Passing multiple values separated by a comma in a single --from-literal flag is no longer supported. Please use multiple --from-literal flags to provide multiple values.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35191)

<!-- Reviewable:end -->
