### PR TITLE
CRI: add streaming APIs to RuntimeService

### DIFF
--- a/pkg/kubelet/api/services.go
+++ b/pkg/kubelet/api/services.go
@@ -43,8 +43,15 @@ type ContainerManager interface {
 	ListContainers(filter *runtimeApi.ContainerFilter) ([]*runtimeApi.Container, error)
 	// ContainerStatus returns the status of the container.
 	ContainerStatus(containerID string) (*runtimeApi.ContainerStatus, error)
-	// Exec executes a command in the container.
-	Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error
+	// ExecLegacy executes a command in the container.
+	// TODO: remove this after full CRI streaming APIs are accomplished.
+	ExecLegacy(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error
+	// Exec prepares a streaming endpoint to execute a command in the container.
+	Exec(containerID string, cmd []string, tty, stdin bool) (string, error)
+	// ExecSync runs a command in a container synchronously and returns stdout, stderr and exit code.
+	ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error)
+	// Attach prepares a streaming endpoint to attach to a running container.
+	Attach(containerID string, stdin bool) (string, error)
 }
 
 // PodSandboxManager contains methods for operating on PodSandboxes. The methods
@@ -63,6 +70,8 @@ type PodSandboxManager interface {
 	PodSandboxStatus(podSandboxID string) (*runtimeApi.PodSandboxStatus, error)
 	// ListPodSandbox returns a list of Sandbox.
 	ListPodSandbox(filter *runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error)
+	// PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+	PortForward(podSandboxID string, port int32) (string, error)
 }
 
 // RuntimeService interface should be implemented by a container runtime.

--- a/pkg/kubelet/api/testing/fake_runtime_service.go
+++ b/pkg/kubelet/api/testing/fake_runtime_service.go
@@ -349,14 +349,50 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeApi.Co
 	return &status, nil
 }
 
-func (r *FakeRuntimeService) Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
+func (r *FakeRuntimeService) ExecLegacy(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
 	r.Lock()
 	defer r.Unlock()
 
-	r.Called = append(r.Called, "Exec")
+	r.Called = append(r.Called, "ExecLegacy")
 	return nil
 }
 
 func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeApi.RuntimeConfig) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "UpdateRuntimeConfig")
 	return nil
+}
+
+func (r *FakeRuntimeService) Exec(containerID string, cmd []string, tty, stdin bool) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Exec")
+	return "", nil
+}
+
+func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ExecSync")
+	return "", "", 0, nil
+}
+
+func (r *FakeRuntimeService) Attach(containerID string, stdin bool) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Attach")
+	return "", nil
+}
+
+func (r *FakeRuntimeService) PortForward(podSandboxID string, port int32) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PortForward")
+	return "", nil
 }

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -383,9 +383,23 @@ func (ds *dockerService) ContainerStatus(containerID string) (*runtimeApi.Contai
 	}, nil
 }
 
