### PR TITLE
allow authentication through a front-proxy

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -232,6 +232,7 @@ func Run(s *options.APIServer) error {
 		KeystoneURL:                 s.KeystoneURL,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
+		RequestHeaderConfig:         s.AuthenticationRequestHeaderConfig(),
 	})
 
 	if err != nil {

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -117,17 +117,18 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	apiAuthenticator, securityDefinitions, err := authenticator.New(authenticator.AuthenticatorConfig{
-		Anonymous:         s.AnonymousAuth,
-		AnyToken:          s.EnableAnyToken,
-		BasicAuthFile:     s.BasicAuthFile,
-		ClientCAFile:      s.ClientCAFile,
-		TokenAuthFile:     s.TokenAuthFile,
-		OIDCIssuerURL:     s.OIDCIssuerURL,
-		OIDCClientID:      s.OIDCClientID,
-		OIDCCAFile:        s.OIDCCAFile,
-		OIDCUsernameClaim: s.OIDCUsernameClaim,
-		OIDCGroupsClaim:   s.OIDCGroupsClaim,
-		KeystoneURL:       s.KeystoneURL,
+		Anonymous:           s.AnonymousAuth,
+		AnyToken:            s.EnableAnyToken,
+		BasicAuthFile:       s.BasicAuthFile,
+		ClientCAFile:        s.ClientCAFile,
+		TokenAuthFile:       s.TokenAuthFile,
+		OIDCIssuerURL:       s.OIDCIssuerURL,
+		OIDCClientID:        s.OIDCClientID,
+		OIDCCAFile:          s.OIDCCAFile,
+		OIDCUsernameClaim:   s.OIDCUsernameClaim,
+		OIDCGroupsClaim:     s.OIDCGroupsClaim,
+		KeystoneURL:         s.KeystoneURL,
+		RequestHeaderConfig: s.AuthenticationRequestHeaderConfig(),
 	})
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -464,6 +464,9 @@ replication-controller-lookup-cache-size
 repo-root
 report-dir
 report-prefix
+requestheader-allowed-names
+requestheader-client-ca-file
+requestheader-username-headers
 require-kubeconfig
 required-contexts
 resolv-conf

--- a/pkg/apiserver/authenticator/BUILD
+++ b/pkg/apiserver/authenticator/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//plugin/pkg/auth/authenticator/password/passwordfile:go_default_library",
         "//plugin/pkg/auth/authenticator/request/anonymous:go_default_library",
         "//plugin/pkg/auth/authenticator/request/basicauth:go_default_library",
+        "//plugin/pkg/auth/authenticator/request/headerrequest:go_default_library",
         "//plugin/pkg/auth/authenticator/request/union:go_default_library",
         "//plugin/pkg/auth/authenticator/request/x509:go_default_library",
         "//plugin/pkg/auth/authenticator/token/anytoken:go_default_library",

--- a/pkg/genericapiserver/options/BUILD
+++ b/pkg/genericapiserver/options/BUILD
@@ -13,6 +13,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "authenticator.go",
         "doc.go",
         "etcd_options.go",
         "server_run_options.go",
@@ -23,6 +24,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/unversioned:go_default_library",
         "//pkg/apimachinery/registered:go_default_library",
+        "//pkg/apiserver/authenticator:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/restclient:go_default_library",
         "//pkg/storage/storagebackend:go_default_library",

--- a/pkg/genericapiserver/options/authenticator.go
+++ b/pkg/genericapiserver/options/authenticator.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"k8s.io/kubernetes/pkg/apiserver/authenticator"
+)
+
+// AuthenticationRequestHeaderConfig returns an authenticator config object for these options
+// if necessary.  nil otherwise.
+func (s *ServerRunOptions) AuthenticationRequestHeaderConfig() *authenticator.RequestHeaderConfig {
+	if len(s.RequestHeaderUsernameHeaders) == 0 {
+		return nil
+	}
+
+	return &authenticator.RequestHeaderConfig{
+		UsernameHeaders:    s.RequestHeaderUsernameHeaders,
+		ClientCA:           s.RequestHeaderClientCAFile,
+		AllowedClientNames: s.RequestHeaderAllowedNames,
+	}
+}

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -67,46 +67,49 @@ type ServerRunOptions struct {
 	AuthorizationWebhookCacheUnauthorizedTTL time.Duration
 	AuthorizationRBACSuperUser               string
 
-	AnonymousAuth             bool
-	BasicAuthFile             string
-	BindAddress               net.IP
-	CertDirectory             string
-	ClientCAFile              string
-	CloudConfigFile           string
-	CloudProvider             string
-	CorsAllowedOriginList     []string
-	DefaultStorageMediaType   string
-	DeleteCollectionWorkers   int
-	AuditLogPath              string
-	AuditLogMaxAge            int
-	AuditLogMaxBackups        int
-	AuditLogMaxSize           int
-	EnableGarbageCollection   bool
-	EnableProfiling           bool
-	EnableSwaggerUI           bool
-	EnableWatchCache          bool
-	EtcdServersOverrides      []string
-	StorageConfig             storagebackend.Config
-	ExternalHost              string
-	InsecureBindAddress       net.IP
-	InsecurePort              int
-	KeystoneURL               string
-	KubernetesServiceNodePort int
-	LongRunningRequestRE      string
-	MasterCount               int
-	MasterServiceNamespace    string
-	MaxRequestsInFlight       int
-	MinRequestTimeout         int
-	OIDCCAFile                string
-	OIDCClientID              string
-	OIDCIssuerURL             string
-	OIDCUsernameClaim         string
-	OIDCGroupsClaim           string
-	RuntimeConfig             config.ConfigurationMap
-	SecurePort                int
-	ServiceClusterIPRange     net.IPNet // TODO: make this a list
-	ServiceNodePortRange      utilnet.PortRange
-	StorageVersions           string
+	AnonymousAuth                bool
+	BasicAuthFile                string
+	BindAddress                  net.IP
+	CertDirectory                string
+	ClientCAFile                 string
+	CloudConfigFile              string
+	CloudProvider                string
+	CorsAllowedOriginList        []string
+	DefaultStorageMediaType      string
+	DeleteCollectionWorkers      int
+	AuditLogPath                 string
+	AuditLogMaxAge               int
+	AuditLogMaxBackups           int
+	AuditLogMaxSize              int
+	EnableGarbageCollection      bool
+	EnableProfiling              bool
+	EnableSwaggerUI              bool
+	EnableWatchCache             bool
+	EtcdServersOverrides         []string
+	StorageConfig                storagebackend.Config
+	ExternalHost                 string
+	InsecureBindAddress          net.IP
+	InsecurePort                 int
+	KeystoneURL                  string
+	KubernetesServiceNodePort    int
+	LongRunningRequestRE         string
+	MasterCount                  int
+	MasterServiceNamespace       string
+	MaxRequestsInFlight          int
+	MinRequestTimeout            int
+	OIDCCAFile                   string
+	OIDCClientID                 string
+	OIDCIssuerURL                string
+	OIDCUsernameClaim            string
+	OIDCGroupsClaim              string
+	RequestHeaderUsernameHeaders []string
+	RequestHeaderClientCAFile    string
+	RequestHeaderAllowedNames    []string
+	RuntimeConfig                config.ConfigurationMap
+	SecurePort                   int
+	ServiceClusterIPRange        net.IPNet // TODO: make this a list
+	ServiceNodePortRange         utilnet.PortRange
+	StorageVersions              string
 	// The default values for StorageVersions. StorageVersions overrides
 	// these; you can change this if you want to change the defaults (e.g.,
 	// for testing). This is not actually exposed as a flag.
@@ -422,6 +425,18 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"If provided, the name of a custom OpenID Connect claim for specifying user groups. "+
 		"The claim value is expected to be a string or array of strings. This flag is experimental, "+
 		"please see the authentication documentation for further details.")
