### PR TITLE
[WIP] Add label selector to 'kubectl patch'

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -898,6 +898,22 @@ __EOF__
   # Post-condition: no PODs exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 
+  ## kubectl patch -f with label selector should only apply matching objects
+  # Pre-Condition: no POD exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # create
+  kubectl create -f hack/testdata/filter/pod-apply-selector.yaml "${kube_flags[@]}"
+  # check pod exists
+  kube::test::get_object_assert 'pods selector-test-pod' "{{${labels_field}.name}}" 'selector-test-pod'
+  # patch non-matching
+  output_message=$(! kubectl patch -l unique-label=foo -f hack/testdata/filter/pod-apply-selector.yaml -p '{"metadata":{"labels":{"a":"b"}}}' 2>&1 "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'no objects passed to patch'
+  # patch matching
+  output_message=$(! kubectl patch -l unique-label=bingbang -f hack/testdata/filter/pod-apply-selector.yaml -p '{"metadata":{"labels":{"a":"b"}}}' 2>&1 "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'patched'
+  # cleanup
+  kubectl delete pods selector-test-pod
+
   ## kubectl apply should update configuration annotations only if apply is already called
   ## 1. kubectl create doesn't set the annotation
   # Pre-Condition: no POD exists

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -41,9 +41,8 @@ var patchTypes = map[string]api.PatchType{"json": api.JSONPatchType, "merge": ap
 // referencing the cmd.Flags()
 type PatchOptions struct {
 	resource.FilenameOptions
-
-	Local bool
-
+	Selector     string
+	Local        bool
 	OutputFormat string
 }
 
@@ -99,6 +98,8 @@ func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringP("patch", "p", "", "The patch to be applied to the resource JSON file.")
 	cmd.MarkFlagRequired("patch")
 	cmd.Flags().String("type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
+	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on")
+	cmd.Flags().Bool("all", false, "[--all] to select all the specified resources.")
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -146,6 +147,8 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
+		SelectorParam(options.Selector).
+		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()
@@ -155,6 +158,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 	}
 
 	count := 0
+
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
This patch add support of -l/--selector and --all flags
to 'kubectl patch'. The former adds filtering by label selectors.
The latter allows 'kubectl patch pods --all p <patch>'.
#32544

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35193)

<!-- Reviewable:end -->
