### PR TITLE
optimise CreateTokenAuthFile method's performance and refine a consta…

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/env.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env.go
@@ -23,20 +23,25 @@ import (
 	"strings"
 )
 
+const (
+	// EnvParamNameHostPkiPath denotes name of the environment parameter 'host_pki_path'
+	EnvParamNameHostPkiPath = "host_pki_path"
+)
+
 // TODO(phase2) use componentconfig
 // we need some params for testing etc, let's keep these hidden for now
 func GetEnvParams() map[string]string {
 
 	envParams := map[string]string{
-		// TODO(phase1+): Mode prefix and host_pki_path to another place as constants, and use them everywhere
-		// Right now they're used here and there, but not consequently
-		"kubernetes_dir":     "/etc/kubernetes",
-		"host_pki_path":      "/etc/kubernetes/pki",
-		"host_etcd_path":     "/var/lib/etcd",
-		"hyperkube_image":    "",
-		"discovery_image":    fmt.Sprintf("gcr.io/google_containers/kube-discovery-%s:%s", runtime.GOARCH, "1.0"),
-		"etcd_image":         "",
-		"component_loglevel": "--v=4",
+		// TODO(phase1+): Move prefix to another place as constants, and use it everywhere
+		// Right now it's used here and there, but not consequently
+		"kubernetes_dir":        "/etc/kubernetes",
+		EnvParamNameHostPkiPath: "/etc/kubernetes/pki",
+		"host_etcd_path":        "/var/lib/etcd",
+		"hyperkube_image":       "",
+		"discovery_image":       fmt.Sprintf("gcr.io/google_containers/kube-discovery-%s:%s", runtime.GOARCH, "1.0"),
+		"etcd_image":            "",
+		"component_loglevel":    "--v=4",
 	}
 
 	for k := range envParams {

--- a/cmd/kubeadm/app/master/pki.go
+++ b/cmd/kubeadm/app/master/pki.go
@@ -158,7 +158,7 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) (*rsa.PrivateKey, *x50
 	}
 	altNames.DNSNames = append(altNames.DNSNames, cfg.API.ExternalDNSNames...)
 
-	pkiPath := path.Join(kubeadmapi.GetEnvParams()["host_pki_path"])
+	pkiPath := path.Join(kubeadmapi.GetEnvParams()[kubeadmapi.EnvParamNameHostPkiPath])
 
 	caKey, caCert, err := newCertificateAuthority()
 	if err != nil {

--- a/cmd/kubeadm/app/master/tokens.go
+++ b/cmd/kubeadm/app/master/tokens.go
@@ -48,12 +48,14 @@ func generateTokenIfNeeded(s *kubeadmapi.Secrets) error {
 }
 
 func CreateTokenAuthFile(s *kubeadmapi.Secrets) error {
-	tokenAuthFilePath := path.Join(kubeadmapi.GetEnvParams()["host_pki_path"], "tokens.csv")
+
+	hostPkiPath := kubeadmapi.GetEnvParams()[kubeadmapi.EnvParamNameHostPkiPath]
+	tokenAuthFilePath := path.Join(hostPkiPath, "tokens.csv")
 	if err := generateTokenIfNeeded(s); err != nil {
 		return fmt.Errorf("<master/tokens> failed to generate token(s) [%v]", err)
 	}
-	if err := os.MkdirAll(kubeadmapi.GetEnvParams()["host_pki_path"], 0700); err != nil {
-		return fmt.Errorf("<master/tokens> failed to create directory %q [%v]", kubeadmapi.GetEnvParams()["host_pki_path"], err)
+	if err := os.MkdirAll(hostPkiPath, 0700); err != nil {
+		return fmt.Errorf("<master/tokens> failed to create directory %q [%v]", hostPkiPath, err)
 	}
 	serialized := []byte(fmt.Sprintf("%s,kubeadm-node-csr,%s,system:kubelet-bootstrap\n", s.BearerToken, uuid.NewUUID()))
 	// DumpReaderToFile create a file with mode 0600


### PR DESCRIPTION
**What this PR does / why we need it**:

1, everytime `kubeadm.GetEnvParams()` method is called, it will retrieve several environment parameters from os. `CreateTokenAuthFile` method invokes `GetEnvParams()` 3 times unnecessarilly. this PR makes `GetEnvParams()` is called only 1 time in `CreateTokenAuthFile` method, so it will run a bit faster.
2, refine an exported constant `EnvParamNameHostPkiPath` in pakcage `kubeadm`.

**Special notes for your reviewer**:

when i refine the constant `EnvParamNameHostPkiPath`, i found there are some `host_pki_path` string literals in `staging\src\k8s.io\client-go\pkg\apis\kubeadm\env.go` , but i think these string literals is not needed to replace with .constant `EnvParamNameHostPkiPath`

Signed-off-by: redhatlinux10 ouyang.qinhua@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35485)

<!-- Reviewable:end -->
