### PR TITLE
Enable containerized storage plugins mounter on GCI

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1164,6 +1164,9 @@ For Kubernetes copyright and licensing information, see:
 EOF
 }
 
+function pre-warm-mounter {
+    ${KUBE_HOME}/bin/mounter &> /dev/null
+}
 
 ########### Main Function ###########
 echo "Start to configure instance for kubernetes"
@@ -1198,6 +1201,8 @@ else
   create-kubeproxy-kubeconfig
 fi
 
+# Run the containerized mounter once to pre-cache the container image.
+pre-warm-mounter
 assemble-docker-flags
 load-docker-images
 start-kubelet

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -475,7 +475,10 @@ function start-kubelet {
   flags+=" --config=/etc/kubernetes/manifests"
   flags+=" --kubelet-cgroups=/kubelet"
   flags+=" --system-cgroups=/system"
-
+  flags+=" --experimental-mounter-path=${KUBE_HOME}/bin/mounter"
+  # Note: This patch must match the rootfs path in mounter/mounter
+  flags+=" --experimental-mounter-rootfs-path=/media/root"
+  
   if [[ -n "${KUBELET_PORT:-}" ]]; then
     flags+=" --port=${KUBELET_PORT}"
   fi


### PR DESCRIPTION
``` release-note
On GCI, kubelet uses an external mounter script (typically a special container running in a chroot) to perform mount operations
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35350)

<!-- Reviewable:end -->
