### PR TITLE
kubeadm: lower default component logging level

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/env.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env.go
@@ -38,7 +38,7 @@ func SetEnvParams() *EnvParams {
 		"hyperkube_image":    "",
 		"discovery_image":    fmt.Sprintf("gcr.io/google_containers/kube-discovery-%s:%s", runtime.GOARCH, "1.0"),
 		"etcd_image":         "",
-		"component_loglevel": "--v=4",
+		"component_loglevel": "--v=2",
 	}
 
 	for k := range envParams {


### PR DESCRIPTION
v=4 is likely to causer perf issues and v=2 is the default in most other setups including scale e2e. ref https://github.com/kubernetes/kubernetes/issues/26637#issuecomment-256859739

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35933)
<!-- Reviewable:end -->
