### PR TITLE
Update Secret.type examples used for provisioning.

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -84,7 +84,7 @@ parameters:
 * `restauthenabled` : Gluster REST service authentication boolean that enables authentication to the REST server. If this value is 'true', `restuser` and `restuserkey` or `secretNamespace` + `secretName` have to be filled. This option is deprecated, authentication is enabled when any of `restuser`, `restuserkey`, `secretName` or `secretNamespace` is specified.
 * `restuser` : Gluster REST service/Heketi user who has access to create volumes in the Gluster Trusted Pool.
 * `restuserkey` : Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of `secretNamespace` + `secretName`.
-* `secretNamespace` + `secretName` : Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both `secretNamespace` and `secretName` are omitted.
+* `secretNamespace` + `secretName` : Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both `secretNamespace` and `secretName` are omitted. The provided secret must have type "kubernetes.io/glusterfs".
 
 When both `restuserkey` and `secretNamespace` + `secretName` is specified, the secret will be used.
 
@@ -131,7 +131,7 @@ parameters:
 
 * `monitors`: Ceph monitors, comma delimited. It is required.
 * `adminId`: Ceph client ID that is capable of creating images in the pool. Default is "admin".
-* `adminSecret`: Secret Name for `adminId`. It is required.
+* `adminSecret`: Secret Name for `adminId`. It is required. The provided secret must have type "kubernetes.io/rbd".
 * `adminSecretNamespace`: The namespace for `adminSecret`. Default is "default".
 * `pool`: Ceph RBD pool. Default is "rbd".
 * `userId`: Ceph client ID that is used to map the RBD image. Default is the same as `adminId`.
@@ -163,7 +163,7 @@ parameters:
 
 * **quobyteAPIServer** API Server of Quobyte in the format http(s)://api-server:7860
 * **registry** Quobyte registry to use to mount the volume. You can specifiy the registry as <host>:<port> pair or if you want to specify multiple registries you just have to put a comma between them e.q. <host1>:<port>,<host2>:<port>,<host3>:<port>. The host can be an IP address or if you have a working DNS you can also provide the DNS names.
-* **adminSecretName** secret that holds information about the Quobyte user and the password to authenticate agains the API server.
+* **adminSecretName** secret that holds information about the Quobyte user and the password to authenticate agains the API server. The provided secret must have type "kubernetes.io/quobyte".
 * **adminSecretNamespace** The namespace for **adminSecretName**. Default is `default`.
 * **user** maps all access to this user. Default is `root`.
 * **group** maps all access to this group. Default is `nfsnobody`.

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   # base64 encoded password. E.g.: echo -n "mypassword" | base64
   key: bXlwYXNzd29yZA==
+type: kubernetes.io/glusterfs

--- a/examples/experimental/persistent-volume-provisioning/quobyte/quobyte-admin-secret.yaml
+++ b/examples/experimental/persistent-volume-provisioning/quobyte/quobyte-admin-secret.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   password: cXVvYnl0ZQ==
   user: YWRtaW4=
+type: kubernetes.io/quobyte

--- a/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-admin.yaml
+++ b/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-admin.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ceph-secret-admin
 data:
   key: QVFEQ1pMdFhPUnQrSmhBQUFYaERWNHJsZ3BsMmNjcDR6RFZST0E9PQ==
+type: kubernetes.io/rbd


### PR DESCRIPTION
Kubernetes now checks that secrets used for provisioning of volumes
have correct type (PR #35675), all examples should reflect it.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35905)
<!-- Reviewable:end -->
