### PR TITLE
Federation: separate notion of zone-name & dns-suffix

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -179,7 +179,7 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 
 	glog.Infof("Loading client config for service controller %q", servicecontroller.UserAgentName)
 	scClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, servicecontroller.UserAgentName))
-	servicecontroller := servicecontroller.New(scClientset, dns, s.FederationName, s.ZoneName)
+	servicecontroller := servicecontroller.New(scClientset, dns, s.FederationName, s.ServiceDnsSuffix, s.ZoneName)
 	glog.Infof("Running service controller")
 	if err := servicecontroller.Run(s.ConcurrentServiceSyncs, wait.NeverStop); err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -39,6 +39,8 @@ type ControllerManagerConfiguration struct {
 	FederationName string `json:"federationName"`
 	// zone name, like example.com.
 	ZoneName string `json:"zoneName"`
+	// ServiceDnsSuffix is the dns suffix to use when publishing federated services.
+	ServiceDnsSuffix string `json:"serviceDnsSuffix"`
 	// dnsProvider is the provider for dns services.
 	DnsProvider string `json:"dnsProvider"`
 	// dnsConfigFile is the path to the dns provider configuration file.
@@ -101,6 +103,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.StringVar(&s.FederationName, "federation-name", s.FederationName, "Federation name.")
 	fs.StringVar(&s.ZoneName, "zone-name", s.ZoneName, "Zone name, like example.com.")
+	fs.StringVar(&s.ServiceDnsSuffix, "service-dns-suffix", s.ServiceDnsSuffix, "DNS Suffix to use when publishing federated service names.  Defaults to zone-name")
 	fs.IntVar(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.IntVar(&s.ConcurrentReplicaSetSyncs, "concurrent-replicaset-syncs", s.ConcurrentReplicaSetSyncs, "The number of ReplicaSets syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.DurationVar(&s.ClusterMonitorPeriod.Duration, "cluster-monitor-period", s.ClusterMonitorPeriod.Duration, "The period for syncing ClusterStatus in ClusterController.")

--- a/federation/pkg/federation-controller/service/BUILD
+++ b/federation/pkg/federation-controller/service/BUILD
@@ -50,6 +50,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "dns_test.go",
         "endpoint_helper_test.go",
         "service_helper_test.go",
         "servicecontroller_test.go",

--- a/federation/pkg/federation-controller/service/dns_test.go
+++ b/federation/pkg/federation-controller/service/dns_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"sync"
+	"testing"
+
+	"fmt"
+	"k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns" // Only for unit testing purposes.
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"reflect"
+	"sort"
+)
+
+func TestServiceController_ensureDnsRecords(t *testing.T) {
+	tests := []struct {
+		name          string
+		service       v1.Service
+		expected      []string
+		serviceStatus v1.LoadBalancerStatus
+	}{
+		{
+			name: "withip",
+			service: v1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "servicename",
+					Namespace: "servicenamespace",
+				},
+			},
+			serviceStatus: buildServiceStatus([][]string{{"198.51.100.1", ""}}),
+			expected: []string{
+				"example.com:servicename.servicenamespace.myfederation.svc.federation.example.com:A:180:[198.51.100.1]",
+				"example.com:servicename.servicenamespace.myfederation.svc.fooregion.federation.example.com:A:180:[198.51.100.1]",
+				"example.com:servicename.servicenamespace.myfederation.svc.foozone.fooregion.federation.example.com:A:180:[198.51.100.1]",
+			},
+		},
+		/*
+			TODO: getResolvedEndpoints preforms DNS lookup.
+			Mock and maybe look at error handling when some endpoints resolve, but also caching?
+			{
+				name: "withname",
+				service: v1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "servicename",
+						Namespace: "servicenamespace",
+					},
+				},
+				serviceStatus: buildServiceStatus([][]string{{"", "randomstring.amazonelb.example.com"}}),
+				expected: []string{
+					"example.com:servicename.servicenamespace.myfederation.svc.federation.example.com:A:180:[198.51.100.1]",
+					"example.com:servicename.servicenamespace.myfederation.svc.fooregion.federation.example.com:A:180:[198.51.100.1]",
+					"example.com:servicename.servicenamespace.myfederation.svc.foozone.fooregion.federation.example.com:A:180:[198.51.100.1]",
+				},
+			},
+		*/
+		{
+			name: "noendpoints",
+			service: v1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "servicename",
+					Namespace: "servicenamespace",
+				},
+			},
+			expected: []string{
+				"example.com:servicename.servicenamespace.myfederation.svc.fooregion.federation.example.com:CNAME:180:[servicename.servicenamespace.myfederation.svc.federation.example.com]",
+				"example.com:servicename.servicenamespace.myfederation.svc.foozone.fooregion.federation.example.com:CNAME:180:[servicename.servicenamespace.myfederation.svc.fooregion.federation.example.com]",
+			},
+		},
+	}
+	for _, test := range tests {
+		fakedns, _ := clouddns.NewFakeInterface()
+		fakednsZones, ok := fakedns.Zones()
+		if !ok {
+			t.Error("Unable to fetch zones")
+		}
+		serviceController := ServiceController{
+			dns:              fakedns,
+			dnsZones:         fakednsZones,
+			serviceDnsSuffix: "federation.example.com",
+			zoneName:         "example.com",
+			federationName:   "myfederation",
+			serviceCache:     &serviceCache{fedServiceMap: make(map[string]*cachedService)},
+			clusterCache: &clusterClientCache{
+				rwlock:    sync.Mutex{},
+				clientMap: make(map[string]*clusterCache),
+			},
+			knownClusterSet: make(sets.String),
+		}
+
+		clusterName := "testcluster"
+
+		serviceController.clusterCache.clientMap[clusterName] = &clusterCache{
+			cluster: &v1beta1.Cluster{
+				Status: v1beta1.ClusterStatus{
+					Zones:  []string{"foozone"},
+					Region: "fooregion",
+				},
+			},
+		}
+
+		cachedService := &cachedService{
+			lastState:        &test.service,
+			endpointMap:      make(map[string]int),
+			serviceStatusMap: make(map[string]v1.LoadBalancerStatus),
+		}
+		cachedService.endpointMap[clusterName] = 1
+		if !reflect.DeepEqual(&test.serviceStatus, &v1.LoadBalancerStatus{}) {
+			cachedService.serviceStatusMap[clusterName] = test.serviceStatus
+		}
+
+		err := serviceController.ensureDnsRecords(clusterName, cachedService)
+		if err != nil {
+			t.Errorf("Test failed for %s, unexpected error %v", test.name, err)
+		}
+
+		zones, err := fakednsZones.List()
+		if err != nil {
+			t.Errorf("error querying zones: %v", err)
+		}
+
+		// Dump every record to a testable-by-string-comparison form
+		var records []string
+		for _, z := range zones {
+			zoneName := z.Name()
+
+			rrs, ok := z.ResourceRecordSets()
+			if !ok {
+				t.Errorf("cannot get rrs for zone %q", zoneName)
+			}
+
+			rrList, err := rrs.List()
+			if err != nil {
+				t.Errorf("error querying rr for zone %q: %v", zoneName, err)
+			}
+			for _, rr := range rrList {
+				rrdatas := rr.Rrdatas()
+
+				// Put in consistent (testable-by-string-comparison) order
+				sort.Strings(rrdatas)
+				records = append(records, fmt.Sprintf("%s:%s:%s:%d:%s", zoneName, rr.Name(), rr.Type(), rr.Ttl(), rrdatas))
+			}
+		}
+
+		// Ignore order of records
+		sort.Strings(records)
+		sort.Strings(test.expected)
+
+		if !reflect.DeepEqual(records, test.expected) {
+			t.Errorf("Test %q failed.  Actual=%v, Expected=%v", test.name, records, test.expected)
+		}
+
+	}
+}

