### PR TITLE
ReplicaSet has onwer ref of the Deployment that created it

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -361,6 +361,26 @@ const (
 	SuccessfulDeletePodReason = "SuccessfulDelete"
 )
 
+// RSControlInterface is an interface that knows how to add or delete
+// ReplicaSets, as well as increment or decrement them. It is used
+// by the deployment controller to ease testing of actions that it takes.
+type RSControlInterface interface {
+	PatchReplicaSet(namespace, name string, data []byte) error
+}
+
+// RealRSControl is the default implementation of RSControllerInterface.
+type RealRSControl struct {
+	KubeClient clientset.Interface
+	Recorder   record.EventRecorder
+}
+
+var _ RSControlInterface = &RealRSControl{}
+
+func (r RealRSControl) PatchReplicaSet(namespace, name string, data []byte) error {
+	_, err := r.KubeClient.Extensions().ReplicaSets(namespace).Patch(name, api.StrategicMergePatchType, data)
+	return err
+}
+
 // PodControlInterface is an interface that knows how to add or delete pods
 // created as an interface to allow testing.
 type PodControlInterface interface {

--- a/pkg/controller/deployment/BUILD
+++ b/pkg/controller/deployment/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/controller/informers:go_default_library",
         "//pkg/labels:go_default_library",
+        "//pkg/runtime/schema:go_default_library",
         "//pkg/util/errors:go_default_library",
         "//pkg/util/integer:go_default_library",
         "//pkg/util/labels:go_default_library",

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -335,6 +335,15 @@ func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployme
 			Template:        newRSTemplate,
 		},
 	}
+	var trueVar = true
+	controllerRef := &metav1.OwnerReference{
+		APIVersion: getDeploymentKind().GroupVersion().String(),
+		Kind:       getDeploymentKind().Kind,
+		Name:       deployment.Name,
+		UID:        deployment.UID,
+		Controller: &trueVar,
+	}
+	newRS.OwnerReferences = append(newRS.OwnerReferences, *controllerRef)
 	allRSs := append(oldRSs, &newRS)
 	newReplicasCount, err := deploymentutil.NewRSNewReplicas(deployment, allRSs, &newRS)
 	if err != nil {

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -468,7 +468,9 @@ func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Durati
 
 	// Delete deployment at the end.
 	// Note: We delete deployment at the end so that if removing RSs fails, we at least have the deployment to retry.
-	return deployments.Delete(name, nil)
+	var falseVar = false
+	nonOrphanOption := api.DeleteOptions{OrphanDependents: &falseVar}
+	return deployments.Delete(name, &nonOrphanOption)
 }
 
 type updateDeploymentFunc func(d *extensions.Deployment)

--- a/pkg/registry/extensions/deployment/strategy.go
+++ b/pkg/registry/extensions/deployment/strategy.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/validation"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
@@ -43,6 +44,12 @@ type deploymentStrategy struct {
 // Strategy is the default logic that applies when creating and updating Deployment
 // objects via the REST API.
 var Strategy = deploymentStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// DefaultGarbageCollectionPolicy returns Orphan because that's the default
+// behavior before the server-side garbage collection is implemented.
+func (deploymentStrategy) DefaultGarbageCollectionPolicy() rest.GarbageCollectionPolicy {
+	return rest.OrphanDependents
+}
 
 // NamespaceScoped is true for deployment.
 func (deploymentStrategy) NamespaceScoped() bool {

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -184,6 +184,7 @@ func stopDeploymentMaybeOverlap(c clientset.Interface, internalClient internalcl
 	reaper, err := kubectl.ReaperFor(extensionsinternal.Kind("Deployment"), internalClient)
 	Expect(err).NotTo(HaveOccurred())
 	timeout := 1 * time.Minute
+
 	err = reaper.Stop(ns, deployment.Name, timeout, api.NewDeleteOptions(0))
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This enabled garbage collection for ReplicaSets and ensures they are owned by their respective Deployment objects.

fixes https://github.com/kubernetes/kubernetes/issues/33845

This is an initial PR to get feedback. Will update this quickly with unit tests if this seems like in the right direction

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35676)

<!-- Reviewable:end -->
