### PR TITLE
Add a function to cluster scripts to obtain the provider specific kubeconfig context of the cluster.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1658,6 +1658,15 @@ function kube-push() {
   echo
 }
 
+# Sets the kubeconfig context value of the cluster.
+#
+# Vars set:
+#   CONFIG_CONTEXT
+function kubeconfig-context {
+  CONFIG_CONTEXT="${PROJECT}_${INSTANCE_PREFIX}"
+}
+
+
 # -----------------------------------------------------------------------------
 # Cluster specific test helpers used from hack/e2e.go
 

--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -75,6 +75,11 @@ function push-node {
 	echo "Skeleton Provider: push-node not implemented" 1>&2
 }
 
+# Sets the kubeconfig context value of the cluster.
+function kubeconfig-context {
+	echo "Skeleton Provider: kubeconfig-context not implemented" 1>&2
+}
+
 # Execute prior to running tests to build a release if required for env
 function test-build-release {
 	echo "Skeleton Provider: test-build-release not implemented" 1>&2

--- a/federation/cmd/kubefed/app/kubefed.go
+++ b/federation/cmd/kubefed/app/kubefed.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"os"
+
+	"k8s.io/kubernetes/federation/pkg/kubefed"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+)
+
+func Run() error {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
+	return cmd.Execute()
+}

