### PR TITLE
don't reread world state after starting reconstruction

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -416,9 +416,9 @@ func (rc *reconciler) reconstructStates(podsDir string) {
 		if rc.operationExecutor.IsOperationPending(volumeToMount.VolumeName, volumeToMount.PodName) {
 			continue
 		}
-		desiredPods := rc.desiredStateOfWorld.GetPods()
-		actualPods := rc.actualStateOfWorld.GetPods()
-		if desiredPods[volume.podName] || actualPods[volume.podName] {
+		dswExist := rc.desiredStateOfWorld.PodExistsInVolume(volumeToMount.PodName, volumeToMount.VolumeName)
+		aswExist, _, _ := rc.actualStateOfWorld.PodExistsInVolume(volumeToMount.PodName, volumeToMount.VolumeName)
+		if dswExist || aswExist {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #35310 by not rereading the world state after reconstructing from on-disk pod volumes

@pmorie @saad-ali @derekwaynecarr

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35320)

<!-- Reviewable:end -->
