### PR TITLE
support skipping the validity check of keystone server's certificate

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -230,6 +230,7 @@ func Run(s *options.APIServer) error {
 		ServiceAccountLookup:        s.ServiceAccountLookup,
 		ServiceAccountTokenGetter:   serviceAccountGetter,
 		KeystoneURL:                 s.KeystoneURL,
+		KeystoneInsecureTLS:         s.KeystoneInsecureTLS,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
 	})

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -117,17 +117,18 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	apiAuthenticator, securityDefinitions, err := authenticator.New(authenticator.AuthenticatorConfig{
-		Anonymous:         s.AnonymousAuth,
-		AnyToken:          s.EnableAnyToken,
-		BasicAuthFile:     s.BasicAuthFile,
-		ClientCAFile:      s.ClientCAFile,
-		TokenAuthFile:     s.TokenAuthFile,
-		OIDCIssuerURL:     s.OIDCIssuerURL,
-		OIDCClientID:      s.OIDCClientID,
-		OIDCCAFile:        s.OIDCCAFile,
-		OIDCUsernameClaim: s.OIDCUsernameClaim,
-		OIDCGroupsClaim:   s.OIDCGroupsClaim,
-		KeystoneURL:       s.KeystoneURL,
+		Anonymous:            s.AnonymousAuth,
+		AnyToken:             s.EnableAnyToken,
+		BasicAuthFile:        s.BasicAuthFile,
+		ClientCAFile:         s.ClientCAFile,
+		TokenAuthFile:        s.TokenAuthFile,
+		OIDCIssuerURL:        s.OIDCIssuerURL,
+		OIDCClientID:         s.OIDCClientID,
+		OIDCCAFile:           s.OIDCCAFile,
+		OIDCUsernameClaim:    s.OIDCUsernameClaim,
+		OIDCGroupsClaim:      s.OIDCGroupsClaim,
+		KeystoneURL:          s.KeystoneURL,
+		KeystoneInsecureTLS:  s.KeystoneInsecureTLS,
 	})
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -186,6 +186,7 @@ exit-on-lock-contention
 experimental-allowed-unsafe-sysctls
 experimental-bootstrap-kubeconfig
 experimental-keystone-url
+experimental-keystone-insecure-tls
 experimental-nvidia-gpus
 experimental-prefix
 experimental-runtime-integration-type

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -54,6 +54,7 @@ type AuthenticatorConfig struct {
 	ServiceAccountLookup        bool
 	ServiceAccountTokenGetter   serviceaccount.ServiceAccountTokenGetter
 	KeystoneURL                 string
+	KeystoneInsecureTLS         bool
 	WebhookTokenAuthnConfigFile string
 	WebhookTokenAuthnCacheTTL   time.Duration
 }
@@ -76,7 +77,7 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 		hasBasicAuth = true
 	}
 	if len(config.KeystoneURL) > 0 {
-		keystoneAuth, err := newAuthenticatorFromKeystoneURL(config.KeystoneURL)
+		keystoneAuth, err := newAuthenticatorFromKeystoneURL(config.KeystoneURL, config.KeystoneInsecureTLS)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -258,8 +259,8 @@ func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Reques
 }
 
 // newAuthenticatorFromTokenFile returns an authenticator.Request or an error
-func newAuthenticatorFromKeystoneURL(keystoneURL string) (authenticator.Request, error) {
-	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneURL)
+func newAuthenticatorFromKeystoneURL(keystoneURL string, keystoneInsecureTLs bool) (authenticator.Request, error) {
+	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneURL, keystoneInsecureTLs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -91,6 +91,7 @@ type ServerRunOptions struct {
 	InsecureBindAddress       net.IP
 	InsecurePort              int
 	KeystoneURL               string
+	KeystoneInsecureTLS       bool
 	KubernetesServiceNodePort int
 	LongRunningRequestRE      string
 	MasterCount               int
@@ -374,6 +375,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.KeystoneURL, "experimental-keystone-url", s.KeystoneURL,
 		"If passed, activates the keystone authentication plugin.")
+
+	fs.BoolVar(&s.KeystoneInsecureTLS, "experimental-keystone-insecure-tls", s.KeystoneInsecureTLS,
+		"If passed, activates the keystone authentication plugin. Boolean value to indicate"+
+		"whether to skip the validity check of the keystone server's certificate.")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Sometimes the keystone server's certificate is self-signed, mainly used for internal development, testing and etc.

Of course, a trusted root certificate for keystone server can be added manually.

Otherwise, below error will occur.

> x509: certificate signed by unknown authority

However, this patch provides an alternative and easy way to support such scenario.

**Which issue this PR fixes** : fixes #22695, #24984

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35280)

<!-- Reviewable:end -->
