### PR TITLE
break endless loop in vagrant cluster

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -241,7 +241,14 @@ function verify-cluster {
   echo "Waiting for each node to be registered with cloud provider"
   for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
     local validated="0"
+    start="$(date +%s)"
     until [[ "$validated" == "1" ]]; do
+      now="$(date +%s)"
+      # Timeout set to 3 minutes
+      if [ $((now - start)) -gt 180 ]; then
+        echo "Timeout while waiting for echo node to be registered with cloud provider"
+        exit 2
+      fi
       local nodes=$("${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o name --api-version=v1)
       validated=$(echo $nodes | grep -c "${NODE_NAMES[i]}") || {
         printf "."


### PR DESCRIPTION
reference to [vagrant.md](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/local-cluster/vagrant.md) troubleshooting ,  I guess we could set a time to return from endless loop to register with cloud provider.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35764)

<!-- Reviewable:end -->
