### PR TITLE
[WIP] Implement timeout in ExecInContainer

### DIFF
--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -114,6 +114,10 @@ func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *do
 // NativeExecHandler executes commands in Docker containers using Docker's exec API.
 type NativeExecHandler struct{}
 
+// ExecInContainer executes a command in a Docker container. It may leave a
+// goroutine running the process in the container after the function returns
+// because of a timeout. However, the goroutine does not leak, it terminates
+// when the process exits.
 func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size, timeout time.Duration) error {
 	createOpts := dockertypes.ExecConfig{
 		Cmd:          cmd,
@@ -127,47 +131,77 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 		return fmt.Errorf("failed to exec in container - Exec setup failed - %v", err)
 	}
 
-	// Have to start this before the call to client.StartExec because client.StartExec is a blocking
-	// call :-( Otherwise, resize events don't get processed and the terminal never resizes.
-	kubecontainer.HandleResizing(resize, func(size term.Size) {
-		client.ResizeExecTTY(execObj.ID, int(size.Height), int(size.Width))
-	})
+	startExec := func() error {
+		// Have to start this before the call to client.StartExec because client.StartExec is a blocking
+		// call :-( Otherwise, resize events don't get processed and the terminal never resizes.
+		kubecontainer.HandleResizing(resize, func(size term.Size) {
+			client.ResizeExecTTY(execObj.ID, int(size.Height), int(size.Width))
+		})
 
-	startOpts := dockertypes.ExecStartCheck{Detach: false, Tty: tty}
-	streamOpts := StreamOptions{
-		InputStream:  stdin,
-		OutputStream: stdout,
-		ErrorStream:  stderr,
-		RawTerminal:  tty,
-	}
-	err = client.StartExec(execObj.ID, startOpts, streamOpts)
-	if err != nil {
+		startOpts := dockertypes.ExecStartCheck{Detach: false, Tty: tty}
+		streamOpts := StreamOptions{
+			InputStream:  stdin,
+			OutputStream: stdout,
+			ErrorStream:  stderr,
+			RawTerminal:  tty,
+		}
+		err = client.StartExec(execObj.ID, startOpts, streamOpts)
+		if err != nil {
+			return err
+		}
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		count := 0
+		for {
+			inspect, err2 := client.InspectExec(execObj.ID)
+			if err2 != nil {
+				return err2
+			}
+			if !inspect.Running {
+				if inspect.ExitCode != 0 {
+					err = &dockerExitError{inspect}
+				}
+				break
+			}
+			count++
+			if count == 5 {
+				glog.Errorf("Exec session %s in container %s terminated but process still running!", execObj.ID, container.ID)
+				break
+			}
+			<-ticker.C
+		}
 		return err
 	}
 
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	count := 0
-	for {
-		inspect, err2 := client.InspectExec(execObj.ID)
-		if err2 != nil {
-			return err2
-		}
-		if !inspect.Running {
-			if inspect.ExitCode != 0 {
-				err = &dockerExitError{inspect}
-			}
-			break
-		}
-
-		count++
-		if count == 5 {
-			glog.Errorf("Exec session %s in container %s terminated but process still running!", execObj.ID, container.ID)
-			break
-		}
-
-		<-ticker.C
+	// No timeout, block until startExec is finished.
+	if timeout <= 0 {
+		return startExec()
 	}
+	// Otherwise, run startExec in a new goroutine and wait for completion
+	// or timeout, whatever happens first.
+	ch := make(chan error, 1)
+	go func() {
+		ch <- startExec()
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		// FIXME: we should kill the process in the container, but the
+		// Docker API doesn't support it. See
+		// https://github.com/docker/docker/issues/9098.
+		// For liveness probes this is probably okay, since the
+		// container will be restarted. For readiness probes it means
+		// that probe processes could start piling up.
+		glog.Errorf("Exec session %s in container %s timed out, but process is still running!", execObj.ID, container.ID)
 
-	return err
+		// Return an utilexec.ExitError with code != 0, so that the
+		// probe result will be probe.Failure, not probe.Unknown as for
+		// errors that don't implement that interface.
+		return utilexec.CodeExitError{
+			Err:  fmt.Errorf("exec session timed out"),
+			Code: 1,
+		}
+	}
 }

--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -74,8 +74,6 @@ func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *do
 		if stdout != nil {
 			go io.Copy(stdout, p)
 		}
-
-		err = command.Wait()
 	} else {
 		if stdin != nil {
 			// Use an os.Pipe here as it returns true *os.File objects.
@@ -96,10 +94,17 @@ func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *do
 		if stderr != nil {
 			command.Stderr = stderr
 		}
-
-		err = command.Run()
+		if err := command.Start(); err != nil {
+			return err
+		}
 	}
-
+	if timeout > 0 {
+		t := time.AfterFunc(timeout, func() {
+			command.Process.Kill()
+		})
+		defer t.Stop()
+	}
+	err = command.Wait()
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		return &utilexec.ExitErrorWrapper{ExitError: exitErr}
 	}

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -2069,28 +2069,37 @@ func (r *Runtime) ExecInContainer(containerID kubecontainer.ContainerID, cmd []s
 		if stdout != nil {
 			go io.Copy(stdout, p)
 		}
-		return newRktExitError(command.Wait())
-	}
-	if stdin != nil {
-		// Use an os.Pipe here as it returns true *os.File objects.
-		// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
-		// the call below to command.Run() can unblock because its Stdin is the read half
-		// of the pipe.
-		r, w, err := r.os.Pipe()
-		if err != nil {
-			return newRktExitError(err)
-		}
-		go io.Copy(w, stdin)
+	} else {
+		if stdin != nil {
+			// Use an os.Pipe here as it returns true *os.File objects.
+			// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
+			// the call below to command.Run() can unblock because its Stdin is the read half
+			// of the pipe.
+			r, w, err := r.os.Pipe()
+			if err != nil {
+				return newRktExitError(err)
+			}
+			go io.Copy(w, stdin)
 
-		command.Stdin = r
+			command.Stdin = r
+		}
+		if stdout != nil {
+			command.Stdout = stdout
+		}
+		if stderr != nil {
+			command.Stderr = stderr
+		}
+		if err := command.Start(); err != nil {
+			return err
+		}
 	}
-	if stdout != nil {
-		command.Stdout = stdout
+	if timeout > 0 {
+		t := time.AfterFunc(timeout, func() {
+			command.Process.Kill()
+		})
+		defer t.Stop()
 	}
-	if stderr != nil {
-		command.Stderr = stderr
-	}
-	return newRktExitError(command.Run())
+	return newRktExitError(command.Wait())
 }
 
 // PortForward executes socat in the pod's network namespace and copies


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: `Exec` probes used to disregard the timeout setting observed by `HTTPGet` and `TCPSocket` probes. This is a follow up to #33366 to actually implement timeouts in Exec probes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: depending on how we handle the Docker API case, this may fix #26895.

**Special notes for your reviewer**: this is meant as a follow up to #33366.
@timstclair @ncdc @sttts FYI.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35893)
<!-- Reviewable:end -->
