### PR TITLE
Fixed handling pod updates in case of multiple RC/RS with the same label co-existance in the system

### DIFF
--- a/pkg/client/cache/listers_core.go
+++ b/pkg/client/cache/listers_core.go
@@ -197,7 +197,10 @@ func (s *StoreToReplicationControllerLister) GetPodControllers(pod *v1.Pod) (con
 		if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
 			continue
 		}
-		controllers = append(controllers, rc)
+		// Do not take in consideration controllers that are being deleted
+		if rc.DeletionTimestamp == nil {
+			controllers = append(controllers, rc)
+		}
 	}
 	if len(controllers) == 0 {
 		err = fmt.Errorf("could not find controller for pod %s in namespace %s with labels: %v", pod.Name, pod.Namespace, pod.Labels)

--- a/pkg/client/cache/listers_extensions.go
+++ b/pkg/client/cache/listers_extensions.go
@@ -202,7 +202,10 @@ func (s *StoreToReplicaSetLister) GetPodReplicaSets(pod *v1.Pod) (rss []*extensi
 		if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
 			continue
 		}
-		rss = append(rss, rs)
+		// Do not take in consideration controllers that are being deleted
+		if rs.DeletionTimestamp == nil {
+			rss = append(rss, rs)
+		}
 	}
 	if len(rss) == 0 {
 		err = fmt.Errorf("could not find ReplicaSet for pod %s in namespace %s with labels: %v", pod.Name, pod.Namespace, pod.Labels)

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -65,7 +65,7 @@ func (m *PodControllerRefManager) Classify(pods []*v1.Pod) (
 				pod.Namespace, pod.Name, pod.Status.Phase, pod.DeletionTimestamp)
 			continue
 		}
-		controllerRef := getControllerOf(pod.ObjectMeta)
+		controllerRef := GetControllerOf(pod.ObjectMeta)
 		if controllerRef != nil {
 			if controllerRef.UID == m.controllerObject.UID {
 				// already controlled
@@ -90,9 +90,9 @@ func (m *PodControllerRefManager) Classify(pods []*v1.Pod) (
 	return matchesAndControlled, matchesNeedsController, controlledDoesNotMatch
 }
 
-// getControllerOf returns the controllerRef if controllee has a controller,
+// GetControllerOf returns the controllerRef if controllee has a controller,
 // otherwise returns nil.
-func getControllerOf(controllee v1.ObjectMeta) *metav1.OwnerReference {
+func GetControllerOf(controllee v1.ObjectMeta) *metav1.OwnerReference {
 	for _, owner := range controllee.OwnerReferences {
 		// controlled by other controller
 		if owner.Controller != nil && *owner.Controller == true {

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -176,8 +176,8 @@ func (rsc *ReplicaSetController) Run(workers int, stopCh <-chan struct{}) {
 
 // getPodReplicaSet returns the replica set managing the given pod.
 // TODO: Surface that we are ignoring multiple replica sets for a single pod.
-// TODO: use ownerReference.Controller to determine if the rs controls the pod.
 func (rsc *ReplicaSetController) getPodReplicaSet(pod *v1.Pod) *extensions.ReplicaSet {
+	controllerRef := controller.GetControllerOf(pod.ObjectMeta)
 	// look up in the cache, if cached and the cache is valid, just return cached value
 	if obj, cached := rsc.lookupCache.GetMatchingObject(pod); cached {
 		rs, ok := obj.(*extensions.ReplicaSet)
@@ -186,7 +186,13 @@ func (rsc *ReplicaSetController) getPodReplicaSet(pod *v1.Pod) *extensions.Repli
 			utilruntime.HandleError(fmt.Errorf("lookup cache does not return a ReplicaSet object"))
 			return nil
 		}
-		if cached && rsc.isCacheValid(pod, rs) {
+		// For the case when we have several active controllers with the same labels in the system,
+		// the cache will return the oldest controller for all pods with the same label and namespace
+		// So we need to check here that the oldest one actually controls the pod,
+		// or the pod doesn't have controller set
+		isValidController := (controllerRef == nil || controllerRef.UID == rs.ObjectMeta.UID)
+		if isValidController && rsc.isCacheValid(pod, rs) {
+			glog.V(4).Infof("Return for pod %s controller from cache: %+v", pod.Name, *rs)
 			return rs
 		}
 	}
@@ -210,7 +216,19 @@ func (rsc *ReplicaSetController) getPodReplicaSet(pod *v1.Pod) *extensions.Repli
 		sort.Sort(overlappingReplicaSets(rss))
 	}
 
+	// check ownerReference.Controller and UID to determine if the rc controls the pod
+	// in case of multiple controllers match the pod's label
+	if controllerRef != nil {
+		for _, rs := range rss {
+			if controllerRef.UID == rs.ObjectMeta.UID {
+				glog.V(4).Infof("Return for pod %s/%s controller: %+v", pod.Namespace, pod.Name, rs)
+				return rs
+			}
+		}
+	}
+
 	// update lookup cache
+	glog.V(4).Infof("Return for pod %s/%s controller: %+v", pod.Namespace, pod.Name, *rss[0])
 	rsc.lookupCache.Update(pod, rss[0])
 
 	return rss[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed handling pod updates in case of multiple RC/RS with the same label co-existance in the system:
- in case of pod's OwnerRef is set added check for matching controller's uid to be returned with set in pod's object
- fixed cache invalidation for stored RC/RS by checking ResourceVersion.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #32829

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35298)

<!-- Reviewable:end -->
