### PR TITLE
Revert "Only delete GKE clusters that exist"

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -401,8 +401,6 @@ function test-teardown() {
 function kube-down() {
   echo "... in gke:kube-down()" >&2
   detect-project >&2
-  if "${GCLOUD}" ${CMD_GROUP:-} container clusters describe --project="${PROJECT}" --zone="${ZONE}" "${CLUSER_NAME}" --quiet &>/dev/null; then
-    "${GCLOUD}" ${CMD_GROUP:-} container clusters delete --project="${PROJECT}" \
-      --zone="${ZONE}" "${CLUSTER_NAME}" --quiet
-  fi
+  "${GCLOUD}" ${CMD_GROUP:-} container clusters delete --project="${PROJECT}" \
+    --zone="${ZONE}" "${CLUSTER_NAME}" --quiet
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#35167

Broke GKE e2e

``` console
./hack/e2e-internal/../../cluster/../cluster/gke/../../cluster/../cluster/../cluster/../cluster/gke/util.sh: line 404: CLUSER_NAME: unbound variable
ERROR: (gcloud.compute.networks.delete) Some requests did not succeed:
 - The network resource 'jenkins-e2e' is already being used by 'gke-jenkins-e2e-6715dfb8-vms'
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35217)

<!-- Reviewable:end -->
