### PR TITLE
Add boilerplate to `kubectl completion bash`

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,22 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
+
+const boilerPlate = `
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+`
 
 var (
 	completion_long = templates.LongDesc(`
@@ -93,24 +109,19 @@ func RunCompletion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 }
 
 func runCompletionBash(out io.Writer, kubectl *cobra.Command) error {
+	_, err := out.Write([]byte(boilerPlate))
+	if err != nil {
+		return err
+	}
 	return kubectl.GenBashCompletion(out)
 }
 
 func runCompletionZsh(out io.Writer, kubectl *cobra.Command) error {
-	zsh_initialilzation := `# Copyright 2016 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+	_, err := out.Write([]byte(boilerPlate))
+	if err != nil {
+		return err
+	}
+	zsh_initialization := `
 __kubectl_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand
@@ -259,7 +270,7 @@ __kubectl_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__kubectl_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
-	out.Write([]byte(zsh_initialilzation))
+	out.Write([]byte(zsh_initialization))
 
 	buf := new(bytes.Buffer)
 	kubectl.GenBashCompletion(buf)


### PR DESCRIPTION
**What this PR does / why we need it**: 

Small refactor to make kubectl bash and zsh completion share
boilerplate.  Previously the boilerplate was not included in the bash
script.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35327)

<!-- Reviewable:end -->
