### PR TITLE
Optimize port_split_test test case.

### DIFF
--- a/pkg/util/net/port_split_test.go
+++ b/pkg/util/net/port_split_test.go
@@ -28,16 +28,18 @@ func TestSplitSchemeNamePort(t *testing.T) {
 		normalized         bool
 	}{
 		{
-			in:    "aoeu:asdf",
-			name:  "aoeu",
-			port:  "asdf",
-			valid: true,
+			in:         "aoeu:asdf",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
 		}, {
-			in:     "http:aoeu:asdf",
-			scheme: "http",
-			name:   "aoeu",
-			port:   "asdf",
-			valid:  true,
+			in:         "http:aoeu:asdf",
+			scheme:     "http",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
 		}, {
 			in:         "https:aoeu:",
 			scheme:     "https",
@@ -46,16 +48,22 @@ func TestSplitSchemeNamePort(t *testing.T) {
 			valid:      true,
 			normalized: false,
 		}, {
-			in:     "https:aoeu:asdf",
-			scheme: "https",
-			name:   "aoeu",
-			port:   "asdf",
-			valid:  true,
+			in:         "https:aoeu:asdf",
+			scheme:     "https",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
 		}, {
 			in:         "aoeu:",
 			name:       "aoeu",
 			valid:      true,
 			normalized: false,
+		}, {
+			in:         "aoeu",
+			name:       "aoeu",
+			valid:      true,
+			normalized: true,
 		}, {
 			in:    ":asdf",
 			valid: false,
@@ -63,9 +71,11 @@ func TestSplitSchemeNamePort(t *testing.T) {
 			in:    "aoeu:asdf:htns",
 			valid: false,
 		}, {
-			in:    "aoeu",
-			name:  "aoeu",
-			valid: true,
+			in:    "http::asdf",
+			valid: false,
+		}, {
+			in:    "http::",
+			valid: false,
 		}, {
 			in:    "",
 			valid: false,


### PR DESCRIPTION
The `normalized` field doesn't take affect in current test case.

This PR:
1. initializes valid and normalized cases with normalized=true.
2. adds some invalid cases.

@resouer Thanks!

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35956)
<!-- Reviewable:end -->
