### PR TITLE
kubeadm preflight checks: Warn user if connections to API or Discovery are going to be over proxy

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -168,16 +168,6 @@ func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight 
 		}
 	}
 
-	if !skipPreFlight {
-		fmt.Println("Running pre-flight checks")
-		err := preflight.RunInitMasterChecks(cfg)
-		if err != nil {
-			return nil, &preflight.PreFlightError{Msg: err.Error()}
-		}
-	} else {
-		fmt.Println("Skipping pre-flight checks")
-	}
-
 	// Auto-detect the IP
 	if len(cfg.API.AdvertiseAddresses) == 0 {
 		// TODO(phase1+) perhaps we could actually grab eth0 and eth1
@@ -186,6 +176,16 @@ func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight 
 			return nil, err
 		}
 		cfg.API.AdvertiseAddresses = []string{ip.String()}
+	}
+
+	if !skipPreFlight {
+		fmt.Println("Running pre-flight checks")
+		err := preflight.RunInitMasterChecks(cfg)
+		if err != nil {
+			return nil, &preflight.PreFlightError{Msg: err.Error()}
+		}
+	} else {
+		fmt.Println("Skipping pre-flight checks")
 	}
 
 	// TODO(phase1+) create a custom flag

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -98,21 +98,21 @@ func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, s
 		}
 	}
 
+	// TODO(phase1+) this we are missing args from the help text, there should be a way to tell cobra about it
+	if len(args) == 0 && len(cfg.MasterAddresses) == 0 {
+		return nil, fmt.Errorf("must specify master IP address (see --help)")
+	}
+	cfg.MasterAddresses = append(cfg.MasterAddresses, args...)
+
 	if !skipPreFlight {
 		fmt.Println("Running pre-flight checks")
-		err := preflight.RunJoinNodeChecks()
+		err := preflight.RunJoinNodeChecks(cfg)
 		if err != nil {
 			return nil, &preflight.PreFlightError{Msg: err.Error()}
 		}
 	} else {
 		fmt.Println("Skipping pre-flight checks")
 	}
-
-	// TODO(phase1+) this we are missing args from the help text, there should be a way to tell cobra about it
-	if len(args) == 0 && len(cfg.MasterAddresses) == 0 {
-		return nil, fmt.Errorf("must specify master IP address (see --help)")
-	}
-	cfg.MasterAddresses = append(cfg.MasterAddresses, args...)
 
 	ok, err := kubeadmutil.UseGivenTokenIfValid(&cfg.Secrets)
 	if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**: Continuing discussion from PR #35044, new version will provide warning if kubeadm run in environment where http connections would go over proxy.
Most of the time, it is not expected behaviour and leads to situations like in #34695

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #34695

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

kubeadm during initialization of master and slave nodes need to make
several API calls directly to the node where it is running or master.
In environments with http/https proxies, user might accidentally
have configuration where connections to API would go over proxy instead
of directly.

User can re-run kubeadm with corrected NO_PROXY variable. Example:

  $ NO_PROXY=* kubeadm join ...

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35972)
<!-- Reviewable:end -->
