### PR TITLE
Fix clear-kubeconfig

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -147,15 +147,14 @@ function clear-kubeconfig() {
   fi
 
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-  "${kubectl}" config unset "clusters.${CONTEXT}"
-  "${kubectl}" config unset "users.${CONTEXT}"
-  "${kubectl}" config unset "users.${CONTEXT}-basic-auth"
-  "${kubectl}" config unset "contexts.${CONTEXT}"
-
   local cc=$("${kubectl}" config view -o jsonpath='{.current-context}')
   if [[ "${cc}" == "${CONTEXT}" ]]; then
     "${kubectl}" config unset current-context
   fi
+  "${kubectl}" config unset "clusters.${CONTEXT}"
+  "${kubectl}" config unset "users.${CONTEXT}"
+  "${kubectl}" config unset "users.${CONTEXT}-basic-auth"
+  "${kubectl}" config unset "contexts.${CONTEXT}"
 
   echo "Cleared config for ${CONTEXT} from ${KUBECONFIG}"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When we bring down the cluster the current-context is not getting unset.
This is because the context is already removed and kubectl throws an error like below:

```
# kubectl config unset current-context
failed to get client config: Error in configuration: context was not found for specified context: federation-e2e-gce-asia-east1-c
```

and further any command you use, will report the same error.

**Special notes for your reviewer**:
The fix is simple, just move unsetting current-context before unsetting the context itself.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35276)

<!-- Reviewable:end -->
