### PR TITLE
fix invalid request to username/password

### DIFF
--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -38,7 +38,7 @@ var (
 
 		for each compute resource, if a limit is specified and a request is omitted, the request will default to the limit.
 
-		Possible resources include (case insensitive):`)
+		Possible resources include (case insensitive): replicationcontrollers, deployments, daemonsets, jobs, replicasets`)
 
 	resources_example = templates.Examples(`
 		# Set a deployments nginx container cpu limits to "200m" and memory to "512Mi"
@@ -87,17 +87,11 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 		Out: out,
 		Err: errOut,
 	}
-	var pod_specs string
-	RESTMappings := cmdutil.ResourcesWithPodSpecs()
-	for _, Map := range RESTMappings {
-		pod_specs = pod_specs + ", " + Map.Resource
-
-	}
 
 	cmd := &cobra.Command{
 		Use:     "resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]",
 		Short:   "update resource requests/limits on objects with pod templates",
-		Long:    resources_long + " " + pod_specs[2:],
+		Long:    resources_long,
 		Example: resources_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))


### PR DESCRIPTION
When use basic-auth/RBAC,  don't set the users in  .kube/config

```
# cat ~/.kube/config
apiVersion: v1
clusters:
- cluster:
    insecure-skip-tls-verify: true
    server: https://127.0.0.1:6443
  name: ubuntu
contexts:
- context:
    cluster: ubuntu
    namespace: default
    user: test
  name: ubuntu
current-context: ubuntu
kind: Config
preferences: {}
users: []
```

kubectl config need the username and password:

```
# kubectl config view
Please enter Username: admin
Please enter Password: *******
```

And it can pass with wrong username or  wrong password . besides, I don't think it‘s necessary to request the username/password for kubectl config.

I find that cmdutil.ResourcesWithPodSpecs() call NewFactory(nil).Object() will request the username.

I guess we would remove it because it's used to get some possible resources values for example.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35599)

<!-- Reviewable:end -->
