### PR TITLE
Fix addon-manager image build

### DIFF
--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -21,7 +21,6 @@ CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 RUN pip install pyyaml
 
 ADD kube-addons.sh /opt/
-ADD kube-addon-update.sh /opt/
 ADD namespace.yaml /opt/
 ADD kubectl /usr/local/bin/
 


### PR DESCRIPTION
addon-manager: remove `kube-addon-update.sh` from Dockerfile

the file no longer exists, so the build fails trying to add this file

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35338)

<!-- Reviewable:end -->
