### PR TITLE
Automated cherry pick of #35331

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -119,6 +119,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7 [Feature:Ingress]", func() {
 		})
 
 		It("shoud create ingress with given static-ip ", func() {
+			// ip released when the rest of lb resources are deleted in cleanupGCE
 			ip := gceController.staticIP(ns)
 			By(fmt.Sprintf("allocated static ip %v: %v through the GCE cloud provider", ns, ip))
 


### PR DESCRIPTION
Cherry pick of #35331 on release-1.4.
#35331: Allocate static-ip through cloudprovider library instead of

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35379)

<!-- Reviewable:end -->
