### PR TITLE
Add validation of namespace node selectors

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -470,6 +470,10 @@ const (
 	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
 	// will fail to launch.
 	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
+
+	// NodeSelectorsAnnotationKey represents the key of node selectors in
+	// the Annotations of a namespace
+	NodeSelectorsAnnotationKey string = "scheduler.alpha.kubernetes.io/node-selector"
 )
 
 // TolerationToleratesTaint checks if the toleration tolerates the taint.

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -35,9 +35,9 @@ import (
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 )
 
-// The annotation key scheduler.alpha.kubernetes.io/node-selector is for assigning
-// node selectors labels to namespaces
-var NamespaceNodeSelectors = []string{"scheduler.alpha.kubernetes.io/node-selector"}
+// The annotation key NodeSelectorsAnnotationKey (scheduler.alpha.kubernetes.io/node-selector)
+// is for assigning node selectors labels to namespaces
+var NamespaceNodeSelectors = []string{api.NodeSelectorsAnnotationKey}
 
 func init() {
 	admission.RegisterPlugin("PodNodeSelector", func(config io.Reader) (admission.Interface, error) {

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -143,7 +143,7 @@ func TestPodAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		if !test.ignoreTestNamespaceNodeSelector {
-			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.alpha.kubernetes.io/node-selector": test.namespaceNodeSelector}
+			namespace.ObjectMeta.Annotations = map[string]string{api.NodeSelectorsAnnotationKey: test.namespaceNodeSelector}
 			handler.namespaceInformer.GetStore().Update(namespace)
 		}
 		handler.clusterNodeSelectors = make(map[string]string)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This PR adds validation for namespace node selectors. Without validation, a namespace with incorrect node selectors could be created.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes #

fixes #35505 

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1415554

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35554)

<!-- Reviewable:end -->
