### PR TITLE
Fixing finalize and status in fake_namespace testclient

### DIFF
--- a/pkg/client/unversioned/testclient/fake_namespaces.go
+++ b/pkg/client/unversioned/testclient/fake_namespaces.go
@@ -73,8 +73,8 @@ func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 }
 
 func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
-	action := CreateActionImpl{}
-	action.Verb = "create"
+	action := UpdateActionImpl{}
+	action.Verb = "update"
 	action.Resource = "namespaces"
 	action.Subresource = "finalize"
 	action.Object = namespace
@@ -88,11 +88,10 @@ func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, err
 }
 
 func (c *FakeNamespaces) Status(namespace *api.Namespace) (*api.Namespace, error) {
-	action := CreateActionImpl{}
-	action.Verb = "create"
+	action := GetActionImpl{}
+	action.Verb = "get"
 	action.Resource = "namespaces"
 	action.Subresource = "status"
-	action.Object = namespace
 
 	obj, err := c.Fake.Invokes(action, namespace)
 	if obj == nil {


### PR DESCRIPTION
Calling Finalize() in fake_namespace should invoke an update on watch and calling Status() should invoke a get. Both of them were incorrectly invoking create.

Ref https://github.com/kubernetes/kubernetes/pull/34648#discussion_r84415869

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35478)

<!-- Reviewable:end -->
