### PR TITLE
always allow decoding of status when returned from the API

### DIFF
--- a/pkg/client/restclient/client.go
+++ b/pkg/client/restclient/client.go
@@ -173,9 +173,16 @@ func createSerializers(config ContentConfig) (*Serializers, error) {
 		info = mediaTypes[0]
 	}
 
-	internalGV := unversioned.GroupVersion{
-		Group:   config.GroupVersion.Group,
-		Version: runtime.APIVersionInternal,
+	internalGV := unversioned.GroupVersions{
+		{
+			Group:   config.GroupVersion.Group,
+			Version: runtime.APIVersionInternal,
+		},
+		// always include the legacy group as a decoding target to handle non-error `Status` return types
+		{
+			Group:   "",
+			Version: runtime.APIVersionInternal,
+		},
 	}
 
 	s := &Serializers{

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -489,6 +489,7 @@ var (
 	clusterRoleColumns           = []string{"NAME", "AGE"}
 	clusterRoleBindingColumns    = []string{"NAME", "AGE"}
 	storageClassColumns          = []string{"NAME", "TYPE"}
+	statusColumns                = []string{"STATUS", "REASON", "MESSAGE"}
 
 	// TODO: consider having 'KIND' for third party resource data
 	thirdPartyResourceDataColumns    = []string{"NAME", "LABELS", "DATA"}
@@ -591,6 +592,7 @@ func (h *HumanReadablePrinter) addDefaultHandlers() {
 	h.Handler(certificateSigningRequestColumns, printCertificateSigningRequestList)
 	h.Handler(storageClassColumns, printStorageClass)
 	h.Handler(storageClassColumns, printStorageClassList)
+	h.Handler(statusColumns, printStatus)
 }
 
 func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
@@ -2111,6 +2113,14 @@ func printStorageClassList(scList *storage.StorageClassList, w io.Writer, option
 			return err
 		}
 	}
+	return nil
+}
+
+func printStatus(status *unversioned.Status, w io.Writer, options PrintOptions) error {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", status.Status, status.Reason, status.Message); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
`unversioned.Status` should be able to come back from any API version and still be properly decoded.  This doesn't happen today by default.

@smarterclayton  Our projectrequest endpoint returns a `Status` object on a 200 return from list to indicate everything went well.  This (or something like it) is needed to make the API accepted by `kubectl`.  Alternatively, we change the API to return a different (still not a `Project`) value from list, which still feels wrong.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35810)

<!-- Reviewable:end -->