-// Exec execute a command in the container.
-// TODO: Need to handle terminal resizing before implementing this function.
-// https://github.com/kubernetes/kubernetes/issues/29579.
-func (ds *dockerService) Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
+// ExecLegacy execute a command in the container.
+// TODO: remove this after full CRI streaming APIs are accomplished.
+func (ds *dockerService) ExecLegacy(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
 	return fmt.Errorf("not implemented")
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container.
+func (ds *dockerService) Exec(containerID string, cmd []string, tty, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// ExecSync runs a command in a container synchronously and returns stdout, stderr and exit code.
+func (ds *dockerService) ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error) {
+	return "", "", -1, fmt.Errorf("not implemented")
+}
+
+// Attach prepares a streaming endpoint to attach to a running container.
+func (ds *dockerService) Attach(containerID string, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -282,3 +282,8 @@ func setSandboxResources(hc *dockercontainer.HostConfig) {
 	// TODO: Get rid of the dependency on kubelet internal package.
 	hc.OomScoreAdj = qos.PodInfraOOMAdj
 }
+
+// PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+func (ds *dockerService) PortForward(podSandboxID string, port int32) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -79,7 +79,9 @@ type DockerLegacyService interface {
 	// Supporting legacy methods for docker.
 	GetContainerLogs(pod *api.Pod, containerID kubecontainer.ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error)
 	kubecontainer.ContainerAttacher
-	PortForward(sandboxID string, port uint16, stream io.ReadWriteCloser) error
+
+	// TODO: Replace this with PortForward once the streaming library is ready.
+	PortForwardLegacy(sandboxID string, port uint16, stream io.ReadWriteCloser) error
 
 	// TODO: Remove this once exec is properly defined in CRI.
 	ExecInContainer(containerID kubecontainer.ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size) error

--- a/pkg/kubelet/dockershim/legacy.go
+++ b/pkg/kubelet/dockershim/legacy.go
@@ -43,7 +43,7 @@ func (ds *dockerService) GetContainerLogs(pod *api.Pod, containerID kubecontaine
 	return dockertools.GetContainerLogs(ds.client, pod, containerID, logOptions, stdout, stderr, container.Config.Tty)
 }
 
-func (ds *dockerService) PortForward(sandboxID string, port uint16, stream io.ReadWriteCloser) error {
+func (ds *dockerService) PortForwardLegacy(sandboxID string, port uint16, stream io.ReadWriteCloser) error {
 	return dockertools.PortForward(ds.client, sandboxID, port, stream)
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1001,7 +1001,7 @@ func (m *kubeGenericRuntimeManager) PortForward(pod *kubecontainer.Pod, port uin
 	// now to unblock other tests.
 	// TODO: remove this hack after portforward is defined in CRI.
 	if ds, ok := m.runtimeService.(dockershim.DockerLegacyService); ok {
-		return ds.PortForward(pod.Sandboxes[0].ID.ID, port, stream)
+		return ds.PortForwardLegacy(pod.Sandboxes[0].ID.ID, port, stream)
 	}
 
 	return fmt.Errorf("not implemented")

--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -247,12 +247,32 @@ func (r *RemoteRuntimeService) ContainerStatus(containerID string) (*runtimeApi.
 	return resp.Status, nil
 }
 
-// Exec executes a command in the container.
-// TODO: support terminal resizing for exec, refer https://github.com/kubernetes/kubernetes/issues/29579.
-func (r *RemoteRuntimeService) Exec(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
-	return fmt.Errorf("Not implemented")
+// ExecLegacy executes a command in the container.
+// TODO: remove this after full CRI streaming APIs are accomplished.
+func (r *RemoteRuntimeService) ExecLegacy(containerID string, cmd []string, tty bool, stdin io.Reader, stdout, stderr io.WriteCloser) error {
+	return fmt.Errorf("not implemented")
 }
 
 func (r *RemoteRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeApi.RuntimeConfig) error {
 	return nil
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container.
+func (r *RemoteRuntimeService) Exec(containerID string, cmd []string, tty, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// ExecSync runs a command in a container synchronously and returns stdout, stderr and exit code.
+func (r *RemoteRuntimeService) ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error) {
+	return "", "", -1, fmt.Errorf("not implemented")
+}
+
+// Attach prepares a streaming endpoint to attach to a running container.
+func (r *RemoteRuntimeService) Attach(containerID string, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+func (r *RemoteRuntimeService) PortForward(podSandboxID string, port int32) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }

--- a/pkg/kubelet/rktshim/app-interface.go
+++ b/pkg/kubelet/rktshim/app-interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rktshim
 
 import (
+	"fmt"
 	"io"
 
 	kubeletApi "k8s.io/kubernetes/pkg/kubelet/api"
@@ -65,7 +66,22 @@ func (*Runtime) ContainerStatus(string) (*runtimeApi.ContainerStatus, error) {
 	panic("not implemented")
 }
 
-// Exec executes a command inside an app running inside a pod sanbox.
-func (*Runtime) Exec(string, []string, bool, io.Reader, io.WriteCloser, io.WriteCloser) error {
+// ExecLegacy executes a command inside an app running inside a pod sanbox.
+func (*Runtime) ExecLegacy(string, []string, bool, io.Reader, io.WriteCloser, io.WriteCloser) error {
 	panic("not implemented")
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container.
+func (*Runtime) Exec(containerID string, cmd []string, tty, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// ExecSync runs a command in a container synchronously and returns stdout, stderr and exit code.
+func (*Runtime) ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error) {
+	return "", "", -1, fmt.Errorf("not implemented")
+}
+
+// Attach prepares a streaming endpoint to attach to a running container.
+func (*Runtime) Attach(containerID string, stdin bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }

--- a/pkg/kubelet/rktshim/fake-app-interface.go
+++ b/pkg/kubelet/rktshim/fake-app-interface.go
@@ -200,7 +200,7 @@ func (r *FakeRuntime) ContainerStatus(id string) (*runtimeApi.ContainerStatus, e
 	return &c.Status, nil
 }
 
-func (r *FakeRuntime) Exec(id string, cmd []string, tty bool, in io.Reader, out, err io.WriteCloser) error {
+func (r *FakeRuntime) ExecLegacy(id string, cmd []string, tty bool, in io.Reader, out, err io.WriteCloser) error {
 	c, ok := r.Containers[id]
 	if !ok {
 		return ErrContainerNotFound
@@ -212,4 +212,20 @@ func (r *FakeRuntime) Exec(id string, cmd []string, tty bool, in io.Reader, out,
 	}
 
 	return c.Exec(cmd, in, out, err)
+}
+
+func (r *FakeRuntime) Exec(containerID string, cmd []string, tty, stdin bool) (string, error) {
+	return "", nil
+}
+
+func (r *FakeRuntime) ExecSync(containerID string, cmd []string, timeout int64) (string, string, int32, error) {
+	return "", "", 0, nil
+}
+
+func (r *FakeRuntime) Attach(containerID string, stdin bool) (string, error) {
+	return "", nil
+}
+
+func (r *FakeRuntime) PortForward(podSandboxID string, port int32) (string, error) {
+	return "", nil
 }

--- a/pkg/kubelet/rktshim/pod-level-interface.go
+++ b/pkg/kubelet/rktshim/pod-level-interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rktshim
 
 import (
+	"fmt"
 	kubeletApi "k8s.io/kubernetes/pkg/kubelet/api"
 	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -56,4 +57,9 @@ func (*PodSandboxManager) PodSandboxStatus(string) (*runtimeApi.PodSandboxStatus
 // ListPodSandbox lists existing sandboxes, filtered by the PodSandboxFilter.
 func (*PodSandboxManager) ListPodSandbox(*runtimeApi.PodSandboxFilter) ([]*runtimeApi.PodSandbox, error) {
 	panic("not implemented")
+}
+
+// PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+func (*PodSandboxManager) PortForward(podSandboxID string, port int32) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
This PR adds streaming APIs to CRI RuntimeService ([reference](https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#)), which includes
- Exec
- ExecSync
- Attach
- PortForward

And also rename old Exec interface to ExecLegacy.

cc/ @yujuhong @timstclair @Random-Liu @yifan-gu 
also cc/ @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35585)

<!-- Reviewable:end -->
