### PR TITLE
Fix remote build instructions

### DIFF
--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -82,10 +82,10 @@ docker-machine create \
 eval $(docker-machine env ${KUBE_BUILD_VM})
 
 # Pin down the port that rsync will be exposed on on the remote machine
-export KUBE_RSYNC_PORT=8370
+export KUBE_RSYNC_PORT=8730
 
 # forward local 8730 to that machine so that rsync works
-docker-machine ssh ${KUBE_BUILD_VM} -L ${KUBE_RSYNC_PORT}:localhost:8730 -N &
+docker-machine ssh ${KUBE_BUILD_VM} -L ${KUBE_RSYNC_PORT}:localhost:${KUBE_RSYNC_PORT} -N &
 ```
 
 Look at `docker-machine stop`, `docker-machine start` and `docker-machine rm` to manage this VM.


### PR DESCRIPTION
You actually need to forward ${KUBE_RSYNC_PORT} from the remote machine, see
https://github.com/kubernetes/kubernetes/blob/e3067f326fd2370c93f56b47326ab2a3a4e3699b/build-tools/common.sh#L618

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35532)

<!-- Reviewable:end -->
