### PR TITLE
"ie." is not the correct abbreviation for "ID EST"

### DIFF
--- a/docs/proposals/pod-resource-management.md
+++ b/docs/proposals/pod-resource-management.md
@@ -131,7 +131,7 @@ A pod can belong to one of the following 3 QoS classes: Guaranteed, Burstable, a
 
 #### Guaranteed
 
-`G` pods will be placed at the `$Root` cgroup by default. `$Root` is the system root ie. "/" by default and if `--cgroup-root` flag is used then we use the specified cgroup-root as the `$Root`. To ensure Kubelet's idempotent behaviour we follow a pod cgroup naming format which is opaque and deterministic. Say we have a pod with UID: `5f9b19c9-3a30-11e6-8eea-28d2444e470d` the pod cgroup PodUID would be named: `pod-5f9b19c93a3011e6-8eea28d2444e470d`.
+`G` pods will be placed at the `$Root` cgroup by default. `$Root` is the system root i.e. "/" by default and if `--cgroup-root` flag is used then we use the specified cgroup-root as the `$Root`. To ensure Kubelet's idempotent behaviour we follow a pod cgroup naming format which is opaque and deterministic. Say we have a pod with UID: `5f9b19c9-3a30-11e6-8eea-28d2444e470d` the pod cgroup PodUID would be named: `pod-5f9b19c93a3011e6-8eea28d2444e470d`.
 
 
 __Note__: The cgroup-root flag would allow the user to configure the root of the QoS cgroup hierarchy. Hence cgroup-root would be redefined as the root of QoS cgroup hierarchy and not containers.
@@ -308,7 +308,7 @@ Example:  We plan to have the following cgroup hierarchy on systemd systems
 
 ### Hierarchy Outline
 
-- "$Root" is the system root of the node ie. "/" by default and if `--cgroup-root` is specified then the specified cgroup-root is used as "$Root".
+- "$Root" is the system root of the node i.e. "/" by default and if `--cgroup-root` is specified then the specified cgroup-root is used as "$Root".
 - We have a top level QoS cgroup for the `Bu` and `BE` QoS classes.
 - But we __dont__ have a separate cgroup for the `G` QoS class. `G` pod cgroups are brought up directly under the `Root` cgroup.
 - Each pod has its own cgroup which is nested under the cgroup matching the pod's QoS class.


### PR DESCRIPTION
**What this PR does / why we need it**:
"i.e." is the correct abbreviation for "ID EST"

Signed-off-by: yupeng yu.peng36@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35674)

<!-- Reviewable:end -->
