### PR TITLE
Build: Use checksum to rsync results

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -383,7 +383,7 @@ kube::golang::place_bins() {
     if [[ -d "${full_binpath_src}" ]]; then
       mkdir -p "${KUBE_OUTPUT_BINPATH}/${platform}"
       find "${full_binpath_src}" -maxdepth 1 -type f -exec \
-        rsync -pt {} "${KUBE_OUTPUT_BINPATH}/${platform}" \;
+        rsync -ptc {} "${KUBE_OUTPUT_BINPATH}/${platform}" \;
     fi
   done
 }


### PR DESCRIPTION
If dependencies are touched, the Makefile will detect that tools like
deepcopy-gen need to be rebuilt.  It will rebuild them, but if Go decides the
dependencies are not ACTUALLY updated (maybe it was a test file - known
limitation of the current Makefile), it does not touch the resulting binary.
The Makefile touches the result explicitly to mark that the dep change has
been handled.  But rsync blows away that change with the older file, and
helpfully preserves the timestamp.  This repeats on every build.

Now rsync ignores it if the checksum is the same.  Result = faster build.

@wojtek-t @gmarek

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35644)

<!-- Reviewable:end -->
