### PR TITLE
bazel: force BUILD files for linux_amd64 on all systems

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -20,4 +20,6 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 go get -u github.com/mikedanese/gazel
+export GOOS=linux
+export GOARCH=amd64
 "${GOPATH}/bin/gazel" -root="$(realpath ${KUBE_ROOT})"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -20,6 +20,8 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 go get -u github.com/mikedanese/gazel
+export GOOS=linux
+export GOARCH=amd64
 if [[ $("${GOPATH}/bin/gazel" -dry-run -root="$(realpath ${KUBE_ROOT})" |& tee /dev/stderr | wc -l) != 0 ]]; then
   echo
   echo "BUILD files are not up to date"


### PR DESCRIPTION
until gazel supports multiarch.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35362)

<!-- Reviewable:end -->
