### PR TITLE
Added Changelog to addon manager

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,0 +1,23 @@
+### Version 5.2 (Wed October 26 2016 Zihong Zheng <zihongz@google.com>)
+ - Added support for ConfigMap and upgraded kubectl version to v1.4.4 (pr #35255)
+
+### Version 5.1 (Mon Jul 4 2016 Marek Grabowski <gmarek@google.com>)
+ - Fixed the way addon-manager handles non-namespaced objects
+
+### Version 5 (Fri Jun 24 2016 Jerzy Szczepkowski @jszczepkowski)
+ - Added PetSet support to addon manager
+
+### Version 4 (Tue Jun 21 2016 Mike Danese @mikedanese)
+ - Increased addon check interval
+
+### Version 3 (Sun Jun 19 2016 Lucas Käldström @luxas)
+ - Bumped up addon-manager to v3
+
+### Version 2 (Fri May 20 2016 Lucas Käldström @luxas)
+ - Removed deprecated kubectl command, added support for DaemonSets
+
+### Version 1 (Thu May 5 2016 Mike Danese @mikedanese)
+ - Run kube-addon-manager in a pod
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/addon-manager/CHANGELOG.md?pixel)]()


### PR DESCRIPTION
From #35651.

It would be good to have this changelog recording who and when pushed a new image to gcr.io. I retrieved the information from the [commit history](https://github.com/kubernetes/kubernetes/commits/master/cluster/addons/addon-manager).

@mikedanese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35668)

<!-- Reviewable:end -->
