### PR TITLE
Loosened validation on PVC LimitRanger

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3010,11 +3010,8 @@ func ValidateLimitRange(limitRange *api.LimitRange) field.ErrorList {
 		if limit.Type == api.LimitTypePersistentVolumeClaim {
 			_, minQuantityFound := limit.Min[api.ResourceStorage]
 			_, maxQuantityFound := limit.Max[api.ResourceStorage]
-			if !minQuantityFound {
-				allErrs = append(allErrs, field.Required(idxPath.Child("min"), "minimum storage value is required"))
-			}
-			if !maxQuantityFound {
-				allErrs = append(allErrs, field.Required(idxPath.Child("max"), "maximum storage value is required"))
+			if !minQuantityFound && !maxQuantityFound {
+				allErrs = append(allErrs, field.Required(idxPath.Child("limits"), "either minimum or maximum storage value is required, but neither was provided"))
 			}
 		}
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -6628,6 +6628,28 @@ func TestValidateLimitRange(t *testing.T) {
 			},
 		},
 		{
+			name: "pvc-min-only",
+			spec: api.LimitRangeSpec{
+				Limits: []api.LimitRangeItem{
+					{
+						Type: api.LimitTypePersistentVolumeClaim,
+						Min:  getStorageResourceList("5Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "pvc-max-only",
+			spec: api.LimitRangeSpec{
+				Limits: []api.LimitRangeItem{
+					{
+						Type: api.LimitTypePersistentVolumeClaim,
+						Max:  getStorageResourceList("10Gi"),
+					},
+				},
+			},
+		},
+		{
 			name: "all-fields-valid-big-numbers",
 			spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
@@ -6834,27 +6856,15 @@ func TestValidateLimitRange(t *testing.T) {
 			}},
 			"must be a standard limit type or fully qualified",
 		},
-		"invalid missing required min field": {
+		"min and max values missing, one required": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
 					{
 						Type: api.LimitTypePersistentVolumeClaim,
-						Max:  getStorageResourceList("10000T"),
 					},
 				},
 			}},
-			"minimum storage value is required",
-		},
-		"invalid missing required max field": {
-			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
-				Limits: []api.LimitRangeItem{
-					{
-						Type: api.LimitTypePersistentVolumeClaim,
-						Min:  getStorageResourceList("10000T"),
-					},
-				},
-			}},
-			"maximum storage value is required",
+			"either minimum or maximum storage value is required, but neither was provided",
 		},
 		"invalid min greater than max": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{


### PR DESCRIPTION
This PR loosens validation on PVC LimitRanger so that either Min or Max are required, but not both.

Per @derekwaynecarr  https://github.com/openshift/origin/pull/11396#discussion_r84533061

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35437)

<!-- Reviewable:end -->
