### PR TITLE
Disable update-staging-client-go until code freeze

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -58,8 +58,9 @@ BASH_TARGETS="
 	generated-swagger-docs
 	swagger-spec
 	openapi-spec
-	api-reference-docs
-	staging-client-go"
+	api-reference-docs"
+# TODO: (caesarxuchao) uncomment after 1.5 code freeze.
+#	staging-client-go"
 
 
 for t in $BASH_TARGETS


### PR DESCRIPTION
I don't want to cause developer friction until code freeze. I'll babysit the script for the moment to keep the client-go up-to-date.

Should had done this in #34489.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35915)
<!-- Reviewable:end -->