--- a/federation/pkg/federation-controller/service/endpoint_helper_test.go
+++ b/federation/pkg/federation-controller/service/endpoint_helper_test.go
@@ -29,11 +29,12 @@ var fakeDns, _ = clouddns.NewFakeInterface() // No need to check for unsupported
 var fakeDnsZones, _ = fakeDns.Zones()
 
 var fakeServiceController = ServiceController{
-	dns:            fakeDns,
-	dnsZones:       fakeDnsZones,
-	federationName: "fed1",
-	zoneName:       "example.com",
-	serviceCache:   &serviceCache{fedServiceMap: make(map[string]*cachedService)},
+	dns:              fakeDns,
+	dnsZones:         fakeDnsZones,
+	federationName:   "fed1",
+	zoneName:         "example.com",
+	serviceDnsSuffix: "federation.example.com",
+	serviceCache:     &serviceCache{fedServiceMap: make(map[string]*cachedService)},
 	clusterCache: &clusterClientCache{
 		clientMap: make(map[string]*clusterCache),
 	},

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -505,6 +505,7 @@ service-address
 service-cidr
 service-cluster-ip-range
 service-dns-domain
+service-dns-suffix
 service-generator
 service-node-port-range
 service-node-ports


### PR DESCRIPTION
We can put subdomains into hosted zones (for example,
foo.federation.example.com can be hosted in example.com)

By allowing sharing a common hosted zone, this means the user doesn't
have to do as much setup.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35372)

<!-- Reviewable:end -->
