### PR TITLE
Return proper error from openstack provider ExternalID

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -466,6 +466,9 @@ func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
 func (i *Instances) ExternalID(name string) (string, error) {
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
+		if err == ErrNotFound {
+			return "", cloudprovider.InstanceNotFound
+		}
 		return "", err
 	}
 	return srv.ID, nil


### PR DESCRIPTION
The node controller iterates over each node to determine whether it still exists.  It calls the provider's ExternalID function to determine this, looking for a specific error:  cloudprovider.InstanceNotFound.  If ExternalID does not return that specific error, the node controller will not evict the node even if it doesn't exist.  The openstack provider ExternalID function was not returning the proper error.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35926)
<!-- Reviewable:end -->
