### PR TITLE
Hopefully fix verify-godeps.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1207,11 +1207,6 @@
 			"Rev": "a9b1ab1dd8d811d419487a631c3361df582346d2"
 		},
 		{
-			"ImportPath": "github.com/google/cadvisor/info/v1/test",
-			"Comment": "v0.24.0-alpha1-39-ga9b1ab1",
-			"Rev": "a9b1ab1dd8d811d419487a631c3361df582346d2"
-		},
-		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
 			"Comment": "v0.24.0-alpha1-39-ga9b1ab1",
 			"Rev": "a9b1ab1dd8d811d419487a631c3361df582346d2"


### PR DESCRIPTION
If I'm not mistaken #35431 removed last occurrence of the "cadvisor/info/v1/test", but Godeps were not regenerated. @deads2k

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35696)

<!-- Reviewable:end -->
