### PR TITLE
bazel: make update-bazel.sh stable across go versions and architectures

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -19,5 +19,5 @@ set -o pipefail
 
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-go get -u github.com/mikedanese/gazel
+go get -u gopkg.in/mikedanese/gazel.v2/gazel
 "${GOPATH}/bin/gazel" -root="$(realpath ${KUBE_ROOT})"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-go get -u github.com/mikedanese/gazel
+go get -u gopkg.in/mikedanese/gazel.v2/gazel
 if [[ $("${GOPATH}/bin/gazel" -dry-run -root="$(realpath ${KUBE_ROOT})" |& tee /dev/stderr | wc -l) != 0 ]]; then
   echo
   echo "BUILD files are not up to date"


### PR DESCRIPTION
By only supporting linux_amd64

This pickups https://github.com/mikedanese/gazel/commit/7ec36c5e3ce31af836ca6dff3f4a156276d5a90c and fixes an issue where ./hack/update-bazel.sh was instable over the go version, architecture and os.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35376)

<!-- Reviewable:end -->
