### PR TITLE
Making the pod.alpha.kubernetes.io/initialized annotation optional in PetSet pods

### DIFF
--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -889,6 +889,9 @@ func newStatefulSet(name, ns, governingSvcName string, replicas int32, petMounts
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
+			Annotations: map[string]string{
+				"pod.alpha.kubernetes.io/initialized": "false",
+			},
 		},
 		Spec: apps.StatefulSetSpec{
 			Selector: &unversioned.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**: As of now, the absence of the annotation `pod.alpha.kubernetes.io/initialized` in PetSets causes the PetSet controller to effectively "pause". Being a debug hook, users expect that its absence has no effect on the working of a PetSet. This PR inverts the logic so that we let the PetSet controller operate as expected in the absence of the annotation.
Letting the annotation remain alpha seems ok. Renaming it to something more meaningful needs further discussion.

**Which issue this PR fixes** _(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)_: fixes https://github.com/kubernetes/kubernetes/issues/35498

**Special notes for your reviewer**: 

**Release note**:

``` release-note
The annotation "pod.alpha.kubernetes.io/initialized" on StatefulSets (formerly PetSets) is now optional and only encouraged for debug use.
```

cc @erictune @smarterclayton @bprashanth @kubernetes/sig-apps 
@kow3ns The examples will need to be cleaned up as well I think later on to remove them.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35739)

<!-- Reviewable:end -->
