### PR TITLE
duplicate Complete() function call

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -84,8 +84,8 @@ func Run(s *options.APIServer) error {
 	genericapiserver.DefaultAndValidateRunOptions(s.ServerRunOptions)
 	genericConfig := genericapiserver.NewConfig(). // create the new config
 							ApplyOptions(s.ServerRunOptions). // apply the options selected
-							Complete()                        // set default values based on the known values
-
+							SkipComplete()                         // call Complete() after all customizations of the config have been done
+	
 	if err := genericConfig.MaybeGenerateServingCerts(); err != nil {
 		glog.Fatalf("Failed to generate service certificate: %v", err)
 	}


### PR DESCRIPTION
When we call the main function app.Run(s),at the beginning, we get the 'genericConfig' by "genericConfig := genericapiserver.NewConfig(). // create the new config
ApplyOptions(s.ServerRunOptions). // apply the options selected
Complete() "
here we call the function "(c *Config) Complete()", and then,we get the struct master by "m, err := config.Complete().New()",in the function config.Complete(),we also call "c.GenericConfig.Complete()".
since the intention of Complete is to be called after all customizations of the config have been done. But in the function Run() a lot is changed in the genericConfig after the Complete call. We can remove the first one.   #35262

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35387)

<!-- Reviewable:end -->
