### PR TITLE
Bump GCE debian image to container-vm-v20161025 (CVE-2016-5195 Dirty…

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -43,7 +43,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 # containervm. If you are updating the containervm version, update this
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-CVM_VERSION=container-v1-3-v20160604
+CVM_VERSION=container-vm-v20161025
 GCI_VERSION="gci-dev-55-8872-18-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}


### PR DESCRIPTION
… COW)

I also verified sysdig support manually with this image, everything works as expected:

$ kubectl get pods
NAME                 READY     STATUS    RESTARTS   AGE
sysdig-agent-06i68   1/1       Running   0          14m
sysdig-agent-o0eg6   1/1       Running   0          14m
sysdig-agent-w1e74   1/1       Running   0          14m

cc/ @mtaufen @jessfraz, 1.4 release czar, @fabioy 1.3 release czar @matchstick @alex-mohr

``` release-note
Bump GCE debian image to container-vm-v20161025 (CVE-2016-5195 Dirty COW)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35825)

<!-- Reviewable:end -->
