### PR TITLE
kubelet: prefer kubelet's listen address

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -426,9 +426,16 @@ func (kl *Kubelet) setNodeAddress(node *api.Node) error {
 			// We tried everything we could, but the IP address wasn't fetchable; error out
 			return fmt.Errorf("can't get ip address of node %s. error: %v", node.Name, err)
 		} else {
+			var nodeInternalIP string
+			if kl.kubeletConfiguration.Address != "0.0.0.0" &&
+				kl.kubeletConfiguration.Address != "" {
+				nodeInternalIP = kl.kubeletConfiguration.Address
+			} else {
+				nodeInternalIP = ipAddr.String()
+			}
 			node.Status.Addresses = []api.NodeAddress{
 				{Type: api.NodeLegacyHostIP, Address: ipAddr.String()},
-				{Type: api.NodeInternalIP, Address: ipAddr.String()},
+				{Type: api.NodeInternalIP, Address: nodeInternalIP},
 			}
 		}
 	}


### PR DESCRIPTION
One of the solutions related to https://github.com/kubernetes/kubernetes/issues/11816
And improvement for the https://github.com/kubernetes/kubernetes/pull/29907 and https://github.com/kubernetes/kubernetes/issues/34615

When kubelet listens to loopback interface, apiserver cannot establish ssh tunnel, thus neither `kubectl exec pod` nor `kubectl logs pod` work (tested on latest master):

```
$ kubectl get nodes ubuntu2 -o yaml | grep -A5 addresses:
  addresses:
  - address: 192.168.122.203
    type: LegacyHostIP
  - address: 192.168.122.203
    type: InternalIP
  allocatable:
$ kubectl get pods -l name=nginx-ingress-lb -o wide
NAME                             READY     STATUS    RESTARTS   AGE       IP           NODE
nginx-ingress-controller-ygxcf   1/1       Running   4          7d        10.64.82.2   ubuntu2
$ kubectl exec -ti nginx-ingress-controller-ygxcf sh
Error from server: ssh: rejected: administratively prohibited (open failed)
```

By default kubelet sends two identical ip addresses to apiserver: 
https://github.com/kubernetes/kubernetes/blob/5423eaf4314f0e0d31e92066b2680d7e35dacf5d/pkg/kubelet/kubelet_node_status.go#L430..L431

Why don't we use `--address=127.0.0.1` as an `nodeInternalIP`?

This solution could be used along with the `~/.ssh/autorized_keys` file below:

```
no-pty,no-X11-forwarding,permitopen="127.0.0.1:10250",command="/bin/false" ssh-rsa %KEY%
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35693)

<!-- Reviewable:end -->
