### PR TITLE
Update NFS testing image to use ganesha, to work on GCI

### DIFF
--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -415,9 +415,10 @@ var _ = framework.KubeDescribe("PersistentVolumes", func() {
 	NFSconfig = VolumeTestConfig{
 		namespace:   api.NamespaceDefault,
 		prefix:      "nfs",
-		serverImage: "gcr.io/google_containers/volume-nfs:0.7",
+		serverImage: "gcr.io/google_containers/volume-nfs:0.8",
 		serverPorts: []int{2049},
 		serverArgs:  []string{"-G", "777", "/exports"},
+		volumes:     map[string]string{"/tmp": "/exports"},
 	}
 
 	BeforeEach(func() {

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -370,8 +370,9 @@ var _ = framework.KubeDescribe("Volumes [Feature:Volumes]", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "nfs",
-				serverImage: "gcr.io/google_containers/volume-nfs:0.6",
+				serverImage: "gcr.io/google_containers/volume-nfs:0.8",
 				serverPorts: []int{2049},
+				volumes:     map[string]string{"/tmp": "/exports"},
 			}
 
 			defer func() {
@@ -386,7 +387,7 @@ var _ = framework.KubeDescribe("Volumes [Feature:Volumes]", func() {
 			volume := api.VolumeSource{
 				NFS: &api.NFSVolumeSource{
 					Server:   serverIP,
-					Path:     "/",
+					Path:     "/exports",
 					ReadOnly: true,
 				},
 			}

--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -12,16 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos
-MAINTAINER Jan Safranek, jsafrane@redhat.com
-RUN yum -y install /usr/bin/ps nfs-utils && yum clean all
+FROM fedora:24
+LABEL maintainers="Jan Safranek, jsafrane@redhat.com; Matthew Wong, mawong@redhat.com"
+
+# install nfs-ganesha
+RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel && dnf clean all \
+    && curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.0.3.tar.gz | tar zx \
+    && curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.1.tar.gz | tar zx \
+    && rm -r nfs-ganesha-2.4.0.3/src/libntirpc \
+    && mv ntirpc-1.4.1 nfs-ganesha-2.4.0.3/src/libntirpc \
+    && cd nfs-ganesha-2.4.0.3 \
+    && sed -i '20i#cmakedefine _NO_PORTMAPPER 1' src/include/config-h.in.cmake \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only -D_NO_PORTMAPPER=ON src/ \
+    && make \
+    && make install \
+    && dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel && dnf clean all
+
+# also need this for ganesha to run
+RUN dnf install -y libntirpc
+
 RUN mkdir -p /exports
-ADD run_nfs.sh /usr/local/bin/
-ADD index.html /tmp/index.html
-RUN chmod 644 /tmp/index.html
 
 # expose mountd 20048/tcp and nfsd 2049/tcp
 EXPOSE 2049/tcp 20048/tcp
 
+COPY index.html /tmp/index.html
+RUN chmod 644 /tmp/index.html
+COPY run_nfs.sh /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/run_nfs.sh"]
-CMD ["/exports", "/"]
+CMD ["/exports"]

--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -17,19 +17,20 @@ LABEL maintainers="Jan Safranek, jsafrane@redhat.com; Matthew Wong, mawong@redha
 
 # install nfs-ganesha
 RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel && dnf clean all \
-    && curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.0.3.tar.gz | tar zx \
-    && curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.1.tar.gz | tar zx \
-    && rm -r nfs-ganesha-2.4.0.3/src/libntirpc \
-    && mv ntirpc-1.4.1 nfs-ganesha-2.4.0.3/src/libntirpc \
-    && cd nfs-ganesha-2.4.0.3 \
-    && sed -i '20i#cmakedefine _NO_PORTMAPPER 1' src/include/config-h.in.cmake \
+    && curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.0.4.tar.gz | tar zx \
+    && curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.0.tar.gz | tar zx \
+    && rm -rf nfs-ganesha-2.4.0.4/src/libntirpc \
+    && mv ntirpc-1.4.0 nfs-ganesha-2.4.0.4/src/libntirpc \
+    && cd nfs-ganesha-2.4.0.4 \
     && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only -D_NO_PORTMAPPER=ON src/ \
     && make \
     && make install \
+    && cd .. \
+    && rm -rf nfs-ganesha-2.4.0.4 \
     && dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel && dnf clean all
 
-# also need this for ganesha to run
-RUN dnf install -y libntirpc
+# also need this for ganesha to run (/etc/netconfig, etc.)
+RUN dnf install -y libtirpc
 
 RUN mkdir -p /exports
 

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.7
+TAG = 0.8
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/volumes-tester/nfs/README.md
+++ b/test/images/volumes-tester/nfs/README.md
@@ -1,6 +1,6 @@
 # NFS server container for testing
 
-This container exports '/' directory with an index.html inside. NFSv4 only.
+This container exports '/exports' directory with an index.html inside. NFSv4 only.
 
 Accepts a -G option for specifying a group id to give exported directories.
 Clients in the specified group will have full rwx permissions, others none.

--- a/test/images/volumes-tester/nfs/run_nfs.sh
+++ b/test/images/volumes-tester/nfs/run_nfs.sh
@@ -16,64 +16,81 @@
 
 function start()
 {
+	unset gid
+	# accept "-G gid" option
+	while getopts "G:" opt; do
+		case ${opt} in
+			G) gid=${OPTARG};;
+		esac
+	done
+	shift $(($OPTIND - 1))
 
-    unset gid
-    # accept "-G gid" option
-    while getopts "G:" opt; do
-        case ${opt} in
-            G) gid=${OPTARG};;
-        esac
-    done
-    shift $(($OPTIND - 1))
+	# prepare ganesha config
+	# set mountd port to 20048
+	cat <<-EOF >> /tmp/ganesha.conf
+	NFS_Core_Param
+	{
+		MNT_Port = 20048;
+		NFS_PROTOCOLS = 4;
+	}
+	EOF
+	# assign unique export ids
+	id=1
+	# if testing group permissions, need to squash
+	squash="no_root_squash"
+	if [ -v gid ] ; then
+		squash="root_id_squash"
+	fi
+	for i in "$@"; do
+		mkdir -p $i
+		if [ -v gid ] ; then
+			chmod 071 $i
+			chgrp $gid $i
+		fi
+		cat <<- EOF >> /tmp/ganesha.conf
+		EXPORT
+		{
+			# Export Id (mandatory, each EXPORT must have a unique Export_Id)
+			Export_Id = $id;
 
-    # prepare /etc/exports
-    for i in "$@"; do
-        # fsid=0: needed for NFSv4
-        echo "$i *(rw,fsid=0,insecure,no_root_squash)" >> /etc/exports
-        if [ -v gid ] ; then
-            chmod 070 $i
-            chgrp $gid $i
-        fi
-        # move index.html to here
-        /bin/cp /tmp/index.html $i/
-        chmod 644 $i/index.html
-        echo "Serving $i"
-    done
-  
-    # start rpcbind if it is not started yet
-    /usr/sbin/rpcinfo 127.0.0.1 > /dev/null; s=$?
-    if [ $s -ne 0 ]; then
-       echo "Starting rpcbind"
-       /usr/sbin/rpcbind -w
-    fi
+			Filesystem_Id = $id.$id;
 
-    mount -t nfsd nfds /proc/fs/nfsd
+			# Exported path (mandatory)
+			Path = "$i";
 
-    # -N 4.x: disable NFSv4
-    # -V 3: enable NFSv3
-    /usr/sbin/rpc.mountd -N 2 -V 3 -N 4 -N 4.1
+			# Pseudo Path (required for NFS v4)
+			Pseudo = "$i";
 
-    /usr/sbin/exportfs -r
-    # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
-    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3 -N 4 -N 4.1 2
-    /usr/sbin/rpc.statd --no-notify
-    echo "NFS started"
+			# Required for access (default is None)
+			# Could use CLIENT blocks instead
+			Access_Type = RW;
+
+			Squash = $squash;
+			SecType = sys;
+			Protocols = 4;
+			# Exporting FSAL
+			FSAL {
+				Name = VFS;
+			}
+		}
+		EOF
+		# move index.html to here
+		/bin/cp /tmp/index.html $i/
+		chmod 644 $i/index.html
+		echo "Serving $i"
+		id=$((id + 1))
+	done
+
+	ganesha.nfsd -L /tmp/ganesha.log -f /tmp/ganesha.conf
+
+	echo "NFS started"
 }
 
 function stop()
 {
-    echo "Stopping NFS"
-
-    /usr/sbin/rpc.nfsd 0
-    /usr/sbin/exportfs -au
-    /usr/sbin/exportfs -f
-
-    kill $( pidof rpc.mountd )
-    umount /proc/fs/nfsd
-    echo > /etc/exports
-    exit 0
+	echo "Stopping NFS"
+	exit 0
 }
-
 
 trap stop TERM
 
@@ -81,5 +98,5 @@ start "$@"
 
 # Ugly hack to do nothing and wait for SIGTERM
 while true; do
-    sleep 5
+	sleep 5
 done


### PR DESCRIPTION
Discussed here https://github.com/kubernetes/kubernetes/pull/34983

@vishh this is the image that will work with the containerized mounter on GCI.

~~The tests will not pass with the 1st commit alone, I have to~~
- mount hostpath volumes (tmpfs) for the nfs-server pod to export out of as seen here https://github.com/wongma7/kubernetes/commit/388603619af53a71a6b75291273ae9b53d993d93#diff-d8068327d664ac7a6620dc0b42d31840R421. 
- and of course also have to change the test tags in volumes.go and persistent_volumes.go to `0.8` for when the image is pushed.

~~working on the above now.~~ edit:done 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35469)

<!-- Reviewable:end -->
