### PR TITLE
e2e: Fix GetReadySchedulableNodesOrDie for taints

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -80,6 +80,8 @@ go_library(
         "//pkg/util/yaml:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/watch:go_default_library",
+        "//plugin/pkg/scheduler/algorithm/predicates:go_default_library",
+        "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//test/e2e/generated:go_default_library",
         "//test/e2e/perftype:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -316,7 +316,9 @@ func (config *NetworkingTestConfig) createNetShellPodSpec(podName string, node s
 					ReadinessProbe: probe,
 				},
 			},
-			NodeName: node,
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": node,
+			},
 		},
 	}
 	return pod


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes framework.GetReadySchedulableNodesOrDie and
framework.GetMasterAndWorkerNodesOrDie so that nodes that can't take a
generic fake pod due to a taint/toleration mismatch aren't returned.

This is a rehash of #35210, but pulls in the scheduler code.

**Which issue this PR fixes**: c.f. #35210

**Special notes for your reviewer**: I think it's gross that we keep having to manually compute this in e2es. Maybe we need a bug for that?

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35937)
<!-- Reviewable:end -->
