### PR TITLE
kubelet: remove unused volumes when under disk pressure

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -43,6 +43,8 @@ type managerImpl struct {
 	killPodFunc KillPodFunc
 	// the interface that knows how to do image gc
 	imageGC ImageGC
+	// the interface that knows how to do volume gc
+	volumeGC VolumeGC
 	// protects access to internal state
 	sync.RWMutex
 	// node conditions are the set of conditions present
@@ -76,6 +78,7 @@ func NewManager(
 	config Config,
 	killPodFunc KillPodFunc,
 	imageGC ImageGC,
+	volumeGC VolumeGC,
 	recorder record.EventRecorder,
 	nodeRef *api.ObjectReference,
 	clock clock.Clock) (Manager, lifecycle.PodAdmitHandler, error) {
@@ -83,6 +86,7 @@ func NewManager(
 		clock:           clock,
 		killPodFunc:     killPodFunc,
 		imageGC:         imageGC,
+		volumeGC:        volumeGC,
 		config:          config,
 		recorder:        recorder,
 		summaryProvider: summaryProvider,
@@ -156,7 +160,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 			return
 		}
 		m.resourceToRankFunc = buildResourceToRankFunc(hasDedicatedImageFs)
-		m.resourceToNodeReclaimFuncs = buildResourceToNodeReclaimFuncs(m.imageGC, hasDedicatedImageFs)
+		m.resourceToNodeReclaimFuncs = buildResourceToNodeReclaimFuncs(m.imageGC, m.volumeGC, hasDedicatedImageFs)
 	}
 
 	// make observations and get a function to derive pod usage stats relative to those observations.

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -119,6 +119,12 @@ type ImageGC interface {
 	DeleteUnusedImages() (int64, error)
 }
 
+// VolumeGC is responsible for performing garbage collection of unused volumes.
+type VolumeGC interface {
+	// DeleteUnusedVolumes deletes unused volumes and returns the number of bytes freed, or an error.
+	DeleteUnusedVolumes() (int64, error)
+}
+
 // KillPodFunc kills a pod.
 // The pod status is updated, and then it is killed with the specified grace period.
 // This function must block until either the pod is killed or an error is encountered.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -742,7 +742,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 	klet.setNodeStatusFuncs = klet.defaultNodeStatusFuncs()
 
 	// setup eviction manager
-	evictionManager, evictionAdmitHandler, err := eviction.NewManager(klet.resourceAnalyzer, evictionConfig, killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.imageManager, kubeDeps.Recorder, nodeRef, klet.clock)
+	evictionManager, evictionAdmitHandler, err := eviction.NewManager(klet.resourceAnalyzer, evictionConfig, killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.volumeManager, kubeDeps.Recorder, nodeRef, klet.clock)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize eviction manager: %v", err)

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -117,7 +117,7 @@ func TestRunOnce(t *testing.T) {
 	fakeKillPodFunc := func(pod *api.Pod, podStatus api.PodStatus, gracePeriodOverride *int64) error {
 		return nil
 	}
-	evictionManager, evictionAdmitHandler, err := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, nil, kb.recorder, nodeRef, kb.clock)
+	evictionManager, evictionAdmitHandler, err := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, nil, nil, kb.recorder, nodeRef, kb.clock)
 	if err != nil {
 		t.Fatalf("failed to initialize eviction manager: %v", err)
 	}

--- a/pkg/kubelet/volumemanager/BUILD
+++ b/pkg/kubelet/volumemanager/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/client/record:go_default_library",
         "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/eviction:go_default_library",
         "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/kubelet/volumemanager/cache:go_default_library",

--- a/pkg/kubelet/volumemanager/populator/BUILD
+++ b/pkg/kubelet/volumemanager/populator/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/eviction:go_default_library",
         "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/kubelet/volumemanager/cache:go_default_library",

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
@@ -138,6 +139,9 @@ type VolumeManager interface {
 	// Marks the specified volume as having successfully been reported as "in
 	// use" in the nodes's volume status.
 	MarkVolumesAsReportedInUse(volumesReportedAsInUse []api.UniqueVolumeName)
+
+	// Volume Manager can act as a volume garbage collector for the eviction manager.
+	eviction.VolumeGC
 }
 
 // NewVolumeManager returns a new concrete instance implementing the
@@ -362,6 +366,12 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *api.Pod) error {
 
 	glog.V(3).Infof("All volumes are attached and mounted for pod %q", format.Pod(pod))
 	return nil
+}
+
+func (vm *volumeManager) DeleteUnusedVolumes() (int64, error) {
+	vm.desiredStateOfWorldPopulator.DeleteTerminatedPodVolumes()
+	// TODO: no reasonable way to calculate space freed by this
+	return 0, nil
 }
 
 // verifyVolumesMountedFunc returns a method that returns true when all expected


### PR DESCRIPTION
Fixes #35406

Kubernetes keeps volumes from terminated pods around for debug purposes.  However, if the node is under disk pressure, these volumes should be deleted to reclaim space.  This includes evicted volumes (a subset of terminated volumes).

Currently even evicted pod volumes are not cleaned up.  This means the pod eviction due to disk pressure doesn't actually work as a means to free up disk space.

This PR does a number of things
1) Evicted pod volumes are removed from the desired state of the world; reconcile later deletes them
2) A garbage collection interface implemented by the volume manager so the eviction manager can trigger reclaim of terminated pod volumes.

TODOs:
- no way to figure out how much space was freed and that param is needed for the eviction manager to bail on actaully evicting pods.
- #35406 also wants the removal of memory backend volumes for all terminated pods which isn't implement here yet.

Looking for feedback.

@derekwaynecarr @pmorie

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35727)

<!-- Reviewable:end -->
