### PR TITLE
CRI: Enable remote dockershim by default

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -138,8 +138,8 @@ func NewKubeGenericRuntimeManager(
 		osInterface:         osInterface,
 		networkPlugin:       networkPlugin,
 		runtimeHelper:       runtimeHelper,
-		runtimeService:      NewInstrumentedRuntimeService(runtimeService),
-		imageService:        NewInstrumentedImageManagerService(imageService),
+		runtimeService:      runtimeService,
+		imageService:        imageService,
 		keyring:             credentialprovider.NewDockerKeyring(),
 	}
 


### PR DESCRIPTION
Enable remote dockershim by default.

Once the grpc integration is stabilized, I'll remove the temporary knob and configure container runtime endpoint in all test suite.

@yujuhong @feiskyer 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35561)

<!-- Reviewable:end -->
