### PR TITLE
Convert - to _ for protobuf package names

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/BUILD
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/BUILD
@@ -33,3 +33,11 @@ go_library(
         "//vendor:k8s.io/gengo/types",
     ],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["namer_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [],
+)

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
@@ -138,9 +138,6 @@ func Run(g *Generator) {
 			d = d[1:]
 			outputPackage = false
 		}
-		if strings.Contains(d, "-") {
-			log.Fatalf("Package names must be valid protobuf package identifiers, which allow only [a-z0-9_]: %s", d)
-		}
 		name := protoSafePackage(d)
 		parts := strings.SplitN(d, "=", 2)
 		if len(parts) > 1 {

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
@@ -94,7 +94,8 @@ func (n *protobufNamer) GoNameToProtoName(name types.Name) types.Name {
 }
 
 func protoSafePackage(name string) string {
-	return strings.Replace(name, "/", ".", -1)
+	pkg := strings.Replace(name, "/", ".", -1)
+	return strings.Replace(pkg, "-", "_", -1)
 }
 
 type typeNameSet map[types.Name]*protobufPackage

--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/namer_test.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/namer_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import "testing"
+
+func TestProtoSafePackage(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		expected string
+	}{
+		{
+			pkg:      "foo",
+			expected: "foo",
+		},
+		{
+			pkg:      "foo/bar",
+			expected: "foo.bar",
+		},
+		{
+			pkg:      "foo/bar/baz",
+			expected: "foo.bar.baz",
+		},
+		{
+			pkg:      "foo/bar-baz/x/y-z/q",
+			expected: "foo.bar_baz.x.y_z.q",
+		},
+	}
+
+	for _, test := range tests {
+		actual := protoSafePackage(test.pkg)
+		if e, a := test.expected, actual; e != a {
+			t.Errorf("%s: expected %s, got %s", test.pkg, e, a)
+		}
+	}
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -452,6 +452,7 @@ k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/util,krousey,1
 k8s.io/kubernetes/cmd/kubelet/app,hurf,1
 k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned,eparis,1
+k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf,smarterclayton,0
 k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators,davidopp,1
 k8s.io/kubernetes/cmd/mungedocs,mwielgus,1
 k8s.io/kubernetes/examples,Random-Liu,0


### PR DESCRIPTION
Convert - to _ for protobuf package names to allow protobuf code generation
support for go packages that have - in their names.

@smarterclayton @deads2k @liggitt @sttts @lavalamp @nikhiljindal @kubernetes/sig-api-machinery

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35432)

<!-- Reviewable:end -->
