### PR TITLE
fix inconsistent util package import, and fix some syntax errors in w…

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/pkg/util/initsystem"
 )
 
@@ -36,7 +36,7 @@ func NewCmdReset(out io.Writer) *cobra.Command {
 		Short: "Revert the actions kubeadm init or join made to the machine",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunReset(out, cmd, skipPreFlight)
-			cmdutil.CheckErr(err)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 

--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -32,7 +32,7 @@ func NewCmdVersion(out io.Writer) *cobra.Command {
 		Short: "Print the version of kubeadm",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunVersion(out, cmd)
-			cmdutil.CheckErr(err)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 	return cmd

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -33,8 +33,8 @@ const (
 )
 
 var AlphaWarningOnExit = dedent.Dedent(`
-	kubeadm: I am an alpha version, my authors welcome your feedback and bug reports
-	kubeadm: please create issue an using https://github.com/kubernetes/kubernetes/issues/new
+	kubeadm: I am at alpha version, my authors welcome your feedback and bug reports
+	kubeadm: please create an issue using https://github.com/kubernetes/kubernetes/issues/new
 	kubeadm: and make sure to mention @kubernetes/sig-cluster-lifecycle. Thank you!
 `)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR makes sure only `kubeadmutil.CheckErr()` function will be called in all kubeadm subcommands. this makes sure that all error handling logics are centralized into `kubeadmutil.CheckErr()`.

in `reset.go`, `RunReset` function only returns `PreFlightError` or `nil`, `kubeadmutil.CheckErr()` is enough for this, `cmdutil.CheckErr()` even doesn't handle `PreFlightError` specially.

in `version.go`,`RunVersion()` function only returns `nil`, `kubeadmutil.CheckErr()` is enough for this
this PR also fix some syntax errors in `AlphaWarningOnExit` message.

Signed-off-by: redhatlinux10 ouyang.qinhua@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35596)

<!-- Reviewable:end -->
