### PR TITLE
Require PV provisioner secrets to match type

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -623,7 +623,7 @@ func (d *glusterfsVolumeDeleter) deleteEndpointService(namespace string, epServi
 
 // parseSecret finds a given Secret instance and reads user password from it.
 func parseSecret(namespace, secretName string, kubeClient clientset.Interface) (string, error) {
-	secretMap, err := volutil.GetSecret(namespace, secretName, kubeClient)
+	secretMap, err := volutil.GetSecretForPV(namespace, secretName, glusterfsPluginName, kubeClient)
 	if err != nil {
 		glog.Errorf("failed to get secret from [%q/%q]", namespace, secretName)
 		return "", fmt.Errorf("failed to get secret from [%q/%q]", namespace, secretName)

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -242,6 +242,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 func TestParseClassParameters(t *testing.T) {
 	secret := api.Secret{
+		Type: "kubernetes.io/glusterfs",
 		Data: map[string][]byte{
 			"data": []byte("mypassword"),
 		},

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -371,7 +371,7 @@ func (provisioner *quobyteVolumeProvisioner) Provision() (*api.PersistentVolume,
 		}
 	}
 
-	secretMap, err := util.GetSecret(adminSecretNamespace, adminSecretName, provisioner.plugin.host.GetKubeClient())
+	secretMap, err := util.GetSecretForPV(adminSecretNamespace, adminSecretName, quobytePluginName, provisioner.plugin.host.GetKubeClient())
 	if err != nil {
 		return nil, err
 	}
@@ -444,9 +444,10 @@ func (deleter *quobyteVolumeDeleter) Delete() error {
 		return err
 	}
 
-	secretMap, err := util.GetSecret(
+	secretMap, err := util.GetSecretForPV(
 		annotations[annotationQuobyteAPISecretNamespace],
 		annotations[annotationQuobyteAPISecret],
+		quobytePluginName,
 		deleter.plugin.host.GetKubeClient())
 
 	if err != nil {


### PR DESCRIPTION
In 1.5, PV provisioners are allowing targeting namespaced secrets via storageclass params. This adds a requirement that those secrets' type match the volume provisioner plugin name, to prevent targeting and extraction of arbitrary secrets

Helps limit secret targeting issues mentioned in https://github.com/kubernetes/kubernetes/issues/34822

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35675)

<!-- Reviewable:end -->
