### PR TITLE
Make the fake RESTClient usable by all the API groups, not just core.

### DIFF
--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -47,6 +47,7 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 type RESTClient struct {
 	Client               *http.Client
 	NegotiatedSerializer runtime.NegotiatedSerializer
+	GroupName            string
 
 	Req  *http.Request
 	Resp *http.Response
@@ -94,8 +95,14 @@ func (c *RESTClient) request(verb string) *restclient.Request {
 	ns := c.NegotiatedSerializer
 	serializer, _ := ns.SerializerForMediaType(runtime.ContentTypeJSON, nil)
 	streamingSerializer, _ := ns.StreamingSerializerForMediaType(runtime.ContentTypeJSON, nil)
+
+	groupName := api.GroupName
+	if c.GroupName != "" {
+		groupName = c.GroupName
+	}
+
 	internalVersion := unversioned.GroupVersion{
-		Group:   registered.GroupOrDie(api.GroupName).GroupVersion.Group,
+		Group:   registered.GroupOrDie(groupName).GroupVersion.Group,
 		Version: runtime.APIVersionInternal,
 	}
 	internalVersion.Version = runtime.APIVersionInternal


### PR DESCRIPTION
cc @kubernetes/sig-cluster-federation @quinton-hoole @nikhiljindal 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35492)

<!-- Reviewable:end -->
