### PR TITLE
Automated cherry pick of #34368 #35158 #35321

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -98,8 +98,17 @@ function split-commas {
   echo $1 | tr "," "\n"
 }
 
+function install-rkt {
+    local -r rkt_binary="rkt-v1.17.0"
+    local -r rkt_sha1="e9183dcae0683e345cc73fef98ffd80a253d371a"
+    download-or-bust "${rkt_sha1}" "https://storage.googleapis.com/kubernetes-release/rkt/${rkt_binary}"
+    local -r rkt_dst="${KUBE_HOME}/bin/rkt"
+    mv "${KUBE_HOME}/${rkt_binary}" "${rkt_dst}"
+    chmod a+x "${rkt_dst}"
+}
+
 # Downloads kubernetes binaries and kube-system manifest tarball, unpacks them,
-# and places them into suitable directories. Files are placed in /home/kubernetes. 
+# and places them into suitable directories. Files are placed in /home/kubernetes.
 function install-kube-binary-config {
   cd "${KUBE_HOME}"
   local -r server_binary_tar_urls=( $(split-commas "${SERVER_BINARY_TAR_URL}") )
@@ -173,6 +182,9 @@ function install-kube-binary-config {
   cp "${dst_dir}/kubernetes/gci-trusty/gci-configure-helper.sh" "${KUBE_HOME}/bin/configure-helper.sh"
   cp "${dst_dir}/kubernetes/gci-trusty/health-monitor.sh" "${KUBE_HOME}/bin/health-monitor.sh"
   chmod -R 755 "${kube_bin}"
+
+  # Install rkt binary to allow mounting storage volumes in GCI
+  install-rkt
 
   # Clean up.
   rm -rf "${KUBE_HOME}/kubernetes"

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -196,8 +196,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 
@@ -217,8 +217,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 
@@ -238,8 +238,8 @@ var _ = framework.KubeDescribe("PetSet [Slow] [Feature:PetSet]", func() {
 			}
 
 			By("Reading value under foo from member with index 2")
-			if v := pet.read(2, "foo"); v != "bar" {
-				framework.Failf("Read unexpected value %v, expected bar under key foo", v)
+			if err := pollReadWithTimeout(pet, 2, "foo", "bar"); err != nil {
+				framework.Failf("%v", err)
 			}
 		})
 	})
@@ -659,6 +659,18 @@ func deleteAllPetSets(c *client.Client, ns string) {
 
 func ExpectNoError(err error) {
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func pollReadWithTimeout(pet petTester, petNumber int, key, expectedVal string) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		val := pet.read(petNumber, key)
+		if val == "" {
+			return false, nil
+		} else if val != expectedVal {
+			return false, fmt.Errorf("Expected value %v, found %v", expectedVal, val)
+		}
+		return true, nil
+	})
 }
 
 func isInitialized(pod api.Pod) bool {

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -56,7 +56,6 @@ const (
 
 	// Timeout for reads from databases running on pets.
 	readTimeout = 60 * time.Second
-
 )
 
 // Time: 25m, slow by design.

--- a/test/e2e_node/jenkins/gci-init.yaml
+++ b/test/e2e_node/jenkins/gci-init.yaml
@@ -3,3 +3,8 @@
 runcmd:
   - mount /tmp /tmp -o remount,exec,suid
   - usermod -a -G docker jenkins
+  - mkdir -p /home/kubernetes/bin/
+  - mount -B /home/kubernetes/bin /home/kubernetes/bin
+  - mount -B -o remount,exec /home/kubernetes/bin
+  - wget https://storage.googleapis.com/kubernetes-release/rkt/rkt-v1.17.0 -O /home/kubernetes/bin/rkt
+  - chmod a+x /home/kubernetes/bin/rkt


### PR DESCRIPTION
Cherry pick of #34368 #35158 #35321 on release-1.4.
#34368: Node status updater should SetNodeStatusUpdateNeeded if it
#35158: Fixing flake caused by lack of polling during read.
#35321: Adding rkt binary to GCI nodes via cloud-init. This is

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35653)

<!-- Reviewable:end -->
