### PR TITLE
Force using versioned objects in apply's patch

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -182,45 +182,17 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *App
 			return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving modified configuration from:\n%v\nfor:", info), info.Source, err)
 		}
 
-		if err := info.Get(); err != nil {
-			if !errors.IsNotFound(err) {
-				return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%v\nfrom server for:", info), info.Source, err)
-			}
-			// Create the resource if it doesn't exist
-			// First, update the annotation used by kubectl apply
-			if err := kubectl.CreateApplyAnnotation(info, encoder); err != nil {
-				return cmdutil.AddSourceToErr("creating", info.Source, err)
-			}
-
-			if cmdutil.ShouldRecord(cmd, info) {
-				if err := cmdutil.RecordChangeCause(info.Object, f.Command()); err != nil {
-					return cmdutil.AddSourceToErr("creating", info.Source, err)
-				}
-			}
-
-			if !dryRun {
-				// Then create the resource and skip the three-way merge
-				if err := createAndRefresh(info); err != nil {
-					return cmdutil.AddSourceToErr("creating", info.Source, err)
-				}
-				if uid, err := info.Mapping.UID(info.Object); err != nil {
-					return err
-				} else {
-					visitedUids.Insert(string(uid))
-				}
-			}
-
-			count++
-			cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
-			return nil
-		}
-
 		if !dryRun {
 			overwrite := cmdutil.GetFlagBool(cmd, "overwrite")
 			helper := resource.NewHelper(info.Client, info.Mapping)
 			patcher := NewPatcher(encoder, decoder, info.Mapping, helper, overwrite)
 
-			patchBytes, err := patcher.patch(info.Object, modified, info.Source, info.Namespace, info.Name)
+			originalObj, ok := info.VersionedObject.(runtime.Object)
+			if !ok {
+				return fmt.Errorf("unable to cast %T to runtime.Object", info.VersionedObject)
+			}
+
+			patchBytes, err := patcher.patch(originalObj, modified, info.Source, info.Namespace, info.Name)
 			if err != nil {
 				return cmdutil.AddSourceToErr(fmt.Sprintf("applying patch:\n%s\nto:\n%v\nfor:", patchBytes, info), info.Source, err)
 			}


### PR DESCRIPTION
Fixes #35149 and #34413.

Until now `kubectl apply` was working with internal version and manually invoking encoding, which resulted in problems converting object to versioned counterpart. It worked until now mostly because each group had only single version, but with multiple versions usually the first/preferred is chosen, which in case of ScheduledJobs isn't true. (ScheduledJobs exists in `batch/v2alpha1`, but preferred version is `batch/v1`). Resource helper has all the necessary information to perform necessary conversion so I've added conversion before actually calling the patch method and passing it as versioned to that method.

@janetkuo or anyone from @kubernetes/kubectl ptal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35688)

<!-- Reviewable:end -->
