### PR TITLE
Expose addon manager's log by logging to file

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -33,7 +33,7 @@ readonly use_kubectl="${LOG_DUMP_USE_KUBECTL:-}"
 readonly master_ssh_supported_providers="gce aws kubemark"
 readonly node_ssh_supported_providers="gce gke aws"
 
-readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd glbc cluster-autoscaler"
+readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd glbc cluster-autoscaler kube-addon-manager"
 readonly node_logfiles="kube-proxy"
 readonly aws_logfiles="cloud-init-output"
 readonly gce_logfiles="startupscript"

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -12,6 +12,10 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
     image: gcr.io/google-containers/kube-addon-manager:v5.2
+    command:
+    - /bin/bash
+    - -c
+    - /opt/kube-addons.sh 1>>/var/log/kube-addon-manager.log 2>&1
     resources:
       requests:
         cpu: 5m
@@ -20,7 +24,13 @@ spec:
     - mountPath: /etc/kubernetes/
       name: addons
       readOnly: true
+    - mountPath: /var/log
+      name: varlog
+      readOnly: false
   volumes:
   - hostPath:
       path: /etc/kubernetes/
     name: addons
+  - hostPath:
+      path: /var/log
+    name: varlog


### PR DESCRIPTION
Fixes #35823.

Use the same way as  how [`kube-proxy`](https://github.com/kubernetes/kubernetes/blob/master/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest) deals with logging. We would be able to check Addon Manager's logs for Jenkins tests after this.

Would like to see the Jenkins test result to examine.

@mikedanese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35832)

<!-- Reviewable:end -->
