### PR TITLE
refactor: remove unused variable according to goreportcard.com

### DIFF
--- a/pkg/registry/core/resourcequota/etcd/etcd_test.go
+++ b/pkg/registry/core/resourcequota/etcd/etcd_test.go
@@ -188,6 +188,9 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	rqOut := obj.(*api.ResourceQuota)
 	// only compare the meaningful update b/c we can't compare due to metadata
 	if !api.Semantic.DeepEqual(resourcequotaIn.Status, rqOut.Status) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In the https://goreportcard.com site, the result of ineffassign is 98%.
There are some unused variables in test code, and I want to refactor it.

**Special notes for your reviewer**:

**Release note**:
NONE

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35749)

<!-- Reviewable:end -->
