### PR TITLE
kubelet: Refactor kuberuntime.SyncPod(), part 1.

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -183,7 +183,7 @@ type Pod struct {
 	// List of sandboxes associated with this pod. The sandboxes are converted
 	// to Container temporariliy to avoid substantial changes to other
 	// components. This is only populated by kuberuntime.
-	// TODO: use the runtimeApi.PodSandbox type directly.
+	// TODO: use the runtimeapi.PodSandbox type directly.
 	Sandboxes []*Container
 }
 

--- a/pkg/kubelet/container/sync_result.go
+++ b/pkg/kubelet/container/sync_result.go
@@ -42,6 +42,7 @@ var (
 	ErrCreatePodSandbox = errors.New("CreatePodSandboxError")
 	ErrConfigPodSandbox = errors.New("ConfigPodSandboxError")
 	ErrKillPodSandbox   = errors.New("KillPodSandboxError")
+	ErrRemoveContainer  = errors.New("RemoveContainerError")
 )
 
 var (
@@ -62,6 +63,7 @@ const (
 	CreatePodSandbox SyncAction = "CreatePodSandbox"
 	ConfigPodSandbox SyncAction = "ConfigPodSandbox"
 	KillPodSandbox   SyncAction = "KillPodSandbox"
+	RemoveContainer  SyncAction = "RemoveContainer"
 )
 
 // SyncResult is the result of sync action.

--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -24,6 +24,7 @@ go_library(
         "labels.go",
         "legacy.go",
         "security_context.go",
+        "sync_action.go",
     ],
     tags = ["automanaged"],
     deps = [

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -236,3 +236,8 @@ func toKubeRuntimeStatus(status *runtimeapi.RuntimeStatus) *kubecontainer.Runtim
 	}
 	return &kubecontainer.RuntimeStatus{Conditions: conditions}
 }
