### PR TITLE
Automated cherry pick of #35319

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -473,8 +473,6 @@ function start-kubelet {
   flags+=" --cluster-dns=${DNS_SERVER_IP}"
   flags+=" --cluster-domain=${DNS_DOMAIN}"
   flags+=" --config=/etc/kubernetes/manifests"
-  flags+=" --kubelet-cgroups=/kubelet"
-  flags+=" --system-cgroups=/system"
 
   if [[ -n "${KUBELET_PORT:-}" ]]; then
     flags+=" --port=${KUBELET_PORT}"
@@ -1170,6 +1168,9 @@ For Kubernetes copyright and licensing information, see:
 EOF
 }
 
+function override-kubectl {
+    echo "export PATH=${KUBE_HOME}/bin:\$PATH" > /etc/profile.d/kube_env.sh
+}
 
 ########### Main Function ###########
 echo "Start to configure instance for kubernetes"
@@ -1204,6 +1205,7 @@ else
   create-kubeproxy-kubeconfig
 fi
 
+override-kubectl
 assemble-docker-flags
 load-docker-images
 start-kubelet


### PR DESCRIPTION
Cherry pick of #35319 on release-1.4.
#35319: On GCI, remove kubelet cgroup overrides and override host

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35820)

<!-- Reviewable:end -->
