### PR TITLE
Implement --prune-whitelist(-w) flag to overwrite default whitelist for --prune

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1138,6 +1138,24 @@ __EOF__
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   kubectl delete pvc b-pvc 2>&1 "${kube_flags[@]}"
 
+  ## kubectl apply --prune --prune-whitelist(-w)
+  # Pre-Condition: no POD exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # apply pod a
+  kubectl apply --prune -l prune-group=true -f hack/testdata/prune/a.yaml "${kube_flags[@]}"
+  # check right pod exists
+  kube::test::get_object_assert 'pods a' "{{${id_field}}}" 'a'
+  # apply svc and don't prune pod a by overwriting whitelist
+  kubectl apply --prune -l prune-group=true -f hack/testdata/prune/svc.yaml -w core/v1/Service 2>&1 "${kube_flags[@]}"
+  kube::test::get_object_assert 'service prune-svc' "{{${id_field}}}" 'prune-svc'
+  kube::test::get_object_assert 'pods a' "{{${id_field}}}" 'a'
+  # apply svc and prune pod a with default whitelist
+  kubectl apply --prune -l prune-group=true -f hack/testdata/prune/svc.yaml 2>&1 "${kube_flags[@]}"
+  kube::test::get_object_assert 'service prune-svc' "{{${id_field}}}" 'prune-svc'
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # cleanup
+  kubectl delete svc prune-svc 2>&1 "${kube_flags[@]}"
+
   ## kubectl run should create deployments or jobs
   # Pre-Condition: no Job exists
   kube::test::get_object_assert jobs "{{range.items}}{{$id_field}}:{{end}}" ''

--- a/hack/testdata/prune/svc.yaml
+++ b/hack/testdata/prune/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prune-svc
+  labels:
+    prune-group: "true"
+spec:
+  selector:
+    prune-group-nomatch: "true"
+  ports:
+  - port: 80
+    protocol: TCP


### PR DESCRIPTION
From kubernetes/kubectl#1854.

Updates:

As suggested, the new commits implement a default whitelist for `kubectl apply --prune`, which could be overwritten by using `--prune-whitelist`or `-w` flag. The default whitelist and example as below.

Also supports `--dry-run` for `--prune` to fix kubernetes/kubernetes#35222.

whitelist:

```
type pruneResource struct {
    group      string
    version    string
    kind       string
    namespaced bool
}

*pruneResources = []pruneResource{
    {"", "v1", "ConfigMap", true},
    {"", "v1", "Endpoints", true},
    {"", "v1", "Namespace", false},
    {"", "v1", "PersistentVolumeClaim", true},
    {"", "v1", "PersistentVolume", false},
    {"", "v1", "Pod", true},
    {"", "v1", "ReplicationController", true},
    {"", "v1", "Secret", true},
    {"", "v1", "Service", true},
    {"batch", "v1", "Job", true},
    {"extensions", "v1beta1", "DaemonSet", true},
    {"extensions", "v1beta1", "Deployment", true},
    {"extensions", "v1beta1", "HorizontalPodAutoscaler", true},
    {"extensions", "v1beta1", "Ingress", true},
    {"extensions", "v1beta1", "ReplicaSet", true},
    {"apps", "v1beta1", "StatefulSet", true},
}
```

example:

```
$ kubectl apply -f /path/to/file --prune -l test=true \
      -w core/v1/Pod \
      -w core/v1/Service \
      -w extensions/v1beta1/Deployment 
```

@mikedanese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35220)

<!-- Reviewable:end -->
