### PR TITLE
Bump kubeadm to use v1.4.4 by default

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/defaults.go
@@ -19,7 +19,7 @@ package kubeadm
 const (
 	DefaultServiceDNSDomain  = "cluster.local"
 	DefaultServicesSubnet    = "10.12.0.0/12"
-	DefaultKubernetesVersion = "v1.4.1"
+	DefaultKubernetesVersion = "v1.4.4"
 	DefaultAPIBindPort       = 6443
 	DefaultDiscoveryBindPort = 9898
 )


### PR DESCRIPTION
**Release note**:

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35270)

<!-- Reviewable:end -->
