### PR TITLE
CRI validation test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,21 @@ test-e2e-node: ginkgo generated_files
 	hack/make-rules/test-e2e-node.sh
 endif
 
+define TEST_E2E_CRI_HELP_INFO
+# Build and run CRI end-to-end tests.
+#
+# Example:
+#   make test-e2e-cri
+endef
+.PHONY: test-e2e-cri
+ifeq ($(PRINT_HELP),y)
+test-e2e-cri:
+	@echo "$$TEST_E2E_CRI_HELP_INFO"
+else
+test-e2e-cri: ginkgo
+	hack/make-rules/test-e2e-cri.sh
+endif
+
 define TEST_CMD_HELP_INFO
 # Build and run cmdline tests.
 #

--- a/hack/make-rules/test-e2e-cri.sh
+++ b/hack/make-rules/test-e2e-cri.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+focus=${FOCUS:-""}
+skip=${SKIP:-""}
+report=${REPORT:-"/tmp/"}
+run_until_failure=${RUN_UNTIL_FAILURE:-"false"}
+test_args=${TEST_ARGS:-""}
+runtime_service_address=${CONTAINER_RUNTIME_ENDPOINT:-"/var/run/dockershim.sock"}
+image_service_address=${IMAGE_SERVICE_ENDPOINT:-""}
+
+# Parse the flags to pass to ginkgo
+ginkgoflags=""
+if [[ $focus != "" ]]; then
+  ginkgoflags="$ginkgoflags -focus=$focus "
+fi
+
+if [[ $skip != "" ]]; then
+  ginkgoflags="$ginkgoflags -skip=$skip "
+fi
+
+if [[ $run_until_failure != "" ]]; then
+  ginkgoflags="$ginkgoflags -untilItFails=$run_until_failure "
+fi
+
+# Test using the host the script was run on
+# Provided for backwards compatibility
+go run test/e2e_cri/runner/run.go --ginkgo-flags="$ginkgoflags" \
+  --test-flags="--alsologtostderr --v 4 --report-dir=${report} \
+  $test_args" --runtime-service-address=${runtime_service_address} \
+  --image-service-address=${image_service_address} --build-dependencies=true
+exit $?

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -264,7 +264,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 	defer GinkgoRecover()
 	f := framework.NewDefaultFramework("kubectl")
 
