### PR TITLE
WIP Quobyte - Use Service Account as default

### DIFF
--- a/examples/volumes/quobyte/Readme.md
+++ b/examples/volumes/quobyte/Readme.md
@@ -62,6 +62,8 @@ The example assumes that you already have a running Kubernetes cluster and you a
 
 Quobyte supports since 1.3 fixed user mounts. The fixed-user mounts simply allow to mount all Quobyte Volumes inside one directory and use them as different users. All access to the Quobyte Volume will be rewritten to the specified user and group – both are optional, independent of the user inside the container. You can read more about it [here](https://blog.inovex.de/docker-plugins) under the section "Quobyte Mount and Docker — what’s special"
 
+As default Quobyte will use the [serviceaccount](http://kubernetes.io/docs/user-guide/service-accounts) name as `user` and `group` and overwrites the specified `user` and `group`. If you create the pod below with the serviceaccount `deployer` the Volume Plugin will overwrite `user` and `group` to `deployer` so that the pod receives the logical mountpoint `/var/lib/kubelet/plugins/kubernetes.io~quobyte/deployer#deployer@testVolume`. One exception is the serviceaccount `default` in this case the Plugin allows you to specify the `user` and the `group` without overwriting it.
+
 ## Creating a pod
 
 See example:

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -52,6 +52,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 		SetDefaults_LimitRangeItem,
 		SetDefaults_ConfigMap,
 		SetDefaults_RBDVolumeSource,
+		SetDefaults_QuobyteVolumeSource,
 	)
 }
 
