### PR TITLE
kubeadm: added unit test for app/preflight pkg

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -19,3 +19,11 @@ go_library(
         "//pkg/util/initsystem:go_default_library",
     ],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["checks_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [],
+)

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -200,7 +200,7 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		InPathCheck{executable: "touch", mandatory: false},
 	}
 
-	return runChecks(checks)
+	return runChecks(checks, os.Stderr)
 }
 
 func RunJoinNodeChecks() error {
@@ -223,7 +223,7 @@ func RunJoinNodeChecks() error {
 		InPathCheck{executable: "touch", mandatory: false},
 	}
 
-	return runChecks(checks)
+	return runChecks(checks, os.Stderr)
 }
 
 func RunResetCheck() error {
@@ -231,17 +231,17 @@ func RunResetCheck() error {
 		IsRootCheck{root: true},
 	}
 
-	return runChecks(checks)
+	return runChecks(checks, os.Stderr)
 }
 
 // runChecks runs each check, displays it's warnings/errors, and once all
 // are processed will exit if any errors occurred.
-func runChecks(checks []PreFlightCheck) error {
+func runChecks(checks []PreFlightCheck, ww io.Writer) error {
 	found := []error{}
 	for _, c := range checks {
 		warnings, errs := c.Check()
 		for _, w := range warnings {
-			fmt.Printf("WARNING: %s\n", w)
+			io.WriteString(ww, fmt.Sprintf("WARNING: %s\n", w))
 		}
 		for _, e := range errs {
 			found = append(found, e)

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+type preflightCheckTest struct {
+	msg string
+}
+
+func (pfct preflightCheckTest) Check() (warning, errors []error) {
+	if pfct.msg == "warning" {
+		return []error{fmt.Errorf("warning")}, nil
+	}
+	if pfct.msg != "" {
+		return nil, []error{fmt.Errorf("fake error")}
+	}
+	return
+}
+
+func TestRunChecks(t *testing.T) {
+	var tokenTest = []struct {
+		p        []PreFlightCheck
+		expected bool
+		output   string
+	}{
+		{[]PreFlightCheck{}, true, ""},
+		{[]PreFlightCheck{preflightCheckTest{"warning"}}, true, "WARNING: warning\n"}, // should just print warning
+		{[]PreFlightCheck{preflightCheckTest{"error"}}, false, ""},
+		{[]PreFlightCheck{preflightCheckTest{"test"}}, false, ""},
+	}
+	for _, rt := range tokenTest {
+		buf := new(bytes.Buffer)
+		actual := runChecks(rt.p, buf)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed runChecks:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+		if buf.String() != rt.output {
+			t.Errorf(
+				"failed runChecks:\n\texpected: %s\n\t  actual: %s",
+				rt.output,
+				buf.String(),
+			)
+		}
+	}
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -455,6 +455,10 @@ k8s.io/kubernetes/cmd/kube-proxy/app,luxas,1
 k8s.io/kubernetes/cmd/kubeadm/app/cmd,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/images,saad-ali,1
 k8s.io/kubernetes/cmd/kubeadm/app/util,eparis,1
+k8s.io/kubernetes/cmd/kubeadm/app/cmd,vishh,1
+k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
+k8s.io/kubernetes/cmd/kubeadm/app/preflight,apprenda,0
+k8s.io/kubernetes/cmd/kubeadm/app/util,krousey,1
 k8s.io/kubernetes/cmd/kubelet/app,hurf,1
 k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned,eparis,1
 k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators,davidopp,1


### PR DESCRIPTION
Added unit test for kubeadm/app/preflight package testing functionality of checks.go.

This PR is part of the ongoing effort to add tests (#35025)

/cc @pires @jbeda

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35326)

<!-- Reviewable:end -->
