### PR TITLE
ignore default.etcd directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ network_closure.sh
 
 # Also ignore etcd installed by hack/install-etcd.sh
 /third_party/etcd*
+/default.etcd
 
 # User cluster configs
 .kubeconfig


### PR DESCRIPTION
When using `hack/install-etcd.sh`, `/default.etcd` is created for the data directory.  Add that to `.gitignore`.

``` release-note
NONE
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35325)

<!-- Reviewable:end -->
