### PR TITLE
Improves error message in update_owners.py

### DIFF
--- a/hack/update_owners.py
+++ b/hack/update_owners.py
@@ -121,7 +121,7 @@ def detect_github_username():
     repos.remove('kubernetes')
     if len(repos) == 1:
         return repos.pop()
-    raise ValueError('unable to guess GitHub user from `git remote -v` output, use --user instead')
+    raise ValueError('unable to guess GitHub user from `git remote -v` output, please run with --user instead')
 
 
 def main():


### PR DESCRIPTION
I added a new e2e test and ran this `update_owners.py` today. The error message I got was a bit obscure.

```
ValueError: unable to guess GitHub user from `git remote -v` output, use --user instead
```

I thought this `--user` is for the git command in the begining but turned out it is not. 

May replace `use` with `please run with` make it better?

@rmmh

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35808)

<!-- Reviewable:end -->
