### PR TITLE
Add constants for node role labels

### DIFF
--- a/cmd/kubeadm/app/master/apiclient.go
+++ b/cmd/kubeadm/app/master/apiclient.go
@@ -170,7 +170,7 @@ func attemptToUpdateMasterRoleLabelsAndTaints(client *clientset.Clientset, sched
 		return err
 	}
 
-	n.ObjectMeta.Labels["kubeadm.alpha.kubernetes.io/role"] = "master"
+	n.ObjectMeta.Labels[unversionedapi.NodeLabelKubeadmAlphaRole] = unversionedapi.NodeLabelRoleMaster
 
 	if !schedulable {
 		taintsAnnotation, _ := json.Marshal([]api.Taint{{Key: "dedicated", Value: "master", Effect: "NoSchedule"}})
@@ -224,7 +224,9 @@ func SetNodeAffinity(meta *api.ObjectMeta, expr ...api.NodeSelectorRequirement) 
 // MasterNodeAffinity returns api.NodeSelectorRequirement to be used with SetNodeAffinity to set affinity to master node
 func MasterNodeAffinity() api.NodeSelectorRequirement {
 	return api.NodeSelectorRequirement{
-		Key: "kubeadm.alpha.kubernetes.io/role", Operator: api.NodeSelectorOpIn, Values: []string{"master"},
+		Key:      unversionedapi.NodeLabelKubeadmAlphaRole,
+		Operator: api.NodeSelectorOpIn,
+		Values:   []string{unversionedapi.NodeLabelRoleMaster},
 	}
 }
 

--- a/pkg/api/unversioned/well_known_labels.go
+++ b/pkg/api/unversioned/well_known_labels.go
@@ -28,3 +28,40 @@ const (
 	LabelOS   = "beta.kubernetes.io/os"
 	LabelArch = "beta.kubernetes.io/arch"
 )
+
+// Role labels are applied to Nodes to mark their purpose.  In particular, we
+// usually want to distinguish the master, so that we can isolate privileged
+// pods and operations.
+//
+// Originally we relied on not registering the master, on the fact that the
+// master was Unschedulable, and on static manifests for master components.
+// But we now do register masters in many environments, are generally moving
+// away from static manifests (for better manageability), and working towards
+// deprecating the unschedulable field (replacing it with taints & tolerations
+// instead).
+//
+// Even with tainting, a label remains the easiest way of making a positive
+// selection, so that pods can schedule only to master nodes for example, and
+// thus installations will likely define a label for their master nodes.
+//
+// So that we can recognize master nodes in consequent places though (such as
+// kubectl get nodes), we encourage installations to use the well-known labels.
+// We define NodeLabelRole, which is the preferred form, but we will also recognize
+// other forms that are known to be in widespread use (NodeLabelKubeadmAlphaRole).
+
+const (
+	// NodeLabelRole is the preferred label applied to a Node as a hint that it has a particular purpose (defined by the value).
+	NodeLabelRole = "kubernetes.io/role"
+
+	// NodeLabelKubeadmAlphaRole is a label that kubeadm applies to a Node as a hint that it has a particular purpose.
+	// Use of NodeLabelRole is preferred.
+	NodeLabelKubeadmAlphaRole = "kubeadm.alpha.kubernetes.io/role"
+
+	// NodeLabelRoleMaster is the value of a NodeLabelRole or NodeLabelKubeadmAlphaRole label, indicating a master node.
+	// A master node typically runs kubernetes system components and will not typically run user workloads.
+	NodeLabelRoleMaster = "master"
+
+	// NodeLabelRoleNode is the value of a NodeLabelRole or NodeLabelKubeadmAlphaRole label, indicating a "normal" node,
+	// as opposed to a RoleMaster node.
+	NodeLabelRoleNode = "node"
+)


### PR DESCRIPTION
Rather than sharing well-known strings, we should be declaring these in
the API.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35975)
<!-- Reviewable:end -->
