### PR TITLE
Add hack/verify-test-owners.sh to ensure tests always have owners.

### DIFF
--- a/hack/update_owners.py
+++ b/hack/update_owners.py
@@ -118,7 +118,7 @@ def get_maintainers():
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--history', action='store_true', help='Generate test list from result history.')
-    parser.add_argument('--user', help='User to assign new tests to (RANDOM for random assignment).')
+    parser.add_argument('--user', help='User to assign new tests to (default: random).')
     parser.add_argument('--check', action='store_true', help='Exit with a nonzero status if the test list has changed.')
     options = parser.parse_args()
 
@@ -135,7 +135,9 @@ def main():
     maintainers = get_maintainers()
 
     print '# OUTDATED TESTS (%d):' % len(outdated_tests)
-    print  '\n'.join(outdated_tests)
+    print  '\n'.join('%s -- %s%s' %
+                     (t, owners[t][0], ['', ' (random)'][owners[t][1]])
+                      for t in outdated_tests)
     print '# NEW TESTS (%d):' % len(new_tests)
     print  '\n'.join(new_tests)
 
@@ -161,14 +163,14 @@ def main():
         owner for name, (owner, random) in owners.iteritems()
         if owner in maintainers)
     for test_name in set(test_names) - set(owners):
-        if options.user == 'RANDOM':
-            new_owner, _count = random.choice(owner_counts.most_common()[-4:])
-        elif options.user:
+        random_assignment = True
+        if options.user:
             new_owner = options.user
+            random_assignment = False
         else:
-            raise AssertionError('--user must be specified for new tests')
+            new_owner, _count = random.choice(owner_counts.most_common()[-4:])
         owner_counts[new_owner] += 1
-        owners[test_name] = (new_owner, True)
+        owners[test_name] = (new_owner, random_assignment)
 
     print '# Tests per maintainer:'
     for owner, count in owner_counts.most_common():

--- a/hack/verify-test-owners.sh
+++ b/hack/verify-test-owners.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+cd "${KUBE_ROOT}"
+if ! hack/update_owners.py --check; then
+    echo 'Run ./hack/update_owners.py to fix it'
+    exit 1
+fi

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -277,10 +277,13 @@ NodeProblemDetector KernelMonitor should generate node condition and events for 
 Nodes Network when a node becomes unreachable *,alex-mohr,1
 Nodes Resize should be able to add nodes,piosz,1
 Nodes Resize should be able to delete nodes,zmerlynn,1
-PersistentVolumes create a PV and a pre-bound PVC: test write access,caesarxuchao,1
-PersistentVolumes create a PVC and a pre-bound PV: test write access,lavalamp,1
-PersistentVolumes create a PVC and non-pre-bound PV: test write access,mwielgus,1
-PersistentVolumes should create a non-pre-bound PV and PVC: test write access,andyzheng0831,1
+PersistentVolumes with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access,alex-mohr,1
+PersistentVolumes with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access,ncdc,1
+PersistentVolumes with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access,dchen1107,1
+PersistentVolumes with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access,dchen1107,1
+PersistentVolumes with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access,lavalamp,1
+PersistentVolumes with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access,ghodss,1
+PersistentVolumes with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access,andyzheng0831,1
 Pet Store should scale to persist a nominal number ( * ) of transactions in * seconds,xiang90,1
 Pet set recreate should recreate evicted petset,hurf,1
 PetSet Basic PetSet functionality should handle healthy pet restarts during scale,kevin-wangzefeng,1
@@ -444,6 +447,7 @@ k8s.io/kubernetes/cmd/kube-apiserver/app,nikhiljindal,0
 k8s.io/kubernetes/cmd/kube-apiserver/app/options,nikhiljindal,0
 k8s.io/kubernetes/cmd/kube-discovery/app,vulpecula,1
 k8s.io/kubernetes/cmd/kube-proxy/app,luxas,1
+k8s.io/kubernetes/cmd/kubeadm/app/cmd,vishh,1
 k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/util,krousey,1
 k8s.io/kubernetes/cmd/kubelet/app,hurf,1
@@ -530,7 +534,6 @@ k8s.io/kubernetes/pkg/client/unversioned/clientcmd,yifan-gu,1
 k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api,thockin,1
 k8s.io/kubernetes/pkg/client/unversioned/portforward,lavalamp,1
 k8s.io/kubernetes/pkg/client/unversioned/remotecommand,andyzheng0831,1
-k8s.io/kubernetes/pkg/client/unversioned/testclient,brendandburns,1
 k8s.io/kubernetes/pkg/cloudprovider/providers/aws,eparis,1
 k8s.io/kubernetes/pkg/cloudprovider/providers/azure,saad-ali,1
 k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack,roberthbailey,1
@@ -617,7 +620,9 @@ k8s.io/kubernetes/pkg/kubelet/qos,vishh,0
 k8s.io/kubernetes/pkg/kubelet/rkt,apelisse,1
 k8s.io/kubernetes/pkg/kubelet/rktshim,mml,1
 k8s.io/kubernetes/pkg/kubelet/server,timstclair,0
+k8s.io/kubernetes/pkg/kubelet/server/portforward,timstclair,0
 k8s.io/kubernetes/pkg/kubelet/server/stats,timstclair,0
+k8s.io/kubernetes/pkg/kubelet/server/streaming,timstclair,0
 k8s.io/kubernetes/pkg/kubelet/status,mwielgus,1
 k8s.io/kubernetes/pkg/kubelet/sysctl,piosz,1
 k8s.io/kubernetes/pkg/kubelet/types,jlowdermilk,1


### PR DESCRIPTION
This ensures that new tests or changed tests are assigned appropriate owners.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35650)

<!-- Reviewable:end -->
