### PR TITLE
Added 'mounterPath' to Mounter interface in 'mount_unsupported.go'.

### DIFF
--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -18,7 +18,9 @@ limitations under the License.
 
 package mount
 
-type Mounter struct{}
+type Mounter struct {
+	mounterPath string
+}
 
 func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {
 	return nil


### PR DESCRIPTION
fixes #35257 .

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35271)

<!-- Reviewable:end -->
