### PR TITLE
Always run the podGC controller.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -271,11 +271,9 @@ func StartControllers(s *options.CMServer, kubeconfig *restclient.Config, rootCl
 	).Run(int(s.ConcurrentRCSyncs), wait.NeverStop)
 	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 
-	if s.TerminatedPodGCThreshold > 0 {
-		go podgc.NewPodGC(client("pod-garbage-collector"), sharedInformers.Pods().Informer(),
-			int(s.TerminatedPodGCThreshold)).Run(wait.NeverStop)
-		time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
-	}
+	go podgc.NewPodGC(client("pod-garbage-collector"), sharedInformers.Pods().Informer(),
+		int(s.TerminatedPodGCThreshold)).Run(wait.NeverStop)
+	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 
 	cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: The podGC controller has evolved to do more than just GC of terminated pods beyond a threshold number. It no longer makes sense to gate running it with the  `terminated-pod-gc-threshold` flag. [We still ensure that it only runs the terminatedPodsGC if the threshold specified in the argument to the controller manager is > 0](https://github.com/kubernetes/kubernetes/blob/6079053407705212c8cc3f039e8b767c6bccd0a0/pkg/controller/podgc/gc_controller.go#L124).

Related discussion: https://github.com/kubernetes/kubernetes/pull/34160#issuecomment-255900898

**Release note**:

``` release-note
The podGC controller will now always run, irrespective of the value supplied to the "terminated-pod-gc-threshold" flag supplied to the controller manager. 
The specific behavior of the podGC controller to clean up terminated pods is still governed by the flag, but the podGC's responsibilities have evolved beyond just cleaning up terminated pods.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35476)

<!-- Reviewable:end -->
