### PR TITLE
Automated cherry pick of #32013 #32235 #34359 #35233

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -67,13 +67,6 @@ else
 
   push_build=${release_infra_clone}/push-build.sh
 
-  if [[ ! -x ${push_build} ]]; then
-    # TODO: Remove/Restore this with the full deprecation PR
-    push_build=${release_infra_clone}/push-ci-build.sh
-    #echo "FATAL: Something went wrong. ${push_build} isn't available." \
-    #     "Exiting..." >&2
-    #exit 1
-  fi
   [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
     && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -68,7 +68,7 @@ make release
 # Push to GCS?
 if [[ ${KUBE_SKIP_PUSH_GCS:-} =~ ^[yY]$ ]]; then
   echo "Not pushed to GCS..."
-elif ${RELEASE_INFRA_PUSH-}; then
+else
   readonly release_infra_clone="${WORKSPACE}/_tmp/release.git"
   mkdir -p ${WORKSPACE}/_tmp
   git clone https://github.com/kubernetes/release ${release_infra_clone}
@@ -85,9 +85,7 @@ elif ${RELEASE_INFRA_PUSH-}; then
   ${FEDERATION} && federation_flag="--federation"
   ${SET_NOMOCK_FLAG} && mock_flag="--nomock"
   ${release_infra_clone}/push-ci-build.sh ${bucket_flag-} ${federation_flag-} \
-                                          ${mock_flag-}
-else
-  ./build/push-ci-build.sh
+                                          ${mock_flag-} --verbose
 fi
 
 sha256sum _output/release-tars/kubernetes*.tar.gz

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -75,9 +75,12 @@ else
     #exit 1
   fi
   [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
-   && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
+    && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"
-  ${push_build} ${bucket_flag-} ${federation_flag-} --nomock --verbose --ci
+  [[ -n "${KUBE_GCS_RELEASE_SUFFIX-}" ]] \
+    && gcs_suffix_flag="--gcs-suffix=${KUBE_GCS_RELEASE_SUFFIX-}"
+  ${push_build} ${bucket_flag-} ${federation_flag-} ${gcs_suffix_flag-} \
+    --nomock --verbose --ci
 fi
 
 sha256sum _output/release-tars/kubernetes*.tar.gz

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -39,15 +39,7 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 # FEDERATION?
 : ${FEDERATION:="false"}
 : ${KUBE_RELEASE_RUN_TESTS:="n"}
-
-# New kubernetes/release/push-ci-build.sh values
-# RELEASE_INFRA_PUSH=true when we're using kubernetes/release/push-ci-build.sh
-: ${RELEASE_INFRA_PUSH:="false"}
-# SET_NOMOCK_FLAG=true means we're doing full pushes and we pass --nomock to 
-# push-ci-build.sh. This is set to false in the
-# testing jobs and only used in the RELEASE_INFRA_PUSH=true scope below.
-: ${SET_NOMOCK_FLAG:="true"}
-export KUBE_RELEASE_RUN_TESTS RELEASE_INFRA_PUSH FEDERATION SET_NOMOCK_FLAG
+export KUBE_RELEASE_RUN_TESTS
 
 # Clean stuff out. Assume the last build left the tree in an odd
 # state.
@@ -73,19 +65,19 @@ else
   mkdir -p ${WORKSPACE}/_tmp
   git clone https://github.com/kubernetes/release ${release_infra_clone}
 
-  if [[ ! -x ${release_infra_clone}/push-ci-build.sh ]]; then
-    echo "FATAL: Something went wrong." \
-         "${release_infra_clone}/push-ci-build.sh isn't available." \
-         "Exiting..." >&2
-    exit 1
-  fi
+  push_build=${release_infra_clone}/push-build.sh
 
+  if [[ ! -x ${push_build} ]]; then
+    # TODO: Remove/Restore this with the full deprecation PR
+    push_build=${release_infra_clone}/push-ci-build.sh
+    #echo "FATAL: Something went wrong. ${push_build} isn't available." \
+    #     "Exiting..." >&2
+    #exit 1
+  fi
   [[ -n "${KUBE_GCS_RELEASE_BUCKET-}" ]] \
    && bucket_flag="--bucket=${KUBE_GCS_RELEASE_BUCKET-}"
   ${FEDERATION} && federation_flag="--federation"
-  ${SET_NOMOCK_FLAG} && mock_flag="--nomock"
-  ${release_infra_clone}/push-ci-build.sh ${bucket_flag-} ${federation_flag-} \
-                                          ${mock_flag-} --verbose
+  ${push_build} ${bucket_flag-} ${federation_flag-} --nomock --verbose --ci
 fi
 
 sha256sum _output/release-tars/kubernetes*.tar.gz


### PR DESCRIPTION
Cherry pick of #32013 #32235 #34359 #35233 on release-1.4.
#32013: Call push-ci-build.sh from the kubernetes/release repo.
#32235: Change push-ci-build.sh to push-build.sh and some cleanup.
#34359: Add support for adding a suffix to the GCS upload dir in
#35233: Delete some old, dead release code

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35671)

<!-- Reviewable:end -->
