### PR TITLE
Disruption e2e: wait for running pods in the table test, too

### DIFF
--- a/test/e2e/disruption.go
+++ b/test/e2e/disruption.go
@@ -163,6 +163,11 @@ var _ = framework.KubeDescribe("DisruptionController", func() {
 				err = cs.Pods(ns).Evict(e)
 				Expect(err).Should(MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
 			} else {
+				// Only wait for running pods in the "allow" case
+				// because one of shouldDeny cases relies on the
+				// replicaSet not fitting on the cluster.
+				waitForPodsOrDie(cs, ns, c.podCount+int(c.replicaSetSize))
+
 				// Since disruptionAllowed starts out false, if an eviction is ever allowed,
 				// that means the controller is working.
 				err = wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**: Makes the `DisruptionController` tests less flaky.
**Which issue this PR fixes**: fixes #34032

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/35984)
<!-- Reviewable:end -->
