### PR TITLE
Add kubeadm to hyperkube

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -75,7 +75,8 @@ RUN ln -s /hyperkube /apiserver \
  && ln -s /hyperkube /kubectl \
  && ln -s /hyperkube /kubelet \
  && ln -s /hyperkube /proxy \
- && ln -s /hyperkube /scheduler
+ && ln -s /hyperkube /scheduler \
+ && ln -s /hyperkube /kubeadm
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube

--- a/cmd/hyperkube/kubeadm.go
+++ b/cmd/hyperkube/kubeadm.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func NewKubeadmServer() *Server {
+	cmd := cmd.NewKubeadmCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
+	localFlags := cmd.LocalFlags()
+	localFlags.SetInterspersed(false)
+
+	return &Server{
+		name:        "kubeadm",
+		SimpleUsage: "Kubernetes clusters lifecycle command line client",
+		Long:        "Kubernetes clusters bootstrap and lifecycle management command line client",
+		Run: func(s *Server, args []string) error {
+			cmd.SetArgs(args)
+			return cmd.Execute()
+		},
+		flags: localFlags,
+	}
+}

--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -43,5 +43,8 @@ func main() {
 	hk.AddServer(NewFederationAPIServer())
 	hk.AddServer(NewFederationCMServer())
 
+	//LCM tools
+	hk.AddServer(NewKubeadmServer())
+
 	hk.RunToExit(os.Args)
 }


### PR DESCRIPTION
Add the kubeadm clusters lifecycle command line client tool to the hyperkube binary.

Closes https://github.com/kubernetes/kubernetes/issues/35041

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35291)

<!-- Reviewable:end -->
