### PR TITLE
authn: added CRL support for the apiserver [WIP]

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -204,6 +204,11 @@ func Run(s *options.APIServer) error {
 		}
 	}
 
+	// Enable CRL check when CRL path was set
+	if s.CRLFile != "" && s.CRLCheck == false {
+		s.CRLCheck = true
+	}
+
 	var serviceAccountGetter serviceaccount.ServiceAccountTokenGetter
 	if s.ServiceAccountLookup {
 		// If we need to look up service accounts and tokens,
@@ -232,6 +237,9 @@ func Run(s *options.APIServer) error {
 		KeystoneURL:                 s.KeystoneURL,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
+		CRLCheck:                    s.CRLCheck,
+		CRLHardFail:                 s.CRLHardFail,
+		CRLFile:                     s.CRLFile,
 	})
 
 	if err != nil {

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -117,6 +117,9 @@ type ServerRunOptions struct {
 	TLSPrivateKeyFile      string
 	TokenAuthFile          string
 	EnableAnyToken         bool
+	CRLCheck               bool
+	CRLHardFail            bool
+	CRLFile                string
 	WatchCacheSizes        []string
 }
 
@@ -146,6 +149,8 @@ func NewServerRunOptions() *ServerRunOptions {
 		SecurePort:                               6443,
 		ServiceNodePortRange:                     DefaultServiceNodePortRange,
 		StorageVersions:                          registered.AllPreferredGroupVersions(),
+		CRLCheck:                                 false,
+		CRLHardFail:                              true,
 	}
 }
 
@@ -484,6 +489,17 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, ""+
 		"If set, the file that will be used to secure the secure port of the API server "+
 		"via token authentication.")
+
+	fs.BoolVar(&s.CRLCheck, "crl-check", s.CRLCheck,
+		"Enable CRL check for the client server.")
+
+	fs.BoolVar(&s.CRLHardFail, "crl-hard-fail", s.CRLHardFail,
+		"Enable hard fail revocation plan for the the client server."+
+			"Fail CRL check if CRL is unavailable.")
+
+	fs.StringVar(&s.CRLFile, "crl-file", s.CRLFile,
+		"Path to the client server certificate revocation list file."+
+			"If set, automatically enables --crl-check flag.")
 
 	fs.BoolVar(&s.EnableAnyToken, "insecure-allow-any-token", s.EnableAnyToken, ""+
 		"If set, your server will be INSECURE.  Any token will be allowed and user information will be parsed "+


### PR DESCRIPTION
Supersedes #29293
Resolves #18982
Depends on #33519

early comments are appreciated

How to run k8s-apiserver with the local CRL file:

``` sh
./kube-apiserver \
 --bind-address=0.0.0.0 \
 --etcd_servers=http://127.0.0.1:2379 \
 --service-cluster-ip-range=10.0.0.1/24 \
 --secure_port=4443 \
 --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --tls-cert-file ~/.ssl/server.pem \
 --tls-private-key-file ~/.ssl/server-key.pem \
 --client-ca-file ~/.ssl/ca.pem \
 --crl-file ~/.ssl/crl.pem
```

With fetching CRL using remote CRL server which is defined inside the client cert:

``` sh
./kube-apiserver \
 --bind-address=0.0.0.0 \
 --etcd_servers=http://127.0.0.1:2379 \
 --service-cluster-ip-range=10.0.0.1/24 \
 --secure_port=4443 \
 --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --tls-cert-file ~/.ssl/server.pem \
 --tls-private-key-file ~/.ssl/server-key.pem \
 --client-ca-file ~/.ssl/ca.pem \
 --crl-check
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35698)

<!-- Reviewable:end -->
