### PR TITLE
[Federation][init-07] Pull the default federation namespace into a constant.

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -242,7 +242,7 @@ func waitForLoadBalancerAddress(clientset *client.Clientset, svc *api.Service) (
 	ips := []string{}
 	hostnames := []string{}
 
-	err := wait.PollInfinite(lbAddrRetryInterval, func() (bool, error) {
+	err := wait.PollImmediateInfinite(lbAddrRetryInterval, func() (bool, error) {
 		pollSvc, err := clientset.Core().Services(svc.Namespace).Get(svc.Name)
 		if err != nil {
 			return false, nil

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -31,6 +31,10 @@ const (
 	// KubeconfigSecretDataKey is the key name used in the secret to
 	// stores a cluster's credentials.
 	KubeconfigSecretDataKey = "kubeconfig"
+
+	// DefaultFederationSystemNamespace is the namespace in which
+	// federation system components are hosted.
+	DefaultFederationSystemNamespace = "federation-system"
 )
 
 // AdminConfig provides a filesystem based kubeconfig (via
@@ -87,7 +91,7 @@ type SubcommandFlags struct {
 func AddSubcommandFlags(cmd *cobra.Command) {
 	cmd.Flags().String("kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 	cmd.Flags().String("host-cluster-context", "", "Host cluster context")
-	cmd.Flags().String("federation-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
+	cmd.Flags().String("federation-system-namespace", DefaultFederationSystemNamespace, "Namespace in the host cluster where the federation system components are installed")
 }
 
 // GetSubcommandFlags retrieves the command line flag values for the

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -192,6 +192,20 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 	return PollUntil(interval, condition, done)
 }
 
+// PollImmediateInfinite is identical to PollInfinite, except that it
+// performs the first check immediately, not waiting interval
+// beforehand.
+func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return PollInfinite(interval, condition)
+}
+
 // PollUntil is like Poll, but it takes a stop change instead of total duration
 func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
 	return WaitFor(poller(interval, 0), condition, stopCh)


### PR DESCRIPTION
Please review only the last commit here. This is based on PR #35863 which will be reviewed independently.

Design Doc: PR #34484

cc @kubernetes/sig-cluster-federation @quinton-hoole

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35864)

<!-- Reviewable:end -->
