### PR TITLE
Automated cherry pick of #31388 #35572

### DIFF
--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -158,7 +158,7 @@ func TestOpenPodHostports(t *testing.T) {
 		},
 	}
 
-	runningPods := make([]*RunningPod, 0)
+	activePods := make([]*ActivePod, 0)
 
 	// Fill in any match rules missing chain names
 	for _, test := range tests {
@@ -179,13 +179,13 @@ func TestOpenPodHostports(t *testing.T) {
 				}
 			}
 		}
-		runningPods = append(runningPods, &RunningPod{
+		activePods = append(activePods, &ActivePod{
 			Pod: test.pod,
 			IP:  net.ParseIP(test.ip),
 		})
 	}
 
-	err := h.OpenPodHostportsAndSync(&RunningPod{Pod: tests[0].pod, IP: net.ParseIP(tests[0].ip)}, "br0", runningPods)
+	err := h.OpenPodHostportsAndSync(&ActivePod{Pod: tests[0].pod, IP: net.ParseIP(tests[0].ip)}, "br0", activePods)
 	if err != nil {
 		t.Fatalf("Failed to OpenPodHostportsAndSync: %v", err)
 	}

--- a/pkg/kubelet/network/hostport/testing/fake.go
+++ b/pkg/kubelet/network/hostport/testing/fake.go
@@ -29,12 +29,12 @@ func NewFakeHostportHandler() hostport.HostportHandler {
 	return &fakeHandler{}
 }
 
-func (h *fakeHandler) OpenPodHostportsAndSync(newPod *hostport.RunningPod, natInterfaceName string, runningPods []*hostport.RunningPod) error {
-	return h.SyncHostports(natInterfaceName, append(runningPods, newPod))
+func (h *fakeHandler) OpenPodHostportsAndSync(newPod *hostport.ActivePod, natInterfaceName string, activePods []*hostport.ActivePod) error {
+	return h.SyncHostports(natInterfaceName, activePods)
 }
 
-func (h *fakeHandler) SyncHostports(natInterfaceName string, runningPods []*hostport.RunningPod) error {
-	for _, r := range runningPods {
+func (h *fakeHandler) SyncHostports(natInterfaceName string, activePods []*hostport.ActivePod) error {
+	for _, r := range activePods {
 		if r.IP.To4() == nil {
 			return fmt.Errorf("Invalid or missing pod %s IP", kubecontainer.GetPodFullName(r.Pod))
 		}

--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+	"time"
+
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	"k8s.io/kubernetes/pkg/api"
+	testutils "k8s.io/kubernetes/test/utils"
+	"os/exec"
+)
+
+// waitForPods waits for timeout duration, for pod_count.
+// If the timeout is hit, it returns the list of currently running pods.
+func waitForPods(f *framework.Framework, pod_count int, timeout time.Duration) (runningPods []*api.Pod) {
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(10 * time.Second) {
+		podList, err := f.PodClient().List(api.ListOptions{})
+		if err != nil {
+			framework.Logf("Failed to list pods on node: %v", err)
+			continue
+		}
+
+		runningPods = []*api.Pod{}
+		for _, pod := range podList.Items {
+			if r, err := testutils.PodRunningReady(&pod); err != nil || !r {
+				continue
+			}
+			runningPods = append(runningPods, &pod)
+		}
+		framework.Logf("Running pod count %d", len(runningPods))
+		if len(runningPods) >= pod_count {
+			break
+		}
+	}
+	return runningPods
+}
+
+var _ = framework.KubeDescribe("Restart [Serial] [Slow] [Disruptive]", func() {
+	const (
+		// Saturate the node. It's not necessary that all these pods enter
+		// Running/Ready, because we don't know the number of cores in the
+		// test node or default limits applied (if any). It's is essential
+		// that no containers end up in terminated. 100 was chosen because
+		// it's the max pods per node.
+		podCount            = 100
+		podCreationInterval = 100 * time.Millisecond
+		recoverTimeout      = 5 * time.Minute
+		startTimeout        = 3 * time.Minute
+		// restartCount is chosen so even with minPods we exhaust the default
+		// allocation of a /24.
+		minPods      = 50
+		restartCount = 6
+	)
+
+	f := framework.NewDefaultFramework("restart-test")
+	Context("Docker Daemon", func() {
+		Context("Network", func() {
+			It("should recover from ip leak", func() {
+
+				pods := newTestPods(podCount, framework.GetPauseImageNameForHostArch(), "restart-docker-test")
+				By(fmt.Sprintf("Trying to create %d pods on node", len(pods)))
+				createBatchPodWithRateControl(f, pods, podCreationInterval)
+				defer deletePodsSync(f, pods)
+
+				// Give the node some time to stabilize, assume pods that enter RunningReady within
+				// startTimeout fit on the node and the node is now saturated.
+				runningPods := waitForPods(f, podCount, startTimeout)
+				if len(runningPods) < minPods {
+					framework.Failf("Failed to start %d pods, cannot test that restarting docker doesn't leak IPs", minPods)
+				}
+
+				for i := 0; i < restartCount; i += 1 {
+					By(fmt.Sprintf("Restarting Docker Daemon iteration %d", i))
+
+					// TODO: Find a uniform way to deal with systemctl/initctl/service operations. #34494
+					if stdout, err := exec.Command("sudo", "systemctl", "restart", "docker").CombinedOutput(); err != nil {
+						framework.Logf("Failed to trigger docker restart with systemd/systemctl: %v, stdout: %q", err, string(stdout))
+						if stdout, err = exec.Command("sudo", "service", "docker", "restart").CombinedOutput(); err != nil {
+							framework.Failf("Failed to trigger docker restart with upstart/service: %v, stdout: %q", err, string(stdout))
+						}
+					}
+					time.Sleep(20 * time.Second)
+				}
+
+				By("Checking currently Running/Ready pods")
+				postRestartRunningPods := waitForPods(f, len(runningPods), recoverTimeout)
+				if len(postRestartRunningPods) == 0 {
+					framework.Failf("Failed to start *any* pods after docker restart, this might indicate an IP leak")
+				}
+				By("Confirm no containers have terminated")
+				for _, pod := range postRestartRunningPods {
+					if c := testutils.TerminatedContainers(pod); len(c) != 0 {
+						framework.Failf("Pod %q has failed containers %+v after docker restart, this might indicate an IP leak", pod.Name, c)
+					}
+				}
+				By(fmt.Sprintf("Docker restart test passed with %d pods", len(postRestartRunningPods)))
+			})
+		})
+	})
+})

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -366,6 +366,7 @@ ResourceQuota should create a ResourceQuota and capture the life of a service.,t
 ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated.,krousey,1
 ResourceQuota should verify ResourceQuota with best effort scope.,mml,1
 ResourceQuota should verify ResourceQuota with terminating scopes.,ncdc,1
+Restart Docker Daemon Network should recover from ip leak,bprashanth,0
 Restart should restart all nodes and ensure all nodes and pods recover,andyzheng0831,1
 RethinkDB should create and stop rethinkdb servers,kargakis,1
 SSH should SSH to all nodes and run commands,quinton-hoole,0

--- a/test/utils/conditions.go
+++ b/test/utils/conditions.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+type ContainerFailures struct {
+	status   *api.ContainerStateTerminated
+	Restarts int
+}
+
+// PodRunningReady checks whether pod p's phase is running and it has a ready
+// condition of status true.
+func PodRunningReady(p *api.Pod) (bool, error) {
+	// Check the phase is running.
+	if p.Status.Phase != api.PodRunning {
+		return false, fmt.Errorf("want pod '%s' on '%s' to be '%v' but was '%v'",
+			p.ObjectMeta.Name, p.Spec.NodeName, api.PodRunning, p.Status.Phase)
+	}
+	// Check the ready condition is true.
+	if !PodReady(p) {
+		return false, fmt.Errorf("pod '%s' on '%s' didn't have condition {%v %v}; conditions: %v",
+			p.ObjectMeta.Name, p.Spec.NodeName, api.PodReady, api.ConditionTrue, p.Status.Conditions)
+	}
+	return true, nil
+}
+
+func PodRunningReadyOrSucceeded(p *api.Pod) (bool, error) {
+	// Check if the phase is succeeded.
+	if p.Status.Phase == api.PodSucceeded {
+		return true, nil
+	}
+	return PodRunningReady(p)
+}
+
+// FailedContainers inspects all containers in a pod and returns failure
+// information for containers that have failed or been restarted.
+// A map is returned where the key is the containerID and the value is a
+// struct containing the restart and failure information
+func FailedContainers(pod *api.Pod) map[string]ContainerFailures {
+	var state ContainerFailures
+	states := make(map[string]ContainerFailures)
+
+	statuses := pod.Status.ContainerStatuses
+	if len(statuses) == 0 {
+		return nil
+	} else {
+		for _, status := range statuses {
+			if status.State.Terminated != nil {
+				states[status.ContainerID] = ContainerFailures{status: status.State.Terminated}
+			} else if status.LastTerminationState.Terminated != nil {
+				states[status.ContainerID] = ContainerFailures{status: status.LastTerminationState.Terminated}
+			}
+			if status.RestartCount > 0 {
+				var ok bool
+				if state, ok = states[status.ContainerID]; !ok {
+					state = ContainerFailures{}
+				}
+				state.Restarts = int(status.RestartCount)
+				states[status.ContainerID] = state
+			}
+		}
+	}
+
+	return states
+}
+
+// TerminatedContainers inspects all containers in a pod and returns a map
+// of "container name: termination reason", for all currently terminated
+// containers.
+func TerminatedContainers(pod *api.Pod) map[string]string {
+	states := make(map[string]string)
+	statuses := pod.Status.ContainerStatuses
+	if len(statuses) == 0 {
+		return states
+	}
+	for _, status := range statuses {
+		if status.State.Terminated != nil {
+			states[status.Name] = status.State.Terminated.Reason
+		}
+	}
+	return states
+}
+
+// PodNotReady checks whether pod p's has a ready condition of status false.
+func PodNotReady(p *api.Pod) (bool, error) {
+	// Check the ready condition is false.
+	if PodReady(p) {
+		return false, fmt.Errorf("pod '%s' on '%s' didn't have condition {%v %v}; conditions: %v",
+			p.ObjectMeta.Name, p.Spec.NodeName, api.PodReady, api.ConditionFalse, p.Status.Conditions)
+	}
+	return true, nil
+}
+
+// podReady returns whether pod has a condition of Ready with a status of true.
+// TODO: should be replaced with api.IsPodReady
+func PodReady(pod *api.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == api.PodReady && cond.Status == api.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Cherry pick of #31388 #35572 on release-1.4.
#31388: kubenet: SyncHostports for both running and ready to run
#35572: periodically GC pod ips

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35816)

<!-- Reviewable:end -->