+
+	fs.StringSliceVar(&s.RequestHeaderUsernameHeaders, "requestheader-username-headers", s.RequestHeaderUsernameHeaders, ""+
+		"List of request headers to inspect for usernames. X-Remote-User is common.")
+
+	fs.StringVar(&s.RequestHeaderClientCAFile, "requestheader-client-ca-file", s.RequestHeaderClientCAFile, ""+
+		"Root certificate bundle to use to verify client certificates on incoming requests "+
+		"before trusting usernames in headers specified by --requestheader-username-headers")
+
+	fs.StringSliceVar(&s.RequestHeaderAllowedNames, "requestheader-allowed-names", s.RequestHeaderAllowedNames, ""+
+		"List of client certificate common names to allow to provide usernames in headers "+
+		"specified by --requestheader-username-headers. If empty, any client certificate validated "+
+		"by the authorities in --requestheader-client-ca-file is allowed.")
 
 	fs.Var(&s.RuntimeConfig, "runtime-config", ""+
 		"A set of key=value pairs that describe runtime configuration that may be passed "+

--- a/plugin/pkg/auth/authenticator/request/headerrequest/BUILD
+++ b/plugin/pkg/auth/authenticator/request/headerrequest/BUILD
@@ -12,29 +12,21 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "doc.go",
-        "x509.go",
-    ],
+    srcs = ["requestheader.go"],
     tags = ["automanaged"],
     deps = [
         "//pkg/auth/authenticator:go_default_library",
         "//pkg/auth/user:go_default_library",
-        "//pkg/util/errors:go_default_library",
+        "//pkg/util/cert:go_default_library",
         "//pkg/util/sets:go_default_library",
-        "//vendor:github.com/golang/glog",
+        "//plugin/pkg/auth/authenticator/request/x509:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["x509_test.go"],
-    data = glob(["testdata/*"]),
+    srcs = ["requestheader_test.go"],
     library = "go_default_library",
     tags = ["automanaged"],
-    deps = [
-        "//pkg/auth/authenticator:go_default_library",
-        "//pkg/auth/user:go_default_library",
-        "//pkg/util/sets:go_default_library",
-    ],
+    deps = ["//pkg/auth/user:go_default_library"],
 )

