### PR TITLE
refactor some interfaces in the 'pkg/api/rest/rest.go'

### DIFF
--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -154,20 +154,12 @@ type CollectionDeleter interface {
 
 // Creater is an object that can create an instance of a RESTful object.
 type Creater interface {
-	// New returns an empty object that can be used with Create after request data has been put into it.
-	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
-	New() runtime.Object
-
 	// Create creates a new version of a resource.
 	Create(ctx api.Context, obj runtime.Object) (runtime.Object, error)
 }
 
 // NamedCreater is an object that can create an instance of a RESTful object using a name parameter.
 type NamedCreater interface {
-	// New returns an empty object that can be used with Create after request data has been put into it.
-	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
-	New() runtime.Object
-
 	// Create creates a new version of a resource. It expects a name parameter from the path.
 	// This is needed for create operations on subresources which include the name of the parent
 	// resource in the path.
@@ -189,10 +181,6 @@ type UpdatedObjectInfo interface {
 
 // Updater is an object that can update an instance of a RESTful object.
 type Updater interface {
-	// New returns an empty object that can be used with Update after request data has been put into it.
-	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
-	New() runtime.Object
-
 	// Update finds a resource in the storage and updates it. Some implementations
 	// may allow updates creates the object - they should set the created boolean
 	// to true.


### PR DESCRIPTION
`Storage` is a generic interface for RESTful storage services. 
`Creater`, `NamedCreater` and `Updater` are storage objects,  so I think we should combine `Storage` into them.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35416)

<!-- Reviewable:end -->