-	// Reustable cluster state function.  This won't be adversly affected by lazy initialization of framework.
+	// Reusable cluster state function.  This won't be adversely affected by lazy initialization of framework.
 	clusterState := func() *framework.ClusterVerification {
 		return f.NewClusterVerification(
 			f.Namespace,

--- a/test/e2e_cri/builder/builder.go
+++ b/test/e2e_cri/builder/builder.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet binaries.")
+
+var buildTargets = []string{
+	"k8s.io/kubernetes/test/e2e_cri",
+	"k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo",
+}
+
+func BuildGo() error {
+	glog.Infof("Building k8s binaries...")
+	outputDir, err := GetK8sBuildOutputDir()
+	if err != nil {
+		glog.Fatalf("Failed to get build output directory: %v", err)
+	}
+
+	err = RunCommand("go", "test", "-c", "-v", "-o", filepath.Join(outputDir, "e2e_cri.test"), buildTargets[0])
+	if err != nil {
+		return fmt.Errorf("failed to build e2e_cri.test %v\n", err)
+	}
+
+	err = RunCommand("go", "build", "-o", filepath.Join(outputDir, "ginkgo"), buildTargets[1])
+	if err != nil {
+		return fmt.Errorf("failed to build go ginkgo %v\n", err)
+	}
+	return nil
+}
+
+func RunCommand(name string, args ...string) error {
+	glog.Infof("Building command: %v %v", name, strings.Join(args, " "))
+	cmd := exec.Command("sh", "-c", strings.Join(append([]string{name}, args...), " "))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// TODO: Dedup / merge this with comparable utilities in e2e/util.go
+func getK8sRootDir() (string, error) {
+	// Get the directory of the current executable
+	_, testExec, _, _ := runtime.Caller(0)
+	path := filepath.Dir(testExec)
+
+	// Look for the kubernetes source root directory
+	if strings.Contains(path, "k8s.io/kubernetes") {
+		splitPath := strings.Split(path, "k8s.io/kubernetes")
+		return filepath.Join(splitPath[0], "k8s.io/kubernetes/"), nil
+	}
+
+	return "", fmt.Errorf("Could not find kubernetes source root directory.")
+}
+
+func GetK8sBuildOutputDir() (string, error) {
+	k8sRoot, err := getK8sRootDir()
+	if err != nil {
+		return "", err
+	}
+	buildOutputDir := filepath.Join(k8sRoot, "_output/local/go/bin")
+	if err := os.MkdirAll(buildOutputDir, 0731); err != nil {
+		return "", err
+	}
+	return buildOutputDir, nil
+}

--- a/test/e2e_cri/container.go
+++ b/test/e2e_cri/container.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_cri
+
+import (
+	internalapi "k8s.io/kubernetes/pkg/kubelet/api"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	"k8s.io/kubernetes/test/e2e_cri/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.KubeDescribe("Test CRI container", func() {
+	f := framework.NewDefaultCRIFramework("CRI-container-test")
+
+	var c internalapi.RuntimeService
+
+	BeforeEach(func() {
+		c = f.CRIClient.CRIRuntimeClient
+	})
+	Context("test basic operations on container", func() {
+		var podID string
+		var podConfig *runtimeapi.PodSandboxConfig
+
+		BeforeEach(func() {
+			podID, podConfig = createPodSandboxForContainer(c)
+		})
+
+		AfterEach(func() {
+			By("stop PodSandbox")
+			c.StopPodSandbox(podID)
+			By("delete PodSandbox")
+			c.RemovePodSandbox(podID)
+		})
+
+		It("test create container", func() {
+			By("test create container")
+			containerID := testCreateContainer(c, podID, podConfig)
+
+			By("test list container")
+			containers := listContainerForIDOrFail(c, containerID)
+			Expect(containerFound(containers, containerID)).To(BeTrue(), "container should be created")
+		})
+
+		It("test start container", func() {
+			By("create container")
+			containerID := createContainerOrFail(c, "container-for-create-test-", podID, podConfig)
+
+			By("test start container")
+			testStartContainer(c, containerID)
+		})
+
+		It("test stop container", func() {
+			By("create container")
+			containerID := createContainerOrFail(c, "container-for-create-test-", podID, podConfig)
+
+			By("start container")
+			startContainerOrFail(c, containerID)
+
+			By("test stop container")
+			testStopContainer(c, containerID)
+		})
+
+		It("test remove container", func() {
+			By("create container")
+			containerID := createContainerOrFail(c, "container-for-create-test-", podID, podConfig)
+
+			By("test remove container")
+			removeContainerOrFail(c, containerID)
+			containers := listContainerForIDOrFail(c, containerID)
+			Expect(containerFound(containers, containerID)).To(BeFalse(), "container should be removed")
+		})
+	})
+})

--- a/test/e2e_cri/e2e_cri_test.go
+++ b/test/e2e_cri/e2e_cri_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// To run tests in this suite
+package e2e_cri
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/test/e2e_cri/framework"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	framework.RegisterCommonFlags()
+	framework.RegisterCRIFlags()
+}
+
+// TestE2eCRI checks configuration parameters (specified through flags) and then runs
+// E2ECRI tests using the Ginkgo runner.
+// If a "report directory" is specified, one or more JUnit test reports will be
+// generated in this directory.
+// This function is called on each Ginkgo node in parallel mode.
+func TestE2eCRI(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	RegisterFailHandler(Fail)
+	r := []Reporter{}
+	reportDir := framework.TestContext.ReportDir
+	if reportDir != "" {
+		// Create the directory if it doesn't already exists
+		if err := os.MkdirAll(reportDir, 0755); err != nil {
+			glog.Errorf("Failed creating report directory: %v", err)
+		} else {
+			// Configure a junit reporter to write to the directory
+			junitFile := fmt.Sprintf("junit_%s%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode)
+			junitPath := path.Join(reportDir, junitFile)
+			r = append(r, reporters.NewJUnitReporter(junitPath))
+		}
+	}
+	RunSpecsWithDefaultAndCustomReporters(t, "E2eCRI Suite", r)
+}

--- a/test/e2e_cri/framework/framework.go
+++ b/test/e2e_cri/framework/framework.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	internalapi "k8s.io/kubernetes/pkg/kubelet/api"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
+// Eventual goal is to merge this with integration test framework.
+type Framework struct {
+	BaseName string
+
+	// CRI client
+	CRIClient *InternalApiClient
+
+	// To make sure that this framework cleans up after itself, no matter what,
+	// we install a Cleanup action before each test and clear it after.  If we
+	// should abort, the AfterSuite hook should run all Cleanup actions.
+	cleanupHandle e2eframework.CleanupActionHandle
+}
+
+type InternalApiClient struct {
+	CRIRuntimeClient internalapi.RuntimeService
+	CRIImageClient   internalapi.ImageManagerService
+}
+
+// NewDefaultCRIFramework makes a new framework and sets up a BeforeEach/AfterEach for
+// you (you can write additional before/after each functions).
+func NewDefaultCRIFramework(baseName string) *Framework {
+	return NewCRIFramework(baseName, nil)
+}
+
+func NewCRIFramework(baseName string, client *InternalApiClient) *Framework {
+	f := &Framework{
+		BaseName:  baseName,
+		CRIClient: client,
+	}
+
+	BeforeEach(f.BeforeEach)
+	AfterEach(f.AfterEach)
+
+	return f
+}
+
+// BeforeEach gets a client
+func (f *Framework) BeforeEach() {
+	// The fact that we need this feels like a bug in ginkgo.
+	// https://github.com/onsi/ginkgo/issues/222
+	f.cleanupHandle = e2eframework.AddCleanupAction(f.AfterEach)
+
+	if f.CRIClient == nil {
+		c, err := LoadCRIClient()
+		Expect(err).NotTo(HaveOccurred())
+		f.CRIClient = c
+	}
+}
+
+// AfterEach clean resourses and print summaries
+func (f *Framework) AfterEach() {
+	// remove the cleanup handle.
+	e2eframework.RemoveCleanupAction(f.cleanupHandle)
+
+	f.CRIClient = nil
+}
+
+func KubeDescribe(text string, body func()) bool {
+	return Describe("[k8s.io] "+text, body)
+}

--- a/test/e2e_cri/framework/test_context.go
+++ b/test/e2e_cri/framework/test_context.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"time"
+
+	"github.com/onsi/ginkgo/config"
+)
+
+type TestContextType struct {
+	// Report related settings.
+	ReportDir    string
+	ReportPrefix string
+
+	// CRI client configurations.
+	ImageServiceAddr      string
+	ImageServiceTimeout   time.Duration
+	RuntimeServiceAddr    string
+	RuntimeServiceTimeout time.Duration
+}
+
+var TestContext TestContextType
+
+// Register flags common to all e2e test suites.
+func RegisterCommonFlags() {
+	// Turn on verbose by default to get spec names
+	config.DefaultReporterConfig.Verbose = true
+
+	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
+	config.GinkgoConfig.EmitSpecProgress = true
+
+	// Randomize specs as well as suites
+	config.GinkgoConfig.RandomizeAllSpecs = true
+
+	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+}
+
+// Register flags specific to the CRIClient e2e test suite.
+func RegisterCRIFlags() {
+	flag.StringVar(&TestContext.ImageServiceAddr, "image-service-address", "/var/run/dockershim.sock", "image service socket for client to connect.")
+	flag.DurationVar(&TestContext.ImageServiceTimeout, "image-service-timeout", 300*time.Second, "Timeout when trying to connect to image service.")
+	flag.StringVar(&TestContext.RuntimeServiceAddr, "runtime-service-address", "/var/run/dockershim.sock", "runtime service socket for client to connect.")
+	flag.DurationVar(&TestContext.RuntimeServiceTimeout, "runtime-service-timeout", 300*time.Second, "Timeout when trying to connect to a runtime service.")
+}

--- a/test/e2e_cri/framework/util.go
+++ b/test/e2e_cri/framework/util.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/remote"
+)
+
+func LoadCRIClient() (*InternalApiClient, error) {
+	rService, err := remote.NewRemoteRuntimeService(TestContext.RuntimeServiceAddr, TestContext.RuntimeServiceTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	iService, err := remote.NewRemoteImageService(TestContext.ImageServiceAddr, TestContext.ImageServiceTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InternalApiClient{
+		CRIRuntimeClient: rService,
+		CRIImageClient:   iService,
+	}, nil
+}

--- a/test/e2e_cri/image.go
+++ b/test/e2e_cri/image.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_cri
+
+import (
+	internalapi "k8s.io/kubernetes/pkg/kubelet/api"
+	"k8s.io/kubernetes/test/e2e_cri/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	// image name for test image api
+	testImageName = "busybox"
+
+	// name-tagged reference for latest test image
+	latestTestImageRef = testImageName + ":latest"
+
+	// Digested reference for test image
+	busyboxDigestRef = testImageName + "@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6"
+)
+
+var _ = framework.KubeDescribe("Test CRI image manager", func() {
+	f := framework.NewDefaultCRIFramework("CRI-image-manager-test")
+
+	var c internalapi.ImageManagerService
+
+	BeforeEach(func() {
+		c = f.CRIClient.CRIImageClient
+	})
+
+	It("public image with tag should be pulled and removed", func() {
+		testPullPublicImage(c, latestTestImageRef)
+	})
+
+	It("public image without tag should be pulled and removed", func() {
+		testPullPublicImage(c, testImageName)
+	})
+
+	It("public image with digest should be pulled and removed", func() {
+		testPullPublicImage(c, busyboxDigestRef)
+	})
+
+	It("image status get image fields should not be empty", func() {
+		pullPublicImageOrFail(c, latestTestImageRef)
+
+		defer removeImage(c, latestTestImageRef)
+
+		status := imageStatusOrFail(c, latestTestImageRef)
+		Expect(status.Id).NotTo(BeNil(), "image Id should not be nil")
+		Expect(len(status.RepoTags)).NotTo(Equal(0), "should have repoTags in image")
+		Expect(status.Size_).NotTo(BeNil(), "image Size should not be nil")
+	})
+
+	It("ListImage should get exactly 3 image in the result list", func() {
+		// different tags refer to different images
+		testImageList := []string{
+			"busybox:1",
+			"busybox:musl",
+			"busybox:glibc",
+		}
+
+		pullImageList(c, testImageList)
+
+		defer removeImageList(c, testImageList)
+
+		images := listImagesOrFail(c, testImageName)
+		Expect(len(images)).To(Equal(3), "should have exactly three images in list")
+	})
+
+	It("ListImage should get exactly 3 repoTags in the result image", func() {
+		// different tags refer to the same image
+		testImageList := []string{
+			"busybox:1",
+			"busybox:1.25",
+			"busybox:uclibc",
+		}
+
+		pullImageList(c, testImageList)
+
+		defer removeImageList(c, testImageList)
+
+		images := listImagesOrFail(c, testImageName)
+
+		Expect(len(images)).To(Equal(1), "should have only one image in list")
+		Expect(len(images[0].RepoTags)).To(Equal(3), "should have three repoTags in image")
+		Expect(images[0].RepoTags).To(ContainElement("busybox:1"), "should have the repoTag named busybox:1")
+		Expect(images[0].RepoTags).To(ContainElement("busybox:1.25"), "should have the repoTag named busybox:1.25")
+		Expect(images[0].RepoTags).To(ContainElement("busybox:uclibc"), "should have the repoTag named busybox:uclibc")
+	})
+})

--- a/test/e2e_cri/pod.go
+++ b/test/e2e_cri/pod.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_cri
+
+import (
+	internalapi "k8s.io/kubernetes/pkg/kubelet/api"
+	"k8s.io/kubernetes/test/e2e_cri/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.KubeDescribe("Test CRI PodSandbox", func() {
+	f := framework.NewDefaultCRIFramework("CRI-PodSandbox-test")
+
+	var c internalapi.RuntimeService
+
+	BeforeEach(func() {
+		c = f.CRIClient.CRIRuntimeClient
+	})
+
+	It("test get version info", func() {
+		testGetVersion(c)
+	})
+
+	Context("test basic operations on PodSandbox", func() {
+		var podID string
+
+		AfterEach(func() {
+			By("stop PodSandbox")
+			c.StopPodSandbox(podID)
+			By("delete PodSandbox")
+			c.RemovePodSandbox(podID)
+		})
+
+		It("test run PodSandbox", func() {
+			By("test run PodSandbox")
+			podID = testRunPodSandbox(c)
+
+			By("test list PodSandbox")
+			pods := listPodSanboxForIDOrFail(c, podID)
+			Expect(podSandboxFound(pods, podID)).To(BeTrue(), "PodSandbox should be listed")
+		})
+
+		It("test stop PodSandbox", func() {
+			By("run PodSandbox")
+			podID = runPodSandboxOrFail(c, "PodSandbox-for-create-test-")
+
+			By("test stop PodSandbox")
+			testStopPodSandbox(c, podID)
+		})
+
+		It("test remove PodSandbox", func() {
+			By("test run PodSandbox")
+			podID = runPodSandboxOrFail(c, "PodSandbox-for-create-test-")
+
+			By("stop PodSandbox")
+			stopPodSandboxOrFail(c, podID)
+
+			By("test remove PodSandbox")
+			removePodSandboxOrFail(c, podID)
+			pods := listPodSanboxForIDOrFail(c, podID)
+			Expect(podSandboxFound(pods, podID)).To(BeFalse(), "PodSandbox should be removed")
+		})
+	})
+})

--- a/test/e2e_cri/runner/run.go
+++ b/test/e2e_cri/runner/run.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"path/filepath"
+
+	"k8s.io/kubernetes/test/e2e_cri/builder"
+
+	"github.com/golang/glog"
+)
+
+var buildDependencies = flag.Bool("build-dependencies", true, "If true, build all dependencies.")
+var ginkgoFlags = flag.String("ginkgo-flags", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
+var testFlags = flag.String("test-flags", "", "Space-separated list of arguments to pass to CRI e2e test.")
+var runtimeServiceAddress = flag.String("runtime-service-address", "/var/run/dockershim.sock", "CRI runtime service address which is tested.")
+var imageServiceAddress = flag.String("image-service-address", "", "CRI image service address which is tested. Same with runtime-address if not specified.")
+
+func main() {
+	flag.Parse()
+
+	// Build dependencies - ginkgo and e2e_cri.test
+	if *buildDependencies {
+		if err := builder.BuildGo(); err != nil {
+			glog.Fatalf("Failed to build the dependencies: %v", err)
+		}
+	}
+
+	// Run CRI e2e test
+	outputDir, err := builder.GetK8sBuildOutputDir()
+	if err != nil {
+		glog.Fatalf("Failed to get build output directory: %v", err)
+	}
+	glog.Infof("Got build output dir: %v", outputDir)
+	ginkgo := filepath.Join(outputDir, "ginkgo")
+	test := filepath.Join(outputDir, "e2e_cri.test")
+
+	if *imageServiceAddress == "" {
+		imageServiceAddress = runtimeServiceAddress
+	}
+	builder.RunCommand(ginkgo, *ginkgoFlags, test, "--", *testFlags, "--image-service-address="+*runtimeServiceAddress, "--runtime-service-address="+*imageServiceAddress)
+	return
+}

--- a/test/e2e_cri/util.go
+++ b/test/e2e_cri/util.go
@@ -1,0 +1,411 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance for the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+forOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_cri
+
+import (
+	"fmt"
+	"strings"
+
+	internalapi "k8s.io/kubernetes/pkg/kubelet/api"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	"k8s.io/kubernetes/pkg/util/uuid"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	defaultUid                  string = "e2e-cri-uid"
+	defaultNamespace            string = "e2e-cri-namespace"
+	defaultAttempt              uint32 = 2
+	defaultContainerImage       string = "gcr.io/google_containers/busybox:1.24"
+	defaultStopContainerTimeout int64  = 60
+)
+
+// sandboxFound returns whether PodSandbox is found.
+func podSandboxFound(podSandboxs []*runtimeapi.PodSandbox, podId string) bool {
+	if len(podSandboxs) == 1 && podSandboxs[0].GetId() == podId {
+		return true
+	}
+	return false
+}
+
+// containerFound returns whether containers is found.
+func containerFound(containers []*runtimeapi.Container, containerID string) bool {
+	if len(containers) == 1 && containers[0].GetId() == containerID {
+		return true
+	}
+	return false
+}
+
+// buildPodSandboxMetadata builds default PodSandboxMetadata with podSandboxName.
+func buildPodSandboxMetadata(podSandboxName *string) *runtimeapi.PodSandboxMetadata {
+	return &runtimeapi.PodSandboxMetadata{
+		Name:      podSandboxName,
+		Uid:       &defaultUid,
+		Namespace: &defaultNamespace,
+		Attempt:   &defaultAttempt,
+	}
+}
+
+// buildContainerMetadata builds default PodSandboxMetadata with containerName.
+func buildContainerMetadata(containerName *string) *runtimeapi.ContainerMetadata {
+	return &runtimeapi.ContainerMetadata{
+		Name:    containerName,
+		Attempt: &defaultAttempt,
+	}
+}
+
+// verifyPodSandboxStatus verifies whether PodSandbox status for given podID matches.
+func verifyPodSandboxStatus(c internalapi.RuntimeService, podID string, expectedStatus runtimeapi.PodSandboxState, statusName string) {
+	status := getPodSandboxStatusOrFail(c, podID)
+	Expect(*status.State).To(Equal(expectedStatus), "PodSandbox state should be "+statusName)
+}
+
+// runPodSandbox runs a PodSandbox with prefixed random name.
+func runPodSandbox(c internalapi.RuntimeService, prefix string) (string, error) {
+	By("create a PodSandbox with name")
+	podSandboxName := prefix + string(uuid.NewUUID())
+	config := &runtimeapi.PodSandboxConfig{
+		Metadata: buildPodSandboxMetadata(&podSandboxName),
+	}
+	return c.RunPodSandbox(config)
+}
+
+// runPodSandboxOrFail runs a PodSandbox with the prefix of podSandboxName and fails if it gets error.
+func runPodSandboxOrFail(c internalapi.RuntimeService, prefix string) string {
+	podID, err := runPodSandbox(c, prefix)
+	e2eframework.ExpectNoError(err, "Failed to create PodSandbox: %v", err)
+	e2eframework.Logf("Created PodSandbox %s\n", podID)
+	return podID
+}
+
+// testRunPodSandbox runs a PodSandbox and make sure it is ready.
+func testRunPodSandbox(c internalapi.RuntimeService) string {
+	podID := runPodSandboxOrFail(c, "PodSandbox-for-create-test-")
+	verifyPodSandboxStatus(c, podID, runtimeapi.PodSandboxState_SANDBOX_READY, "ready")
+	return podID
+}
+
+// getPodSandboxStatus gets gets PodSandboxStatus, error for podID.
+func getPodSandboxStatus(c internalapi.RuntimeService, podID string) (*runtimeapi.PodSandboxStatus, error) {
+	By("get PodSandbox status")
+	return c.PodSandboxStatus(podID)
+}
+
+// getPodSandboxStatusOrFail gets PodSandboxStatus for podID and fails if it gets error.
+func getPodSandboxStatusOrFail(c internalapi.RuntimeService, podID string) *runtimeapi.PodSandboxStatus {
+	status, err := getPodSandboxStatus(c, podID)
+	e2eframework.ExpectNoError(err, "Failed to get PodSandbox %s status: %v", podID, err)
+	return status
+}
+
+// stopPodSandbox stops the PodSandbox for podID.
+func stopPodSandbox(c internalapi.RuntimeService, podID string) error {
+	By("stop PodSandbox for podID")
+	return c.StopPodSandbox(podID)
+}
+
+// stopPodSandboxOrFail stops the PodSandbox for podID and fails if it gets error.
+func stopPodSandboxOrFail(c internalapi.RuntimeService, podID string) {
+	err := stopPodSandbox(c, podID)
+	e2eframework.ExpectNoError(err, "Failed to stop PodSandbox: %v", err)
+	e2eframework.Logf("Stopped PodSandbox %s\n", podID)
+}
+
+// testStopPodSandbox stops the PodSandbox for podID and make sure it is not ready.
+func testStopPodSandbox(c internalapi.RuntimeService, podID string) {
+	stopPodSandboxOrFail(c, podID)
+	verifyPodSandboxStatus(c, podID, runtimeapi.PodSandboxState_SANDBOX_NOTREADY, "not ready")
+}
+
+// removePodSandbox removes the PodSandbox for podID.
+func removePodSandbox(c internalapi.RuntimeService, podID string) error {
+	By("remove PodSandbox for podID")
+	return c.RemovePodSandbox(podID)
+}
+
+// removePodSandboxOrFail removes the PodSandbox for podID and fails if it gets error.
+func removePodSandboxOrFail(c internalapi.RuntimeService, podID string) {
+	err := removePodSandbox(c, podID)
+	e2eframework.ExpectNoError(err, "Failed to remove PodSandbox: %v", err)
+	e2eframework.Logf("Removed PodSandbox %s\n", podID)
+}
+
+// listPodSanboxforID lists PodSandbox for podID.
+func listPodSanboxForID(c internalapi.RuntimeService, podID string) ([]*runtimeapi.PodSandbox, error) {
+	By("list PodSandbox for podID")
+	filter := &runtimeapi.PodSandboxFilter{
+		Id: &podID,
+	}
+	return c.ListPodSandbox(filter)
+}
+
+// listPodSanboxforIDOrFail lists PodSandbox for podID and fails if it gets error.
+func listPodSanboxForIDOrFail(c internalapi.RuntimeService, podID string) []*runtimeapi.PodSandbox {
+	pods, err := listPodSanboxForID(c, podID)
+	e2eframework.ExpectNoError(err, "Failed to list PodSandbox %s status: %v", podID, err)
+	return pods
+}
+
+// getContainerStatus gets ContainerState for containerID.
+func getContainerStatus(c internalapi.RuntimeService, containerID string) (*runtimeapi.ContainerStatus, error) {
+	By("get container status")
+	return c.ContainerStatus(containerID)
+}
+
+// getPodSandboxStatusOrFail gets ContainerState for containerID and fails if it gets error.
+func getContainerStatusOrFail(c internalapi.RuntimeService, containerID string) *runtimeapi.ContainerStatus {
+	status, err := getContainerStatus(c, containerID)
+	e2eframework.ExpectNoError(err, "Failed to get container %s status: %v", containerID, err)
+	return status
+}
+
+// verifyContainerStatus verifies whether status for given containerID matches.
+func verifyContainerStatus(c internalapi.RuntimeService, containerID string, expectedStatus runtimeapi.ContainerState, stateName string) {
+	status := getContainerStatusOrFail(c, containerID)
+	Expect(*status.State).To(Equal(expectedStatus), "Container state should be %s", stateName)
+}
+
+// runPodSandbox creates a container with the prefix of containerName.
+func createContainer(c internalapi.RuntimeService, prefix string, podID string, podConfig *runtimeapi.PodSandboxConfig) (string, error) {
+	By("create a container with name")
+	containerName := prefix + string(uuid.NewUUID())
+	containerConfig := &runtimeapi.ContainerConfig{
+		Metadata: buildContainerMetadata(&containerName),
+		Image:    &runtimeapi.ImageSpec{Image: &defaultContainerImage},
+		Command:  []string{"sh", "-c", "top"},
+	}
+	return c.CreateContainer(podID, containerConfig, podConfig)
+}
+
+// createContainerOrFail creates a container with the prefix of containerName and fails if it gets error.
+func createContainerOrFail(c internalapi.RuntimeService, prefix string, podID string, podConfig *runtimeapi.PodSandboxConfig) string {
+	containerID, err := createContainer(c, prefix, podID, podConfig)
+	e2eframework.ExpectNoError(err, "Failed to create container: %v", err)
+	e2eframework.Logf("Created container %s\n", containerID)
+	return containerID
+}
+
+// testCreateContainer creates a container in the pod which ID is podID and make sure it be ready.
+func testCreateContainer(c internalapi.RuntimeService, podID string, podConfig *runtimeapi.PodSandboxConfig) string {
+	containerID := createContainerOrFail(c, "container-for-create-test-", podID, podConfig)
+	verifyContainerStatus(c, containerID, runtimeapi.ContainerState_CONTAINER_CREATED, "created")
+	return containerID
+}
+
+// startContainer start the container for containerID.
+func startContainer(c internalapi.RuntimeService, containerID string) error {
+	By("start container")
+	return c.StartContainer(containerID)
+}
+
+// startcontainerOrFail starts the container for containerID and fails if it gets error.
+func startContainerOrFail(c internalapi.RuntimeService, containerID string) {
+	err := startContainer(c, containerID)
+	e2eframework.ExpectNoError(err, "Failed to start container: %v", err)
+	e2eframework.Logf("Start container %s\n", containerID)
+}
+
+// testStartContainer starts the container for containerID and make sure it be running.
+func testStartContainer(c internalapi.RuntimeService, containerID string) {
+	startContainerOrFail(c, containerID)
+	verifyContainerStatus(c, containerID, runtimeapi.ContainerState_CONTAINER_RUNNING, "running")
+}
+
+// stopContainer stops the container for containerID.
+func stopContainer(c internalapi.RuntimeService, containerID string, timeout int64) error {
+	By("stop container")
+	return c.StopContainer(containerID, timeout)
+}
+
+// stopContainerOrFail stops the container for containerID and fails if it gets error.
+func stopContainerOrFail(c internalapi.RuntimeService, containerID string, timeout int64) {
+	err := stopContainer(c, containerID, timeout)
+	e2eframework.ExpectNoError(err, "Failed to stop container: %v", err)
+	e2eframework.Logf("Stop container %s\n", containerID)
+}
+
+// testStopContainer stops the container for containerID and make sure it be exited.
+func testStopContainer(c internalapi.RuntimeService, containerID string) {
+	stopContainerOrFail(c, containerID, defaultStopContainerTimeout)
+	verifyContainerStatus(c, containerID, runtimeapi.ContainerState_CONTAINER_EXITED, "exited")
+}
+
+// removePodSandbox removes the container for containerID.
+func removeContainer(c internalapi.RuntimeService, containerID string) error {
+	By("remove container for containerID")
+	return c.RemoveContainer(containerID)
+}
+
+// removeContainerOrFail removes the container for containerID and fails if it gets error.
+func removeContainerOrFail(c internalapi.RuntimeService, containerID string) {
+	err := removeContainer(c, containerID)
+	e2eframework.ExpectNoError(err, "Failed to remove container: %v", err)
+	e2eframework.Logf("Removed container %s\n", containerID)
+}
+
+// listContainerforID lists container for podID.
+func listContainerForID(c internalapi.RuntimeService, containerID string) ([]*runtimeapi.Container, error) {
+	By("list containers for containerID")
+	filter := &runtimeapi.ContainerFilter{
+		Id: &containerID,
+	}
+	return c.ListContainers(filter)
+}
+
+// listContainerforID lists container for podID and fails if it gets error.
+func listContainerForIDOrFail(c internalapi.RuntimeService, containerID string) []*runtimeapi.Container {
+	containers, err := listContainerForID(c, containerID)
+	e2eframework.ExpectNoError(err, "Failed to list containers %s status: %v", containerID, err)
+	return containers
+}
+
+// createPodSandboxForContainer creates a PodSandbox for creating containers.
+func createPodSandboxForContainer(c internalapi.RuntimeService) (string, *runtimeapi.PodSandboxConfig) {
+	By("create a PodSandbox for creating containers")
+	podName := "PodSandbox-for-create-container-" + string(uuid.NewUUID())
+	podConfig := &runtimeapi.PodSandboxConfig{
+		Metadata: buildPodSandboxMetadata(&podName),
+	}
+	podID, err := c.RunPodSandbox(podConfig)
+	e2eframework.ExpectNoError(err, "Failed to create PodSandbox: %v", err)
+	e2eframework.Logf("Created PodSandbox %s\n", podID)
+	return podID, podConfig
+}
+
+// pullPublicImage pulls an image named imageName.
+func pullPublicImage(c internalapi.ImageManagerService, imageName string) error {
+	By(fmt.Sprintf("pull image %s", imageName))
+	imageSpec := &runtimeapi.ImageSpec{
+		Image: &imageName,
+	}
+	return c.PullImage(imageSpec, nil)
+}
+
+// pullPublicImageOrFail pulls an image named imageName and fails if it gets error.
+func pullPublicImageOrFail(c internalapi.ImageManagerService, imageName string) {
+	err := pullPublicImage(c, imageName)
+	e2eframework.ExpectNoError(err, "Failed to pull image: %v", err)
+}
+
+// listImages lists the images named imageName.
+func listImages(c internalapi.ImageManagerService, imageName string) ([]*runtimeapi.Image, error) {
+	By("get image list")
+	imageSpec := &runtimeapi.ImageSpec{
+		Image: &imageName,
+	}
+	filter := &runtimeapi.ImageFilter{
+		Image: imageSpec,
+	}
+	return c.ListImages(filter)
+}
+
+// listImagesOrFail lists the images named imageName and fails if it gets error.
+func listImagesOrFail(c internalapi.ImageManagerService, imageName string) []*runtimeapi.Image {
+	images, err := listImages(c, imageName)
+	e2eframework.ExpectNoError(err, "Failed to get image list: %v", err)
+	return images
+}
+
+// removeImage removes the image named imagesName.
+func removeImage(c internalapi.ImageManagerService, imageName string) error {
+	By(fmt.Sprintf("remove image %s", imageName))
+	imageSpec := &runtimeapi.ImageSpec{
+		Image: &imageName,
+	}
+	return c.RemoveImage(imageSpec)
+}
+
+// removeImageOrFail removes the image named imagesName and fails if it gets error.
+func removeImageOrFail(c internalapi.ImageManagerService, imageName string) {
+	err := removeImage(c, imageName)
+	e2eframework.ExpectNoError(err, "Failed to remove image: %v", err)
+}
+
+// testRemoveImage removes the image name imageName and check if it successes.
+func testRemoveImage(c internalapi.ImageManagerService, imageName string) {
+	By(fmt.Sprintf("remove image %s", imageName))
+	removeImageOrFail(c, imageName)
+
+	By("check image list empty")
+	iamges := listImagesOrFail(c, imageName)
+	Expect(len(iamges)).To(Equal(0), "should have none image in list")
+}
+
+// testPullPublicImage pulls the image named imageName, make sure it success and remove the image.
+func testPullPublicImage(c internalapi.ImageManagerService, imageName string) {
+	if !strings.Contains(imageName, ":") {
+		imageName = imageName + ":latest"
+	}
+	pullPublicImageOrFail(c, imageName)
+
+	By("check image list to make sure pulling image success")
+	images := listImagesOrFail(c, imageName)
+	Expect(len(images)).To(Equal(1), "should have one image in list")
+
+	testRemoveImage(c, imageName)
+}
+
+// imageStatus gets the status of the image named imageName.
+func imageStatus(c internalapi.ImageManagerService, imageName string) (*runtimeapi.Image, error) {
+	By("get image status")
+	imageSpec := &runtimeapi.ImageSpec{
+		Image: &imageName,
+	}
+	return c.ImageStatus(imageSpec)
+}
+
+// imageStatusOrFail gets the status of the image named imageName and fails if it gets error.
+func imageStatusOrFail(c internalapi.ImageManagerService, imageName string) *runtimeapi.Image {
+	status, err := imageStatus(c, imageName)
+	e2eframework.ExpectNoError(err, "Failed to get image status: %v", err)
+	return status
+}
+
+// pullImageList pulls the images listed in the imageList.
+func pullImageList(c internalapi.ImageManagerService, imageList []string) {
+	for _, imageName := range imageList {
+		pullPublicImageOrFail(c, imageName)
+	}
+}
+
+// pullImageList removes the images listed in the imageList.
+func removeImageList(c internalapi.ImageManagerService, imageList []string) {
+	for _, imageName := range imageList {
+		removeImageOrFail(c, imageName)
+	}
+}
+
+// getVersion gets version info from server.
+func getVersion(c internalapi.RuntimeService, apiVersion string) (*runtimeapi.VersionResponse, error) {
+	return c.Version("test")
+}
+
+// getVersion gets version info from server and fails if it gets error.
+func getVersionOrFail(c internalapi.RuntimeService, apiVersion string) *runtimeapi.VersionResponse {
+	version, err := getVersion(c, apiVersion)
+	e2eframework.ExpectNoError(err, "Failed to get version: %v", err)
+	return version
+}
+
+// testGetVersion test if we can get runtime name.
+func testGetVersion(c internalapi.RuntimeService) {
+	version := getVersionOrFail(c, "test")
+	e2eframework.Logf("get version runtime name " + *version.RuntimeName)
+}


### PR DESCRIPTION
This pr use e2e framework to validate a CRI (grpc) server alone. I test this pr against dockershim and frakti. It works fine.

**How to run cri e2e test**

``` sh
cd $GOPATH/src/k8s.io/kubernetes
make test-e2e-cri
```

The default server is dockershim. If we want to test other CRI server such as frakti, we can `export CONTAINER_RUNTIME_ENDPOINT=/var/run/frakti.sock`. And we can run this test against frakti. 

And we also can `go get`  this package, then run the following commands to run this test.

``` sh
go run test/e2e_cri/runner/run.go
```

If we don't need to build dependencies, we can add this flag `--build-dependencies=false`.

A beginning of #34040

/cc @Random-Liu @yujuhong @resouer @feiskyer 

Signed-off-by: Xianglin Gao xlgao@zju.edu.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35266)

<!-- Reviewable:end -->
