### PR TITLE
Update grafana in kubernetes to version 3.1.1

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -36,7 +36,7 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster_grafana:v2.6.0-2
+        - image: gcr.io/google_containers/heapster_grafana:v3.1.1
           name: grafana
           env:
           resources:

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster_influxdb:v0.5
+        - image: gcr.io/google_containers/heapster_influxdb:v0.7
           name: influxdb
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -36,7 +36,7 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster_grafana:v2.6.0-2
+        - image: gcr.io/google_containers/heapster_grafana:v3.1.1
           name: grafana
           env:
           resources:


### PR DESCRIPTION
Fix #33775

``` release-note
Update grafana version used by default in kubernetes to 3.1.1
```

@piosz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35435)

<!-- Reviewable:end -->
