### PR TITLE
don't import pkg/client/unversioned when generating clients

### DIFF
--- a/cmd/libs/go2idl/client-gen/main.go
+++ b/cmd/libs/go2idl/client-gen/main.go
@@ -150,7 +150,6 @@ func main() {
 		"k8s.io/kubernetes/pkg/fields",
 		"k8s.io/kubernetes/pkg/labels",
 		"k8s.io/kubernetes/pkg/watch",
-		"k8s.io/kubernetes/pkg/client/unversioned",
 		"k8s.io/kubernetes/pkg/apimachinery/registered",
 	}
 


### PR DESCRIPTION
This is causing weird dependency graphs in bazel and is no longer necessary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35762)

<!-- Reviewable:end -->
