### PR TITLE
add generic shared informer backed by existing informer

### DIFF
--- a/pkg/controller/informers/factory.go
+++ b/pkg/controller/informers/factory.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
@@ -31,9 +32,14 @@ type SharedInformerFactory interface {
 	// Start starts informers that can start AFTER the API server and controllers have started
 	Start(stopCh <-chan struct{})
 
+	ForResource(unversioned.GroupResource) (GenericInformer, error)
+
+	// when you update these, update generic.go/ForResource, same package
+
 	Pods() PodInformer
-	Nodes() NodeInformer
+	LimitRanges() LimitRangeInformer
 	Namespaces() NamespaceInformer
+	Nodes() NodeInformer
 	PersistentVolumeClaims() PVCInformer
 	PersistentVolumes() PVInformer
 	ServiceAccounts() ServiceAccountInformer
@@ -42,12 +48,10 @@ type SharedInformerFactory interface {
 	Deployments() DeploymentInformer
 	ReplicaSets() ReplicaSetInformer
 
-	ClusterRoles() ClusterRoleInformer
 	ClusterRoleBindings() ClusterRoleBindingInformer
-	Roles() RoleInformer
+	ClusterRoles() ClusterRoleInformer
 	RoleBindings() RoleBindingInformer
-
-	LimitRanges() LimitRangeInformer
+	Roles() RoleInformer
 
 	StorageClasses() StorageClassInformer
 }

--- a/pkg/controller/informers/generic.go
+++ b/pkg/controller/informers/generic.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/client/cache"
+)
+
+// GenericInformer is type of SharedIndexInformer which will locate and delegate to other
+// sharedInformers based on type
+type GenericInformer interface {
+	Informer() cache.SharedIndexInformer
+	Lister() cache.GenericLister
+}
+
+// ForResource gives generic access to a shared informer of the matching type
+// TODO extend this to unknown resources with a client pool
+func (f *sharedInformerFactory) ForResource(resource unversioned.GroupResource) (GenericInformer, error) {
+	switch resource {
+	case api.Resource("pods"):
+		return &genericInformer{resource: resource, informer: f.Pods().Informer()}, nil
+	case api.Resource("limitranges"):
+		return &genericInformer{resource: resource, informer: f.LimitRanges().Informer()}, nil
+	case api.Resource("namespaces"):
+		return &genericInformer{resource: resource, informer: f.Namespaces().Informer()}, nil
+	case api.Resource("nodes"):
+		return &genericInformer{resource: resource, informer: f.Nodes().Informer()}, nil
+	case api.Resource("persistentvolumeclaims"):
+		return &genericInformer{resource: resource, informer: f.PersistentVolumeClaims().Informer()}, nil
+	case api.Resource("persistentvolumes"):
+		return &genericInformer{resource: resource, informer: f.PersistentVolumes().Informer()}, nil
+	case api.Resource("serviceaccounts"):
+		return &genericInformer{resource: resource, informer: f.ServiceAccounts().Informer()}, nil
+
+	case extensions.Resource("daemonsets"):
+		return &genericInformer{resource: resource, informer: f.DaemonSets().Informer()}, nil
+	case extensions.Resource("deployments"):
+		return &genericInformer{resource: resource, informer: f.Deployments().Informer()}, nil
+	case extensions.Resource("replicasets"):
+		return &genericInformer{resource: resource, informer: f.ReplicaSets().Informer()}, nil
+
+	case rbac.Resource("clusterrolebindings"):
+		return &genericInformer{resource: resource, informer: f.ClusterRoleBindings().Informer()}, nil
+	case rbac.Resource("clusterroles"):
+		return &genericInformer{resource: resource, informer: f.ClusterRoles().Informer()}, nil
+	case rbac.Resource("rolebindings"):
+		return &genericInformer{resource: resource, informer: f.RoleBindings().Informer()}, nil
+	case rbac.Resource("roles"):
+		return &genericInformer{resource: resource, informer: f.Roles().Informer()}, nil
+	}
+
+	return nil, fmt.Errorf("no informer found for %v", resource)
+}
+
+type genericInformer struct {
+	informer cache.SharedIndexInformer
+	resource unversioned.GroupResource
+}
+
+func (f *genericInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+
+func (f *genericInformer) Lister() cache.GenericLister {
+	return cache.NewGenericLister(f.Informer().GetIndexer(), f.resource)
+}


### PR DESCRIPTION
Adds the ability to get an informer and lister that returns `[]runtime.Object` methods with the "normal" filtering capabilities based on a `GroupResource`. Right now, it only works on known types (and re-uses those caches for efficiency by having a different skin on the `Index`).  It should be extended in the future.

@derekwaynecarr I think this gives you the types you were looking for to avoid the ugly array copies.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35227)

<!-- Reviewable:end -->
