### PR TITLE
Automated cherry pick of #28922 #29892 #30182 #31025 #32013 #32235 #34359 #35233

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -67,7 +67,7 @@ go run ./hack/e2e.go -v --build
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then
   echo "Not pushed to GCS..."
-elif ${RELEASE_INFRA_PUSH-}; then
+else
   readonly release_infra_clone="${WORKSPACE}/_tmp/release.git"
   mkdir -p ${WORKSPACE}/_tmp
   git clone https://github.com/kubernetes/release ${release_infra_clone}
@@ -84,9 +84,7 @@ elif ${RELEASE_INFRA_PUSH-}; then
   ${FEDERATION} && federation_flag="--federation"
   ${SET_NOMOCK_FLAG} && mock_flag="--nomock"
   ${release_infra_clone}/push-ci-build.sh ${bucket_flag-} ${federation_flag-} \
-                                          ${mock_flag-}
-else
-  ./build/push-ci-build.sh
+                                          ${mock_flag-} --verbose
 fi
 
 sha256sum _output/release-tars/kubernetes*.tar.gz

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -79,8 +79,8 @@ elif ${RELEASE_INFRA_PUSH-}; then
     exit 1
   fi
 
-  [[ -n "$KUBE_GCS_RELEASE_BUCKET" ]] \
-   && bucket_flag="--bucket=$KUBE_GCS_RELEASE_BUCKET"
+  [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
+   && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"
   ${SET_NOMOCK_FLAG} && mock_flag="--nomock"
   ${release_infra_clone}/push-ci-build.sh ${bucket_flag-} ${federation_flag-} \

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -74,9 +74,12 @@ else
     #exit 1
   fi
   [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
-   && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
+    && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"
-  ${push_build} ${bucket_flag-} ${federation_flag-} --nomock --verbose --ci
+  [[ -n "${KUBE_GCS_RELEASE_SUFFIX-}" ]] \
+    && gcs_suffix_flag="--gcs-suffix=${KUBE_GCS_RELEASE_SUFFIX-}"
+  ${push_build} ${bucket_flag-} ${federation_flag-} ${gcs_suffix_flag-} \
+    --nomock --verbose --ci
 fi
 
 sha256sum _output/release-tars/kubernetes*.tar.gz

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -66,13 +66,6 @@ else
 
   push_build=${release_infra_clone}/push-build.sh
 
-  if [[ ! -x ${push_build} ]]; then
-    # TODO: Remove/Restore this with the full deprecation PR
-    push_build=${release_infra_clone}/push-ci-build.sh
-    #echo "FATAL: Something went wrong. ${push_build} isn't available." \
-    #     "Exiting..." >&2
-    #exit 1
-  fi
   [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
     && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -60,20 +60,21 @@ go run ./hack/e2e.go -v --build
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then
   echo "Not pushed to GCS..."
-elif $RELEASE_INFRA_PUSH; then
-  git clone https://github.com/kubernetes/release $WORKSPACE/release
-  readonly release_infra_clone=$WORKSPACE/release
+elif ${RELEASE_INFRA_PUSH-}; then
+  readonly release_infra_clone="${WORKSPACE}/_tmp/release.git"
+  mkdir -p ${WORKSPACE}/_tmp
+  git clone https://github.com/kubernetes/release ${release_infra_clone}
 
-  if [[ ! -x $release_infra_clone/push-ci-build.sh ]]; then
+  if [[ ! -x ${release_infra_clone}/push-ci-build.sh ]]; then
     echo "FATAL: Something went wrong." \
-         "$release_infra_clone/push-ci-build.sh isn't available. Exiting..." >&2
+         "${release_infra_clone}/push-ci-build.sh isn't available. Exiting..." >&2
     exit 1
   fi
 
-  $FEDERATION && federation_flag="--federation"
+  ${FEDERATION} && federation_flag="--federation"
   # Use --nomock to do the real thing
   #$release_infra_clone/push-ci-build.sh --nomock ${federation_flag-}
-  $release_infra_clone/push-ci-build.sh ${federation_flag-}
+  ${release_infra_clone}/push-ci-build.sh ${federation_flag-}
 else
   ./build/push-ci-build.sh
 fi


### PR DESCRIPTION
Cherry pick of #28922 #29892 #30182 #31025 #32013 #32235 #34359 #35233 on release-1.3.
#28922: Add RELEASE_INFRA_PUSH related code to support pushes from
#29892: Clone kubernetes/release into something other than /release
#30182: Add SET_NOMOCK_FLAG handling.
#31025: Fix unbound variable issue (set -e).
#32013: Call push-ci-build.sh from the kubernetes/release repo.
#32235: Change push-ci-build.sh to push-build.sh and some cleanup.
#34359: Add support for adding a suffix to the GCS upload dir in
#35233: Delete some old, dead release code

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35458)

<!-- Reviewable:end -->
