### PR TITLE
add rootdir input argument to unsupported cadvisor manager interface

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -31,7 +31,7 @@ type cadvisorUnsupported struct {
 
 var _ Interface = new(cadvisorUnsupported)
 
-func New(port uint, runtime string) (Interface, error) {
+func New(_ uint, _, _ string) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 


### PR DESCRIPTION
Fixes builds on non-linux platforms

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35835)

<!-- Reviewable:end -->
