### PR TITLE
RunnningContainerStatues spelling mistake

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -347,13 +347,13 @@ func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *Con
 
 // Get container status of all the running containers in a pod
 func (podStatus *PodStatus) GetRunningContainerStatuses() []*ContainerStatus {
-	runnningContainerStatues := []*ContainerStatus{}
+	runningContainerStatuses := []*ContainerStatus{}
 	for _, containerStatus := range podStatus.ContainerStatuses {
 		if containerStatus.State == ContainerStateRunning {
-			runnningContainerStatues = append(runnningContainerStatues, containerStatus)
+			runningContainerStatuses = append(runningContainerStatuses, containerStatus)
 		}
 	}
-	return runnningContainerStatues
+	return runningContainerStatuses
 }
 
 // Basic information about a container image.


### PR DESCRIPTION
runtime.go：in the function GetRunningContainerStatuses， runnningContainerStatues spelling mistake,  modified into runningContainerStatus

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35417)

<!-- Reviewable:end -->
