### PR TITLE
Temporarily disable GCI mounter in e2e node tests

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -278,7 +278,9 @@ func RunRemote(archive string, host string, cleanup bool, junitFilePrefix string
 		// Insert args at beginning of testArgs, so any values from command line take precedence
 		testArgs = fmt.Sprintf("--experimental-mounter-rootfs-path=%s ", mounterRootfsPath) + testArgs
 		testArgs = fmt.Sprintf("--experimental-mounter-path=%s ", mounterPath) + testArgs
-		glog.Infof("GCI node and GCI mounter both detected, setting --experimental-mounter-path=%q and --experimental-mounter-rootfs-path=%q accordingly", mounterPath, mounterRootfsPath)
+
+		// Temporarily disabled (associated Kubelet flags commented out in k8s.io/kubernetes/test/e2e_node/services/services.go):
+		// glog.Infof("GCI node and GCI mounter both detected, setting --experimental-mounter-path=%q and --experimental-mounter-rootfs-path=%q accordingly", mounterPath, mounterRootfsPath)
 	}
 
 	// Run the tests

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -211,8 +211,10 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--eviction-pressure-transition-period", "30s",
 		"--feature-gates", framework.TestContext.FeatureGates,
 		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
-		"--experimental-mounter-path", framework.TestContext.MounterPath,
-		"--experimental-mounter-rootfs-path", framework.TestContext.MounterRootfsPath,
+
+		// Temporarily disabled:
+		// "--experimental-mounter-path", framework.TestContext.MounterPath,
+		// "--experimental-mounter-rootfs-path", framework.TestContext.MounterRootfsPath,
 	)
 
 	if framework.TestContext.RuntimeIntegrationType != "" {


### PR DESCRIPTION
This is just so we have an off-switch ready to go if we need it. Don't merge unless we need to disable this functionality in the e2e node tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35724)

<!-- Reviewable:end -->
