### PR TITLE
Refactor some functions in kube-dns to reduce surface area

### DIFF
--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	fake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/dns/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -190,7 +191,9 @@ func TestSkySimpleSRVLookup(t *testing.T) {
 	targets := []string{}
 	for _, eip := range endpointIPs {
 		// A portal service is always created with a port of '0'
-		targets = append(targets, fmt.Sprintf("%v.%v", fmt.Sprintf("%x", hashServiceRecord(newServiceRecord(eip, 0))), name))
+		targets = append(targets,
+			fmt.Sprintf("%x.%v",
+				util.HashServiceRecord(util.NewServiceRecord(eip, 0)), name))
 	}
 	assertSRVRecordsMatchTarget(t, rec, targets...)
 }
@@ -255,7 +258,8 @@ func TestSkyNamedPortSRVLookup(t *testing.T) {
 
 	svcDomain := strings.Join([]string{testService, testNamespace, "svc", testDomain}, ".")
 	assertARecordsMatchIPs(t, extra, eip)
-	assertSRVRecordsMatchTarget(t, rec, fmt.Sprintf("%v.%v", fmt.Sprintf("%x", hashServiceRecord(newServiceRecord(eip, 0))), svcDomain))
+	assertSRVRecordsMatchTarget(
+		t, rec, fmt.Sprintf("%x.%v", util.HashServiceRecord(util.NewServiceRecord(eip, 0)), svcDomain))
 	assertSRVRecordsMatchPort(t, rec, 8081)
 }
 

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -55,7 +55,7 @@ func newKubeDNS() *KubeDNS {
 		reverseRecordMap:    make(map[string]*skymsg.Service),
 		clusterIPServiceMap: make(map[string]*kapi.Service),
 		cacheLock:           sync.RWMutex{},
-		domainPath:          reverseArray(strings.Split(strings.TrimRight(testDomain, "."), ".")),
+		domainPath:          util.ReverseArray(strings.Split(strings.TrimRight(testDomain, "."), ".")),
 		nodesStore:          cache.NewStore(cache.MetaNamespaceKeyFunc),
 	}
 	return kd
