### PR TITLE
Add BindNetwork to genericapiserver Config

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -177,6 +177,9 @@ type Config struct {
 type ServingInfo struct {
 	// BindAddress is the ip:port to serve on
 	BindAddress string
+	// BindNetwork is the type of network to bind to - defaults to "tcp", accepts "tcp",
+	// "tcp4", and "tcp6".
+	BindNetwork string
 }
 
 type SecureServingInfo struct {


### PR DESCRIPTION
This is needed for downstream use:

`BindNetwork` is the type of network to bind to - defaults to "tcp4", accepts "tcp", "tcp4", and "tcp6".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35292)

<!-- Reviewable:end -->
