### PR TITLE
Set KillMode for kubelet to control-group, instead of process.

### DIFF
--- a/cluster/centos/node/scripts/kubelet.sh
+++ b/cluster/centos/node/scripts/kubelet.sh
@@ -65,7 +65,7 @@ Requires=docker.service
 EnvironmentFile=-/opt/kubernetes/cfg/kubelet
 ExecStart=/opt/kubernetes/bin/kubelet ${KUBE_PROXY_OPTS}
 Restart=on-failure
-KillMode=process
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/gce/coreos/master-docker.yaml
+++ b/cluster/gce/coreos/master-docker.yaml
@@ -128,7 +128,7 @@ coreos:
         --reconcile-cidr=false
         Restart=always
         RestartSec=10
-        KillMode=process
+        KillMode=control-group
 
     - name: docker.service
       drop-ins:

--- a/cluster/gce/coreos/master-rkt.yaml
+++ b/cluster/gce/coreos/master-rkt.yaml
@@ -188,7 +188,7 @@ coreos:
         --reconcile-cidr=false
         Restart=always
         RestartSec=10
-        KillMode=process
+        KillMode=control-group
 
     - name: docker.service
       command: stop

--- a/cluster/gce/coreos/node-docker.yaml
+++ b/cluster/gce/coreos/node-docker.yaml
@@ -107,7 +107,7 @@ coreos:
         --reconcile-cidr=true
         Restart=always
         RestartSec=10
-        KillMode=process
+        KillMode=control-group
 
     - name: kube-proxy.service
       command: start

--- a/cluster/gce/coreos/node-rkt.yaml
+++ b/cluster/gce/coreos/node-rkt.yaml
@@ -153,7 +153,7 @@ coreos:
         --reconcile-cidr=true
         Restart=always
         RestartSec=10
-        KillMode=process
+        KillMode=control-group
 
     - name: kube-proxy.service
       command: start

--- a/cluster/rackspace/cloud-config/node-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/node-cloud-config.yaml
@@ -161,7 +161,7 @@ coreos:
         --v=2
         Restart=always
         RestartSec=5
-        KillMode=process
+        KillMode=control-group
     - name: kube-proxy.service
       command: start
       content: |

--- a/cluster/saltbase/salt/kubelet/kubelet.service
+++ b/cluster/saltbase/salt/kubelet/kubelet.service
@@ -8,7 +8,7 @@ ExecStart=/usr/local/bin/kubelet "$DAEMON_ARGS"
 Restart=always
 RestartSec=2s
 StartLimitInterval=0
-KillMode=process
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixed the journalctl process leakage issue caused by #23491 which fix gcluster umount issue.

Fixed https://github.com/kubernetes/kubernetes/issues/34965

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35479)

<!-- Reviewable:end -->
