### PR TITLE
Bump Kubelet workingset upper bound

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -74,7 +74,7 @@ var _ = framework.KubeDescribe("Summary API", func() {
 					// We don't limit system container memory.
 					"AvailableBytes":  BeNil(),
 					"UsageBytes":      bounded(1*mb, 10*gb),
-					"WorkingSetBytes": bounded(1*mb, 1*gb),
+					"WorkingSetBytes": bounded(1*mb, 10*gb),
 					"RSSBytes":        bounded(1*mb, 1*gb),
 					"PageFaults":      bounded(1000, 1E9),
 					"MajorPageFaults": bounded(0, 100000),


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/34990

Follow up to https://github.com/kubernetes/kubernetes/pull/35828, because working memory is too high now too.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35927)
<!-- Reviewable:end -->
