### PR TITLE
remove defaulting for deployment strategy

### DIFF
--- a/pkg/registry/extensions/deployment/strategy.go
+++ b/pkg/registry/extensions/deployment/strategy.go
@@ -77,6 +77,12 @@ func (deploymentStrategy) PrepareForUpdate(ctx api.Context, obj, old runtime.Obj
 	oldDeployment := old.(*extensions.Deployment)
 	newDeployment.Status = oldDeployment.Status
 
+	if newDeployment.Spec.Strategy.Type == extensions.RecreateDeploymentStrategyType {
+		if newDeployment.Spec.Strategy.RollingUpdate != nil {
+			newDeployment.Spec.Strategy.RollingUpdate = nil
+		}
+	}
+
 	// Spec updates bump the generation so that we can distinguish between
 	// scaling events and template changes, annotation updates bump the generation
 	// because annotations are copied from deployments to their replica sets.

--- a/pkg/registry/extensions/deployment/strategy_test.go
+++ b/pkg/registry/extensions/deployment/strategy_test.go
@@ -62,6 +62,21 @@ func TestStatusUpdates(t *testing.T) {
 	}
 }
 
+func TestDeploymentStrategyUpdates(t *testing.T) {
+	old := newDeployment(map[string]string{"test": "label"}, map[string]string{"test": "annotation"})
+	old.Spec.Strategy = *newDeploymentStrategy(extensions.RollingUpdateDeploymentStrategyType)
+	obj := newDeployment(map[string]string{"test": "label"}, map[string]string{"test": "annotation"})
+	obj.Spec.Strategy = *newDeploymentStrategy(extensions.RollingUpdateDeploymentStrategyType)
+	resetDeploymentStrategyType(obj, extensions.RecreateDeploymentStrategyType)
+	expected := newDeployment(map[string]string{"test": "label"}, map[string]string{"test": "annotation"})
+	expected.Spec.Strategy = *newDeploymentStrategy(extensions.RecreateDeploymentStrategyType)
+
+	deploymentStrategy{}.PrepareForUpdate(api.NewContext(), obj, old)
+	if !reflect.DeepEqual(expected.Spec, obj.Spec) {
+		t.Errorf("Unexpected object mismatch! Expected:\n%#v\ngot:\n%#v", expected, obj)
+	}
+}
+
 func newDeployment(labels, annotations map[string]string) *extensions.Deployment {
 	return &extensions.Deployment{
 		ObjectMeta: api.ObjectMeta{
@@ -86,4 +101,18 @@ func newDeployment(labels, annotations map[string]string) *extensions.Deployment
 			},
 		},
 	}
+}
+
+func newDeploymentStrategy(strategyType extensions.DeploymentStrategyType) *extensions.DeploymentStrategy {
+	strategy := &extensions.DeploymentStrategy{
+		Type: strategyType,
+	}
+	if strategyType == extensions.RollingUpdateDeploymentStrategyType {
+		strategy.RollingUpdate = &extensions.RollingUpdateDeployment{}
+	}
+	return strategy
+}
+
+func resetDeploymentStrategyType(deployment *extensions.Deployment, strategyType extensions.DeploymentStrategyType) {
+	deployment.Spec.Strategy.Type = strategyType
 }


### PR DESCRIPTION
This PR remove the defaulting for RollingUpdate when the deployment strategy change from `RolingUpdate` to `Recreate`.

Partially addresses: #34292, #24198

cc: @pwittrock

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35343)

<!-- Reviewable:end -->
