### PR TITLE
prevent panic if resourceversion checked early

### DIFF
--- a/pkg/client/cache/shared_informer.go
+++ b/pkg/client/cache/shared_informer.go
@@ -207,7 +207,7 @@ func (s *sharedIndexInformer) LastSyncResourceVersion() string {
 	s.startedLock.Lock()
 	defer s.startedLock.Unlock()
 
-	if s.controller == nil {
+	if s.controller == nil || s.controller.reflector == nil {
 		return ""
 	}
 	return s.controller.reflector.LastSyncResourceVersion()


### PR DESCRIPTION
Found panic while trying to use this in a separate API server.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35322)

<!-- Reviewable:end -->