+
+// isContainerActive returns true if the container is created or running.
+func isContainerActive(status *kubecontainer.ContainerStatus) bool {
+	return status.State == kubecontainer.ContainerStateRunning || status.State == kubecontainer.ContainerStateCreated
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -753,4 +754,59 @@ func (m *kubeGenericRuntimeManager) removeContainerLog(containerID string) error
 // DeleteContainer removes a container.
 func (m *kubeGenericRuntimeManager) DeleteContainer(containerID kubecontainer.ContainerID) error {
 	return m.removeContainer(containerID.ID)
+}
+
+// pruneInitContainers will reduce the number of
+// outstanding init containers still present.
+// This reduces load on the container garbage collector
+// by only preserving the most recent terminated init container.
+//
+// If 'all' is set to true, then all init containers will
+// be removed.
+//
+// The 'statues' must only contain init container statuses.
+func (m *kubeGenericRuntimeManager) pruneInitContainers(statuses []*kubecontainer.ContainerStatus, all bool) ([]*kubecontainer.SyncResult, error) {
+	var syncResult []*kubecontainer.SyncResult
+	var errlist []error
+	var indexesToPrune []int
+
+	names := sets.NewString()
+
+	// Assume statuses are sorted so that the latest status comes first.
+	for i, s := range statuses {
+		if all || names.Has(s.Name) && !isContainerActive(s) {
+			indexesToPrune = append(indexesToPrune, i)
+			continue
+		}
+		names.Insert(s.Name)
+	}
+
+	// Remove containers.
+	for _, idx := range indexesToPrune {
+		status := statuses[idx]
+
+		result := kubecontainer.NewSyncResult(kubecontainer.RemoveContainer, status.Name)
+		syncResult = append(syncResult, result)
+
+		if err := m.runtimeService.RemoveContainer(status.ID.ID); err != nil {
+			result.Fail(kubecontainer.ErrRemoveContainer, err.Error())
+			glog.Errorf("Failed to remove container %q: %v", status.ID.ID, err)
+			continue
+		}
+
+		// Remove any references to this container.
+		if _, ok := m.containerRefManager.GetRef(status.ID); ok {
+			m.containerRefManager.ClearRef(status.ID)
+		} else {
+			glog.Warningf("No ref for container %q", status.ID)
+		}
+	}
+
+	// Aggregate the errors.
+	for _, result := range syncResult {
+		if result.Error != nil {
+			errlist = append(errlist, result.Error)
+		}
+	}
+	return syncResult, errors.NewAggregate(errlist)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -558,7 +558,7 @@ func TestSyncPod(t *testing.T) {
 	}
 }
 
-func TestPruneInitContainers(t *testing.T) {
+func TestPruneInitContainersBeforeStart(t *testing.T) {
 	fakeRuntime, _, m, err := createTestRuntimeManager()
 	assert.NoError(t, err)
 
@@ -676,6 +676,47 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	assert.Equal(t, 3, len(fakeRuntime.Containers))
 	expectedContainers = []string{initContainerID, buildContainerID(pod, containers[0]),
 		buildContainerID(pod, containers[1])}
+	if actual, ok := verifyFakeContainerList(fakeRuntime, expectedContainers); !ok {
+		t.Errorf("expected %q, got %q", expectedContainers, actual)
+	}
+}
+
+func TestPruneInitContainers(t *testing.T) {
+	fakeRuntime, _, m, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+
+	statuses := []*kubecontainer.ContainerStatus{
+		{Name: "init2", ID: kubecontainer.ContainerID{ID: "init2_1"}, State: kubecontainer.ContainerStateExited},
+		{Name: "init2", ID: kubecontainer.ContainerID{ID: "init2_0"}, State: kubecontainer.ContainerStateExited},
+		{Name: "init1", ID: kubecontainer.ContainerID{ID: "init1_2"}, State: kubecontainer.ContainerStateExited},
+		{Name: "init1", ID: kubecontainer.ContainerID{ID: "init1_1"}, State: kubecontainer.ContainerStateExited},
+		{Name: "init1", ID: kubecontainer.ContainerID{ID: "init1_0"}, State: kubecontainer.ContainerStateExited},
+		{Name: "init3", ID: kubecontainer.ContainerID{ID: "init3_0"}, State: kubecontainer.ContainerStateRunning},
+	}
+
+	var fakeContainers []*apitest.FakeContainer
+	for _, s := range statuses {
+		fakeContainers = append(fakeContainers, &apitest.FakeContainer{
+			runtimeapi.ContainerStatus{
+				Id:       s.ID.ID,
+				Metadata: &runtimeapi.ContainerMetadata{Name: s.Name},
+			},
+			"sandbox-foo",
+		})
+	}
+
+	// 1. Prune extra exited init containers.
+	fakeRuntime.SetFakeContainers(fakeContainers)
+	m.pruneInitContainers(statuses, false)
+	expectedContainers := []string{"init2_1", "init1_2", "init3_0"}
+	if actual, ok := verifyFakeContainerList(fakeRuntime, expectedContainers); !ok {
+		t.Errorf("expected %q, got %q", expectedContainers, actual)
+	}
+
+	// 2. Prune all init containers.
+	fakeRuntime.SetFakeContainers(fakeContainers)
+	m.pruneInitContainers(statuses, true)
+	expectedContainers = []string{}
 	if actual, ok := verifyFakeContainerList(fakeRuntime, expectedContainers); !ok {
 		t.Errorf("expected %q, got %q", expectedContainers, actual)
 	}

--- a/pkg/kubelet/kuberuntime/sync_action.go
+++ b/pkg/kubelet/kuberuntime/sync_action.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -34,7 +33,7 @@ type statusGroup struct {
 
 // newStatusGroup returns a statusGroup object that contains the sandbox statuses,
 // init container statuses and the app container statuses.
-func newStatusGroup(pod *api.Pod, podStatus *kubecontainer.PodStatus) *statusGroup {
+func newStatusGroup(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *statusGroup {
 	var initContainerStatuses []*kubecontainer.ContainerStatus
 	var appContainerStatuses []*kubecontainer.ContainerStatus
 
@@ -81,7 +80,7 @@ type containerKillInfo struct {
 // containerStartInfo describes a container that needs to be started, and the reason for that.
 type containerStartInfo struct {
 	// The pointer to the API container that needs to be started.
-	container *api.Container
+	container *v1.Container
 	// The reason why the container will be started, e.g. due to restart.
 	// Used for logging.
 	reason string
@@ -105,7 +104,7 @@ type sandboxKillInfo struct {
 // sandboxStartInfo describes a sandbox that needs to be started, and the reason for that.
 type sandboxStartInfo struct {
 	// The pointer to the API pod that needs to be started.
-	sandbox *api.Pod
+	sandbox *v1.Pod
 	// The number of the attempts that we have tried so far to start
 	// the sandbox.
 	attempt int
@@ -149,7 +148,7 @@ func (a *syncAction) addContainerToKill(s *kubecontainer.ContainerStatus, reason
 }
 
 // addSandboxToStart add the info of the sandbox that's going to be started.
-func (a *syncAction) addSandboxToStart(pod *api.Pod, attempt int, reason string) {
+func (a *syncAction) addSandboxToStart(pod *v1.Pod, attempt int, reason string) {
 	a.sandboxToStart = &sandboxStartInfo{
 		attempt: attempt,
 		reason:  reason,
@@ -157,7 +156,7 @@ func (a *syncAction) addSandboxToStart(pod *api.Pod, attempt int, reason string)
 }
 
 // addContainerToStart add one more container info the the containersToStart list.
-func (a *syncAction) addContainerToStart(container *api.Container, reason string, status *kubecontainer.ContainerStatus) {
+func (a *syncAction) addContainerToStart(container *v1.Container, reason string, status *kubecontainer.ContainerStatus) {
 	a.containersToStart = append(a.containersToStart, &containerStartInfo{
 		container: container,
 		reason:    reason,
@@ -199,6 +198,7 @@ func (a *syncAction) computeSyncActionSandboxCleanup(statuses *statusGroup) {}
 // - (3) sandbox cleanup phase computation, which checks if we need to clean up the sandbox.
 func computeSyncAction(pod *v1.Pod, statuses *statusGroup, livenessManager proberesults.Manager) *syncAction {
 	var a syncAction
+
 	// (1) compute the sandboxes, and containers that we need to kill.
 	a.computeSyncActionKillingPhase(statuses, livenessManager)
 

--- a/pkg/kubelet/kuberuntime/sync_action.go
+++ b/pkg/kubelet/kuberuntime/sync_action.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+)
+
+// statusGroup groups the sandbox statuses, init container statuses and app container
+// (i.e., regular user-defined container in the pod spec) statues.
+type statusGroup struct {
+	sandboxStatuses       []*runtimeapi.PodSandboxStatus
+	initContainerStatuses []*kubecontainer.ContainerStatus
+	appContainerStatuses  []*kubecontainer.ContainerStatus
+}
+
+// newStatusGroup returns a statusGroup object that contains the sandbox statuses,
+// init container statuses and the app container statuses.
+func newStatusGroup(pod *api.Pod, podStatus *kubecontainer.PodStatus) *statusGroup {
+	var initContainerStatuses []*kubecontainer.ContainerStatus
+	var appContainerStatuses []*kubecontainer.ContainerStatus
+
+	initContainers := make(map[string]struct{})
+	appContainers := make(map[string]struct{})
+
+	for _, c := range pod.Spec.InitContainers {
+		initContainers[c.Name] = struct{}{}
+	}
+	for _, c := range pod.Spec.Containers {
+		appContainers[c.Name] = struct{}{}
+	}
+
+	for _, s := range podStatus.ContainerStatuses {
+		if _, ok := initContainers[s.Name]; ok {
+			initContainerStatuses = append(initContainerStatuses, s)
+			continue
+		}
+		if _, ok := appContainers[s.Name]; ok {
+			appContainerStatuses = append(appContainerStatuses, s)
+		}
+	}
+
+	return &statusGroup{
+		sandboxStatuses:       podStatus.SandboxStatuses,
+		initContainerStatuses: initContainerStatuses,
+		appContainerStatuses:  appContainerStatuses,
+	}
+}
+
+// containerKillInfo describes a running container that needs to be killed, and the reason for that.
+type containerKillInfo struct {
+	// The status of the container, it contains the
+	// container ID, name, restart count, finished timestamp.
+	// The status will be passed to containerStartInfo if the container
+	// needs to be restart.
+	status *kubecontainer.ContainerStatus
+	// The reason why the container will be killed, e.g. due to failures.
+	reason string
+	// The boolean indicates whether the container will be restarted.
+	restart bool
+}
+
+// containerStartInfo describes a container that needs to be started, and the reason for that.
+type containerStartInfo struct {
+	// The pointer to the API container that needs to be started.
+	container *api.Container
+	// The reason why the container will be started, e.g. due to restart.
+	// Used for logging.
+	reason string
+	// The last status of the container if it exits.
+	// This is used to determine the "attempt count" and whether we need to do backoff.
+	status *kubecontainer.ContainerStatus
+}
+
+// sandboxKillInfo describes a sandbox that needs to be killed, and the reason for that.
+type sandboxKillInfo struct {
+	// The ID of the sandbox, runtime uses it to kill the sandbox.
+	id string
+	// The name of the sandbox, used for logging.
+	name string
+	// The reason why the sandbox will be killed. e.g. due to failures.
+	reason string
+	// The boolean indicates whether the sandbox will be restarted.
+	restart bool
+}
+
+// sandboxStartInfo describes a sandbox that needs to be started, and the reason for that.
+type sandboxStartInfo struct {
+	// The pointer to the API pod that needs to be started.
+	sandbox *api.Pod
+	// The number of the attempts that we have tried so far to start
+	// the sandbox.
+	attempt int
+	// The reason why the sandbox will be started. e.g. due to restart.
+	reason string
+}
+
+// syncAction describes the actions that needs to be taken for one sync pod iteration.
+// Note that containersToKill/containersToStart includes both regular (app) and init containers.
+type syncAction struct {
+	containersToKill  []*containerKillInfo
+	containersToStart []*containerStartInfo
+
+	sandboxesToKill []*sandboxKillInfo
+	sandboxToStart  *sandboxStartInfo
+}
+
+// addSandboxToKill add one more sandbox info to the sandboxesToKill list.
+func (a *syncAction) addSandboxToKill(status *runtimeapi.PodSandboxStatus, reason string, restart bool) {
+	var name string
+
+	// Metadata must be non nil.
+	if status.Metadata != nil {
+		name = status.Metadata.Name
+	}
+	a.sandboxesToKill = append(a.sandboxesToKill, &sandboxKillInfo{
+		id:      status.Id,
+		name:    name,
+		reason:  reason,
+		restart: restart,
+	})
+}
+
+// addContainerToKill add one more container info the the containersToKill list.
+func (a *syncAction) addContainerToKill(s *kubecontainer.ContainerStatus, reason string, restart bool) {
+	a.containersToKill = append(a.containersToKill, &containerKillInfo{
+		status:  s,
+		reason:  reason,
+		restart: restart,
+	})
+}
+
+// addSandboxToStart add the info of the sandbox that's going to be started.
+func (a *syncAction) addSandboxToStart(pod *api.Pod, attempt int, reason string) {
+	a.sandboxToStart = &sandboxStartInfo{
+		attempt: attempt,
+		reason:  reason,
+	}
+}
+
+// addContainerToStart add one more container info the the containersToStart list.
+func (a *syncAction) addContainerToStart(container *api.Container, reason string, status *kubecontainer.ContainerStatus) {
+	a.containersToStart = append(a.containersToStart, &containerStartInfo{
+		container: container,
+		reason:    reason,
+		status:    status,
+	})
+}
+
+// needsToKillContainers returns true if there are any containers need to be killed.
+func (a *syncAction) needsToKillContainers() bool {
+	return len(a.containersToKill) > 0
+}
+
+// needsToKillSandboxes returns true if there are any sandboxes need to be killed.
+func (a *syncAction) needsToKillSandboxes() bool {
+	return len(a.sandboxesToKill) > 0
+}
+
+// needsToStartSandbox returns true if a sandbox needs to be started.
+func (a *syncAction) needsToStartSandbox() bool {
+	return a.sandboxToStart != nil
+}
+
+// needsToStartContainers returns true if there are any containers that need
+// to be started.
+func (a *syncAction) needsToStartContainers() bool {
+	return len(a.containersToStart) > 0
+}
+
+func (a *syncAction) computeSyncActionKillingPhase(statuses *statusGroup, manager proberesults.Manager) {
+}
+func (a *syncAction) computeSyncActionStartingPhase(statuses *statusGroup)  {}
+func (a *syncAction) computeSyncActionSandboxCleanup(statuses *statusGroup) {}
+
+// computeSyncAction generates the sync action object that contains the actions
+// we need to take in the current sync pod iteration.
+// The whole computation is splitted into 3 phases:
+// - (1) killing phase computation, which constructs a list of sandboxs and containers that needs to be killed.
+// - (2) starting phase computation, which constructs the sandbox and a list containers that needs to be started.
+// - (3) sandbox cleanup phase computation, which checks if we need to clean up the sandbox.
+func computeSyncAction(pod *v1.Pod, statuses *statusGroup, livenessManager proberesults.Manager) *syncAction {
+	var a syncAction
+	// (1) compute the sandboxes, and containers that we need to kill.
+	a.computeSyncActionKillingPhase(statuses, livenessManager)
+
+	// (2) compute the sandbox, and containers that we need to start.
+	a.computeSyncActionStartingPhase(statuses)
+
+	// (3) do an additional check to make sure we kill the sandbox when
+	//     all containers are exited (or will be killed), and none of them will
+	//     be restarted.
+	a.computeSyncActionSandboxCleanup(statuses)
+
+	return &a
+}


### PR DESCRIPTION
Adds kuberuntime.NewSyncPod() which has the same signature as
the old one, so the PR can be merged without causing big disruption.

The NewSyncPod() has 3 major parts:
- (1) Prune init containers
- (2) Compute changes (sandbox to kill, containers to kill,
    sandbox to start, containers to start).
- (3) Apply the changes (kill containers, kill sandboxes,
    start sandbox, start containers).

The computation part is further splited into 3 phases:
- (1) Construct list of sandboxes and containers that needs to
    be killed.
- (2) Construct list of sandbox and containers that needs to
    be started.
- (3) Make sure the sandbox will be killed if all active containers
    exited or are going to be killed.

In order to make the process more readable, a new type called
`syncAction` is added, which preserves the result of the computation
through different phases.

For this PR, the actuall computation and action part is left not implemented
to make review easier.

Based on #34282 
/cc @kubernetes/sig-node @kubernetes/sig-rktnetes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35245)

<!-- Reviewable:end -->
