### PR TITLE
make kubeadm version use kubeadmutil

### DIFF
--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -32,7 +32,7 @@ func NewCmdVersion(out io.Writer) *cobra.Command {
 		Short: "Print the version of kubeadm",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunVersion(out, cmd)
-			cmdutil.CheckErr(err)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 	return cmd


### PR DESCRIPTION
What this PR does / why we need it:

this PR makes sure `kubeadmutil.CheckErr()` other than `cmdutil.CheckErr()` is called in `kubeadm version` subcommand. 
in `version.go`, `RunVersion()` function only returns `nil`, `kubeadmutil.CheckErr()` is enough for this

Signed-off-by: redhatlinux10 ouyang.qinhua@zte.com.cn

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35777)

<!-- Reviewable:end -->
