### PR TITLE
use LC_ALL=C on all sort commands

### DIFF
--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -205,7 +205,7 @@ endif
 DEEPCOPY_DIRS := $(shell                                             \
     grep --color=never -l '+k8s:deepcopy-gen=' $(ALL_K8S_TAG_FILES)  \
         | xargs -n1 dirname                                          \
-        | sort -u                                                    \
+        | LC_ALL=C sort -u                                           \
 )
 DEEPCOPY_FILES := $(addsuffix /$(DEEPCOPY_FILENAME), $(DEEPCOPY_DIRS))
 
@@ -318,7 +318,7 @@ endif
 DEFAULTER_DIRS := $(shell                                            \
     grep --color=never -l '+k8s:defaulter-gen=' $(ALL_K8S_TAG_FILES) \
         | xargs -n1 dirname                                          \
-        | sort -u                                                    \
+        | LC_ALL=C sort -u                                           \
 )
 
 DEFAULTER_FILES := $(addsuffix /$(DEFAULTER_FILENAME), $(DEFAULTER_DIRS))
@@ -448,7 +448,7 @@ endif
 OPENAPI_DIRS := $(shell                                             \
     grep --color=never -l '+k8s:openapi-gen=' $(ALL_K8S_TAG_FILES)  \
         | xargs -n1 dirname                                         \
-        | sort -u                                                   \
+        | LC_ALL=C sort -u                                          \
 )
 
 OPENAPI_OUTFILE := $(OPENAPI_OUTPUT_PKG)/$(OPENAPI_FILENAME)
@@ -555,7 +555,7 @@ CONVERSION_DIRS := $(shell                                              \
     grep --color=never '^// *+k8s:conversion-gen=' $(ALL_K8S_TAG_FILES) \
         | cut -f1 -d:                                                   \
         | xargs -n1 dirname                                             \
-        | sort -u                                                       \
+        | LC_ALL=C sort -u                                              \
 )
 
 CONVERSION_FILES := $(addsuffix /$(CONVERSION_FILENAME), $(CONVERSION_DIRS))

--- a/hack/grab-profiles.sh
+++ b/hack/grab-profiles.sh
@@ -249,9 +249,9 @@ SSH_PID=$(pgrep -f "/usr/bin/ssh.*${tunnel_port}:localhost:8080")
 kube::util::trap_add 'kill $SSH_PID' EXIT
 kube::util::trap_add 'kill $SSH_PID' SIGTERM
 
-requested_profiles=$(echo ${requested_profiles} | xargs -n1 | sort -u | xargs)
-profile_components=$(echo ${profile_components} | xargs -n1 | sort -u | xargs)
-kubelet_addreses=$(echo ${kubelet_addreses} | xargs -n1 | sort -u | xargs)
+requested_profiles=$(echo ${requested_profiles} | xargs -n1 | LC_ALL=C sort -u | xargs)
+profile_components=$(echo ${profile_components} | xargs -n1 | LC_ALL=C sort -u | xargs)
+kubelet_addreses=$(echo ${kubelet_addreses} | xargs -n1 | LC_ALL=C sort -u | xargs)
 echo "requested profiles: ${requested_profiles}"
 echo "flags for heap profile: ${mem_pprof_flags}"
 

--- a/hack/list-feature-tests.sh
+++ b/hack/list-feature-tests.sh
@@ -20,4 +20,4 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-grep "\[Feature:\w+\]" "${KUBE_ROOT}"/test/e2e/*.go -Poh | sort | uniq
+grep "\[Feature:\w+\]" "${KUBE_ROOT}"/test/e2e/*.go -Poh | LC_ALL=C sort -u

--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -61,7 +61,7 @@ mkdir -p $(dirname "${CACHE}")
 if $("${NEED_FIND}"); then
     kfind -type f -name \*.go  \
         | xargs -n1 dirname    \
-        | sort -u              \
+        | LC_ALL=C sort -u     \
         | sed 's|^./||'        \
         > "${CACHE}"
 fi

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -43,8 +43,7 @@ kube::test::find_integration_test_dirs() {
     cd ${KUBE_ROOT}
     find test/integration/${1-} -name '*_test.go' -print0 \
       | xargs -0n1 dirname \
-      | uniq \
-      | sort -u
+      | LC_ALL=C sort -u
   )
 }
 

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -47,12 +47,12 @@ kube::test::find_dirs() {
           -o -path './staging/*' \
           -o -path './vendor/*' \
         \) -prune \
-      \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
+      \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | LC_ALL=C sort -u
 
     find -L . \
         -path './_output' -prune \
         -o -path './vendor/k8s.io/client-go/*' \
-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
+      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | LC_ALL=C sort -u
   )
 }
 

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -38,7 +38,7 @@ generated_files=($(
         -o -wholename '*/vendor/*' \
         -o -wholename '*/codecgen-*-1234.generated.go' \
       \) -prune \
-    \) -name '*.generated.go' | sort -r))
+    \) -name '*.generated.go' | LC_ALL=C sort -r))
 
 # We only work for deps within this prefix.
 my_prefix="k8s.io/kubernetes"
@@ -67,7 +67,7 @@ for (( i=0; i<number; i++ )); do
   deps[${i}]=$(go list -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}' ${file} | grep "^${my_prefix}")
 done
 ###echo "DBG: found $number generated files"
-###for f in $(echo "${generated_files[@]}" | sort); do
+###for f in $(echo "${generated_files[@]}" | LC_ALL=C sort); do
 ###    echo "DBG:   $f"
 ###done
 

--- a/hack/verify-test-images.sh
+++ b/hack/verify-test-images.sh
@@ -25,13 +25,13 @@ result=0
 
 # Find mentions of untagged gcr.io images in test/e2e/*.go 
 find_e2e_test_untagged_gcr_images() {
-    grep -o -E -e 'gcr.io/[-a-z0-9/_:.]+' test/e2e/*.go | grep -v -E "gcr.io/.*:" | cut -d ":" -f 1 | sort | uniq
+    grep -o -E -e 'gcr.io/[-a-z0-9/_:.]+' test/e2e/*.go | grep -v -E "gcr.io/.*:" | cut -d ":" -f 1 | LC_ALL=C sort -u
 }
 
 
 # Find mentions of latest gcr.io images in test/e2e/*.go 
 find_e2e_test_latest_gcr_images() {
-    grep -o -E -e 'gcr.io/.*:latest' test/e2e/*.go | cut -d ":" -f 1 | sort | uniq
+    grep -o -E -e 'gcr.io/.*:latest' test/e2e/*.go | cut -d ":" -f 1 | LC_ALL=C sort -u
 }
 
 if find_e2e_test_latest_gcr_images; then


### PR DESCRIPTION
Most of these don't matter, but this makes it predicable no matter who runs the commands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35221)

<!-- Reviewable:end -->
