### PR TITLE
[WIP] discussion/idea/proposal for simple way to restrict storageclass by namespace using annotation

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -46,6 +46,8 @@ const BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
 //TODO: Update this to final annotation value as it matches BetaStorageClassAnnotation for now
 const StorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
 
+const StorageClassNamespaces = "volume.beta.kubernetes.io/namespaces-can-use"
+
 // GetVolumeStorageClass returns value of StorageClassAnnotation or empty string in case
 // the annotation does not exist.
 // TODO: change to PersistentVolume.Spec.Class value when this attribute is
@@ -83,6 +85,15 @@ func GetStorageClassAnnotation(obj api.ObjectMeta) string {
 		return class
 	}
 	if class, ok := obj.Annotations[AlphaStorageClassAnnotation]; ok {
+		return class
+	}
+
+	return ""
+}
+
+// GetStorageClassProjects
+func GetStorageClassNamespaces(obj api.ObjectMeta) string {
+	if class, ok := obj.Annotations[StorageClassNamespaces]; ok {
 		return class
 	}
 

--- a/plugin/pkg/admission/storageclass/default/admission.go
+++ b/plugin/pkg/admission/storageclass/default/admission.go
@@ -19,6 +19,7 @@ package admission
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -118,6 +119,13 @@ func (c *claimDefaulterPlugin) Admit(a admission.Attributes) error {
 
 	if storageutil.HasStorageClassAnnotation(pvc.ObjectMeta) {
 		// The user asked for a class.
+		// check and make sure the user has access to this class
+		// if they do not, then return a NewForbidden error to prevent creation
+		err := isValidStorageClassNamespace(c.store, pvc)
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+
 		return nil
 	}
 
@@ -162,4 +170,48 @@ func getDefaultClass(store cache.Store) (*storage.StorageClass, error) {
 		return nil, errors.NewInternalError(fmt.Errorf("%d default StorageClasses were found", len(defaultClasses)))
 	}
 	return defaultClasses[0], nil
+}
+
+// isValidStorageClassNamespace checks to see if a StorageClass has been restricted to what
+// namespaces can use it via an annotation, this will return an error if the requested StorageClass on
+// the claim does not match the StorageClass namespaces annotation and Name.
+func isValidStorageClassNamespace(store cache.Store, claim *api.PersistentVolumeClaim) error {
+	sc := []*storage.StorageClass{}
+
+	// if no storageclasses exist yet, then we can return nil and wait
+	// for the storageclass as normal
+	if len(store.List()) == 0 {
+		return nil
+	}
+
+	for _, c := range store.List() {
+		class, ok := c.(*storage.StorageClass)
+		if !ok {
+			return errors.NewInternalError(fmt.Errorf("error converting stored object to StorageClass: %v", c))
+		}
+		// Check the storageclass Namespace Annotation,
+		// if exists, split the strings and see if we match
+		scProjects := storageutil.GetStorageClassNamespaces(class.ObjectMeta)
+		if len(scProjects) > 0 {
+			result := strings.Split(scProjects, ",")
+			for i := range result {
+				// annotation must equal Namespace AND class Name
+				if strings.TrimSpace(result[i]) == claim.Namespace && class.Name == storageutil.GetClaimStorageClass(claim){
+					return nil
+				}
+			}
+		} else {
+			// StorageClass has no annotation for namespace and therefor no
+			// restrictions
+			sc = append(sc, class)
+		}
+	}
+
+	if len(sc) > 0 {
+		// we have at least one storageclass that exists
+		// and no restrictions
+		return nil
+	}
+
+	return errors.NewInternalError(fmt.Errorf("claim %s in namespace %s is not allowed to use StorageClass %s - contact the cluster-admin or storage-admin for access", claim.Name, claim.Namespace, storageutil.GetStorageClassAnnotation(claim.ObjectMeta)))
 }


### PR DESCRIPTION
@eparis @erinboyd @childsb - 
I know there has been a lot of discussion on how best to accomplish some access control over StorageClasses (limits, quotas, taints, etc...).  I don't think we want to take a global scoped object like StorageClass and turn it into a Namespaced scope object, we just need a simple way to be able to control which Namespaces can access and create claims for that StorageClass.  I propose a simple annotation that holds a list of values (or single or none) that can be used on the StorageClass to control access.  This approach doesn't impact any other inner workings, other than if a pvc can be created.  The StorageClass is still global in scope, and there are no major changes to any apis.

I coded up a quick prototype that will allow storage-admin/cluster-admin to create an annotation that will hold a list of  Namespaces (projects) that are able to use a StorageClass, or none (meaning annotation doesn't exist or annotation is empty, then SC is open to the cluster).  If a user in a Namespace tries to use a StorageClass that they are not allowed, an error is given back on admission, so the pvc is never created.  Below example is a storage class called _fast_ which is only available to _scottproject_ via the annotation.  If I try to use _fast_ storage class from _default_ namespace, I get an error as expected.

```
[root@ose1 gce]# kubectl create -f gce-pvc-storage-class.yaml 
Error from server (Forbidden): error when creating "gce-pvc-storage-class.yaml": persistentvolumeclaims "gce-claim" is forbidden: Internal error occurred: claim gce-claim in namespace default is not allowed to use StorageClass fast - contact the cluster-admin or storage-admin for access
```

If I create the same pvc in Namespace=scottproject, then it is successful.

```
[root@ose1 gce]# kubectl create -f gce-pvc-storage-class.yaml --namespace=scottproject
persistentvolumeclaim "gce-claim" created
```

The annotation is optional and if it doesn't exist, then the StorageClass is open to the cluster as usual.  This alleviates any complicated design flow and makes it easy and powerful for easy access control of the SC.

```
[root@ose1 gce]# kubectl describe storageclass fast
Name:       fast
IsDefaultClass: No
Annotations:    volume.beta.kubernetes.io/namespaces-can-use=scottproject
Provisioner:    kubernetes.io/gce-pd
Parameters: type=pd-standard,zone=us-central1-a
No events.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35538)

<!-- Reviewable:end -->
