### PR TITLE
Use UI instead of DNS in Rescheduler e2e

### DIFF
--- a/test/e2e/rescheduler.go
+++ b/test/e2e/rescheduler.go
@@ -52,8 +52,8 @@ var _ = framework.KubeDescribe("Rescheduler [Serial]", func() {
 		defer framework.DeleteRCAndPods(f.ClientSet, ns, "reserve-all-cpu")
 		framework.ExpectNoError(err)
 
-		By("creating a new instance of DNS and waiting for DNS to be scheduled")
-		label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
+		By("creating a new instance of Dashboard and waiting for Dashboard to be scheduled")
+		label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kubernetes-dashboard"}))
 		listOpts := api.ListOptions{LabelSelector: label}
 		rcs, err := f.ClientSet.Core().ReplicationControllers(api.NamespaceSystem).List(listOpts)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
fix #33289

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35428)

<!-- Reviewable:end -->
