### PR TITLE
Update rkt version on GCI nodes to v1.18.0

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -99,8 +99,8 @@ function split-commas {
 }
 
 function install-rkt {
-    local -r rkt_binary="rkt-v1.17.0"
-    local -r rkt_sha1="e9183dcae0683e345cc73fef98ffd80a253d371a"
+    local -r rkt_binary="rkt-v1.18.0"
+    local -r rkt_sha1="75fc8f29c79bc9e505f3e7f6e8fadf2425c21967"
     download-or-bust "${rkt_sha1}" "https://storage.googleapis.com/kubernetes-release/rkt/${rkt_binary}"
     local -r rkt_dst="${KUBE_HOME}/bin/rkt"
     mv "${KUBE_HOME}/${rkt_binary}" "${rkt_dst}"

--- a/test/e2e_node/jenkins/gci-init.yaml
+++ b/test/e2e_node/jenkins/gci-init.yaml
@@ -6,5 +6,5 @@ runcmd:
   - mkdir -p /home/kubernetes/bin/
   - mount -B /home/kubernetes/bin /home/kubernetes/bin
   - mount -B -o remount,exec /home/kubernetes/bin 
-  - wget https://storage.googleapis.com/kubernetes-release/rkt/rkt-v1.17.0 -O /home/kubernetes/bin/rkt
+  - wget https://storage.googleapis.com/kubernetes-release/rkt/rkt-v1.18.0 -O /home/kubernetes/bin/rkt
   - chmod a+x /home/kubernetes/bin/rkt


### PR DESCRIPTION
v1.18.0 avoids outputting debug information by default which happens to
pollute events and kubelet logs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35717)

<!-- Reviewable:end -->
