### PR TITLE
Automated cherry pick of #31367

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -33,6 +33,7 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
       ExecStart=/home/kubernetes/bin/configure-helper.sh
 
       [Install]
@@ -51,6 +52,7 @@ write_files:
       RestartSec=10
       RemainAfterExit=yes
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh docker
 
       [Install]
@@ -69,6 +71,7 @@ write_files:
       RestartSec=10
       RemainAfterExit=yes
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet
 
       [Install]

--- a/cluster/gce/gci/node.yaml
+++ b/cluster/gce/gci/node.yaml
@@ -33,6 +33,7 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
       ExecStart=/home/kubernetes/bin/configure-helper.sh
 
       [Install]
@@ -51,6 +52,7 @@ write_files:
       RestartSec=10
       RemainAfterExit=yes
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh docker
 
       [Install]
@@ -69,6 +71,7 @@ write_files:
       RestartSec=10
       RemainAfterExit=yes
       RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet
 
       [Install]


### PR DESCRIPTION
Cherry pick of #31367 on release-1.3.
#31367: gci: decouple from the built-in kubelet version

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35455)

<!-- Reviewable:end -->
