### PR TITLE
Fixing a typo in federated secrets test

### DIFF
--- a/test/e2e/federated-secret.go
+++ b/test/e2e/federated-secret.go
@@ -38,7 +38,7 @@ const (
 )
 
 // Create/delete secret api objects
-var _ = framework.KubeDescribe("Federation secrets [Feature:Federation12]", func() {
+var _ = framework.KubeDescribe("Federation secrets [Feature:Federation]", func() {
 	var clusters map[string]*cluster // All clusters, keyed by cluster name
 
 	f := framework.NewDefaultFederatedFramework("federated-secret")


### PR DESCRIPTION
Realized that our secret e2e test was not running due to a typo in my last PR :)

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35241)

<!-- Reviewable:end -->
