### PR TITLE
Added support for HOME environment variable on Windows

### DIFF
--- a/pkg/util/homedir/homedir.go
+++ b/pkg/util/homedir/homedir.go
@@ -24,6 +24,13 @@ import (
 // HomeDir returns the home directory for the current user
 func HomeDir() string {
 	if runtime.GOOS == "windows" {
+
+		// First prefer the HOME environmental variable
+		if home := os.Getenv("HOME"); len(home) > 0 {
+			if _, err := os.Stat(home); err == nil {
+				return home
+			}
+		}
 		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
 			homeDir := homeDrive + homePath
 			if _, err := os.Stat(homeDir); err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
On Windows the HOME environment variable should be taken in account when trying to find the home directory.
Several tools already support the HOME environment variable, notably git-bash. It would be very convenient to have the kubernete tools (including minikube) to also support the environment variable. 

The current situation

**Special notes for your reviewer**:

**Release note**:

```
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35745)

<!-- Reviewable:end -->
