### PR TITLE
Node E2E: Reorganize node e2e output directories.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -38,11 +38,11 @@ if [[ $parallelism > 1 ]]; then
 fi
 
 if [[ $focus != "" ]]; then
-  ginkgoflags="$ginkgoflags -focus=$focus "
+  ginkgoflags="$ginkgoflags -focus='$focus' "
 fi
 
 if [[ $skip != "" ]]; then
-  ginkgoflags="$ginkgoflags -skip=$skip "
+  ginkgoflags="$ginkgoflags -skip='$skip' "
 fi
 
 if [[ $run_until_failure != "" ]]; then
@@ -130,7 +130,7 @@ if [ $remote = true ] ; then
     --results-dir="$artifacts" --ginkgo-flags="$ginkgoflags" \
     --image-project="$image_project" --instance-name-prefix="$instance_prefix" --setup-node="true" \
     --delete-instances="$delete_instances" --test_args="$test_args" --instance-metadata="$metadata" \
-    2>&1 | tee "${artifacts}/build-log.txt"
+    2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 
 else
@@ -149,6 +149,6 @@ else
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \
     --test-flags="--alsologtostderr --v 4 --report-dir=${artifacts} --node-name $(hostname) \
-    $test_args" --build-dependencies=true 2>&1 | tee "${artifacts}/build-log.txt"
+    $test_args" --build-dependencies=true 2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 fi

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -26,8 +26,7 @@ skip=${SKIP:-""}
 # Currently, parallelism only affects when REMOTE=true. For local test,
 # ginkgo default parallelism (cores - 1) is used.
 parallelism=${PARALLELISM:-8}
-report=${REPORT:-"/tmp/"}
-artifacts=${ARTIFACTS:-"/tmp/_artifacts"}
+artifacts=${ARTIFACTS:-"/tmp/_artifacts/`date +%y%m%dT%H%M%S`"}
 remote=${REMOTE:-"false"}
 run_until_failure=${RUN_UNTIL_FAILURE:-"false"}
 test_args=${TEST_ARGS:-""}
@@ -50,6 +49,12 @@ if [[ $run_until_failure != "" ]]; then
   ginkgoflags="$ginkgoflags -untilItFails=$run_until_failure "
 fi
 
+# Setup the directory to copy test artifacts (logs, junit.xml, etc) from remote host to local host
+if [ ! -d "${artifacts}" ]; then
+  echo "Creating artifacts directory at ${artifacts}"
+  mkdir -p ${artifacts}
+fi
+echo "Test artifacts will be written to ${artifacts}"
 
 if [ $remote = true ] ; then
   # The following options are only valid in remote run.
@@ -73,18 +78,6 @@ if [ $remote = true ] ; then
   instance_prefix=${INSTANCE_PREFIX:-"test"}
   cleanup=${CLEANUP:-"true"}
   delete_instances=${DELETE_INSTANCES:-"false"}
-
-  # Setup the directory to copy test artifacts (logs, junit.xml, etc) from remote host to local host
-  if [[ $gubernator = true && -d "${artifacts}" ]]; then
-    echo "Removing artifacts directory at ${artifacts}"
-    rm -r ${artifacts}
-  fi
-
-  if [ ! -d "${artifacts}" ]; then
-    echo "Creating artifacts directory at ${artifacts}"
-    mkdir -p ${artifacts}
-  fi
-  echo "Test artifacts will be written to ${artifacts}"
 
   # Get the compute zone
   zone=$(gcloud info --format='value(config.properties.compute.zone)')
@@ -155,7 +148,7 @@ else
   # Test using the host the script was run on
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \
-    --test-flags="--alsologtostderr --v 4 --report-dir=${report} --node-name $(hostname) \
-    $test_args" --build-dependencies=true
+    --test-flags="--alsologtostderr --v 4 --report-dir=${artifacts} --node-name $(hostname) \
+    $test_args" --build-dependencies=true 2>&1 | tee "${artifacts}/build-log.txt"
   exit $?
 fi

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -115,7 +115,8 @@ func (es *e2eServices) stop() {
 // startEtcd starts the embedded etcd instance or returns an error.
 func (es *e2eServices) startEtcd() error {
 	glog.Info("Starting etcd")
-	dataDir, err := ioutil.TempDir("", "node-e2e")
+	// Create data directory in current working space.
+	dataDir, err := ioutil.TempDir(".", "etcd")
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -82,7 +82,11 @@ func (e *E2EServices) Start() error {
 		// Start kubelet
 		// Create the manifest path for kubelet.
 		// TODO(random-liu): Remove related logic when we move kubelet starting logic out of the test.
-		framework.TestContext.ManifestPath, err = ioutil.TempDir("", "node-e2e-pod")
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %v", err)
+		}
+		framework.TestContext.ManifestPath, err = ioutil.TempDir(cwd, "pod-manifest")
 		if err != nil {
 			return fmt.Errorf("failed to create static pod manifest directory: %v", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/35074.

This PR cleans up the result directory and workspace directory of node e2e test.

Local result directory:

```
/tmp/_artifacts/
        |----- build-log.txt  (build log)
        |----- *.xml  (junit xml file)
        |----- local/  (local run *.log)
        |----- hostname1/  (remote run *.log)
        |----- hostname2/
```

Workspace directory on test node:

```
/tmp/node-e2e-yyyy-mm-ddThh-mm-ss/
        |----- cluster/  (gci mounter)
        |----- cni/  (cni binary)
        |----- e2e_node.test  (test binary)
        |----- e2e_node_test.tar.gz  (test tar)
        |----- etcd060429031/  (etcd data directory)
        |----- ginkgo  (ginkgo binary)
        |----- kubelet (kubelet binary)
        |----- pod-manifest365096781/  (mirror pod directory)
        |----- results/  (test result directory)
```

@mtaufen 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35868)

<!-- Reviewable:end -->
