### PR TITLE
Return an empty network namespace path for exited infra containers

### DIFF
--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -213,6 +213,12 @@ func getSandboxSecurityOpts(sandboxConfig *runtimeApi.PodSandboxConfig, seccompP
 }
 
 func getNetworkNamespace(c *dockertypes.ContainerJSON) string {
+	if c.State.Pid == 0 {
+		// Docker reports pid 0 for an exited container. We can't use it to
+		// check the network namespace, so return an empty string instead.
+		glog.V(4).Infof("Cannot find network namespace for the terminated container %q", c.ID)
+		return ""
+	}
 	return fmt.Sprintf(dockerNetNSFmt, c.State.Pid)
 }
 

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -2531,6 +2531,13 @@ func (dm *DockerManager) GetNetNS(containerID kubecontainer.ContainerID) (string
 		glog.Errorf("Error inspecting container: '%v'", err)
 		return "", err
 	}
+	if inspectResult.State.Pid == 0 {
+		// Docker reports pid 0 for an exited container. We can't use it to
+		// check the network namespace, so return an empty string instead.
+		glog.V(4).Infof("Cannot find network namespace for the terminated container %q", containerID.ID)
+		return "", nil
+	}
+
 	netnsPath := fmt.Sprintf(DockerNetnsFmt, inspectResult.State.Pid)
 	return netnsPath, nil
 }


### PR DESCRIPTION
If the infra container has already terminated, `docker inspect` will report
pid 0. The path constructed using the pid to check the network namespace of
the process will be invalid. This commit changes docker to report an empty
path to stop kubenet from erroring out whenever TearDown is called on an
exited infra container.

This is not a fix for all the plugins, as some plugins may require the actual
network namespace to tear down properly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35240)

<!-- Reviewable:end -->
