### PR TITLE
Update kubectl in addon-manager to v1.5.0-alpha.1

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -16,25 +16,22 @@ IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 VERSION=v5.1
+KUBECTL_VERSION?=v1.5.0-alpha.1
 
 # amd64 and arm has "stable" binaries pushed for v1.2, arm64 and ppc64le hasn't so they have to fetch the latest alpha
 # however, arm64 and ppc64le are very experimental right now, so it's okay
 ifeq ($(ARCH),amd64)
-	KUBECTL_VERSION?=v1.3.0-beta.2
 	BASEIMAGE?=python:2.7-slim
 endif
 ifeq ($(ARCH),arm)
-	KUBECTL_VERSION?=v1.3.0-beta.2
 	BASEIMAGE?=hypriot/rpi-python:2.7
 	QEMUARCH=arm
 endif
 ifeq ($(ARCH),arm64)
-	KUBECTL_VERSION?=v1.3.0-beta.2
 	BASEIMAGE?=aarch64/python:2.7-slim
 	QEMUARCH=aarch64
 endif
 ifeq ($(ARCH),ppc64le)
-	KUBECTL_VERSION?=v1.3.0-beta.2
 	BASEIMAGE?=ppc64le/python:2.7-slim
 	QEMUARCH=ppc64le
 endif


### PR DESCRIPTION
This updates the kubectl version that is vendored into the addon-manager image

`kubectl apply --prune` is currently only implemented in v1.5.0-alpha.1 https://github.com/kubernetes/kubernetes/commit/ea5ecc414510320ac07437702f314bda012f55f6

The kube-addon-manager script will fail on kubectl versions that don't have this flag
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/kube-addons.sh#L154

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35219)

<!-- Reviewable:end -->