--- a/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
+++ b/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package headerrequest
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+	utilcert "k8s.io/kubernetes/pkg/util/cert"
+	"k8s.io/kubernetes/pkg/util/sets"
+	x509request "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509"
+)
+
+type requestHeaderAuthRequestHandler struct {
+	nameHeaders []string
+}
+
+func New(nameHeaders []string) (authenticator.Request, error) {
+	headers := []string{}
+	for _, headerName := range nameHeaders {
+		trimmedHeader := strings.TrimSpace(headerName)
+		if len(trimmedHeader) == 0 {
+			return nil, fmt.Errorf("empty header %q", headerName)
+		}
+		headers = append(headers, trimmedHeader)
+	}
+
+	return &requestHeaderAuthRequestHandler{nameHeaders: headers}, nil
+}
+
+func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string) (authenticator.Request, error) {
+	headerAuthenticator, err := New(nameHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(clientCA) == 0 {
+		return nil, fmt.Errorf("missing clientCA file")
+	}
+
+	// Wrap with an x509 verifier
+	caData, err := ioutil.ReadFile(clientCA)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", clientCA, err)
+	}
+	opts := x509request.DefaultVerifyOptions()
+	opts.Roots = x509.NewCertPool()
+	certs, err := utilcert.ParseCertsPEM(caData)
+	if err != nil {
+		return nil, fmt.Errorf("error loading certs from  %s: %v", clientCA, err)
+	}
+	for _, cert := range certs {
+		opts.Roots.AddCert(cert)
+	}
+
+	return x509request.NewVerifier(opts, headerAuthenticator, sets.NewString(proxyClientNames...)), nil
+}
+
+func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	name := headerValue(req.Header, a.nameHeaders)
+	if len(name) == 0 {
+		return nil, false, nil
+	}
+
+	return &user.DefaultInfo{Name: name}, true, nil
+}
+
+func headerValue(h http.Header, headerNames []string) string {
+	for _, headerName := range headerNames {
+		headerValue := h.Get(headerName)
+		if len(headerValue) > 0 {
+			return headerValue
+		}
+	}
+	return ""
+}

