### PR TITLE
On GCI, cleanup kubelet startup

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -473,8 +473,6 @@ function start-kubelet {
   flags+=" --cluster-dns=${DNS_SERVER_IP}"
   flags+=" --cluster-domain=${DNS_DOMAIN}"
   flags+=" --config=/etc/kubernetes/manifests"
-  flags+=" --kubelet-cgroups=/kubelet"
-  flags+=" --system-cgroups=/system"
 
   if [[ -n "${KUBELET_PORT:-}" ]]; then
     flags+=" --port=${KUBELET_PORT}"
@@ -1167,6 +1165,9 @@ For Kubernetes copyright and licensing information, see:
 EOF
 }
 
+function override-kubectl {
+    echo "export PATH=${KUBE_HOME}/bin:\$PATH" > /etc/profile.d/kube_env.sh
+}
 
 ########### Main Function ###########
 echo "Start to configure instance for kubernetes"
@@ -1201,6 +1202,7 @@ else
   create-kubeproxy-kubeconfig
 fi
 
+override-kubectl
 assemble-docker-flags
 load-docker-images
 start-kubelet


### PR DESCRIPTION
-->

``` release-note
* Avoid overriding system and kubelet cgroups on GCI
* Make the kubectl from k8s release the default on GCI
```

cc @kubernetes/sig-node @mtaufen

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35319)

<!-- Reviewable:end -->
