### PR TITLE
map counter: needed for things like summations of events to reduce noise

### DIFF
--- a/pkg/util/maps/BUILD
+++ b/pkg/util/maps/BUILD
@@ -13,8 +13,17 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "counter.go",
         "doc.go",
         "string.go",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["maps_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [],
 )

--- a/pkg/util/maps/counter.go
+++ b/pkg/util/maps/counter.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps
+
+import (
+	"sync"
+)
+
+// Counter counts the occurences of a item, it is thread safe.
+type Counter struct {
+	mu     sync.Mutex
+	values map[string]int64
+}
+
+// NewCounter returns a new counter object which counts elements in a map.
+func NewCounter() *Counter {
+	return &Counter{
+		values: make(map[string]int64),
+	}
+}
+
+// Get returns the count for a given value.
+func (c *Counter) Get(key string) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.values[key]
+}
+
+// Incr increases the count for a given value by 1.
+func (c *Counter) Incr(key string) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[key]++
+	return c.values[key]
+}

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps
+
+import "fmt"
+
+// ExampleNewCounter is a https://blog.golang.org/examples styled unit test.
+func ExampleNewCounter() {
+
+	c := NewCounter()
+	c.Incr("kubernetes")
+	c.Incr("kubernetes")
+	c.Incr("counters")
+	c.Incr("are great!")
+	fmt.Println(c.Get("kubernetes"))
+	fmt.Println(c.Get("counters"))
+	fmt.Println(c.Get("are great!"))
+	fmt.Println(c.Get("THIS KEY DOESNT EXIST!"))
+
+	// Output:
+	// 2
+	// 1
+	// 1
+	// 0
+}


### PR DESCRIPTION
part of #35842 : a counter mechanism that we can maintain internally for reducing spam by aggregating identical events before spamming them

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35873)

<!-- Reviewable:end -->
