### PR TITLE
Don't count failed pods as "not-ready"

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -565,7 +565,12 @@ func waitForAllCaPodsReadyInNamespace(f *framework.Framework, c *client.Client) 
 					ready = true
 				}
 			}
-			if !ready {
+			// Failed pods in this context generally mean that they have been
+			// double scheduled onto a node, but then failed a constraint check.
+			if pod.Status.Phase == api.PodFailed {
+				glog.Warningf("Pod has failed: %v", pod)
+			}
+			if !ready && pod.Status.Phase != api.PodFailed {
 				notready = append(notready, pod.Name)
 			}
 		}


### PR DESCRIPTION
Closes #35108 (I hope)

@wojtek-t @kubernetes/autoscaling

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35404)

<!-- Reviewable:end -->
