### PR TITLE
Increase sys container usageBytes upper bound

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -73,7 +73,7 @@ var _ = framework.KubeDescribe("Summary API", func() {
 					"Time": recent(maxStatsAge),
 					// We don't limit system container memory.
 					"AvailableBytes":  BeNil(),
-					"UsageBytes":      bounded(1*mb, 1*gb),
+					"UsageBytes":      bounded(1*mb, 10*gb),
 					"WorkingSetBytes": bounded(1*mb, 1*gb),
 					"RSSBytes":        bounded(1*mb, 1*gb),
 					"PageFaults":      bounded(1000, 1E9),


### PR DESCRIPTION
Fix one of flakes in https://github.com/kubernetes/kubernetes/issues/34990

UsageBytes can grow large since it's only cleaned up under memory pressure.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35828)

<!-- Reviewable:end -->
