### PR TITLE
cni: add configure-cbr0 effect to cni

### DIFF
--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -76,7 +76,7 @@ env > {{.OutputEnv}}
 echo "%@" >> {{.OutputEnv}}
 export $(echo ${CNI_ARGS} | sed 's/;/ /g') &> /dev/null
 mkdir -p {{.OutputDir}} &> /dev/null
-echo -n "$CNI_COMMAND $CNI_NETNS $K8S_POD_NAMESPACE $K8S_POD_NAME $K8S_POD_INFRA_CONTAINER_ID" >& {{.OutputFile}}
+echo -n "$CNI_COMMAND $CNI_NETNS $K8S_POD_NAMESPACE $K8S_POD_NAME $K8S_POD_INFRA_CONTAINER_ID $K8S_POD_CIDR $K8S_POD_GW" >& {{.OutputFile}}
 echo -n "{ \"ip4\": { \"ip\": \"10.1.0.23/24\" } }"
 `
 	execTemplateData := &map[string]interface{}{
@@ -205,6 +205,10 @@ func TestCNIPlugin(t *testing.T) {
 		t.Fatalf("Failed to select the desired plugin: %v", err)
 	}
 
+	details := make(map[string]interface{})
+	details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = "10.0.0.1/24"
+	plug.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
+
 	// Set up the pod
 	err = plug.SetUpPod("podNamespace", "podName", containerID)
 	if err != nil {
@@ -217,7 +221,7 @@ func TestCNIPlugin(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to read output file %s: %v (env %s err %v)", outputFile, err, eo, eerr)
 	}
-	expectedOutput := "ADD /proc/12345/ns/net podNamespace podName test_infra_container"
+	expectedOutput := "ADD /proc/12345/ns/net podNamespace podName test_infra_container 10.0.0.0/24 10.0.0.1"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))
 	}
@@ -237,7 +241,7 @@ func TestCNIPlugin(t *testing.T) {
 		t.Errorf("Expected nil: %v", err)
 	}
 	output, err = ioutil.ReadFile(path.Join(testNetworkConfigPath, pluginName, pluginName+".out"))
-	expectedOutput = "DEL /proc/12345/ns/net podNamespace podName test_infra_container"
+	expectedOutput = "DEL /proc/12345/ns/net podNamespace podName test_infra_container 10.0.0.0/24 10.0.0.1"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `configure-cbr0` functionality to the CNI plugin. It doesn't affect the current CNI plugins already present and allows new ones to implement that functionality by reading the provided `K8S_POD_CIDR` and `K8S_POD_GW` args.

**Special notes for your reviewer**:
Ping @thockin @dcbw 

Signed-off-by: André Martins aanm90@gmail.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35472)

<!-- Reviewable:end -->
