### PR TITLE
[kubeadm] Add standarized and colorful logging

### DIFF
--- a/cmd/kubeadm/app/BUILD
+++ b/cmd/kubeadm/app/BUILD
@@ -17,8 +17,10 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm/install:go_default_library",
         "//cmd/kubeadm/app/cmd:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/util/logs:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
         "//vendor:github.com/spf13/pflag",
     ],
 )

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -19,10 +19,12 @@ package app
 import (
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"
 )
@@ -30,6 +32,8 @@ import (
 func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	logrus.SetFormatter(util.LogFormatter{})
 
 	// We do not want these flags to show up in --help
 	pflag.CommandLine.MarkHidden("google-json-key")

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -15,6 +15,7 @@ go_library(
     srcs = [
         "error.go",
         "kubeconfig.go",
+        "log_formatter.go",
         "tokens.go",
     ],
     tags = ["automanaged"],
@@ -23,6 +24,7 @@ go_library(
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",
         "//pkg/client/unversioned/clientcmd/api:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/renstrom/dedent",
     ],

--- a/cmd/kubeadm/app/util/log_formatter.go
+++ b/cmd/kubeadm/app/util/log_formatter.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// Attribute represents ansi codes used for formatting, coloring, etc.
+type Color int
+
+const (
+	// Base code used to disable colored output
+	nocolor Color = 0
+
+	// Escape codes used for coloring output
+	escape                = "\x1b"
+	extendedPalettePrefix = "38;5"
+
+	// Color table available at: http://misc.flogisoft.com/_media/bash/colors_format/256_colors_fg.png
+	black  Color = 0
+	red    Color = 196
+	orange Color = 208
+	blue   Color = 39
+	green  Color = 34
+)
+
+var supportsColorPalette = SupportsColorPalette()
+
+// Implements logrus TextFormatter
+type LogFormatter struct {
+	// Set to true to disable timestamp logging (useful when the output
+	// is redirected to a logging system already adding a timestamp)
+	DisableTimestamp bool
+}
+
+func (l LogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var keys []string
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	b := &bytes.Buffer{}
+	timestamp := entry.Time.Format("15:04:05")
+	caller := getCaller()
+
+	if supportsColorPalette {
+		timestamp = colorizeString(green, timestamp)
+		caller = colorizeString(blue, caller)
+		entry.Message = colorizeString(getLevelColor(entry.Level), entry.Message)
+	}
+
+	if !l.DisableTimestamp {
+		fmt.Fprintf(b, "%v ", timestamp)
+	}
+
+	fmt.Fprintf(b, "%v ", caller)
+	fmt.Fprintf(b, "%v ", entry.Message)
+	for _, key := range keys {
+		fmt.Fprintf(b, "%v ", entry.Data[key])
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func getLevelColor(level log.Level) Color {
+	switch level {
+	case log.WarnLevel:
+		return orange
+	case log.ErrorLevel:
+		return red
+	default:
+		return nocolor
+	}
+}
+
+// Adds given color to the provided string.
+func colorizeString(color Color, str string) string {
+	if color == nocolor {
+		return str
+	}
+
+	enableColor := fmt.Sprintf("%s[%s;%sm", escape, extendedPalettePrefix,
+		strconv.Itoa(int(color)))
+	disableColor := fmt.Sprintf("%s[%dm", escape, nocolor)
+
+	return fmt.Sprintf("%s%s%s", enableColor, str, disableColor)
+}
+
+// Returns original caller info in format: '[dir/file]'.
+func getCaller() string {
+	const callerDepth = 9
+
+	if _, file, _, ok := runtime.Caller(callerDepth); ok && len(file) > 0 {
+		// Remove file extension and split file path
+		parts := strings.Split(strings.Replace(file, ".go", "", 1),
+			string(os.PathSeparator))
+
+		// Take only last 2 parts from the path [dir/file]
+		return fmt.Sprint("[", strings.Join(parts[len(parts)-2:],
+			string(os.PathSeparator)), "]")
+	}
+
+	return ""
+}
+
+func needsQuoting(text string) bool {
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch < '9') ||
+			ch == '-' || ch == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *LogFormatter) appendKeyValue(b *bytes.Buffer, key, value interface{}) {
+	fmt.Fprintf(b, "%v ", value)
+}
+
+func SupportsColorPalette() bool {
+	// minimum required color number supported by tty
+	requiredColorPalette := 8
+
+	if !log.IsTerminal() {
+		return false
+	}
+
+	// Get info about supported color palette from terminfo db
+	out, err := exec.Command("tput", "colors").Output()
+	if err != nil {
+		return false
+	}
+
+	ncolors, err := strconv.Atoi(strings.Trim(string(out), "\n"))
+	if err != nil || ncolors < requiredColorPalette {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Simple logger for kubeadm to standarize logs format and colorize them (if supported by TTY).

**Which issue this PR fixes**: fixes #34559
### Todo
- [ ] Agree on coloring
- [ ] Add tests
- [ ] Refactor current messages to use new logger (as a kickoff)

I'm open for discussion and extending this if needed.
### Visualization

![zrzut ekranu z 2016-10-27 10-47-05](https://cloud.githubusercontent.com/assets/2285385/19761674/3b35cb08-9c37-11e6-9159-b00b6b8be59d.png)
![zrzut ekranu z 2016-10-27 10-47-13](https://cloud.githubusercontent.com/assets/2285385/19761675/3c70fdd0-9c37-11e6-8106-4690b5582a7e.png)
### Usage

`logger` package exposes 3 logging levels: `info` `warn` `error`. Info and warn are writing to `stdout` and error to `stderr`. Colors are only added if they are supported by TTY, otherwise only timestamp and caller info (place where log method was called) are added as a prefix to the actual log.

``` go
logger.Info("msg")
logger.Infof("%s", "msg")
...
```

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

``` release-note
[kubeadm] Add standarized and colorful logging
```

cc @mikedanese @errordeveloper @pires @dgoodwin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35685)

<!-- Reviewable:end -->
