### PR TITLE
cluster-addons: enable Jemalloc for Fluentd based images

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -38,5 +38,7 @@ COPY td-agent.conf /etc/td-agent/td-agent.conf
 COPY build.sh /tmp/build.sh
 RUN /tmp/build.sh
 
+ENV LD_PRELOAD /opt/td-agent/embedded/lib/libjemalloc.so
+
 # Run the Fluentd service.
 ENTRYPOINT ["td-agent"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pull Request includes two patches that enable the recommended use of Jemalloc memory allocator for container images that are based in Fluentd. The patches applies to the following cluster-addons:
- fluentd-es-image
- fluentd-gcp-image

**Which issue this PR fixes** 

This PR is part of the solution for issues:
-  kubernetes/kubernetes/issues/32762
-  GoogleCloudPlatform/fluent-plugin-google-cloud/issues/87

When Fluentd runs in high load environments, it's likely the default operating system memory allocator will generate a high fragmentation ending up in a high memory usage. In order to reduce fragmentation and decrease memory usage an alternative memory allocator as Jemalloc is used. 

![](https://cloud.githubusercontent.com/assets/369718/19498577/eaa9f324-954e-11e6-9a6b-6b30310a66a3.png)

For the record: fluentd-es-image uses [td-agent](https://docs.treasuredata.com/articles/td-agent) Fluentd package maintained by Treasure Data, which contains Jemalloc 4.2.1 (latest stable version). The google-fluentd package used in fluentd-gcp-image comes with Jemalloc 2.2.5, which have many known issues, I strongly suggest google-fluentd package gets updated.

**Special notes for your reviewer**:

In the research of this topic have been involved @piosz and @Crassirostris.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35216)

<!-- Reviewable:end -->
