### PR TITLE
Add a retry when reading a file content from a container

### DIFF
--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -49,6 +49,7 @@ const (
 	nodeStatusPollTime  = 1 * time.Second
 	gcePDRetryTimeout   = 5 * time.Minute
 	gcePDRetryPollTime  = 5 * time.Second
+	maxReadRetry        = 3
 )
 
 var _ = framework.KubeDescribe("Pod Disks", func() {
@@ -450,20 +451,28 @@ func deletePDWithRetry(diskName string) {
 
 func verifyPDContentsViaContainer(f *framework.Framework, podName, containerName string, fileAndContentToVerify map[string]string) {
 	for filePath, expectedContents := range fileAndContentToVerify {
-		v, err := f.ReadFileViaContainer(podName, containerName, filePath)
-		if err != nil {
-			framework.Logf("Error reading file: %v", err)
-		}
-		framework.ExpectNoError(err)
-		framework.Logf("Read file %q with content: %v", filePath, v)
-		if strings.TrimSpace(v) != strings.TrimSpace(expectedContents) {
-			size, err := f.CheckFileSizeViaContainer(podName, containerName, filePath)
+		var value string
+		// Add a retry to avoid temporal failure in reading the content
+		for i := 0; i < maxReadRetry; i++ {
+			v, err := f.ReadFileViaContainer(podName, containerName, filePath)
+			value = v
 			if err != nil {
 				framework.Logf("Error reading file: %v", err)
 			}
-			framework.Logf("Check file %q size: %q", filePath, size)
+			framework.ExpectNoError(err)
+			framework.Logf("Read file %q with content: %v (iteration %d)", filePath, v, i)
+			if strings.TrimSpace(v) != strings.TrimSpace(expectedContents) {
+				framework.Logf("Warning: read content <%q> does not match execpted content <%q>.", v, expectedContents)
+				size, err := f.CheckFileSizeViaContainer(podName, containerName, filePath)
+				if err != nil {
+					framework.Logf("Error checking file size: %v", err)
+				}
+				framework.Logf("Check file %q size: %q", filePath, size)
+			} else {
+				break
+			}
 		}
-		Expect(strings.TrimSpace(v)).To(Equal(strings.TrimSpace(expectedContents)))
+		Expect(strings.TrimSpace(value)).To(Equal(strings.TrimSpace(expectedContents)))
 	}
 }
 


### PR DESCRIPTION
To avoid temporal failure in reading the file content, add a retry
process in function verifyPDContentsViaContainer

```release-note
Add a retry when reading a file content from a container
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35560)

<!-- Reviewable:end -->
