### PR TITLE
Remove the = 0 from var declarations

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -74,7 +74,7 @@ func (a *APIInstaller) Install(ws *restful.WebService) (apiResources []unversion
 
 	// Register the paths in a deterministic (sorted) order to get a deterministic swagger spec.
 	paths := make([]string, len(a.group.Storage))
-	var i int = 0
+	var i int
 	for path := range a.group.Storage {
 		paths[i] = path
 		i++

--- a/pkg/client/cache/undelta_store_test.go
+++ b/pkg/client/cache/undelta_store_test.go
@@ -47,7 +47,7 @@ func TestUpdateCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m
@@ -73,7 +73,7 @@ func TestDeleteCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m
@@ -110,7 +110,7 @@ func TestReplaceCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -63,7 +63,7 @@ func TestListContainers(t *testing.T) {
 
 	expected := []*runtimeApi.Container{}
 	state := runtimeApi.ContainerState_RUNNING
-	var createdAt int64 = 0
+	var createdAt int64
 	for i := range configs {
 		// We don't care about the sandbox id; pass a bogus one.
 		sandboxID := fmt.Sprintf("sandboxid%d", i)

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -63,7 +63,7 @@ func TestListSandboxes(t *testing.T) {
 
 	expected := []*runtimeApi.PodSandbox{}
 	state := runtimeApi.PodSandBoxState_READY
-	var createdAt int64 = 0
+	var createdAt int64
 	for i := range configs {
 		id, err := ds.RunPodSandbox(configs[i])
 		assert.NoError(t, err)

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -1338,7 +1338,7 @@ func TestVerifyNonRoot(t *testing.T) {
 	dm, fakeDocker := newTestDockerManager()
 
 	// setup test cases.
-	var rootUid int64 = 0
+	var rootUid int64
 	var nonRootUid int64 = 1
 
 	tests := map[string]struct {

--- a/pkg/registry/core/service/allocator/utils.go
+++ b/pkg/registry/core/service/allocator/utils.go
@@ -20,7 +20,7 @@ import "math/big"
 
 // countBits returns the number of set bits in n
 func countBits(n *big.Int) int {
-	var count int = 0
+	var count int
 	for _, b := range n.Bytes() {
 		count += int(bitCounts[b])
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/undelta_store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/undelta_store_test.go
@@ -47,7 +47,7 @@ func TestUpdateCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m
@@ -73,7 +73,7 @@ func TestDeleteCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m
@@ -110,7 +110,7 @@ func TestReplaceCallsPush(t *testing.T) {
 	}
 
 	var got []interface{}
-	var callcount int = 0
+	var callcount int
 	push := func(m []interface{}) {
 		callcount++
 		got = m

--- a/test/e2e/chaosmonkey/chaosmonkey_test.go
+++ b/test/e2e/chaosmonkey/chaosmonkey_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDoWithPanic(t *testing.T) {
-	var counter int64 = 0
+	var counter int64
 	cm := New(func() {})
 	tests := []Test{
 		// No panic


### PR DESCRIPTION
Makes code more idiomatic by removing unnecessary explicit zero initializations

i.e.
var something int = 0
->
var something int

Signed-off-by: nick <nicholasjamesrusso@gmail.com>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35942)
<!-- Reviewable:end -->
