### PR TITLE
[Federation][init-06] Check for the availability of federation API server's service loadbalancer address before waiting.

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -242,7 +242,7 @@ func waitForLoadBalancerAddress(clientset *client.Clientset, svc *api.Service) (
 	ips := []string{}
 	hostnames := []string{}
 
-	err := wait.PollInfinite(lbAddrRetryInterval, func() (bool, error) {
+	err := wait.PollImmediateInfinite(lbAddrRetryInterval, func() (bool, error) {
 		pollSvc, err := clientset.Core().Services(svc.Namespace).Get(svc.Name)
 		if err != nil {
 			return false, nil

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -192,6 +192,20 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 	return PollUntil(interval, condition, done)
 }
 
+// PollImmediateInfinite is identical to PollInfinite, except that it
+// performs the first check immediately, not waiting interval
+// beforehand.
+func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return PollInfinite(interval, condition)
+}
+
 // PollUntil is like Poll, but it takes a stop change instead of total duration
 func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
 	return WaitFor(poller(interval, 0), condition, stopCh)


### PR DESCRIPTION
Please review only the last commit here. This is based on PR #35862 which will be reviewed independently.

Design Doc: PR #34484

cc @kubernetes/sig-cluster-federation @nikhiljindal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35863)

<!-- Reviewable:end -->
