### PR TITLE
Remove outdated parts of density test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3216,33 +3216,6 @@ func UpdateDeploymentWithRetries(c clientset.Interface, namespace, name string, 
 	return deployment, err
 }
 
-// Prints the histogram of the events and returns the number of bad events.
-func BadEvents(events []*api.Event) int {
-	type histogramKey struct {
-		reason string
-		source string
-	}
-	histogram := make(map[histogramKey]int)
-	for _, e := range events {
-		histogram[histogramKey{reason: e.Reason, source: e.Source.Component}]++
-	}
-	for key, number := range histogram {
-		Logf("- reason: %s, source: %s -> %d", key.reason, key.source, number)
-	}
-	badPatterns := []string{"kill", "fail"}
-	badEvents := 0
-	for key, number := range histogram {
-		for _, s := range badPatterns {
-			if strings.Contains(key.reason, s) {
-				Logf("WARNING %d events from %s with reason: %s", number, key.source, key.reason)
-				badEvents += number
-				break
-			}
-		}
-	}
-	return badEvents
-}
-
 // NodeAddresses returns the first address of the given type of each node.
 func NodeAddresses(nodelist *api.NodeList, addrType api.NodeAddressType) []string {
 	hosts := []string{}


### PR DESCRIPTION
Removed functionality is handled by RunRC in other way. Events were a proxy for checking if Pods are running. They're not needed anymore (for good few releases;)

cc @timothysc

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35686)

<!-- Reviewable:end -->
