### PR TITLE
Automated cherry pick of #32658 #33039

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1177,12 +1177,14 @@ function kube-down() {
   fi
 
   # Delete the master replica pd (possibly leaked by kube-up if master create failed).
-  if gcloud compute disks describe "${REPLICA_NAME}"-pd --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
+  # TODO(jszczepkowski): remove also possibly leaked replicas' pds
+  local -r replica-pd="${REPLICA_NAME:-${MASTER_NAME}}-pd"
+  if gcloud compute disks describe "${replica-pd}" --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
     gcloud compute disks delete \
       --project "${PROJECT}" \
       --quiet \
       --zone "${ZONE}" \
-      "${REPLICA_NAME}"-pd
+      "${replica-pd}"
   fi
 
   # Delete disk for cluster registry if enabled

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1178,13 +1178,13 @@ function kube-down() {
 
   # Delete the master replica pd (possibly leaked by kube-up if master create failed).
   # TODO(jszczepkowski): remove also possibly leaked replicas' pds
-  local -r replica-pd="${REPLICA_NAME:-${MASTER_NAME}}-pd"
-  if gcloud compute disks describe "${replica-pd}" --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
+  local -r replica_pd="${REPLICA_NAME:-${MASTER_NAME}}-pd"
+  if gcloud compute disks describe "${replica_pd}" --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
     gcloud compute disks delete \
       --project "${PROJECT}" \
       --quiet \
       --zone "${ZONE}" \
-      "${replica-pd}"
+      "${replica_pd}"
   fi
 
   # Delete disk for cluster registry if enabled


### PR DESCRIPTION
Cherry pick of #32658 #33039 on release-1.4.
#32658: Fixed #32366: wrong master pd name during kube-down.
#33039: gce/util: $replica-pd --> $replica_pd

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35802)

<!-- Reviewable:end -->
