### PR TITLE
Update PodAntiAffinity to ignore calls to subresources

### DIFF
--- a/plugin/pkg/admission/antiaffinity/BUILD
+++ b/plugin/pkg/admission/antiaffinity/BUILD
@@ -36,5 +36,6 @@ go_test(
         "//pkg/admission:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/unversioned:go_default_library",
+        "//pkg/runtime:go_default_library",
     ],
 )

--- a/plugin/pkg/admission/antiaffinity/admission.go
+++ b/plugin/pkg/admission/antiaffinity/admission.go
@@ -51,7 +51,8 @@ func NewInterPodAntiAffinity(client clientset.Interface) admission.Interface {
 // Admit will deny any pod that defines AntiAffinity topology key other than unversioned.LabelHostname i.e. "kubernetes.io/hostname"
 // in  requiredDuringSchedulingRequiredDuringExecution and requiredDuringSchedulingIgnoredDuringExecution.
 func (p *plugin) Admit(attributes admission.Attributes) (err error) {
-	if attributes.GetResource().GroupResource() != api.Resource("pods") {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 	pod, ok := attributes.GetObject().(*api.Pod)


### PR DESCRIPTION
@smarterclayton I hit this when I was trying to evict a pod, apparently k8s does not have this particular admission plugin on by default. ptal

@mml @davidopp fyi

```release-note
Update PodAntiAffinity to ignore calls to subresources
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35608)

<!-- Reviewable:end -->
