### PR TITLE
specify custom ca file to verify the keystone server

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -230,6 +230,7 @@ func Run(s *options.ServerRunOptions) error {
 		ServiceAccountLookup:        s.ServiceAccountLookup,
 		ServiceAccountTokenGetter:   serviceAccountGetter,
 		KeystoneURL:                 s.GenericServerRunOptions.KeystoneURL,
+		KeystoneCAFile:              s.GenericServerRunOptions.KeystoneCAFile,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
 		RequestHeaderConfig:         s.GenericServerRunOptions.AuthenticationRequestHeaderConfig(),

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -189,6 +189,7 @@ exit-on-lock-contention
 experimental-allowed-unsafe-sysctls
 experimental-bootstrap-kubeconfig
 experimental-keystone-url
+experimental-keystone-ca-file
 experimental-mounter-path
 experimental-mounter-rootfs-path
 experimental-nvidia-gpus

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -64,6 +64,7 @@ type AuthenticatorConfig struct {
 	ServiceAccountLookup        bool
 	ServiceAccountTokenGetter   serviceaccount.ServiceAccountTokenGetter
 	KeystoneURL                 string
+	KeystoneCAFile              string
 	WebhookTokenAuthnConfigFile string
 	WebhookTokenAuthnCacheTTL   time.Duration
 
@@ -101,7 +102,7 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 		hasBasicAuth = true
 	}
 	if len(config.KeystoneURL) > 0 {
-		keystoneAuth, err := newAuthenticatorFromKeystoneURL(config.KeystoneURL)
+		keystoneAuth, err := newAuthenticatorFromKeystoneURL(config.KeystoneURL, config.KeystoneCAFile)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,8 +284,8 @@ func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Reques
 }
 
 // newAuthenticatorFromTokenFile returns an authenticator.Request or an error
-func newAuthenticatorFromKeystoneURL(keystoneURL string) (authenticator.Request, error) {
-	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneURL)
+func newAuthenticatorFromKeystoneURL(keystoneURL string, keystoneCAFile string) (authenticator.Request, error) {
+	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneURL, keystoneCAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -91,6 +91,7 @@ type ServerRunOptions struct {
 	InsecureBindAddress          net.IP
 	InsecurePort                 int
 	KeystoneURL                  string
+	KeystoneCAFile               string
 	KubernetesServiceNodePort    int
 	LongRunningRequestRE         string
 	MasterCount                  int
@@ -378,6 +379,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.KeystoneURL, "experimental-keystone-url", s.KeystoneURL,
 		"If passed, activates the keystone authentication plugin.")
+
+	fs.StringVar(&s.KeystoneCAFile, "experimental-keystone-ca-file", s.KeystoneCAFile, ""+
+		"If set, the Keystone server's certificate will be verified by one of the authorities "+
+		"in the experimental-keystone-ca-file, otherwise the host's root CA set will be used.")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.

--- a/plugin/pkg/auth/authenticator/password/keystone/BUILD
+++ b/plugin/pkg/auth/authenticator/password/keystone/BUILD
@@ -19,6 +19,8 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/auth/user:go_default_library",
+        "//pkg/util/cert:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/rackspace/gophercloud",
         "//vendor:github.com/rackspace/gophercloud/openstack",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Sometimes the keystone server's certificate is self-signed, mainly used for internal development, testing and etc.

For this kind of ca, we need a way to verify the keystone server.

Otherwise, below error will occur.

> x509: certificate signed by unknown authority

This patch provide a way to pass in a ca file to verify the keystone server when starting `kube-apiserver`.

**Which issue this PR fixes** : fixes #22695, #24984

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35488)

<!-- Reviewable:end -->
