### PR TITLE
rescale immediately if the basic constraints are not satisfied

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -292,9 +292,12 @@ func (a *HorizontalController) reconcileAutoscaler(hpa *autoscaling.HorizontalPo
 	rescaleReason := ""
 	timestamp := time.Now()
 
+	rescale := true
+
 	if scale.Spec.Replicas == 0 {
 		// Autoscaling is disabled for this resource
 		desiredReplicas = 0
+		rescale = false
 	} else if currentReplicas > hpa.Spec.MaxReplicas {
 		rescaleReason = "Current number of replicas above Spec.MaxReplicas"
 		desiredReplicas = hpa.Spec.MaxReplicas
@@ -360,9 +363,10 @@ func (a *HorizontalController) reconcileAutoscaler(hpa *autoscaling.HorizontalPo
 		if desiredReplicas > calculateScaleUpLimit(currentReplicas) {
 			desiredReplicas = calculateScaleUpLimit(currentReplicas)
 		}
+
+		rescale = shouldScale(hpa, currentReplicas, desiredReplicas, timestamp)
 	}
 
-	rescale := shouldScale(hpa, currentReplicas, desiredReplicas, timestamp)
 	if rescale {
 		scale.Spec.Replicas = desiredReplicas
 		_, err = a.scaleNamespacer.Scales(hpa.Namespace).Update(hpa.Spec.ScaleTargetRef.Kind, scale)


### PR DESCRIPTION
refactor reconcileAutoscaler.
If the basic constraints are not satisfied, we should rescale the target ref immediately.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35272)

<!-- Reviewable:end -->
