### PR TITLE
Update drain test

### DIFF
--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -658,11 +659,11 @@ func createPods(ifCreateNewPods bool) (map[string]api.Pod, []api.Pod) {
 		if ifCreateNewPods {
 			uid = types.UID(i)
 		} else {
-			uid = types.UID(string(i) + string(i))
+			uid = types.UID(strconv.Itoa(i) + strconv.Itoa(i))
 		}
 		pod := api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				Name:       "pod" + string(i),
+				Name:       "pod" + strconv.Itoa(i),
 				Namespace:  "default",
 				UID:        uid,
 				Generation: int64(i),


### PR DESCRIPTION
Update how int convert to string in the kubectl drain test.
It is safer to use `strconv.Itoa()` than `string()`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35664)

<!-- Reviewable:end -->
