### PR TITLE
Automated cherry pick of #29851

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -74,11 +74,11 @@ echo "Provider: ${KUBERNETES_PROVIDER:-}"
 # List resources related to instances, filtering by the instance prefix if
 # provided.
 gcloud-compute-list instance-templates --regexp="${INSTANCE_PREFIX}.*"
-gcloud-compute-list instance-groups ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
-gcloud-compute-list instances ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list instance-groups ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list instances ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
 
 # List disk resources, filterying by instance prefix if provided.
-gcloud-compute-list disks ${ZONE:+"--zone=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
+gcloud-compute-list disks ${ZONE:+"--zones=${ZONE}"} --regexp="${INSTANCE_PREFIX}.*"
 
 # List network resources. We include names starting with "a", corresponding to
 # those that Kubernetes creates.

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -250,7 +250,7 @@ function do-node-upgrade() {
   for group in ${INSTANCE_GROUPS[@]}; do
     old_templates+=($(gcloud compute instance-groups managed list \
         --project="${PROJECT}" \
-        --zone="${ZONE}" \
+        --zones="${ZONE}" \
         --regexp="${group}" \
         --format='value(instanceTemplate)' || true))
     update=$(gcloud alpha compute rolling-updates \


### PR DESCRIPTION
Cherry pick of #29851 on release-1.3.

#29851: Correct gcloud list arg from '--zone' to '--zones'

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35925)
<!-- Reviewable:end -->