@@ -333,5 +334,15 @@ func SetDefaults_RBDVolumeSource(obj *RBDVolumeSource) {
 	}
 	if obj.Keyring == "" {
 		obj.Keyring = "/etc/ceph/keyring"
+	}
+}
+
+func SetDefaults_QuobyteVolumeSource(source *QuobyteVolumeSource) {
+	if source.User == "" {
+		source.User = "root"
+	}
+
+	if source.Group == "" {
+		source.Group = "nfsnobody"
 	}
 }

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -124,6 +124,9 @@ func SetObjectDefaults_PersistentVolume(in *PersistentVolume) {
 	if in.Spec.PersistentVolumeSource.ISCSI != nil {
 		SetDefaults_ISCSIVolumeSource(in.Spec.PersistentVolumeSource.ISCSI)
 	}
+	if in.Spec.PersistentVolumeSource.Quobyte != nil {
+		SetDefaults_QuobyteVolumeSource(in.Spec.PersistentVolumeSource.Quobyte)
+	}
 	if in.Spec.PersistentVolumeSource.AzureDisk != nil {
 		SetDefaults_AzureDiskVolumeSource(in.Spec.PersistentVolumeSource.AzureDisk)
 	}
@@ -173,6 +176,9 @@ func SetObjectDefaults_Pod(in *Pod) {
 		}
 		if a.VolumeSource.ConfigMap != nil {
 			SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
+		}
+		if a.VolumeSource.Quobyte != nil {
+			SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
@@ -301,6 +307,9 @@ func SetObjectDefaults_PodTemplate(in *PodTemplate) {
 		if a.VolumeSource.ConfigMap != nil {
 			SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}
@@ -421,6 +430,9 @@ func SetObjectDefaults_ReplicationController(in *ReplicationController) {
 			}
 			if a.VolumeSource.ConfigMap != nil {
 				SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
+			}
+			if a.VolumeSource.Quobyte != nil {
+				SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
 			}
 			if a.VolumeSource.AzureDisk != nil {
 				SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)

--- a/pkg/apis/apps/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.defaults.go
@@ -61,6 +61,9 @@ func SetObjectDefaults_PetSet(in *PetSet) {
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}

--- a/pkg/apis/batch/v1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1/zz_generated.defaults.go
@@ -61,6 +61,9 @@ func SetObjectDefaults_Job(in *Job) {
 		if a.VolumeSource.ConfigMap != nil {
 			api_v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			api_v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			api_v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}

--- a/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
@@ -64,6 +64,9 @@ func SetObjectDefaults_Job(in *Job) {
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}
@@ -183,6 +186,9 @@ func SetObjectDefaults_JobTemplate(in *JobTemplate) {
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}
@@ -295,6 +301,9 @@ func SetObjectDefaults_ScheduledJob(in *ScheduledJob) {
 		}
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
+		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)

--- a/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
@@ -73,6 +73,9 @@ func SetObjectDefaults_DaemonSet(in *DaemonSet) {
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}
@@ -192,6 +195,9 @@ func SetObjectDefaults_Deployment(in *Deployment) {
 		}
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
+		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
@@ -324,6 +330,9 @@ func SetObjectDefaults_Job(in *Job) {
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
 		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
+		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)
 		}
@@ -454,6 +463,9 @@ func SetObjectDefaults_ReplicaSet(in *ReplicaSet) {
 		}
 		if a.VolumeSource.ConfigMap != nil {
 			v1.SetDefaults_ConfigMapVolumeSource(a.VolumeSource.ConfigMap)
+		}
+		if a.VolumeSource.Quobyte != nil {
+			v1.SetDefaults_QuobyteVolumeSource(a.VolumeSource.Quobyte)
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			v1.SetDefaults_AzureDiskVolumeSource(a.VolumeSource.AzureDisk)

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -158,21 +158,10 @@ func (plugin *quobytePlugin) newMounterInternal(spec *volume.Spec, pod *api.Pod,
 		return nil, err
 	}
 
-	if pod != nil {
-		// We use the service account if it's not the default service account
-		if len(pod.Spec.ServiceAccountName) != 0 && pod.Spec.ServiceAccountName != "default" {
-			source.User = pod.Spec.ServiceAccountName
-			source.Group = pod.Spec.ServiceAccountName
-		} else {
-			// If the default service account is used or none is specified we use the specified user and group or default to root#nfsnobody
-			if len(source.User) == 0 {
-				source.User = "root"
-			}
-
-			if len(source.Group) == 0 {
-				source.Group = "nfsnobody"
-			}
-		}
+	// We use the service account if it's not the default service account
+	if pod != nil && len(pod.Spec.ServiceAccountName) != 0 && pod.Spec.ServiceAccountName != "default" {
+		source.User = pod.Spec.ServiceAccountName
+		source.Group = pod.Spec.ServiceAccountName
 	}
 
 	return &quobyteMounter{

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -158,6 +158,23 @@ func (plugin *quobytePlugin) newMounterInternal(spec *volume.Spec, pod *api.Pod,
 		return nil, err
 	}
 
+	if pod != nil {
+		// We use the service account if it's not the default service account
+		if len(pod.Spec.ServiceAccountName) != 0 && pod.Spec.ServiceAccountName != "default" {
+			source.User = pod.Spec.ServiceAccountName
+			source.Group = pod.Spec.ServiceAccountName
+		} else {
+			// If the default service account is used or none is specified we use the specified user and group or default to root#nfsnobody
+			if len(source.User) == 0 {
+				source.User = "root"
+			}
+
+			if len(source.Group) == 0 {
+				source.Group = "nfsnobody"
+			}
+		}
+	}
+
 	return &quobyteMounter{
 		quobyte: &quobyte{
 			volName: spec.Name(),
@@ -253,20 +270,13 @@ func (mounter *quobyteMounter) SetUpAt(dir string, fsGroup *int64) error {
 // GetPath returns the path to the user specific mount of a Quobyte volume
 // Returns a path in the format ../user#group@volume
 func (quobyteVolume *quobyte) GetPath() string {
-	user := quobyteVolume.user
-	if len(user) == 0 {
-		user = "root"
-	}
-
-	group := quobyteVolume.group
-	if len(group) == 0 {
-		group = "nfsnobody"
-	}
-
 	// Quobyte has only one mount in the PluginDir where all Volumes are mounted
 	// The Quobyte client does a fixed-user mapping
-	pluginDir := quobyteVolume.plugin.host.GetPluginDir(strings.EscapeQualifiedNameForDisk(quobytePluginName))
-	return path.Join(pluginDir, fmt.Sprintf("%s#%s@%s", user, group, quobyteVolume.volume))
+	return path.Join(quobyteVolume.plugin.host.GetPluginDir(strings.EscapeQualifiedNameForDisk(quobytePluginName)),
+		fmt.Sprintf("%s#%s@%s",
+			quobyteVolume.user,
+			quobyteVolume.group,
+			quobyteVolume.volume))
 }
 
 type quobyteUnmounter struct {

--- a/staging/src/k8s.io/client-go/pkg/api/v1/defaults.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/defaults.go
@@ -51,6 +51,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 		SetDefaults_LimitRangeItem,
 		SetDefaults_ConfigMap,
 		SetDefaults_RBDVolumeSource,
+		SetDefaults_QuobyteVolumeSource,
 	)
 }
 
@@ -332,5 +333,15 @@ func SetDefaults_RBDVolumeSource(obj *RBDVolumeSource) {
 	}
 	if obj.Keyring == "" {
 		obj.Keyring = "/etc/ceph/keyring"
+	}
+}
+
+func SetDefaults_QuobyteVolumeSource(source *QuobyteVolumeSource) {
+	if source.User == "" {
+		source.User = "root"
+	}
+
+	if source.Group == "" {
+		source.Group = "nfsnobody"
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR modifies the Quobyte Volume Plugin to use the `serviceaccount` name as `user` and `group`. This PR makes the plugin more secure/robust in an shared environment using service account names instead of letting the developer/user specify any user and group name they want. 

**Special notes for your reviewer**:
This will also works for the Dynamic Provisioning and create (if requested) a volume for the according service account as user/group.

FYI: @quolix @saad-ali @rootfs

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35412)

<!-- Reviewable:end -->