--- a/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
+++ b/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
@@ -31,6 +31,7 @@ import (
 )
 
 type requestHeaderAuthRequestHandler struct {
+	// nameHeaders are the headers to check (in order, case-insensitively) for an identity. The first header with a value wins.
 	nameHeaders []string
 }
 

--- a/plugin/pkg/auth/authenticator/request/headerrequest/requestheader_test.go
+++ b/plugin/pkg/auth/authenticator/request/headerrequest/requestheader_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package headerrequest
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+func TestRequestHeader(t *testing.T) {
+	testcases := map[string]struct {
+		nameHeaders    []string
+		requestHeaders http.Header
+
+		expectedUser user.Info
+		expectedOk   bool
+	}{
+		"empty": {},
+		"no match": {
+			nameHeaders: []string{"X-Remote-User"},
+		},
+		"match": {
+			nameHeaders:    []string{"X-Remote-User"},
+			requestHeaders: http.Header{"X-Remote-User": {"Bob"}},
+			expectedUser:   &user.DefaultInfo{Name: "Bob"},
+			expectedOk:     true,
+		},
+		"exact match": {
+			nameHeaders: []string{"X-Remote-User"},
+			requestHeaders: http.Header{
+				"Prefixed-X-Remote-User-With-Suffix": {"Bob"},
+				"X-Remote-User-With-Suffix":          {"Bob"},
+			},
+		},
+		"first match": {
+			nameHeaders: []string{
+				"X-Remote-User",
+				"A-Second-X-Remote-User",
+				"Another-X-Remote-User",
+			},
+			requestHeaders: http.Header{
+				"X-Remote-User":          {"", "First header, second value"},
+				"A-Second-X-Remote-User": {"Second header, first value", "Second header, second value"},
+				"Another-X-Remote-User":  {"Third header, first value"}},
+			expectedUser: &user.DefaultInfo{Name: "Second header, first value"},
+			expectedOk:   true,
+		},
+		"case-insensitive": {
+			nameHeaders:    []string{"x-REMOTE-user"},             // configured headers can be case-insensitive
+			requestHeaders: http.Header{"X-Remote-User": {"Bob"}}, // the parsed headers are normalized by the http package
+			expectedUser:   &user.DefaultInfo{Name: "Bob"},
+			expectedOk:     true,
+		},
+	}
+
+	for k, testcase := range testcases {
+		auth, err := New(testcase.nameHeaders)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := &http.Request{Header: testcase.requestHeaders}
+
+		user, ok, _ := auth.AuthenticateRequest(req)
+		if testcase.expectedOk != ok {
+			t.Errorf("%v: expected %v, got %v", k, testcase.expectedOk, ok)
+		}
+		if e, a := testcase.expectedUser, user; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: expected %#v, got %#v", k, e, a)
+
+		}
+	}
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -839,6 +839,7 @@ k8s.io/kubernetes/plugin/pkg/auth/authenticator/password/allow,liggitt,0
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/password/passwordfile,liggitt,0
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/anonymous,ixdy,1
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/basicauth,liggitt,0
+k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/headerrequest,deads2k,0
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union,liggitt,0
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509,liggitt,0
 k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/anytoken,timstclair,1


### PR DESCRIPTION
This allows a front proxy to set a request header and have that be a valid `user.Info` in the authentication chain.  To secure this power, a client certificate may be used to confirm the identity of the front proxy

@kubernetes/sig-auth fyi
@erictune per-request
@liggitt you wrote the openshift one, ptal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35452)

<!-- Reviewable:end -->
