### PR TITLE
Allow PATCH in an API CORS setup

### DIFF
--- a/pkg/genericapiserver/filters/cors.go
+++ b/pkg/genericapiserver/filters/cors.go
@@ -53,7 +53,7 @@ func WithCORS(handler http.Handler, allowedOriginPatterns []string, allowedMetho
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				// Set defaults for methods and headers if nothing was passed
 				if allowedMethods == nil {
-					allowedMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE"}
+					allowedMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE", "PATCH"}
 				}
 				if allowedHeaders == nil {
 					allowedHeaders = []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "X-Requested-With", "If-Modified-Since"}


### PR DESCRIPTION
Allows the PATCH method to be used in a REST API CORS setup.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35978)
<!-- Reviewable:end -->
