### PR TITLE
Delete the redundant annotation

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -24,11 +24,9 @@ import (
 )
 
 const (
-	// TODO: to be de!eted after v1.3 is released. PodSpec has a dedicated Hostname field.
 	// The annotation value is a string specifying the hostname to be used for the pod e.g 'my-webserver-1'
 	PodHostnameAnnotation = "pod.beta.kubernetes.io/hostname"
 
-	// TODO: to be de!eted after v1.3 is released. PodSpec has a dedicated Subdomain field.
 	// The annotation value is a string specifying the subdomain e.g. "my-web-service"
 	// If specified, on the pod itself, "<hostname>.my-web-service.<namespace>.svc.<cluster domain>" would resolve to
 	// the pod's IP.


### PR DESCRIPTION
This PR delete the redundant annotation, because the const "PodHostnameAnnotation" and "PodSubdomainAnnotation" are used, and needn't deleted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35512)

<!-- Reviewable:end -->