--- a/federation/cmd/kubefed/kubefed.go
+++ b/federation/cmd/kubefed/kubefed.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"k8s.io/kubernetes/federation/cmd/kubefed/app"
+)
+
+func main() {
+	if err := app.Run(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -27,6 +27,7 @@ limitations under the License.
 // 6. Add the ability to customize DNS domain suffix. It should probably be derived
 //    from cluster config.
 // 7. Make etcd PVC size configurable.
+// 8. Make API server and controller manager replicas customizable via the HA work.
 package init
 
 import (
@@ -383,6 +384,7 @@ func createAPIServer(clientset *client.Clientset, namespace, name, credentialsNa
 			Labels:    componentLabel,
 		},
 		Spec: extensions.DeploymentSpec{
+			Replicas: 1,
 			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Name:   name,
@@ -462,6 +464,7 @@ func createControllerManager(clientset *client.Clientset, namespace, name, kubec
 			Labels:    componentLabel,
 		},
 		Spec: extensions.DeploymentSpec{
+			Replicas: 1,
 			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Name:   name,

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -196,7 +196,7 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	}
 
 	// 7. Create federation controller manager
-	_, err = createControllerManager(hostClientset, initFlags.FederationSystemNamespace, cmName, cmKubeconfigName, dnsZoneName)
+	_, err = createControllerManager(hostClientset, initFlags.FederationSystemNamespace, initFlags.Name, cmName, cmKubeconfigName, dnsZoneName)
 	if err != nil {
 		return err
 	}
@@ -456,10 +456,10 @@ func createAPIServer(clientset *client.Clientset, namespace, name, credentialsNa
 	return clientset.Extensions().Deployments(namespace).Create(dep)
 }
 
-func createControllerManager(clientset *client.Clientset, namespace, name, kubeconfigName, dnsZoneName string) (*extensions.Deployment, error) {
+func createControllerManager(clientset *client.Clientset, namespace, name, cmName, kubeconfigName, dnsZoneName string) (*extensions.Deployment, error) {
 	dep := &extensions.Deployment{
 		ObjectMeta: api.ObjectMeta{
-			Name:      name,
+			Name:      cmName,
 			Namespace: namespace,
 			Labels:    componentLabel,
 		},
@@ -467,7 +467,7 @@ func createControllerManager(clientset *client.Clientset, namespace, name, kubec
 			Replicas: 1,
 			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Name:   name,
+					Name:   cmName,
 					Labels: controllerManagerPodLabels,
 				},
 				Spec: api.PodSpec{

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -94,14 +94,14 @@ var (
 
 // NewCmdInit defines the `init` command that bootstraps a federation
 // control plane inside a set of host clusters.
-func NewCmdInit(f cmdutil.Factory, cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
+func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init FEDERATION_NAME --host-cluster-context=HOST_CONTEXT",
 		Short:   "init initializes a federation control plane",
 		Long:    init_long,
 		Example: init_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := initFederation(f, cmdOut, config, cmd, args)
+			err := initFederation(cmdOut, config, cmd, args)
 			cmdutil.CheckErr(err)
 		},
 	}
@@ -120,7 +120,7 @@ type entityKeyPairs struct {
 // initFederation initializes a federation control plane.
 // See the design doc in https://github.com/kubernetes/kubernetes/pull/34484
 // for details.
-func initFederation(f cmdutil.Factory, cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Command, args []string) error {
+func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Command, args []string) error {
 	initFlags, err := util.GetSubcommandFlags(cmd, args)
 	if err != nil {
 		return err

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // TODO(madhusdancs):
+// 1. Make printSuccess prepend protocol/scheme to the IPs/hostnames.
 // 1. Add a dry-run support.
 // 2. Make all the API object names customizable.
 //    Ex: federation-apiserver, federation-controller-manager, etc.
@@ -31,6 +32,7 @@ package init
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -197,7 +199,8 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	if err != nil {
 		return err
 	}
-	return nil
+
+	return printSuccess(cmdOut, ips, hostnames)
 }
 
 func createNamespace(clientset *client.Clientset, namespace string) (*api.Namespace, error) {
@@ -515,3 +518,10 @@ func createControllerManager(clientset *client.Clientset, namespace, name, kubec
 
 	return clientset.Extensions().Deployments(namespace).Create(dep)
 }
+
+func printSuccess(cmdOut io.Writer, ips, hostnames []string) error {
+	svcEndpoints := append(ips, hostnames...)
+	_, err := fmt.Fprintf(cmdOut, "Federation API server is running at: %s\n", strings.Join(svcEndpoints, ", "))
+	return err
+}
+

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -1,0 +1,502 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO(madhusdancs):
+// 1. Add a dry-run support.
+// 2. Make all the API object names customizable.
+//    Ex: federation-apiserver, federation-controller-manager, etc.
+// 3. Make image name and tag customizable.
+// 4. Separate etcd container from API server pod as a first step towards enabling HA.
+// 5. Generate credentials of the following types for the API server:
+//    i.  "known_tokens.csv"
+//    ii. "basic_auth.csv"
+// 6. Add the ability to customize DNS domain suffix. It should probably be derived
+//    from cluster config.
+// 7. Make etcd PVC size configurable.
+package init
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	certutil "k8s.io/kubernetes/pkg/util/cert"
+	triple "k8s.io/kubernetes/pkg/util/cert/triple"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	APIServerCN         = "federation-apiserver"
+	ControllerManagerCN = "federation-controller-manager"
+	DNSDomain           = "cluster.local."
+
+	lbAddrRetryInterval = 5 * time.Second
+)
+
+var (
+	init_long = templates.LongDesc(`
+		Initialize a federation control plane.
+
+        Federation control plane is hosted inside a Kubernetes
+        cluster. The host cluster must be specified using the
+        --host flag.`)
+	init_example = templates.Examples(`
+		# Initialize federation control plane for a federation
+		# named foo in the host cluster whose local kubeconfig
+		# context is bar.
+		kubectl init foo --host=bar`)
+)
+
+// NewCmdInit defines the `init` command that bootstraps a federation
+// control plane inside a set of host clusters.
+func NewCmdInit(f cmdutil.Factory, cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "init FEDERATION --host=HOST_CONTEXT",
+		Short:   "init initializes a federation control plane",
+		Long:    init_long,
+		Example: init_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := initFederation(f, cmdOut, config, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	util.AddSubcommandFlags(cmd)
+	cmd.Flags().String("dns-zone-name", "", "DNS suffix for this federation. Federated Service DNS names are published with this suffix.")
+	return cmd
+}
+
+type entityKeyPairs struct {
+	ca     *triple.KeyPair
+	server *triple.KeyPair
+	cm     *triple.KeyPair
+}
+
+// initFederation initializes a federation control plane.
+// See the design doc in https://github.com/kubernetes/kubernetes/pull/34484
+// for details.
+func initFederation(f cmdutil.Factory, cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Command, args []string) error {
+	initFlags, err := util.GetSubcommandFlags(cmd, args)
+	if err != nil {
+		return err
+	}
+	dnsZoneName := cmdutil.GetFlagString(cmd, "dns-zone-name")
+
+	hostFactory := config.HostFactory(initFlags.Host, initFlags.Kubeconfig)
+	hostClientset, err := hostFactory.ClientSet()
+	if err != nil {
+		return err
+	}
+
+	serverName := fmt.Sprintf("%s-apiserver", initFlags.Name)
+	serverCredName := fmt.Sprintf("%s-credentials", serverName)
+	cmName := fmt.Sprintf("%s-controller-manager", initFlags.Name)
+	cmKubeconfigName := fmt.Sprintf("%s-kubeconfig", cmName)
+
+	// 1. Create a namespace for federation system components
+	_, err = createNamespace(hostClientset, initFlags.HostSystemNamespace)
+	if err != nil {
+		return err
+	}
+
+	// 2. Expose a network endpoint for the federation API server
+	svc, err := createService(hostClientset, initFlags.HostSystemNamespace, serverName)
+	if err != nil {
+		return err
+	}
+	ips, hostnames, err := waitForLoadBalancerAddress(hostClientset, svc)
+	if err != nil {
+		return err
+	}
+
+	// 3. Generate TLS certificates and credentials
+	entKeyPairs, err := genCerts(hostClientset, initFlags.HostSystemNamespace, initFlags.Name, svc.Name, DNSDomain, ips, hostnames)
+	if err != nil {
+		return err
+	}
+
+	_, err = createAPIServerCredentialsSecret(hostClientset, initFlags.HostSystemNamespace, serverCredName, entKeyPairs)
+	if err != nil {
+		return err
+	}
+
+	// 4. Create a kubeconfig secret
+	_, err = createControllerManagerKubeconfigSecret(hostClientset, initFlags.HostSystemNamespace, initFlags.Name, svc.Name, cmKubeconfigName, entKeyPairs)
+	if err != nil {
+		return err
+	}
+
+	// 5. Create a persistent volume and a claim to store the federation API server's state
+	pvc, err := createPVC(hostClientset, initFlags.HostSystemNamespace, svc.Name)
+	if err != nil {
+		return err
+	}
+
+	// 6. Create federation API server
+	_, err = createAPIServer(hostClientset, initFlags.HostSystemNamespace, serverName, serverCredName, pvc.Name, ips)
+	if err != nil {
+		return err
+	}
+
+	// 7. Create federation controller manager
+	_, err = createControllerManager(hostClientset, initFlags.HostSystemNamespace, cmName, cmKubeconfigName, dnsZoneName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createNamespace(clientset *client.Clientset, namespace string) (*api.Namespace, error) {
+	ns := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	return clientset.Core().Namespaces().Create(ns)
+}
+
+func createService(clientset *client.Clientset, namespace, svcName string) (*api.Service, error) {
+	svc := &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "federated-cluster",
+			},
+		},
+		Spec: api.ServiceSpec{
+			Type: api.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				"app":    "federated-cluster",
+				"module": "federation-apiserver",
+			},
+			Ports: []api.ServicePort{
+				{
+					Name:       "https",
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(443),
+				},
+			},
+		},
+	}
+
+	return clientset.Core().Services(namespace).Create(svc)
+}
+
+func waitForLoadBalancerAddress(clientset *client.Clientset, svc *api.Service) ([]string, []string, error) {
+	ips := []string{}
+	hostnames := []string{}
+
+	err := wait.PollInfinite(lbAddrRetryInterval, func() (bool, error) {
+		pollSvc, err := clientset.Core().Services(svc.Namespace).Get(svc.Name)
+		if err != nil {
+			return false, nil
+		}
+		if ings := pollSvc.Status.LoadBalancer.Ingress; len(ings) > 0 {
+			for _, ing := range ings {
+				if len(ing.IP) > 0 {
+					ips = append(ips, ing.IP)
+				}
+				if len(ing.Hostname) > 0 {
+					hostnames = append(hostnames, ing.Hostname)
+				}
+			}
+			if len(ips) > 0 || len(hostnames) > 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ips, hostnames, nil
+}
+
+func genCerts(clientset *client.Clientset, svcNamespace, name, svcName, dnsDomain string, ips, hostnames []string) (*entityKeyPairs, error) {
+	ca, err := triple.NewCA(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA key and certificate: %v", err)
+	}
+	server, err := triple.NewServerKeyPair(ca, APIServerCN, svcName, svcNamespace, dnsDomain, ips, hostnames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create federation API server key and certificate: %v", err)
+	}
+	cm, err := triple.NewClientKeyPair(ca, ControllerManagerCN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create federation controller manager client key and certificate: %v", err)
+	}
+	return &entityKeyPairs{
+		ca:     ca,
+		server: server,
+		cm:     cm,
+	}, nil
+}
+
+func createAPIServerCredentialsSecret(clientset *client.Clientset, namespace, credentialsName string, entKeyPairs *entityKeyPairs) (*api.Secret, error) {
+	// Build the secret object with API server credentials.
+	secret := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      credentialsName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"ca.crt":     certutil.EncodeCertPEM(entKeyPairs.ca.Cert),
+			"server.crt": certutil.EncodeCertPEM(entKeyPairs.server.Cert),
+			"server.key": certutil.EncodePrivateKeyPEM(entKeyPairs.server.Key),
+		},
+	}
+
+	// Boilerplate to create the secret in the host cluster.
+	return clientset.Core().Secrets(namespace).Create(secret)
+
+}
+
+func createControllerManagerKubeconfigSecret(clientset *client.Clientset, namespace, name, svcName, kubeconfigName string, entKeyPairs *entityKeyPairs) (*api.Secret, error) {
+	basicClientConfig := kubeadmutil.CreateBasicClientConfig(
+		name,
+		fmt.Sprintf("https://%s", svcName),
+		certutil.EncodeCertPEM(entKeyPairs.ca.Cert),
+	)
+
+	config := kubeadmutil.MakeClientConfigWithCerts(
+		basicClientConfig,
+		name,
+		"federation-controller-manager",
+		certutil.EncodePrivateKeyPEM(entKeyPairs.cm.Key),
+		certutil.EncodeCertPEM(entKeyPairs.cm.Cert),
+	)
+
+	return util.CreateKubeconfigSecret(clientset, config, namespace, kubeconfigName, false)
+}
+
+func createPVC(clientset *client.Clientset, namespace, svcName string) (*api.PersistentVolumeClaim, error) {
+	capacity, err := resource.ParseQuantity("10Gi")
+	if err != nil {
+		return nil, err
+	}
+
+	pvc := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      fmt.Sprintf("%s-etcd-claim", svcName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "federated-cluster",
+			},
+			Annotations: map[string]string{
+				"volume.alpha.kubernetes.io/storage-class": "yes",
+			},
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceStorage: capacity,
+				},
+			},
+		},
+	}
+
+	return clientset.Core().PersistentVolumeClaims(namespace).Create(pvc)
+}
+
+func createAPIServer(clientset *client.Clientset, namespace, name, credentialsName, pvcName string, ips []string) (*extensions.Deployment, error) {
+	command := []string{
+		"/hyperkube",
+		"federation-apiserver",
+		"--bind-address=0.0.0.0",
+		"--etcd-servers=http://localhost:2379",
+		"--service-cluster-ip-range=10.0.0.0/16",
+		"--secure-port=443",
+		"--token-auth-file=/etc/federation/apiserver/known_tokens.csv",
+		"--basic-auth-file=/etc/federation/apiserver/basic_auth.csv",
+		"--client-ca-file=/etc/federation/apiserver/ca.crt",
+		"--tls-cert-file=/etc/federation/apiserver/server.crt",
+		"--tls-private-key-file=/etc/federation/apiserver/server.key",
+	}
+	// Since only one IP address can be specified as advertise address, we arbitrarily pick the first availabe IP address
+	if len(ips) > 0 {
+		command = append(command, fmt.Sprintf("--advertise-address=%s", ips[0]))
+	}
+
+	dep := &extensions.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "federated-cluster",
+			},
+		},
+		Spec: extensions.DeploymentSpec{
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{
+						"app":    "federated-cluster",
+						"module": "federation-apiserver",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:    "apiserver",
+							Image:   "gcr.io/google_containers/hyperkube-amd64:v1.5.0",
+							Command: command,
+							Ports: []api.ContainerPort{
+								{
+									Name:          "https",
+									ContainerPort: 443,
+								},
+								{
+									Name:          "local",
+									ContainerPort: 8080,
+								},
+							},
+							VolumeMounts: []api.VolumeMount{
+								{
+									Name:      credentialsName,
+									MountPath: "/etc/federation/apiserver",
+									ReadOnly:  true,
+								},
+							},
+						},
+						{
+							Name:  "etcd",
+							Image: "quay.io/coreos/etcd:v2.3.3",
+							Command: []string{
+								"/etcd",
+								"--data-dir",
+								"/var/etcd/data",
+							},
+							VolumeMounts: []api.VolumeMount{
+								{
+									Name:      "etcddata",
+									MountPath: "/var/etcd",
+								},
+							},
+						},
+					},
+					Volumes: []api.Volume{
+						{
+							Name: credentialsName,
+							VolumeSource: api.VolumeSource{
+								Secret: &api.SecretVolumeSource{
+									SecretName: credentialsName,
+								},
+							},
+						},
+						{
+							Name: "etcddata",
+							VolumeSource: api.VolumeSource{
+								PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return clientset.Extensions().Deployments(namespace).Create(dep)
+}
+
+func createControllerManager(clientset *client.Clientset, namespace, name, kubeconfigName, dnsZoneName string) (*extensions.Deployment, error) {
+	dep := &extensions.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "federated-cluster",
+			},
+		},
+		Spec: extensions.DeploymentSpec{
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{
+						"app":    "federated-cluster",
+						"module": "federation-controller-manager",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "controller-manager",
+							Image: "gcr.io/google_containers/hyperkube-amd64:v1.5.0",
+							Command: []string{
+								"/hyperkube",
+								"federation-controller-manager",
+								"--master=https://federation-apiserver",
+								"--kubeconfig=/etc/federation/controller-manager/kubeconfig",
+								"--dns-provider=gce",
+								"--dns-provider-config=",
+								fmt.Sprintf("--federation-name=%s", name),
+								fmt.Sprintf("--zone-name=%s", dnsZoneName),
+							},
+							VolumeMounts: []api.VolumeMount{
+								{
+									Name:      kubeconfigName,
+									MountPath: "/etc/federation/controller-manager",
+									ReadOnly:  true,
+								},
+							},
+							Env: []api.EnvVar{
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &api.EnvVarSource{
+										FieldRef: &api.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []api.Volume{
+						{
+							Name: kubeconfigName,
+							VolumeSource: api.VolumeSource{
+								Secret: &api.SecretVolumeSource{
+									SecretName: kubeconfigName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return clientset.Extensions().Deployments(namespace).Create(dep)
+}

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -242,7 +242,7 @@ func waitForLoadBalancerAddress(clientset *client.Clientset, svc *api.Service) (
 	ips := []string{}
 	hostnames := []string{}
 
-	err := wait.PollInfinite(lbAddrRetryInterval, func() (bool, error) {
+	err := pollImmediateInfinite(lbAddrRetryInterval, func() (bool, error) {
 		pollSvc, err := clientset.Core().Services(svc.Namespace).Get(svc.Name)
 		if err != nil {
 			return false, nil
@@ -528,3 +528,13 @@ func printSuccess(cmdOut io.Writer, ips, hostnames []string) error {
 	return err
 }
 
+func pollImmediateInfinite(interval time.Duration, condition wait.ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return wait.PollInfinite(interval, condition)
+}

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package init
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testNamespace    = "test-ns"
+	testSvcName      = "test-service"
+	testCertValidity = 1 * time.Hour
+
+	helloMsg = "Hello, certificate test!"
+)
+
+type clientServerTLSConfigs struct {
+	server *tls.Config
+	client *tls.Config
+}
+
+type certParams struct {
+	cAddr     string
+	ips       []string
+	hostnames []string
+}
+
+// TestCertsTLS tests TLS handshake with client authentication for any server
+// name. There is a separate test below to test the certificate generation
+// end-to-end over HTTPS.
+// TODO(madhusudancs): Consider using a deterministic random number generator
+// for generating certificates in tests.
+func TestCertsTLS(t *testing.T) {
+	params := []certParams{
+		{
+			cAddr:     "10.1.2.3",
+			ips:       []string{"10.1.2.3", "10.2.3.4"},
+			hostnames: []string{"federation.test", "federation2.test"},
+		},
+		{
+			cAddr:     "10.10.20.30",
+			ips:       []string{"10.20.30.40", "10.64.128.4"},
+			hostnames: []string{"tls.federation.test"},
+		},
+	}
+
+	tlsCfgs, err := tlsConfigs(params)
+	if err != nil {
+		t.Errorf("failed to generate tls configs: %v", err)
+		// No point in proceeding further
+		return
+	}
+
+	testCases := []struct {
+		serverName string
+		sCfg       *tls.Config
+		cCfg       *tls.Config
+		failType   string
+	}{
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "10.2.3.4",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "federation.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+		},
+		{
+			serverName: "10.20.30.40",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[1].client,
+		},
+		{
+			serverName: "tls.federation.test",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[1].client,
+		},
+		{
+			serverName: "10.100.200.50",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "noexist.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "10.64.128.4",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "tls.federation.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[1].client,
+			failType:   "UnknownAuthorityError",
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[0].server,
+			cCfg:       tlsCfgs[1].client,
+			failType:   "UnknownAuthorityError",
+		},
+		{
+			serverName: "10.1.2.3",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+		{
+			serverName: "federation2.test",
+			sCfg:       tlsCfgs[1].server,
+			cCfg:       tlsCfgs[0].client,
+			failType:   "HostnameError",
+		},
+	}
+
+	for i, tc := range testCases {
+		// Make a copy of the client config before modifying it.
+		cCfgCopy := *tc.cCfg
+		cCfg := &cCfgCopy
+		cCfg.ServerName = tc.serverName
+		cCfg.BuildNameToCertificate()
+
+		err := tlsHandshake(t, tc.sCfg, cCfg)
+		if len(tc.failType) > 0 {
+			switch tc.failType {
+			case "HostnameError":
+				if _, ok := err.(x509.HostnameError); !ok {
+					t.Errorf("[%d] unexpected error: want x509.HostnameError, got: %T", i, err)
+				}
+			case "UnknownAuthorityError":
+				if _, ok := err.(x509.UnknownAuthorityError); !ok {
+					t.Errorf("[%d] unexpected error: want x509.UnknownAuthorityError, got: %T", i, err)
+				}
+			default:
+				t.Errorf("cannot handle error type: %s", tc.failType)
+
+			}
+		} else if err != nil {
+			t.Errorf("[%d] unexpected error: %v", i, err)
+		}
+	}
+}
+
+// TestCertsHTTPS cannot test client authentication for non-localhost server
+// names, but it tests TLS handshake end-to-end over HTTPS.
+func TestCertsHTTPS(t *testing.T) {
+	params := []certParams{
+		{
+			// Unfortunately, due to the limitation in the way Go
+			// net/http/httptest package sets up the test HTTPS/TLS server,
+			// 127.0.0.1 is the only accepted server address. So, we need to
+			// generate certificates for this address.
+			cAddr:     "127.0.0.1",
+			ips:       []string{"127.0.0.1"},
+			hostnames: []string{},
+		},
+		{
+			// Unfortunately, due to the limitation in the way Go
+			// net/http/httptest package sets up the test HTTPS/TLS server,
+			// 127.0.0.1 is the only accepted server address. So, we need to
+			// generate certificates for this address.
+			cAddr:     "localhost",
+			ips:       []string{"127.0.0.1"},
+			hostnames: []string{"localhost"},
+		},
+	}
+
+	tlsCfgs, err := tlsConfigs(params)
+	if err != nil {
+		t.Errorf("failed to generate tls configs: %v", err)
+		// No point in proceeding further
+		return
+	}
+
+	testCases := []struct {
+		sCfg *tls.Config
+		cCfg *tls.Config
+		fail bool
+	}{
+		{
+			sCfg: tlsCfgs[0].server,
+			cCfg: tlsCfgs[0].client,
+			fail: false,
+		},
+		{
+			sCfg: tlsCfgs[0].server,
+			cCfg: tlsCfgs[1].client,
+			fail: true,
+		},
+		{
+			sCfg: tlsCfgs[1].server,
+			cCfg: tlsCfgs[0].client,
+			fail: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		// Make a copy of the client config before modifying it.
+		cCfgCopy := *tc.cCfg
+		cCfg := &cCfgCopy
+		cCfg.BuildNameToCertificate()
+
+		s, err := fakeHTTPSServer(tc.sCfg)
+		if err != nil {
+			t.Errorf("[%d] unexpected error starting TLS server: %v", i, err)
+			// No point in proceeding
+			continue
+		}
+		defer s.Close()
+
+		tr := &http.Transport{
+			TLSClientConfig: cCfg,
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(s.URL)
+		if tc.fail {
+			_, ok := err.(*url.Error)
+			if !ok || !strings.HasSuffix(err.Error(), "x509: certificate signed by unknown authority") {
+				t.Errorf("[%d] unexpected error: want x509.HostnameError, got: %T", i, err)
+			}
+			// We are done for this test.
+			continue
+		} else if err != nil {
+			t.Errorf("[%d] unexpected error while sending GET request to the server: %T", i, err)
+			// No point in proceeding
+			continue
+		}
+		defer resp.Body.Close()
+
+		got, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("[%d] unexpected error reading server response: %v", i, err)
+		} else if string(got) != helloMsg {
+			t.Errorf("[%d] want %q, got %q", i, helloMsg, got)
+		}
+	}
+}
+
+func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {
+	// Tried to use net.Pipe() instead of TCP. But the connections returned by
+	// net.Pipe() do a fully-synchronous reads and writes on both the ends.
+	// So if a TLS handshake fails, they can't return the error until the
+	// other side reads the message which it did not expect. Since the other
+	// side does not read the message it did not expect, the server and
+	// clients hang. Since TCP is non-blocking we use that as transport
+	// instead. One could have as well used a Unix Domain Socket, but TCP is
+	// more portable.
+	s, err := tls.Listen("tcp", "", sCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create a test TLS server: %v", err)
+	}
+	defer s.Close()
+
+	errCh := make(chan error)
+	go func() {
+		for {
+			conn, err := s.Accept()
+			if err != nil {
+				errCh <- fmt.Errorf("failed to accept a TLS connection: %v", err)
+				return
+			}
+			gotByte := make([]byte, len(helloMsg))
+			_, err = conn.Read(gotByte)
+			if err != nil && err != io.EOF {
+				errCh <- fmt.Errorf("failed to read input: %v", err)
+			} else if got := string(gotByte); got != helloMsg {
+				errCh <- fmt.Errorf("got %q, want %q", got, helloMsg)
+			}
+			errCh <- nil
+			return
+		}
+	}()
+
+	c, err := tls.Dial("tcp", s.Addr().String(), cCfg)
+	if err != nil {
+		// Intentionally not serializing the error received because we want to
+		// test for the failure case in the caller test function.
+		return err
+	}
+	defer c.Close()
+	if _, err := c.Write([]byte(helloMsg)); err != nil {
+		return fmt.Errorf("failed to write to server: %v", err)
+	}
+
+	return <-errCh
+}
+
+func fakeHTTPSServer(sCfg *tls.Config) (*httptest.Server, error) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helloMsg)
+	}))
+
+	s.TLS.Certificates = sCfg.Certificates
+	s.TLS.RootCAs = sCfg.RootCAs
+	s.TLS.ClientAuth = sCfg.ClientAuth
+	s.TLS.ClientCAs = sCfg.ClientCAs
+	s.TLS.InsecureSkipVerify = sCfg.InsecureSkipVerify
+	return s, nil
+}
+
+func tlsConfigs(params []certParams) ([]clientServerTLSConfigs, error) {
+	tlsCfgs := []clientServerTLSConfigs{}
+	for i, p := range params {
+		sCfg, cCfg, err := genServerClientTLSConfigs(testNamespace, p.cAddr, testSvcName, HostClusterLocalDNSZoneName, p.ips, p.hostnames)
+		if err != nil {
+			return nil, fmt.Errorf("[%d] failed to generate tls configs: %v", i, err)
+		}
+		tlsCfgs = append(tlsCfgs, clientServerTLSConfigs{sCfg, cCfg})
+	}
+	return tlsCfgs, nil
+}
+
+func genServerClientTLSConfigs(namespace, name, svcName, localDNSZoneName string, ips, hostnames []string) (*tls.Config, *tls.Config, error) {
+	entKeyPairs, err := genCerts(namespace, name, svcName, localDNSZoneName, ips, hostnames)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected error generating certs: %v", err)
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(entKeyPairs.ca.Cert)
+
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{
+			entKeyPairs.server.Cert.Raw,
+		},
+		PrivateKey: entKeyPairs.server.Key,
+	}
+
+	cmCert := tls.Certificate{
+		Certificate: [][]byte{
+			entKeyPairs.controllerManager.Cert.Raw,
+		},
+		PrivateKey: entKeyPairs.controllerManager.Key,
+	}
+
+	sCfg := &tls.Config{
+		Certificates:       []tls.Certificate{serverCert},
+		RootCAs:            roots,
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ClientCAs:          roots,
+		InsecureSkipVerify: false,
+	}
+
+	cCfg := &tls.Config{
+		Certificates: []tls.Certificate{cmCert},
+		RootCAs:      roots,
+	}
+
+	return sCfg, cCfg, nil
+}

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package init
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -28,6 +29,22 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/pkg/util/diff"
+	kubefedtesting "k8s.io/kubernetes/federation/pkg/kubefed/testing"
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
 const (
@@ -38,15 +55,74 @@ const (
 	helloMsg = "Hello, certificate test!"
 )
 
-type clientServerTLSConfigs struct {
-	server *tls.Config
-	client *tls.Config
-}
+func TestInitFederation(t *testing.T) {
+	cmdErrMsg := ""
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		cmdErrMsg = str
+	})
 
-type certParams struct {
-	cAddr     string
-	ips       []string
-	hostnames []string
+	fakeKubeFiles, err := kubefedtesting.FakeKubeconfigFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer kubefedtesting.RemoveFakeKubeconfigFiles(fakeKubeFiles)
+
+	testCases := []struct {
+		federation         string
+		kubeconfigGlobal   string
+		kubeconfigExplicit string
+		dnsZoneName        string
+		lbIP               string
+		expectedErr        string
+	}{
+		{
+			federation:         "union",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			dnsZoneName:        "example.test.",
+			lbIP:               "10.20.30.40",
+			expectedErr:        "",
+		},
+	}
+
+	for i, tc := range testCases {
+		cmdErrMsg = ""
+		buf := bytes.NewBuffer([]byte{})
+
+		hostFactory, err := fakeInitHostFactory(tc.federation, util.DefaultFederationSystemNamespace, tc.lbIP, tc.dnsZoneName)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error: %v", i, err)
+		}
+
+		adminConfig, err := kubefedtesting.NewFakeAdminConfig(hostFactory, tc.kubeconfigGlobal)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error: %v", i, err)
+		}
+
+		cmd := NewCmdInit(buf, adminConfig)
+
+		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
+		cmd.Flags().Set("host-cluster-context", "substrate")
+		cmd.Flags().Set("dns-zone-name", tc.dnsZoneName)
+		cmd.Run(cmd, []string{tc.federation})
+
+		if tc.expectedErr == "" {
+			// uses the name from the federation, not the response
+			// Actual data passed are tested in the fake secret and cluster
+			// REST clients.
+			want := fmt.Sprintf("Federation API server is running at: %s\n", tc.lbIP)
+			if got := buf.String(); got != want {
+				t.Errorf("[%d] unexpected output: got: %s, want: %s", i, got, want)
+				if cmdErrMsg != "" {
+					t.Errorf("[%d] unexpected error message: %s", i, cmdErrMsg)
+				}
+			}
+		} else {
+			if cmdErrMsg != tc.expectedErr {
+				t.Errorf("[%d] expected error: %s, got: %s, output: %s", i, tc.expectedErr, cmdErrMsg, buf.String())
+			}
+		}
+	}
 }
 
 // TestCertsTLS tests TLS handshake with client authentication for any server
@@ -282,6 +358,394 @@ func TestCertsHTTPS(t *testing.T) {
 			t.Errorf("[%d] want %q, got %q", i, helloMsg, got)
 		}
 	}
+}
+
+func fakeInitHostFactory(federationName, namespaceName, ip, dnsZoneName string) (cmdutil.Factory, error) {
+	svcName := federationName + "-apiserver"
+	svcUrlPrefix := "/api/v1/namespaces/federation-system/services"
+	credSecretName := svcName + "-credentials"
+	cmKubeconfigSecretName := federationName + "-controller-manager-kubeconfig"
+	capacity, err := resource.ParseQuantity("10Gi")
+	if err != nil {
+		return nil, err
+	}
+	pvcName := svcName + "-etcd-claim"
+	replicas := int32(1)
+
+	namespace := v1.Namespace{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: testapi.Default.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: namespaceName,
+		},
+	}
+
+	svc := v1.Service{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Service",
+			APIVersion: testapi.Default.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespaceName,
+			Name:      svcName,
+			Labels:    componentLabel,
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeLoadBalancer,
+			Selector: apiserverSvcSelector,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "https",
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(443),
+				},
+			},
+		},
+	}
+
+	svcWithLB := svc
+	svcWithLB.Status = v1.ServiceStatus{
+		LoadBalancer: v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{
+				{
+					IP: ip,
+				},
+			},
+		},
+	}
+
+	credSecret := v1.Secret{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: testapi.Default.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      credSecretName,
+			Namespace: namespaceName,
+		},
+		Data: nil,
+	}
+
+	cmKubeconfigSecret := v1.Secret{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: testapi.Default.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      cmKubeconfigSecretName,
+			Namespace: namespaceName,
+		},
+		Data: nil,
+	}
+
+	pvc := v1.PersistentVolumeClaim{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: testapi.Default.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespaceName,
+			Labels:    componentLabel,
+			Annotations: map[string]string{
+				"volume.alpha.kubernetes.io/storage-class": "yes",
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: capacity,
+				},
+			},
+		},
+	}
+
+	apiserver := v1beta1.Deployment{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: testapi.Extensions.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespaceName,
+			Labels:    componentLabel,
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: nil,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   svcName,
+					Labels: apiserverPodLabels,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "apiserver",
+							Image: hyperkubeImage,
+							Command: []string{
+								"/hyperkube",
+								"federation-apiserver",
+								"--bind-address=0.0.0.0",
+								"--etcd-servers=http://localhost:2379",
+								"--service-cluster-ip-range=10.0.0.0/16",
+								"--secure-port=443",
+								"--token-auth-file=/etc/federation/apiserver/known_tokens.csv",
+								"--basic-auth-file=/etc/federation/apiserver/basic_auth.csv",
+								"--client-ca-file=/etc/federation/apiserver/ca.crt",
+								"--tls-cert-file=/etc/federation/apiserver/server.crt",
+								"--tls-private-key-file=/etc/federation/apiserver/server.key",
+								"--advertise-address=" + ip,
+							},
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "https",
+									ContainerPort: 443,
+								},
+								{
+									Name:          "local",
+									ContainerPort: 8080,
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      credSecretName,
+									MountPath: "/etc/federation/apiserver",
+									ReadOnly:  true,
+								},
+							},
+						},
+						{
+							Name:  "etcd",
+							Image: "quay.io/coreos/etcd:v2.3.3",
+							Command: []string{
+								"/etcd",
+								"--data-dir",
+								"/var/etcd/data",
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "etcddata",
+									MountPath: "/var/etcd",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: credSecretName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: credSecretName,
+								},
+							},
+						},
+						{
+							Name: "etcddata",
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cmName := federationName + "-controller-manager"
+	cm := v1beta1.Deployment{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: testapi.Extensions.GroupVersion().String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespaceName,
+			Labels:    componentLabel,
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: nil,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   cmName,
+					Labels: controllerManagerPodLabels,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "controller-manager",
+							Image: hyperkubeImage,
+							Command: []string{
+								"/hyperkube",
+								"federation-controller-manager",
+								"--master=https://federation-apiserver",
+								"--kubeconfig=/etc/federation/controller-manager/kubeconfig",
+								"--dns-provider=gce",
+								"--dns-provider-config=",
+								fmt.Sprintf("--federation-name=%s", federationName),
+								fmt.Sprintf("--zone-name=%s", dnsZoneName),
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      cmKubeconfigSecretName,
+									MountPath: "/etc/federation/controller-manager",
+									ReadOnly:  true,
+								},
+							},
+							Env: []v1.EnvVar{
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: cmKubeconfigSecretName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: cmKubeconfigSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
+	extCodec := testapi.Extensions.Codec()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
+	tf.ClientConfig = kubefedtesting.DefaultClientConfig()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api/v1/namespaces" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got v1.Namespace
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				if !api.Semantic.DeepEqual(got, namespace) {
+					return nil, fmt.Errorf("Unexpected namespace object\n\tDiff: %s", diff.ObjectGoPrintDiff(got, namespace))
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &namespace)}, nil
+			case p == svcUrlPrefix && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got v1.Service
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				if !api.Semantic.DeepEqual(got, svc) {
+					return nil, fmt.Errorf("Unexpected service object\n\tDiff: %s", diff.ObjectGoPrintDiff(got, svc))
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &svc)}, nil
+			case strings.HasPrefix(p, svcUrlPrefix) && m == http.MethodGet:
+				got := strings.TrimPrefix(p, svcUrlPrefix+"/")
+				if got != svcName {
+					return nil, errors.NewNotFound(api.Resource("services"), got)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &svcWithLB)}, nil
+			case p == "/api/v1/namespaces/federation-system/secrets" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got, want v1.Secret
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				// Obtained secret contains generated data which cannot
+				// be compared, so we just nullify the generated part
+				// and compare the rest of the secret. The generated
+				// parts are tested in other tests.
+				got.Data = nil
+				switch got.Name {
+				case credSecretName:
+					want = credSecret
+				case cmKubeconfigSecretName:
+					want = cmKubeconfigSecret
+				}
+				if !api.Semantic.DeepEqual(got, want) {
+					return nil, fmt.Errorf("Unexpected secret object\n\tDiff: %s", diff.ObjectGoPrintDiff(got, want))
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &want)}, nil
+			case p == "/api/v1/namespaces/federation-system/persistentvolumeclaims" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got v1.PersistentVolumeClaim
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				if !api.Semantic.DeepEqual(got, pvc) {
+					return nil, fmt.Errorf("Unexpected PVC object\n\tDiff: %s", diff.ObjectGoPrintDiff(got, pvc))
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &pvc)}, nil
+			case p == "/apis/extensions/v1beta1/namespaces/federation-system/deployments" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got, want v1beta1.Deployment
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				switch got.Name {
+				case svcName:
+					want = apiserver
+				case cmName:
+					want = cm
+				}
+				if !api.Semantic.DeepEqual(got.Spec, want.Spec) {
+					return nil, fmt.Errorf("Unexpected deployment object\n\tDiff: %s", diff.ObjectGoPrintDiff(got.Spec, want.Spec))
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(extCodec, &want)}, nil
+			default:
+				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
+			}
+		}),
+	}
+	return f, nil
+}
+
+type clientServerTLSConfigs struct {
+	server *tls.Config
+	client *tls.Config
+}
+
+type certParams struct {
+	cAddr     string
+	ips       []string
+	hostnames []string
 }
 
 func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {

--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/kubectl"
+	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// KubeconfigSecretDataKey is the key name used in the secret to
+	// stores a cluster's credentials.
+	KubeconfigSecretDataKey = "kubeconfig"
+)
+
+var (
+	join_long = templates.LongDesc(`
+		Join a cluster to a federation.
+
+        Current context is assumed to be a federation endpoint.
+        Please use the --context flag otherwise.`)
+	join_example = templates.Examples(`
+		# Join a cluster to a federation by specifying the
+		# cluster context name and the context name of the
+		# federation control plane's host cluster.
+		kubectl join foo --host=bar`)
+)
+
+// JoinFederationConfig provides a filesystem based kubeconfig (via
+// `PathOptions()`) and a mechanism to talk to the federation host
+// cluster.
+type JoinFederationConfig interface {
+	// PathOptions provides filesystem based kubeconfig access.
+	PathOptions() *clientcmd.PathOptions
+	// HostFactory provides a mechanism to communicate with the
+	// cluster where federation control plane is hosted.
+	HostFactory(host, kubeconfigPath string) cmdutil.Factory
+}
+
+// joinFederationConfig implements JoinFederationConfig interface.
+type joinFederationConfig struct {
+	pathOptions *clientcmd.PathOptions
+}
+
+func NewJoinFederationConfig(pathOptions *clientcmd.PathOptions) JoinFederationConfig {
+	return &joinFederationConfig{
+		pathOptions: pathOptions,
+	}
+}
+
+func (r *joinFederationConfig) PathOptions() *clientcmd.PathOptions {
+	return r.pathOptions
+}
+
+func (r *joinFederationConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+	loadingRules := *r.pathOptions.LoadingRules
+	loadingRules.Precedence = r.pathOptions.GetLoadingPrecedence()
+	loadingRules.ExplicitPath = kubeconfigPath
+	overrides := &clientcmd.ConfigOverrides{
+		CurrentContext: host,
+	}
+
+	hostClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
+
+	return cmdutil.NewFactory(hostClientConfig)
+}
+
+// NewCmdJoin defines the `join` command that joins a cluster to a
+// federation.
+func NewCmdJoin(f cmdutil.Factory, cmdOut io.Writer, config JoinFederationConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "join CLUSTER_CONTEXT --host=HOST_CONTEXT",
+		Short:   "Join a cluster to a federation",
+		Long:    join_long,
+		Example: join_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := joinFederation(f, cmdOut, config, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddPrinterFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, cmdutil.ClusterV1Beta1GeneratorName)
+	addJoinFlags(cmd)
+	return cmd
+}
+
+// joinFederation is the implementation of the `join federation` command.
+func joinFederation(f cmdutil.Factory, cmdOut io.Writer, config JoinFederationConfig, cmd *cobra.Command, args []string) error {
+	name, err := kubectlcmd.NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	host := cmdutil.GetFlagString(cmd, "host")
+	hostSystemNamespace := cmdutil.GetFlagString(cmd, "host-system-namespace")
+	kubeconfig := cmdutil.GetFlagString(cmd, "kubeconfig")
+	dryRun := cmdutil.GetDryRunFlag(cmd)
+
+	po := config.PathOptions()
+	po.LoadingRules.ExplicitPath = kubeconfig
+	clientConfig, err := po.GetStartingConfig()
+	if err != nil {
+		return err
+	}
+	generator, err := clusterGenerator(clientConfig, name)
+	if err != nil {
+		return err
+	}
+
+	// We are not using the `kubectl create secret` machinery through
+	// `RunCreateSubcommand` as we do to the cluster resource below
+	// because we have a bunch of requirements that the machinery does
+	// not satisfy.
+	// 1. We want to create the secret in a specific namespace, which
+	//    is neither the "default" namespace nor the one specified
+	//    via the `--namespace` flag.
+	// 2. `SecretGeneratorV1` requires LiteralSources in a string-ified
+	//    form that it parses to generate the secret data key-value
+	//    pairs. We, however, have the key-value pairs ready without a
+	//    need for parsing.
+	// 3. The result printing mechanism needs to be mostly quiet. We
+	//    don't have to print the created secret in the default case.
+	// Having said that, secret generation machinery could be altered to
+	// suit our needs, but it is far less invasive and readable this way.
+	hostFactory := config.HostFactory(host, kubeconfig)
+	_, err = createSecret(hostFactory, clientConfig, hostSystemNamespace, name, dryRun)
+	if err != nil {
+		return err
+	}
+
+	return kubectlcmd.RunCreateSubcommand(f, cmd, cmdOut, &kubectlcmd.CreateSubcommandOptions{
+		Name:                name,
+		StructuredGenerator: generator,
+		DryRun:              dryRun,
+		OutputFormat:        cmdutil.GetFlagString(cmd, "output"),
+	})
+}
+
+func addJoinFlags(cmd *cobra.Command) {
+	cmd.Flags().String("kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+	cmd.Flags().String("host", "", "Host cluster context")
+	cmd.Flags().String("host-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
+}
+
+// minifyConfig is a wrapper around `clientcmdapi.MinifyConfig()` that
+// sets the current context to the given context before calling
+// `clientcmdapi.MinifyConfig()`.
+func minifyConfig(clientConfig *clientcmdapi.Config, context string) (*clientcmdapi.Config, error) {
+	// MinifyConfig inline-modifies the passed clientConfig. So we make a
+	// copy of it before passing the config to it. A shallow copy is
+	// sufficient because the underlying fields will be reconstructed by
+	// MinifyConfig anyway.
+	newClientConfig := *clientConfig
+	newClientConfig.CurrentContext = context
+	err := clientcmdapi.MinifyConfig(&newClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &newClientConfig, nil
+}
+
+// createSecret extracts the kubeconfig for a given cluster and populates
+// a secret with that kubeconfig.
+func createSecret(hostFactory cmdutil.Factory, clientConfig *clientcmdapi.Config, namespace, name string, dryRun bool) (runtime.Object, error) {
+	// Minify the kubeconfig to ensure that there is only information
+	// relevant to the cluster we are registering.
+	newClientConfig, err := minifyConfig(clientConfig, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Flatten the kubeconfig to ensure that all the referenced file
+	// contents are inlined.
+	err = clientcmdapi.FlattenConfig(newClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	configBytes, err := clientcmd.Write(*newClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the secret object with the minified and flattened
+	// kubeconfig content.
+	secret := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			KubeconfigSecretDataKey: configBytes,
+		},
+	}
+
+	if !dryRun {
+		// Boilerplate to create the secret in the host cluster.
+		clientset, err := hostFactory.ClientSet()
+		if err != nil {
+			return nil, err
+		}
+		return clientset.Core().Secrets(namespace).Create(secret)
+	}
+	return secret, nil
+}
+
+// clusterGenerator extracts the cluster information from the supplied
+// kubeconfig and builds a StructuredGenerator for the
+// `federation/cluster` API resource.
+func clusterGenerator(clientConfig *clientcmdapi.Config, name string) (kubectl.StructuredGenerator, error) {
+	// Get the context from the config.
+	ctx, found := clientConfig.Contexts[name]
+	if !found {
+		return nil, fmt.Errorf("cluster context %q not found", name)
+	}
+
+	// Get the cluster object corresponding to the supplied context.
+	cluster, found := clientConfig.Clusters[ctx.Cluster]
+	if !found {
+		return nil, fmt.Errorf("cluster endpoint not found for %q", name)
+	}
+
+	// Parse the cluster APIServer endpoint into a `urlScheme` struct
+	// to extract and normalize the schema. If the schema is specified,
+	// it is used as is. It is otherwise inferred from the port in the
+	// host:port part of the endpoint URL.
+	u, err := urlParse(cluster.Server)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cluster endpoint %q for cluster %q", cluster.Server, name)
+	}
+	serverAddress := cluster.Server
+	if u.scheme == "" {
+		// Use "https" as the default scheme if the port isn't "80". It
+		// is not a perfect inference, it is just a safe heuristic.
+		scheme := "https"
+		if u.port == "80" {
+			scheme = "http"
+		}
+		serverAddress = strings.Join([]string{scheme, serverAddress}, "://")
+	}
+
+	generator := &kubectl.ClusterGeneratorV1Beta1{
+		Name:          name,
+		ServerAddress: serverAddress,
+		SecretName:    name,
+	}
+	return generator, nil
+}
+
+// url represents a APIServer URL in the structured form.
+type urlScheme struct {
+	scheme string
+	host   string
+	port   string
+	path   string
+}
+
+// urlParse implements a logic similar to `net/url.Parse()`, but unlike
+// the standard library function, it gracefully handles the URLs without
+// scheme. On the other hand, it only parses the segments we care about.
+func urlParse(rawurl string) (*urlScheme, error) {
+	scheme := ""
+	port := ""
+	path := ""
+	hostport := rawurl
+	segs := strings.SplitN(rawurl, "://", 2)
+	if len(segs) == 2 {
+		scheme = segs[0]
+		hostport = segs[1]
+	}
+
+	remsegs := strings.SplitN(hostport, "/", 2)
+	if len(remsegs) == 2 {
+		hostport = remsegs[0]
+		path = remsegs[1]
+	}
+
+	host := hostport
+	hpsegs := strings.SplitN(hostport, ":", 2)
+	if len(hpsegs) == 2 {
+		host = hpsegs[0]
+		port = hpsegs[1]
+	}
+
+	return &urlScheme{
+		scheme: scheme,
+		host:   host,
+		port:   port,
+		path:   path,
+	}, nil
+}

--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -103,7 +103,7 @@ func joinFederation(f cmdutil.Factory, cmdOut io.Writer, config util.AdminConfig
 	//    don't have to print the created secret in the default case.
 	// Having said that, secret generation machinery could be altered to
 	// suit our needs, but it is far less invasive and readable this way.
-	_, err = createSecret(hostFactory, clientConfig, joinFlags.HostSystemNamespace, joinFlags.Name, dryRun)
+	_, err = createSecret(hostFactory, clientConfig, joinFlags.FederationSystemNamespace, joinFlags.Name, dryRun)
 	if err != nil {
 		return err
 	}

--- a/federation/pkg/kubefed/join_test.go
+++ b/federation/pkg/kubefed/join_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestJoinFederation(t *testing.T) {
+	cmdErrMsg := ""
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		cmdErrMsg = str
+	})
+
+	fakeKubeFiles, err := fakeKubeconfigFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer rmFakeKubeconfigFiles(fakeKubeFiles)
+
+	testCases := []struct {
+		cluster            string
+		server             string
+		token              string
+		kubeconfigGlobal   string
+		kubeconfigExplicit string
+		expectedServer     string
+		expectedErr        string
+	}{
+		{
+			cluster:            "syndicate",
+			server:             "https://10.20.30.40",
+			token:              "badge",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			expectedServer:     "https://10.20.30.40",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "ally",
+			server:             "ally256.example.com:80",
+			token:              "souvenir",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: fakeKubeFiles[1],
+			expectedServer:     "http://ally256.example.com:80",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "confederate",
+			server:             "10.8.8.8",
+			token:              "totem",
+			kubeconfigGlobal:   fakeKubeFiles[1],
+			kubeconfigExplicit: fakeKubeFiles[2],
+			expectedServer:     "https://10.8.8.8",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "affiliate",
+			server:             "https://10.20.30.40",
+			token:              "badge",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			expectedServer:     "https://10.20.30.40",
+			expectedErr:        fmt.Sprintf("error: cluster context %q not found", "affiliate"),
+		},
+	}
+
+	for i, tc := range testCases {
+		cmdErrMsg = ""
+		f := testJoinFederationFactory(tc.cluster, tc.expectedServer)
+		buf := bytes.NewBuffer([]byte{})
+
+		hostFactory, err := fakeJoinHostFactory(tc.cluster, tc.server, tc.token)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error: %v", i, err)
+		}
+
+		joinConfig, err := newFakeJoinFederationConfig(hostFactory, tc.kubeconfigGlobal)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error: %v", i, err)
+		}
+
+		cmd := NewCmdJoin(f, buf, joinConfig)
+
+		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
+		cmd.Flags().Set("host", "substrate")
+		cmd.Run(cmd, []string{tc.cluster})
+
+		if tc.expectedErr == "" {
+			// uses the name from the cluster, not the response
+			// Actual data passed are tested in the fake secret and cluster
+			// REST clients.
+			if msg := buf.String(); msg != fmt.Sprintf("cluster %q created\n", tc.cluster) {
+				t.Errorf("[%d] unexpected output: %s", i, msg)
+				if cmdErrMsg != "" {
+					t.Errorf("[%d] unexpected error message: %s", i, cmdErrMsg)
+				}
+			}
+		} else {
+			if cmdErrMsg != tc.expectedErr {
+				t.Errorf("[%d] expected error: %s, got: %s, output: %s", i, tc.expectedErr, cmdErrMsg, buf.String())
+			}
+		}
+	}
+}
+
+func testJoinFederationFactory(name, server string) cmdutil.Factory {
+	want := fakeCluster(name, server)
+	f, tf, _, _ := cmdtesting.NewAPIFactory()
+	codec := testapi.Federation.Codec()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/clusters" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got federationapi.Cluster
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				if !api.Semantic.DeepEqual(got, want) {
+					return nil, fmt.Errorf("unexpected cluster object\n\tgot: %#v\n\twant: %#v", got, want)
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &want)}, nil
+			default:
+				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
+			}
+		}),
+	}
+	tf.Namespace = "test"
+	return f
+}
+
+type fakeJoinFederationConfig struct {
+	pathOptions *clientcmd.PathOptions
+	hostFactory cmdutil.Factory
+}
+
+func newFakeJoinFederationConfig(f cmdutil.Factory, kubeconfigGlobal string) (JoinFederationConfig, error) {
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions.GlobalFile = kubeconfigGlobal
+	pathOptions.EnvVar = ""
+
+	return &fakeJoinFederationConfig{
+		pathOptions: pathOptions,
+		hostFactory: f,
+	}, nil
+}
+
+func (r *fakeJoinFederationConfig) PathOptions() *clientcmd.PathOptions {
+	return r.pathOptions
+}
+
+func (r *fakeJoinFederationConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+	return r.hostFactory
+}
+
+func fakeJoinHostFactory(name, server, token string) (cmdutil.Factory, error) {
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			name: {
+				Server: server,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			name: {
+				Token: token,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			name: {
+				Cluster:  name,
+				AuthInfo: name,
+			},
+		},
+		CurrentContext: name,
+	}
+	configBytes, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	secretObject := v1.Secret{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "federation-system",
+		},
+		Data: map[string][]byte{
+			"kubeconfig": configBytes,
+		},
+	}
+
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
+	tf.ClientConfig = defaultClientConfig()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api/v1/namespaces/federation-system/secrets" && m == http.MethodPost:
+				body, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var got v1.Secret
+				_, _, err = codec.Decode(body, nil, &got)
+				if err != nil {
+					return nil, err
+				}
+				if !api.Semantic.DeepEqual(got, secretObject) {
+					return nil, fmt.Errorf("Unexpected secret object\n\tgot: %#v\n\twant: %#v", got, secretObject)
+				}
+				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, &secretObject)}, nil
+			default:
+				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
+			}
+		}),
+	}
+	return f, nil
+}
+
+func fakeCluster(name, server string) federationapi.Cluster {
+	return federationapi.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: federationapi.ClusterSpec{
+			ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+				{
+					ServerAddress: server,
+				},
+			},
+			SecretRef: &v1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}
+
+func fakeKubeconfigFiles() ([]string, error) {
+	kubeconfigs := []clientcmdapi.Config{
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"syndicate": {
+					Server: "https://10.20.30.40",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"syndicate": {
+					Token: "badge",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"syndicate": {
+					Cluster:  "syndicate",
+					AuthInfo: "syndicate",
+				},
+			},
+			CurrentContext: "syndicate",
+		},
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"ally": {
+					Server: "ally256.example.com:80",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"ally": {
+					Token: "souvenir",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"ally": {
+					Cluster:  "ally",
+					AuthInfo: "ally",
+				},
+			},
+			CurrentContext: "ally",
+		},
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"ally": {
+					Server: "https://ally64.example.com",
+				},
+				"confederate": {
+					Server: "10.8.8.8",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"ally": {
+					Token: "souvenir",
+				},
+				"confederate": {
+					Token: "totem",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"ally": {
+					Cluster:  "ally",
+					AuthInfo: "ally",
+				},
+				"confederate": {
+					Cluster:  "confederate",
+					AuthInfo: "confederate",
+				},
+			},
+			CurrentContext: "confederate",
+		},
+	}
+	kubefiles := []string{}
+	for _, cfg := range kubeconfigs {
+		fakeKubeFile, _ := ioutil.TempFile("", "")
+		err := clientcmd.WriteToFile(cfg, fakeKubeFile.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		kubefiles = append(kubefiles, fakeKubeFile.Name())
+	}
+	return kubefiles, nil
+}
+
+func rmFakeKubeconfigFiles(kubefiles []string) {
+	for _, file := range kubefiles {
+		os.Remove(file)
+	}
+}
+
+func defaultHeader() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}
+
+func objBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
+}
+
+func defaultClientConfig() *restclient.Config {
+	return &restclient.Config{
+		APIPath: "/api",
+		ContentConfig: restclient.ContentConfig{
+			NegotiatedSerializer: api.Codecs,
+			ContentType:          runtime.ContentTypeJSON,
+			GroupVersion:         &registered.GroupOrDie(api.GroupName).GroupVersion,
+		},
+	}
+}

