### PR TITLE
Clean up static-ip in e2e

### DIFF
--- a/test/e2e/ingress_utils.go
+++ b/test/e2e/ingress_utils.go
@@ -359,6 +359,14 @@ func (cont *GCEIngressController) deleteAddresses(del bool) string {
 		if err := gcloudDelete("addresses", cont.staticIPName, cont.cloud.ProjectID, "--global"); err == nil {
 			cont.staticIPName = ""
 		}
+	} else {
+		e2eIPs := []compute.Address{}
+		gcloudList("addresses", "e2e-.*", cont.cloud.ProjectID, &e2eIPs)
+		ips := []string{}
+		for _, ip := range e2eIPs {
+			ips = append(ips, ip.Name)
+		}
+		framework.Logf("None of the remaining %d static-ips were created by this e2e: %v", len(ips), strings.Join(ips, ", "))
 	}
 	return msg
 }
@@ -605,6 +613,8 @@ func (cont *GCEIngressController) staticIP(name string) string {
 		}
 		framework.Failf("Failed to allocated static ip %v: %v", name, err)
 	}
+	cont.staticIPName = ip.Name
+	framework.Logf("Reserved static ip %v: %v", cont.staticIPName, ip.Address)
 	return ip.Address
 }
 


### PR DESCRIPTION
I dropped this line: https://github.com/kubernetes/kubernetes/pull/35331/files#diff-5997d488011ead8354bdddfceaf1515dL595, in a previous refactor https://github.com/kubernetes/kubernetes/pull/35331, so we started leaking static ips. This commit adds it back in, along with some debug info if it happens again. Marking p2 since test is currently leaking.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35798)

<!-- Reviewable:end -->
