### PR TITLE
test-images: server address is now configurable

### DIFF
--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.0
+TAG = 1.1
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/port-forward-tester/portforwardtester.go
+++ b/test/images/port-forward-tester/portforwardtester.go
@@ -48,8 +48,12 @@ func getEnvInt(name string) int {
 }
 
 func main() {
+	bindAddress := os.Getenv("BIND_ADDRESS")
+	if bindAddress == "" {
+		bindAddress = "localhost"
+	}
 	bindPort := os.Getenv("BIND_PORT")
-	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%s", bindPort))
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", bindAddress, bindPort))
 	if err != nil {
 		fmt.Printf("Error listening: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This commit perform changes discussed in #32128
Should be merged before #35301

cc: @pskrzyns

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35302)

<!-- Reviewable:end -->