--- a/federation/pkg/kubefed/join_test.go
+++ b/federation/pkg/kubefed/join_test.go
@@ -110,12 +110,12 @@ func TestJoinFederation(t *testing.T) {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
 
-		joinConfig, err := newFakeJoinFederationConfig(hostFactory, tc.kubeconfigGlobal)
+		adminConfig, err := newFakeAdminConfig(hostFactory, tc.kubeconfigGlobal)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
 
-		cmd := NewCmdJoin(f, buf, joinConfig)
+		cmd := NewCmdJoin(f, buf, adminConfig)
 
 		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
 		cmd.Flags().Set("host", "substrate")
@@ -171,28 +171,28 @@ func testJoinFederationFactory(name, server string) cmdutil.Factory {
 	return f
 }
 
-type fakeJoinFederationConfig struct {
+type fakeAdminConfig struct {
 	pathOptions *clientcmd.PathOptions
 	hostFactory cmdutil.Factory
 }
 
-func newFakeJoinFederationConfig(f cmdutil.Factory, kubeconfigGlobal string) (JoinFederationConfig, error) {
+func newFakeAdminConfig(f cmdutil.Factory, kubeconfigGlobal string) (AdminConfig, error) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = kubeconfigGlobal
 	pathOptions.EnvVar = ""
 
-	return &fakeJoinFederationConfig{
+	return &fakeAdminConfig{
 		pathOptions: pathOptions,
 		hostFactory: f,
 	}, nil
 }
 
-func (r *fakeJoinFederationConfig) PathOptions() *clientcmd.PathOptions {
-	return r.pathOptions
+func (f *fakeAdminConfig) PathOptions() *clientcmd.PathOptions {
+	return f.pathOptions
 }
 
-func (r *fakeJoinFederationConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
-	return r.hostFactory
+func (f *fakeAdminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+	return f.hostFactory
 }
 
 func fakeJoinHostFactory(name, server, token string) (cmdutil.Factory, error) {

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -19,6 +19,7 @@ package kubefed
 import (
 	"io"
 
+	kubefedinit "k8s.io/kubernetes/federation/pkg/kubefed/init"
 	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
@@ -52,6 +53,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
+				kubefedinit.NewCmdInit(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -53,7 +53,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				kubefedinit.NewCmdInit(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"io"
+
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/flag"
+
+	"github.com/spf13/cobra"
+)
+
+// NewKubeFedCommand creates the `kubefed` command and its nested children.
+func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "kubefed",
+		Short: "kubefed controls a Kubernetes Cluster Federation",
+		Long: templates.LongDesc(`
+      kubefed controls a Kubernetes Cluster Federation.
+
+      Find more information at https://github.com/kubernetes/kubernetes.`),
+		Run: runHelp,
+	}
+
+	f.BindFlags(cmds.PersistentFlags())
+	f.BindExternalFlags(cmds.PersistentFlags())
+
+	// From this point and forward we get warnings on flags that contain "_" separators
+	cmds.SetGlobalNormalizationFunc(flag.WarnWordSepNormalizeFunc)
+
+	groups := templates.CommandGroups{
+		{
+			Message: "Basic Commands:",
+			Commands: []*cobra.Command{
+				NewCmdJoin(f, out, NewJoinFederationConfig(clientcmd.NewDefaultPathOptions())),
+				NewCmdUnjoin(f, out, err, NewJoinFederationConfig(clientcmd.NewDefaultPathOptions())),
+			},
+		},
+	}
+	groups.Add(cmds)
+
+	filters := []string{
+		"options",
+	}
+	templates.ActsAsRootCommand(cmds, filters, groups...)
+
+	cmds.AddCommand(kubectl.NewCmdVersion(f, out))
+	cmds.AddCommand(kubectl.NewCmdOptions(out))
+
+	return cmds
+}
+
+func runHelp(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -19,6 +19,7 @@ package kubefed
 import (
 	"io"
 
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -51,8 +52,8 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				NewCmdJoin(f, out, NewJoinFederationConfig(clientcmd.NewDefaultPathOptions())),
-				NewCmdUnjoin(f, out, err, NewJoinFederationConfig(clientcmd.NewDefaultPathOptions())),
+				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},
 		},
 	}

--- a/federation/pkg/kubefed/testing/testing.go
+++ b/federation/pkg/kubefed/testing/testing.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type fakeAdminConfig struct {
+	pathOptions *clientcmd.PathOptions
+	hostFactory cmdutil.Factory
+}
+
+func NewFakeAdminConfig(f cmdutil.Factory, kubeconfigGlobal string) (util.AdminConfig, error) {
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions.GlobalFile = kubeconfigGlobal
+	pathOptions.EnvVar = ""
+
+	return &fakeAdminConfig{
+		pathOptions: pathOptions,
+		hostFactory: f,
+	}, nil
+}
+
+func (f *fakeAdminConfig) PathOptions() *clientcmd.PathOptions {
+	return f.pathOptions
+}
+
+func (f *fakeAdminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+	return f.hostFactory
+}
+
+func FakeKubeconfigFiles() ([]string, error) {
+	kubeconfigs := []clientcmdapi.Config{
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"syndicate": {
+					Server: "https://10.20.30.40",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"syndicate": {
+					Token: "badge",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"syndicate": {
+					Cluster:  "syndicate",
+					AuthInfo: "syndicate",
+				},
+			},
+			CurrentContext: "syndicate",
+		},
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"ally": {
+					Server: "ally256.example.com:80",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"ally": {
+					Token: "souvenir",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"ally": {
+					Cluster:  "ally",
+					AuthInfo: "ally",
+				},
+			},
+			CurrentContext: "ally",
+		},
+		{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"ally": {
+					Server: "https://ally64.example.com",
+				},
+				"confederate": {
+					Server: "10.8.8.8",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"ally": {
+					Token: "souvenir",
+				},
+				"confederate": {
+					Token: "totem",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"ally": {
+					Cluster:  "ally",
+					AuthInfo: "ally",
+				},
+				"confederate": {
+					Cluster:  "confederate",
+					AuthInfo: "confederate",
+				},
+			},
+			CurrentContext: "confederate",
+		},
+	}
+	kubefiles := []string{}
+	for _, cfg := range kubeconfigs {
+		fakeKubeFile, _ := ioutil.TempFile("", "")
+		err := clientcmd.WriteToFile(cfg, fakeKubeFile.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		kubefiles = append(kubefiles, fakeKubeFile.Name())
+	}
+	return kubefiles, nil
+}
+
+func RemoveFakeKubeconfigFiles(kubefiles []string) {
+	for _, file := range kubefiles {
+		os.Remove(file)
+	}
+}
+
+func DefaultHeader() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}
+
+func ObjBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
+}
+
+func DefaultClientConfig() *restclient.Config {
+	return &restclient.Config{
+		APIPath: "/api",
+		ContentConfig: restclient.ContentConfig{
+			NegotiatedSerializer: api.Codecs,
+			ContentType:          runtime.ContentTypeJSON,
+			GroupVersion:         &registered.GroupOrDie(api.GroupName).GroupVersion,
+		},
+	}
+}

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	federationapi "k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	unjoin_long = templates.LongDesc(`
+		Unjoin removes a cluster from a federation.
+
+        Current context is assumed to be a federation endpoint.
+        Please use the --context flag otherwise.`)
+	unjoin_example = templates.Examples(`
+		# Unjoin removes the specified cluster from a federation.
+		# Federation control plane's host cluster context name
+		# must be specified properly cleanup the credentials.
+		kubectl unjoin foo --host=bar`)
+)
+
+// NewCmdUnjoin defines the `unjoin` command that removes a cluster
+// from a federation.
+func NewCmdUnjoin(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config JoinFederationConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "unjoin CLUSTER_CONTEXT --host=HOST_CONTEXT",
+		Short:   "Unjoins a cluster from a federation",
+		Long:    unjoin_long,
+		Example: unjoin_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := unjoinFederation(f, cmdOut, cmdErr, config, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	addJoinFlags(cmd)
+	return cmd
+}
+
+// unjoinFederation is the implementation of the `unjoin` command.
+func unjoinFederation(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config JoinFederationConfig, cmd *cobra.Command, args []string) error {
+	name, err := kubectlcmd.NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	host := cmdutil.GetFlagString(cmd, "host")
+	hostSystemNamespace := cmdutil.GetFlagString(cmd, "host-system-namespace")
+	kubeconfig := cmdutil.GetFlagString(cmd, "kubeconfig")
+
+	cluster, err := popCluster(f, name)
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		fmt.Fprintf(cmdErr, "WARNING: cluster %q not found in federation, so its credentials' secret couldn't be deleted", name)
+		return nil
+	}
+
+	// We want a separate client factory to communicate with the
+	// federation host cluster. See join_federation.go for details.
+	hostFactory := config.HostFactory(host, kubeconfig)
+	err = deleteSecret(hostFactory, cluster.Spec.SecretRef.Name, hostSystemNamespace)
+	if isNotFound(err) {
+		fmt.Fprintf(cmdErr, "WARNING: secret %q not found in the host cluster, so it couldn't be deleted", cluster.Spec.SecretRef.Name)
+	} else if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmdOut, "Successfully removed cluster %q from federation\n", name)
+	return err
+}
+
+func popCluster(f cmdutil.Factory, name string) (*federationapi.Cluster, error) {
+	// Boilerplate to create the secret in the host cluster.
+	mapper, typer := f.Object()
+	gvks, _, err := typer.ObjectKinds(&federationapi.Cluster{})
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	mapping, err := mapper.RESTMapping(unversioned.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	client, err := f.ClientForMapping(mapping)
+	if err != nil {
+		return nil, err
+	}
+
+	rh := resource.NewHelper(client, mapping)
+	obj, err := rh.Get("", name, false)
+
+	if isNotFound(err) {
+		// Cluster isn't registered, there isn't anything to be done here.
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	cluster, ok := obj.(*federationapi.Cluster)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type: expected \"federation/v1beta1.Cluster\", got %T: obj: %#v", obj, obj)
+	}
+
+	return cluster, rh.Delete("", name)
+}
+
+func deleteSecret(hostFactory cmdutil.Factory, name, namespace string) error {
+	clientset, err := hostFactory.ClientSet()
+	if err != nil {
+		return err
+	}
+	return clientset.Core().Secrets(namespace).Delete(name, &api.DeleteOptions{})
+}
+
+func isNotFound(err error) bool {
+	statusErr := err
+	if urlErr, ok := err.(*url.Error); ok {
+		statusErr = urlErr.Err
+	}
+	return errors.IsNotFound(statusErr)
+}

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -83,7 +83,7 @@ func unjoinFederation(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config util.A
 	// We want a separate client factory to communicate with the
 	// federation host cluster. See join_federation.go for details.
 	hostFactory := config.HostFactory(unjoinFlags.Host, unjoinFlags.Kubeconfig)
-	err = deleteSecret(hostFactory, cluster.Spec.SecretRef.Name, unjoinFlags.HostSystemNamespace)
+	err = deleteSecret(hostFactory, cluster.Spec.SecretRef.Name, unjoinFlags.FederationSystemNamespace)
 	if isNotFound(err) {
 		fmt.Fprintf(cmdErr, "WARNING: secret %q not found in the host cluster, so it couldn't be deleted", cluster.Spec.SecretRef.Name)
 	} else if err != nil {

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -22,10 +22,10 @@ import (
 	"net/url"
 
 	federationapi "k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -48,7 +48,7 @@ var (
 
 // NewCmdUnjoin defines the `unjoin` command that removes a cluster
 // from a federation.
-func NewCmdUnjoin(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config JoinFederationConfig) *cobra.Command {
+func NewCmdUnjoin(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config util.AdminConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unjoin CLUSTER_CONTEXT --host=HOST_CONTEXT",
 		Short:   "Unjoins a cluster from a federation",
@@ -60,42 +60,41 @@ func NewCmdUnjoin(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config JoinFedera
 		},
 	}
 
-	addJoinFlags(cmd)
+	util.AddSubcommandFlags(cmd)
 	return cmd
 }
 
 // unjoinFederation is the implementation of the `unjoin` command.
-func unjoinFederation(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config JoinFederationConfig, cmd *cobra.Command, args []string) error {
-	name, err := kubectlcmd.NameFromCommandArgs(cmd, args)
+func unjoinFederation(f cmdutil.Factory, cmdOut, cmdErr io.Writer, config util.AdminConfig, cmd *cobra.Command, args []string) error {
+	unjoinFlags, err := util.GetSubcommandFlags(cmd, args)
 	if err != nil {
 		return err
 	}
-	host := cmdutil.GetFlagString(cmd, "host")
-	hostSystemNamespace := cmdutil.GetFlagString(cmd, "host-system-namespace")
-	kubeconfig := cmdutil.GetFlagString(cmd, "kubeconfig")
 
-	cluster, err := popCluster(f, name)
+	cluster, err := popCluster(f, unjoinFlags.Name)
 	if err != nil {
 		return err
 	}
 	if cluster == nil {
-		fmt.Fprintf(cmdErr, "WARNING: cluster %q not found in federation, so its credentials' secret couldn't be deleted", name)
+		fmt.Fprintf(cmdErr, "WARNING: cluster %q not found in federation, so its credentials' secret couldn't be deleted", unjoinFlags.Name)
 		return nil
 	}
 
 	// We want a separate client factory to communicate with the
 	// federation host cluster. See join_federation.go for details.
-	hostFactory := config.HostFactory(host, kubeconfig)
-	err = deleteSecret(hostFactory, cluster.Spec.SecretRef.Name, hostSystemNamespace)
+	hostFactory := config.HostFactory(unjoinFlags.Host, unjoinFlags.Kubeconfig)
+	err = deleteSecret(hostFactory, cluster.Spec.SecretRef.Name, unjoinFlags.HostSystemNamespace)
 	if isNotFound(err) {
 		fmt.Fprintf(cmdErr, "WARNING: secret %q not found in the host cluster, so it couldn't be deleted", cluster.Spec.SecretRef.Name)
 	} else if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(cmdOut, "Successfully removed cluster %q from federation\n", name)
+	_, err = fmt.Fprintf(cmdOut, "Successfully removed cluster %q from federation\n", unjoinFlags.Name)
 	return err
 }
 
+// popCluster fetches the cluster object with the given name, deletes
+// it and returns the deleted cluster object.
 func popCluster(f cmdutil.Factory, name string) (*federationapi.Cluster, error) {
 	// Boilerplate to create the secret in the host cluster.
 	mapper, typer := f.Object()
@@ -130,6 +129,8 @@ func popCluster(f cmdutil.Factory, name string) (*federationapi.Cluster, error) 
 	return cluster, rh.Delete("", name)
 }
 
+// deleteSecret deletes the secret with the given name from the host
+// cluster.
 func deleteSecret(hostFactory cmdutil.Factory, name, namespace string) error {
 	clientset, err := hostFactory.ClientSet()
 	if err != nil {
@@ -138,6 +139,7 @@ func deleteSecret(hostFactory cmdutil.Factory, name, namespace string) error {
 	return clientset.Core().Secrets(namespace).Delete(name, &api.DeleteOptions{})
 }
 
+// isNotFound checks if the given error is a NotFound status error.
 func isNotFound(err error) bool {
 	statusErr := err
 	if urlErr, ok := err.(*url.Error); ok {

--- a/federation/pkg/kubefed/unjoin_test.go
+++ b/federation/pkg/kubefed/unjoin_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	federationapi "k8s.io/kubernetes/federation/apis/federation"
+	kubefedtesting "k8s.io/kubernetes/federation/pkg/kubefed/testing"
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
@@ -109,7 +111,7 @@ func TestUnjoinFederation(t *testing.T) {
 		errBuf := bytes.NewBuffer([]byte{})
 
 		hostFactory := fakeUnjoinHostFactory(tc.cluster)
-		adminConfig, err := newFakeAdminConfig(hostFactory, tc.kubeconfigGlobal)
+		adminConfig, err := kubefedtesting.NewFakeAdminConfig(hostFactory, tc.kubeconfigGlobal)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
@@ -149,7 +151,7 @@ func testUnjoinFederationFactory(name, server, secret string) cmdutil.Factory {
 
 	f, tf, _, _ := cmdtesting.NewAPIFactory()
 	codec := testapi.Federation.Codec()
-	tf.ClientConfig = defaultClientConfig()
+	tf.ClientConfig = kubefedtesting.DefaultClientConfig()
 	ns := testapi.Federation.NegotiatedSerializer()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
@@ -186,7 +188,7 @@ func fakeUnjoinHostFactory(name string) cmdutil.Factory {
 	urlPrefix := "/api/v1/namespaces/federation-system/secrets/"
 	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
-	tf.ClientConfig = defaultClientConfig()
+	tf.ClientConfig = kubefedtesting.DefaultClientConfig()
 	tf.Client = &fake.RESTClient{
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/federation/pkg/kubefed/unjoin_test.go
+++ b/federation/pkg/kubefed/unjoin_test.go
@@ -109,12 +109,12 @@ func TestUnjoinFederation(t *testing.T) {
 		errBuf := bytes.NewBuffer([]byte{})
 
 		hostFactory := fakeUnjoinHostFactory(tc.cluster)
-		joinConfig, err := newFakeJoinFederationConfig(hostFactory, tc.kubeconfigGlobal)
+		adminConfig, err := newFakeAdminConfig(hostFactory, tc.kubeconfigGlobal)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
 
-		cmd := NewCmdUnjoin(f, buf, errBuf, joinConfig)
+		cmd := NewCmdUnjoin(f, buf, errBuf, adminConfig)
 
 		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
 		cmd.Flags().Set("host", "substrate")

--- a/federation/pkg/kubefed/unjoin_test.go
+++ b/federation/pkg/kubefed/unjoin_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	federationapi "k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func TestUnjoinFederation(t *testing.T) {
+	cmdErrMsg := ""
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		cmdErrMsg = str
+	})
+
+	fakeKubeFiles, err := fakeKubeconfigFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer rmFakeKubeconfigFiles(fakeKubeFiles)
+
+	testCases := []struct {
+		cluster            string
+		wantCluster        string
+		wantSecret         string
+		kubeconfigGlobal   string
+		kubeconfigExplicit string
+		expectedServer     string
+		expectedErr        string
+	}{
+		{
+			cluster:            "syndicate",
+			wantCluster:        "syndicate",
+			wantSecret:         "",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			expectedServer:     "https://10.20.30.40",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "ally",
+			wantCluster:        "ally",
+			wantSecret:         "",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: fakeKubeFiles[1],
+			expectedServer:     "http://ally256.example.com:80",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "confederate",
+			wantCluster:        "confederate",
+			wantSecret:         "",
+			kubeconfigGlobal:   fakeKubeFiles[1],
+			kubeconfigExplicit: fakeKubeFiles[2],
+			expectedServer:     "https://10.8.8.8",
+			expectedErr:        "",
+		},
+		{
+			cluster:            "noexist",
+			wantCluster:        "affiliate",
+			wantSecret:         "",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			expectedServer:     "https://10.20.30.40",
+			expectedErr:        fmt.Sprintf("WARNING: cluster %q not found in federation, so its credentials' secret couldn't be deleted", "affiliate"),
+		},
+		{
+			cluster:            "affiliate",
+			wantCluster:        "affiliate",
+			wantSecret:         "noexist",
+			kubeconfigGlobal:   fakeKubeFiles[0],
+			kubeconfigExplicit: "",
+			expectedServer:     "https://10.20.30.40",
+			expectedErr:        fmt.Sprintf("WARNING: secret %q not found in the host cluster, so it couldn't be deleted", "noexist"),
+		},
+	}
+
+	for i, tc := range testCases {
+		cmdErrMsg = ""
+		f := testUnjoinFederationFactory(tc.cluster, tc.expectedServer, tc.wantSecret)
+		buf := bytes.NewBuffer([]byte{})
+		errBuf := bytes.NewBuffer([]byte{})
+
+		hostFactory := fakeUnjoinHostFactory(tc.cluster)
+		joinConfig, err := newFakeJoinFederationConfig(hostFactory, tc.kubeconfigGlobal)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error: %v", i, err)
+		}
+
+		cmd := NewCmdUnjoin(f, buf, errBuf, joinConfig)
+
+		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
+		cmd.Flags().Set("host", "substrate")
+		cmd.Run(cmd, []string{tc.wantCluster})
+
+		if tc.expectedErr == "" {
+			// uses the name from the cluster, not the response
+			// Actual data passed are tested in the fake secret and cluster
+			// REST clients.
+			if msg := buf.String(); msg != fmt.Sprintf("Successfully removed cluster %q from federation\n", tc.cluster) {
+				t.Errorf("[%d] unexpected output: %s", i, msg)
+				if cmdErrMsg != "" {
+					t.Errorf("[%d] unexpected error message: %s", i, cmdErrMsg)
+				}
+			}
+		} else {
+			if errMsg := errBuf.String(); errMsg != tc.expectedErr {
+				t.Errorf("[%d] expected warning: %s, got: %s, output: %s", i, tc.expectedErr, errMsg, buf.String())
+			}
+
+		}
+	}
+}
+
+func testUnjoinFederationFactory(name, server, secret string) cmdutil.Factory {
+	urlPrefix := "/clusters/"
+
+	cluster := fakeCluster(name, server)
+	if secret != "" {
+		cluster.Spec.SecretRef.Name = secret
+	}
+
+	f, tf, _, _ := cmdtesting.NewAPIFactory()
+	codec := testapi.Federation.Codec()
+	tf.ClientConfig = defaultClientConfig()
+	ns := testapi.Federation.NegotiatedSerializer()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		GroupName:            "federation",
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case strings.HasPrefix(p, urlPrefix):
+				got := strings.TrimPrefix(p, urlPrefix)
+				if got != name {
+					return nil, errors.NewNotFound(federationapi.Resource("clusters"), got)
+				}
+
+				switch m {
+				case http.MethodGet:
+					return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &cluster)}, nil
+				case http.MethodDelete:
+					status := unversioned.Status{
+						Status: "Success",
+					}
+					return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &status)}, nil
+				default:
+					return nil, fmt.Errorf("unexpected method: %#v\n%#v", req.URL, req)
+				}
+			default:
+				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
+			}
+		}),
+	}
+	tf.Namespace = "test"
+	return f
+}
+
+func fakeUnjoinHostFactory(name string) cmdutil.Factory {
+	urlPrefix := "/api/v1/namespaces/federation-system/secrets/"
+	f, tf, codec, _ := cmdtesting.NewAPIFactory()
+	ns := dynamic.ContentConfig().NegotiatedSerializer
+	tf.ClientConfig = defaultClientConfig()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case strings.HasPrefix(p, urlPrefix) && m == http.MethodDelete:
+				got := strings.TrimPrefix(p, urlPrefix)
+				if got != name {
+					return nil, errors.NewNotFound(api.Resource("secrets"), got)
+				}
+				status := unversioned.Status{
+					Status: "Success",
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &status)}, nil
+			default:
+				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
+			}
+		}),
+	}
+	return f
+}

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// KubeconfigSecretDataKey is the key name used in the secret to
+	// stores a cluster's credentials.
+	KubeconfigSecretDataKey = "kubeconfig"
+)
+
+// AdminConfig provides a filesystem based kubeconfig (via
+// `PathOptions()`) and a mechanism to talk to the federation
+// host cluster.
+type AdminConfig interface {
+	// PathOptions provides filesystem based kubeconfig access.
+	PathOptions() *clientcmd.PathOptions
+	// HostFactory provides a mechanism to communicate with the
+	// cluster where federation control plane is hosted.
+	HostFactory(host, kubeconfigPath string) cmdutil.Factory
+}
+
+// adminConfig implements the AdminConfig interface.
+type adminConfig struct {
+	pathOptions *clientcmd.PathOptions
+}
+
+// NewAdminConfig creates an admin config for `kubefed` commands.
+func NewAdminConfig(pathOptions *clientcmd.PathOptions) AdminConfig {
+	return &adminConfig{
+		pathOptions: pathOptions,
+	}
+}
+
+func (a *adminConfig) PathOptions() *clientcmd.PathOptions {
+	return a.pathOptions
+}
+
+func (a *adminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+	loadingRules := *a.pathOptions.LoadingRules
+	loadingRules.Precedence = a.pathOptions.GetLoadingPrecedence()
+	loadingRules.ExplicitPath = kubeconfigPath
+	overrides := &clientcmd.ConfigOverrides{
+		CurrentContext: host,
+	}
+
+	hostClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
+
+	return cmdutil.NewFactory(hostClientConfig)
+}
+
+// SubcommandFlags holds the flags required by the subcommands of
+// `kubefed`.
+type SubcommandFlags struct {
+	Name                string
+	Host                string
+	HostSystemNamespace string
+	Kubeconfig          string
+}
+
+// AddSubcommandFlags adds the definition for `kubefed` subcommand
+// flags.
+func AddSubcommandFlags(cmd *cobra.Command) {
+	cmd.Flags().String("kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+	cmd.Flags().String("host", "", "Host cluster context")
+	cmd.Flags().String("host-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
+}
+
+// GetSubcommandFlags retrieves the command line flag values for the
+// `kubefed` subcommands.
+func GetSubcommandFlags(cmd *cobra.Command, args []string) (*SubcommandFlags, error) {
+	name, err := kubectlcmd.NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return nil, err
+	}
+	return &SubcommandFlags{
+		Name:                name,
+		Host:                cmdutil.GetFlagString(cmd, "host"),
+		HostSystemNamespace: cmdutil.GetFlagString(cmd, "host-system-namespace"),
+		Kubeconfig:          cmdutil.GetFlagString(cmd, "kubeconfig"),
+	}, nil
+}
+
+func CreateKubeconfigSecret(clientset *client.Clientset, kubeconfig *clientcmdapi.Config, namespace, name string, dryRun bool) (*api.Secret, error) {
+	configBytes, err := clientcmd.Write(*kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the secret object with the minified and flattened
+	// kubeconfig content.
+	secret := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			KubeconfigSecretDataKey: configBytes,
+		},
+	}
+
+	if !dryRun {
+		return clientset.Core().Secrets(namespace).Create(secret)
+	}
+	return secret, nil
+}

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -31,6 +31,10 @@ const (
 	// KubeconfigSecretDataKey is the key name used in the secret to
 	// stores a cluster's credentials.
 	KubeconfigSecretDataKey = "kubeconfig"
+
+	// DefaultFederationSystemNamespace is the namespace in which
+	// federation system components are hosted.
+	DefaultFederationSystemNamespace = "federation-system"
 )
 
 // AdminConfig provides a filesystem based kubeconfig (via
@@ -87,7 +91,7 @@ type SubcommandFlags struct {
 func AddSubcommandFlags(cmd *cobra.Command) {
 	cmd.Flags().String("kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 	cmd.Flags().String("host-cluster-context", "", "Host cluster context")
-	cmd.Flags().String("federation-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
+	cmd.Flags().String("federation-system-namespace", DefaultFederationSystemNamespace, "Namespace in the host cluster where the federation system components are installed")
 }
 
 // GetSubcommandFlags retrieves the command line flag values for the

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -76,18 +76,18 @@ func (a *adminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
 // SubcommandFlags holds the flags required by the subcommands of
 // `kubefed`.
 type SubcommandFlags struct {
-	Name                string
-	Host                string
-	HostSystemNamespace string
-	Kubeconfig          string
+	Name                      string
+	Host                      string
+	FederationSystemNamespace string
+	Kubeconfig                string
 }
 
 // AddSubcommandFlags adds the definition for `kubefed` subcommand
 // flags.
 func AddSubcommandFlags(cmd *cobra.Command) {
 	cmd.Flags().String("kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
-	cmd.Flags().String("host", "", "Host cluster context")
-	cmd.Flags().String("host-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
+	cmd.Flags().String("host-cluster-context", "", "Host cluster context")
+	cmd.Flags().String("federation-system-namespace", "federation-system", "Namespace in the host cluster where the federation system components are installed")
 }
 
 // GetSubcommandFlags retrieves the command line flag values for the
@@ -98,10 +98,10 @@ func GetSubcommandFlags(cmd *cobra.Command, args []string) (*SubcommandFlags, er
 		return nil, err
 	}
 	return &SubcommandFlags{
-		Name:                name,
-		Host:                cmdutil.GetFlagString(cmd, "host"),
-		HostSystemNamespace: cmdutil.GetFlagString(cmd, "host-system-namespace"),
-		Kubeconfig:          cmdutil.GetFlagString(cmd, "kubeconfig"),
+		Name: name,
+		Host: cmdutil.GetFlagString(cmd, "host-cluster-context"),
+		FederationSystemNamespace: cmdutil.GetFlagString(cmd, "federation-system-namespace"),
+		Kubeconfig:                cmdutil.GetFlagString(cmd, "kubeconfig"),
 	}, nil
 }
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -95,6 +95,7 @@ fi
 # The set of client targets that we are building for all platforms
 readonly KUBE_CLIENT_TARGETS=(
   cmd/kubectl
+  federation/cmd/kubefed
 )
 readonly KUBE_CLIENT_BINARIES=("${KUBE_CLIENT_TARGETS[@]##*/}")
 readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -239,6 +239,7 @@ host-ipc-sources
 host-network-sources
 host-pid-sources
 host-port-endpoints
+host-system-namespace
 hostname-override
 http-check-frequency
 http-port

--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -45,6 +45,7 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 type RESTClient struct {
 	Client               *http.Client
 	NegotiatedSerializer runtime.NegotiatedSerializer
+	GroupName            string
 
 	Req  *http.Request
 	Resp *http.Response
@@ -80,8 +81,14 @@ func (c *RESTClient) request(verb string) *restclient.Request {
 	ns := c.NegotiatedSerializer
 	serializer, _ := ns.SerializerForMediaType(runtime.ContentTypeJSON, nil)
 	streamingSerializer, _ := ns.StreamingSerializerForMediaType(runtime.ContentTypeJSON, nil)
+
+	groupName := api.GroupName
+	if c.GroupName != "" {
+		groupName = c.GroupName
+	}
+
 	internalVersion := unversioned.GroupVersion{
-		Group:   registered.GroupOrDie(api.GroupName).GroupVersion.Group,
+		Group:   registered.GroupOrDie(groupName).GroupVersion.Group,
 		Version: runtime.APIVersionInternal,
 	}
 	internalVersion.Version = runtime.APIVersionInternal

--- a/pkg/kubectl/cluster.go
+++ b/pkg/kubectl/cluster.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+
+	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// ClusterGeneratorV1Beta1 supports stable generation of a
+// federation/cluster resource.
+type ClusterGeneratorV1Beta1 struct {
+	// Name of the cluster context (required)
+	Name string
+	// ServerAddress is the APIServer address of the Kubernetes cluster
+	// that is being registered (optional)
+	ServerAddress string
+	// SecretName is the name of the secret that stores the credentials
+	// for the Kubernetes cluster that is being registered (optional)
+	SecretName string
+}
+
+// Ensure it supports the generator pattern that uses parameter
+// injection.
+var _ Generator = &ClusterGeneratorV1Beta1{}
+
+// Ensure it supports the generator pattern that uses parameters
+// specified during construction.
+var _ StructuredGenerator = &ClusterGeneratorV1Beta1{}
+
+// Generate returns a cluster resource using the specified parameters.
+func (s ClusterGeneratorV1Beta1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	clustergen := &ClusterGeneratorV1Beta1{}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	clustergen.Name = params["name"]
+	clustergen.ServerAddress = params["serverAddress"]
+	clustergen.SecretName = params["secret"]
+	return clustergen.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using
+// the parameter injection generator pattern.
+func (s ClusterGeneratorV1Beta1) ParamNames() []GeneratorParam {
+	return []GeneratorParam{
+		{"name", true},
+		{"serverAddress", false},
+		{"secret", false},
+	}
+}
+
+// StructuredGenerate outputs a federation cluster resource object
+// using the configured fields.
+func (s ClusterGeneratorV1Beta1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	cluster := &federationapi.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: s.Name,
+		},
+		Spec: federationapi.ClusterSpec{
+			ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+				{
+					ServerAddress: s.ServerAddress,
+				},
+			},
+			SecretRef: &v1.LocalObjectReference{
+				Name: s.SecretName,
+			},
+		},
+	}
+	return cluster, nil
+}
+
+// validate validates required fields are set to support structured
+// generation.
+func (s ClusterGeneratorV1Beta1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}

--- a/pkg/kubectl/cluster_test.go
+++ b/pkg/kubectl/cluster_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"reflect"
+	"testing"
+
+	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func TestClusterGenerate(t *testing.T) {
+	tests := []struct {
+		params    map[string]interface{}
+		expected  *federationapi.Cluster
+		expectErr bool
+	}{
+		{
+			params: map[string]interface{}{
+				"name": "foo",
+			},
+			expected: &federationapi.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: federationapi.ClusterSpec{
+					ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+						{
+							ServerAddress: "",
+						},
+					},
+					SecretRef: &v1.LocalObjectReference{
+						Name: "",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			params: map[string]interface{}{
+				"name":          "foo",
+				"serverAddress": "10.20.30.40",
+			},
+			expected: &federationapi.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: federationapi.ClusterSpec{
+					ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+						{
+							ServerAddress: "10.20.30.40",
+						},
+					},
+					SecretRef: &v1.LocalObjectReference{
+						Name: "",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			params: map[string]interface{}{
+				"name":   "foo",
+				"secret": "foo-credentials",
+			},
+			expected: &federationapi.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: federationapi.ClusterSpec{
+					ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+						{
+							ServerAddress: "",
+						},
+					},
+					SecretRef: &v1.LocalObjectReference{
+						Name: "foo-credentials",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			params: map[string]interface{}{
+				"name":          "foo",
+				"serverAddress": "https://foo.example.com",
+				"secret":        "foo-credentials",
+			},
+			expected: &federationapi.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: federationapi.ClusterSpec{
+					ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+						{
+							ServerAddress: "https://foo.example.com",
+						},
+					},
+					SecretRef: &v1.LocalObjectReference{
+						Name: "foo-credentials",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			params: map[string]interface{}{
+				"name":          "bar-cluster",
+				"serverAddress": "http://10.20.30.40",
+				"secret":        "credentials",
+			},
+			expected: &federationapi.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "bar-cluster",
+				},
+				Spec: federationapi.ClusterSpec{
+					ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+						{
+							ServerAddress: "http://10.20.30.40",
+						},
+					},
+					SecretRef: &v1.LocalObjectReference{
+						Name: "credentials",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			params: map[string]interface{}{
+				"serverAddress": "https://10.20.30.40",
+			},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			params: map[string]interface{}{
+				"secret": "baz-credentials",
+			},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			params: map[string]interface{}{
+				"serverAddress": "http://foo.example.com",
+				"secret":        "foo-credentials",
+			},
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+	generator := ClusterGeneratorV1Beta1{}
+	for i, test := range tests {
+		obj, err := generator.Generate(test.params)
+		if !test.expectErr && err != nil {
+			t.Errorf("[%d] unexpected error: %v", i, err)
+		}
+		if test.expectErr && err != nil {
+			continue
+		}
+		if !reflect.DeepEqual(obj.(*federationapi.Cluster), test.expected) {
+			t.Errorf("\n[%d] want:\n%#v\n[%d] got:\n%#v", i, test.expected, i, obj.(*federationapi.Cluster))
+		}
+	}
+}

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -405,14 +405,22 @@ func (f *fakeAPIFactory) JSONEncoder() runtime.Encoder {
 }
 
 func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
-	// Swap out the HTTP client out of the client with the fake's version.
+	// Swap the HTTP client out of the REST client with the fake
+	// version.
 	fakeClient := f.tf.Client.(*fake.RESTClient)
-	restClient, err := restclient.RESTClientFor(f.tf.ClientConfig)
-	if err != nil {
-		panic(err)
-	}
-	restClient.Client = fakeClient.Client
-	return internalclientset.New(restClient), f.tf.Err
+	clientset := internalclientset.NewForConfigOrDie(f.tf.ClientConfig)
+	clientset.CoreClient.RESTClient.Client = fakeClient.Client
+	clientset.AuthenticationClient.RESTClient.Client = fakeClient.Client
+	clientset.AuthorizationClient.RESTClient.Client = fakeClient.Client
+	clientset.AutoscalingClient.RESTClient.Client = fakeClient.Client
+	clientset.BatchClient.RESTClient.Client = fakeClient.Client
+	clientset.CertificatesClient.RESTClient.Client = fakeClient.Client
+	clientset.ExtensionsClient.RESTClient.Client = fakeClient.Client
+	clientset.RbacClient.RESTClient.Client = fakeClient.Client
+	clientset.StorageClient.RESTClient.Client = fakeClient.Client
+	clientset.AppsClient.RESTClient.Client = fakeClient.Client
+	clientset.PolicyClient.RESTClient.Client = fakeClient.Client
+	return clientset, f.tf.Err
 }
 
 func (f *fakeAPIFactory) RESTClient() (*restclient.RESTClient, error) {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -202,6 +202,7 @@ const (
 	SecretForDockerRegistryV1GeneratorName      = "secret-for-docker-registry/v1"
 	SecretForTLSV1GeneratorName                 = "secret-for-tls/v1"
 	ConfigMapV1GeneratorName                    = "configmap/v1"
+	ClusterV1Beta1GeneratorName                 = "cluster/v1beta1"
 )
 
 // DefaultGenerators returns the set of default generators for use in Factory instances

--- a/pkg/util/cert/triple/triple.go
+++ b/pkg/util/cert/triple/triple.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package triple
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"net"
+
+	certutil "k8s.io/kubernetes/pkg/util/cert"
+)
+
+type KeyPair struct {
+	Key  *rsa.PrivateKey
+	Cert *x509.Certificate
+}
+
+func NewCA(name string) (*KeyPair, error) {
+	key, err := certutil.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a private key for a new CA: %v", err)
+	}
+
+	config := certutil.Config{
+		CommonName: name,
+	}
+
+	cert, err := certutil.NewSelfSignedCACert(config, key)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a self-signed certificate for a new CA: %v", err)
+	}
+
+	return &KeyPair{
+		Key:  key,
+		Cert: cert,
+	}, nil
+}
+
+func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace, dnsDomain string, ips, hostnames []string) (*KeyPair, error) {
+	key, err := certutil.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a server private key: %v", err)
+	}
+
+	namespacedName := fmt.Sprintf("%s.%s", svcName, svcNamespace)
+	internalAPIServerFQDN := []string{
+		svcName,
+		namespacedName,
+		fmt.Sprintf("%s.svc", namespacedName),
+		fmt.Sprintf("%s.svc.%s", namespacedName, dnsDomain),
+	}
+
+	altNames := certutil.AltNames{}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip != nil {
+			altNames.IPs = append(altNames.IPs, ip)
+		}
+	}
+	altNames.DNSNames = append(altNames.DNSNames, hostnames...)
+	altNames.DNSNames = append(altNames.DNSNames, internalAPIServerFQDN...)
+
+	config := certutil.Config{
+		CommonName: commonName,
+		AltNames:   altNames,
+	}
+	cert, err := certutil.NewSignedCert(config, key, ca.Cert, ca.Key)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign the server certificate: %v", err)
+	}
+
+	return &KeyPair{
+		Key:  key,
+		Cert: cert,
+	}, nil
+}
+
+func NewClientKeyPair(ca *KeyPair, commonName string) (*KeyPair, error) {
+	key, err := certutil.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a client private key: %v", err)
+	}
+
+	config := certutil.Config{
+		CommonName: commonName,
+	}
+	cert, err := certutil.NewSignedCert(config, key, ca.Cert, ca.Key)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign the client certificate: %v", err)
+	}
+
+	return &KeyPair{
+		Key:  key,
+		Cert: cert,
+	}, nil
+}


### PR DESCRIPTION
Please review only the last commit here. This is based on PR #35867 which will be reviewed independently.

Design Doc: PR #34484

cc @kubernetes/sig-cluster-federation @nikhiljindal 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35958)
<!-- Reviewable:end -->
