### PR TITLE
e2e: Treat tainted nodes as unschedulable

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2350,15 +2350,27 @@ func waitListSchedulableNodesOrDie(c clientset.Interface) *api.NodeList {
 	return nodes
 }
 
+// isNodeTainted checks if a node is tainted and thus not schedulable to pods (without a toleration)
+func isNodeTainted(node *api.Node) bool {
+	nodeTaints, err := api.GetTaintsFromNodeAnnotations(node.Annotations)
+	if err != nil {
+		Failf("error getting taints: %v", err)
+	}
+
+	return len(nodeTaints) > 0
+}
+
 // Node is schedulable if:
 // 1) doesn't have "unschedulable" field set
 // 2) it's Ready condition is set to true
 // 3) doesn't have NetworkUnavailable condition set to true
+// 4) it isn't tainted
 func isNodeSchedulable(node *api.Node) bool {
 	nodeReady := IsNodeConditionSetAsExpected(node, api.NodeReady, true)
+	isTainted := isNodeTainted(node)
 	networkReady := IsNodeConditionUnset(node, api.NodeNetworkUnavailable) ||
 		IsNodeConditionSetAsExpectedSilent(node, api.NodeNetworkUnavailable, false)
-	return !node.Spec.Unschedulable && nodeReady && networkReady
+	return !node.Spec.Unschedulable && nodeReady && networkReady && !isTainted
 }
 
 // GetReadySchedulableNodesOrDie addresses the common use case of getting nodes you can do work on.


### PR DESCRIPTION
We are moving towards deprecating the unschedulable flags, and replacing
it with a taint.  Our e2e tests need to look for taints as well now,
where they were previously just considering unschedulable, otherwise
they break on clusters that mark the master as schedulable but tainted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35210)

<!-- Reviewable:end -->