@@ -671,7 +671,7 @@ func assertDNSForHeadlessService(t *testing.T, kd *KubeDNS, e *kapi.Endpoints) {
 }
 
 func assertDNSForExternalService(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	records, err := kd.Records(getServiceFQDN(kd, s), false)
+	records, err := kd.Records(getServiceFQDN(kd.domain, s), false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(records))
 	assert.Equal(t, testExternalName, records[0].Host)
@@ -704,13 +704,13 @@ func getIPForCName(t *testing.T, kd *KubeDNS, cname string) string {
 }
 
 func assertNoDNSForHeadlessService(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	records, err := kd.Records(getServiceFQDN(kd, s), false)
+	records, err := kd.Records(getServiceFQDN(kd.domain, s), false)
 	require.Error(t, err)
 	assert.Equal(t, 0, len(records))
 }
 
 func assertNoDNSForExternalService(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	records, err := kd.Records(getServiceFQDN(kd, s), false)
+	records, err := kd.Records(getServiceFQDN(kd.domain, s), false)
 	require.Error(t, err)
 	assert.Equal(t, 0, len(records))
 }
@@ -719,7 +719,7 @@ func assertSRVForNamedPort(t *testing.T, kd *KubeDNS, s *kapi.Service, portName 
 	records, err := kd.Records(getSRVFQDN(kd, s, portName), false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(records))
-	assert.Equal(t, getServiceFQDN(kd, s), records[0].Host)
+	assert.Equal(t, getServiceFQDN(kd.domain, s), records[0].Host)
 }
 
 func assertNoSRVForNamedPort(t *testing.T, kd *KubeDNS, s *kapi.Service, portName string) {
@@ -729,7 +729,7 @@ func assertNoSRVForNamedPort(t *testing.T, kd *KubeDNS, s *kapi.Service, portNam
 }
 
 func assertNoDNSForClusterIP(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	serviceFQDN := getServiceFQDN(kd, s)
+	serviceFQDN := getServiceFQDN(kd.domain, s)
 	queries := getEquivalentQueries(serviceFQDN, s.Namespace)
 	for _, query := range queries {
 		records, err := kd.Records(query, false)
@@ -739,7 +739,7 @@ func assertNoDNSForClusterIP(t *testing.T, kd *KubeDNS, s *kapi.Service) {
 }
 
 func assertDNSForClusterIP(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	serviceFQDN := getServiceFQDN(kd, s)
+	serviceFQDN := getServiceFQDN(kd.domain, s)
 	queries := getEquivalentQueries(serviceFQDN, s.Namespace)
 	for _, query := range queries {
 		records, err := kd.Records(query, false)
@@ -750,16 +750,16 @@ func assertDNSForClusterIP(t *testing.T, kd *KubeDNS, s *kapi.Service) {
 }
 
 func assertReverseRecord(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	segments := reverseArray(strings.Split(s.Spec.ClusterIP, "."))
-	reverseLookup := fmt.Sprintf("%s%s", strings.Join(segments, "."), arpaSuffix)
+	segments := util.ReverseArray(strings.Split(s.Spec.ClusterIP, "."))
+	reverseLookup := fmt.Sprintf("%s%s", strings.Join(segments, "."), util.ArpaSuffix)
 	reverseRecord, err := kd.ReverseRecord(reverseLookup)
 	require.NoError(t, err)
-	assert.Equal(t, kd.getServiceFQDN(s), reverseRecord.Host)
+	assert.Equal(t, getServiceFQDN(kd.domain, s), reverseRecord.Host)
 }
 
 func assertNoReverseRecord(t *testing.T, kd *KubeDNS, s *kapi.Service) {
-	segments := reverseArray(strings.Split(s.Spec.ClusterIP, "."))
-	reverseLookup := fmt.Sprintf("%s%s", strings.Join(segments, "."), arpaSuffix)
+	segments := util.ReverseArray(strings.Split(s.Spec.ClusterIP, "."))
+	reverseLookup := fmt.Sprintf("%s%s", strings.Join(segments, "."), util.ArpaSuffix)
 	reverseRecord, err := kd.ReverseRecord(reverseLookup)
 	require.Error(t, err)
 	require.Nil(t, reverseRecord)
@@ -777,10 +777,6 @@ func getEquivalentQueries(serviceFQDN, namespace string) []string {
 
 func getFederationServiceFQDN(kd *KubeDNS, s *kapi.Service, federationName string) string {
 	return fmt.Sprintf("%s.%s.%s.svc.%s", s.Name, s.Namespace, federationName, kd.domain)
-}
-
-func getServiceFQDN(kd *KubeDNS, s *kapi.Service) string {
-	return fmt.Sprintf("%s.%s.svc.%s", s.Name, s.Namespace, kd.domain)
 }
 
 func getEndpointsFQDN(kd *KubeDNS, e *kapi.Endpoints) string {

--- a/pkg/dns/util/util.go
+++ b/pkg/dns/util/util.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/skynetservices/skydns/msg"
+)
+
+const (
+	// ArpaSuffix is the standard suffix for PTR IP reverse lookups.
+	ArpaSuffix = ".in-addr.arpa."
+	// defaultPriority used for service records
+	defaultPriority = 10
+	// defaultWeight used for service records
+	defaultWeight = 10
+	// defaultTTL used for service records
+	defaultTTL = 30
+)
+
+// extractIP turns a standard PTR reverse record lookup name
+// into an IP address
+func ExtractIP(reverseName string) (string, bool) {
+	if !strings.HasSuffix(reverseName, ArpaSuffix) {
+		return "", false
+	}
+	search := strings.TrimSuffix(reverseName, ArpaSuffix)
+
+	// reverse the segments and then combine them
+	segments := ReverseArray(strings.Split(search, "."))
+	return strings.Join(segments, "."), true
+}
+
+// ReverseArray reverses an array.
+func ReverseArray(arr []string) []string {
+	for i := 0; i < len(arr)/2; i++ {
+		j := len(arr) - i - 1
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	return arr
+}
+
+// Returns record in a format that SkyDNS understands.
+// Also return the hash of the record.
+func GetSkyMsg(ip string, port int) (*msg.Service, string) {
+	msg := NewServiceRecord(ip, port)
+	hash := HashServiceRecord(msg)
+	glog.V(2).Infof("DNS Record:%s, hash:%s", fmt.Sprintf("%v", msg), hash)
+	return msg, fmt.Sprintf("%x", hash)
+}
+
+// NewServiceRecord creates a new service DNS message.
+func NewServiceRecord(ip string, port int) *msg.Service {
+	return &msg.Service{
+		Host:     ip,
+		Port:     port,
+		Priority: defaultPriority,
+		Weight:   defaultWeight,
+		Ttl:      defaultTTL,
+	}
+}
+
+// HashServiceRecord hashes the string representation of a DNS
+// message.
+func HashServiceRecord(msg *msg.Service) string {
+	s := fmt.Sprintf("%v", msg)
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum32())
+}


### PR DESCRIPTION
- Moves federation query path out to its own method
- Creates dns/util and moves some trivial methods to that package

This is just moving of code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35246)

<!-- Reviewable:end -->
