### PR TITLE
Make the fake command factory return the clientset with appropriate rest clients for all the API groups.

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -417,18 +417,18 @@ func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
 	// version.
 	fakeClient := f.tf.Client.(*fake.RESTClient)
 	clientset := internalclientset.NewForConfigOrDie(f.tf.ClientConfig)
-	clientset.CoreClient.RESTClient.Client = fakeClient.Client
-	clientset.AuthenticationClient.RESTClient.Client = fakeClient.Client
-	clientset.AuthorizationClient.RESTClient.Client = fakeClient.Client
-	clientset.AutoscalingClient.RESTClient.Client = fakeClient.Client
-	clientset.BatchClient.RESTClient.Client = fakeClient.Client
-	clientset.CertificatesClient.RESTClient.Client = fakeClient.Client
-	clientset.ExtensionsClient.RESTClient.Client = fakeClient.Client
-	clientset.RbacClient.RESTClient.Client = fakeClient.Client
-	clientset.StorageClient.RESTClient.Client = fakeClient.Client
-	clientset.AppsClient.RESTClient.Client = fakeClient.Client
-	clientset.PolicyClient.RESTClient.Client = fakeClient.Client
-	clientset.DiscoveryClient.RESTClient.Client = fakeClient.Client
+	clientset.CoreClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AuthenticationClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AuthorizationClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AutoscalingClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.BatchClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.CertificatesClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.ExtensionsClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.RbacClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.StorageClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AppsClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.PolicyClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.DiscoveryClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	return clientset, f.tf.Err
 }
 

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -413,14 +413,23 @@ func (f *fakeAPIFactory) JSONEncoder() runtime.Encoder {
 }
 
 func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
-	// Swap out the HTTP client out of the client with the fake's version.
+	// Swap the HTTP client out of the REST client with the fake
+	// version.
 	fakeClient := f.tf.Client.(*fake.RESTClient)
-	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
-	if err != nil {
-		panic(err)
-	}
-	restClient.Client = fakeClient.Client
-	return internalclientset.New(restClient), f.tf.Err
+	clientset := internalclientset.NewForConfigOrDie(f.tf.ClientConfig)
+	clientset.CoreClient.RESTClient.Client = fakeClient.Client
+	clientset.AuthenticationClient.RESTClient.Client = fakeClient.Client
+	clientset.AuthorizationClient.RESTClient.Client = fakeClient.Client
+	clientset.AutoscalingClient.RESTClient.Client = fakeClient.Client
+	clientset.BatchClient.RESTClient.Client = fakeClient.Client
+	clientset.CertificatesClient.RESTClient.Client = fakeClient.Client
+	clientset.ExtensionsClient.RESTClient.Client = fakeClient.Client
+	clientset.RbacClient.RESTClient.Client = fakeClient.Client
+	clientset.StorageClient.RESTClient.Client = fakeClient.Client
+	clientset.AppsClient.RESTClient.Client = fakeClient.Client
+	clientset.PolicyClient.RESTClient.Client = fakeClient.Client
+	clientset.DiscoveryClient.RESTClient.Client = fakeClient.Client
+	return clientset, f.tf.Err
 }
 
 func (f *fakeAPIFactory) RESTClient() (*restclient.RESTClient, error) {


### PR DESCRIPTION
Please review only the last commit here. This is based on PR #35865 which will be reviewed independently.

Design Doc: PR #34484

cc @kubernetes/sig-cluster-federation @nikhiljindal

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35866)

<!-- Reviewable:end -->
