### PR TITLE
Removing pod force-deletion with kubelet <= v1.1.0

### DIFF
--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -1702,21 +1702,21 @@ func TestCheckPod(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{DeletionTimestamp: &unversioned.Time{}},
 				Spec:       api.PodSpec{NodeName: "old"},
 			},
-			prune: true,
+			prune: false,
 		},
 		{
 			pod: api.Pod{
 				ObjectMeta: api.ObjectMeta{DeletionTimestamp: &unversioned.Time{}},
 				Spec:       api.PodSpec{NodeName: "older"},
 			},
-			prune: true,
+			prune: false,
 		},
 		{
 			pod: api.Pod{
 				ObjectMeta: api.ObjectMeta{DeletionTimestamp: &unversioned.Time{}},
 				Spec:       api.PodSpec{NodeName: "oldest"},
 			},
-			prune: true,
+			prune: false,
 		},
 		{
 			pod: api.Pod{


### PR DESCRIPTION
**What this PR does / why we need it**: We can safely remove this as kubelet v1.1.0 and below are unsupported with release 1.5.

Related to: https://github.com/kubernetes/kubernetes/issues/35145

**Release note**:

``` release-note
Do not forcibly delete pods when kubelet version is either unknown or too old.
```

We only support 2 versions back and hence, the piece of code for kubelet <= v1.1.0 can be removed. 
If for some reason, we are unable to parse the kubelet version string (which should never happen), force-deleting pods is not the safest thing to do. 

cc @erictune @kubernetes/sig-apps @bgrant0607

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35464)

<!-- Reviewable:end -->
