### PR TITLE
Avoid double decoding all client responses

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/register.go
+++ b/cmd/kubeadm/app/apis/kubeadm/register.go
@@ -50,6 +50,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterInfo{},
 		&api.ListOptions{},
 		&api.DeleteOptions{},
+		&api.ExportOptions{},
 	)
 	return nil
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
@@ -50,6 +50,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterInfo{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	return nil
 }

--- a/federation/apis/federation/v1beta1/register.go
+++ b/federation/apis/federation/v1beta1/register.go
@@ -40,6 +40,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterList{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/api/testapi/BUILD
+++ b/pkg/api/testapi/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/authentication/install:go_default_library",
+        "//pkg/apis/authorization:go_default_library",
         "//pkg/apis/authorization/install:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/autoscaling/install:go_default_library",

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/apps"
+	"k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/certificates"
@@ -66,18 +67,19 @@ import (
 )
 
 var (
-	Groups       = make(map[string]TestGroup)
-	Default      TestGroup
-	Autoscaling  TestGroup
-	Batch        TestGroup
-	Extensions   TestGroup
-	Apps         TestGroup
-	Policy       TestGroup
-	Federation   TestGroup
-	Rbac         TestGroup
-	Certificates TestGroup
-	Storage      TestGroup
-	ImagePolicy  TestGroup
+	Groups        = make(map[string]TestGroup)
+	Default       TestGroup
+	Authorization TestGroup
+	Autoscaling   TestGroup
+	Batch         TestGroup
+	Extensions    TestGroup
+	Apps          TestGroup
+	Policy        TestGroup
+	Federation    TestGroup
+	Rbac          TestGroup
+	Certificates  TestGroup
+	Storage       TestGroup
+	ImagePolicy   TestGroup
 
 	serializer        runtime.SerializerInfo
 	storageSerializer runtime.SerializerInfo
@@ -258,6 +260,15 @@ func init() {
 			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
 		}
 	}
+	if _, ok := Groups[authorization.GroupName]; !ok {
+		externalGroupVersion := unversioned.GroupVersion{Group: authorization.GroupName, Version: registered.GroupOrDie(authorization.GroupName).GroupVersion.Version}
+		Groups[authorization.GroupName] = TestGroup{
+			externalGroupVersion: externalGroupVersion,
+			internalGroupVersion: authorization.SchemeGroupVersion,
+			internalTypes:        api.Scheme.KnownTypes(authorization.SchemeGroupVersion),
+			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
+		}
+	}
 	if _, ok := Groups[kubeadm.GroupName]; !ok {
 		externalGroupVersion := unversioned.GroupVersion{Group: kubeadm.GroupName, Version: registered.GroupOrDie(kubeadm.GroupName).GroupVersion.Version}
 		Groups[kubeadm.GroupName] = TestGroup{
@@ -279,6 +290,7 @@ func init() {
 	Rbac = Groups[rbac.GroupName]
 	Storage = Groups[storage.GroupName]
 	ImagePolicy = Groups[imagepolicy.GroupName]
+	Authorization = Groups[authorization.GroupName]
 }
 
 func (g TestGroup) ContentConfig() (string, *unversioned.GroupVersion, runtime.Codec) {

--- a/pkg/apis/apps/v1alpha1/register.go
+++ b/pkg/apis/apps/v1alpha1/register.go
@@ -41,6 +41,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&StatefulSetList{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/apis/authorization/v1beta1/register.go
+++ b/pkg/apis/authorization/v1beta1/register.go
@@ -39,6 +39,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 
 		&SelfSubjectAccessReview{},
 		&SubjectAccessReview{},

--- a/pkg/apis/autoscaling/v1/register.go
+++ b/pkg/apis/autoscaling/v1/register.go
@@ -42,6 +42,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Scale{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/apis/batch/v1/register.go
+++ b/pkg/apis/batch/v1/register.go
@@ -41,6 +41,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&JobList{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/apis/certificates/v1alpha1/register.go
+++ b/pkg/apis/certificates/v1alpha1/register.go
@@ -51,6 +51,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&CertificateSigningRequestList{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 
 	// Add the watch version that applies

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -56,6 +56,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&IngressList{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 		&ReplicaSet{},
 		&ReplicaSetList{},
 		&PodSecurityPolicy{},

--- a/pkg/apis/policy/v1alpha1/register.go
+++ b/pkg/apis/policy/v1alpha1/register.go
@@ -42,6 +42,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Eviction{},
 		&v1.ListOptions{},
 		&v1.DeleteOptions{},
+		&v1.ExportOptions{},
 	)
 	// Add the watch version that applies
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/client/restclient/client_test.go
+++ b/pkg/client/restclient/client_test.go
@@ -83,9 +83,48 @@ func TestDoRequestFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	err = c.Get().Do().Error()
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	ss, ok := err.(errors.APIStatus)
+	if !ok {
+		t.Errorf("unexpected error type %v", err)
+	}
+	actual := ss.Status()
+	if !reflect.DeepEqual(status, &actual) {
+		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, &actual))
+	}
+}
+
+func TestDoRawRequestFailed(t *testing.T) {
+	status := &unversioned.Status{
+		Code:    http.StatusNotFound,
+		Status:  unversioned.StatusFailure,
+		Reason:  unversioned.StatusReasonNotFound,
+		Message: "the server could not find the requested resource",
+		Details: &unversioned.StatusDetails{
+			Causes: []unversioned.StatusCause{
+				{Type: unversioned.CauseTypeUnexpectedServerResponse, Message: "unknown"},
+			},
+		},
+	}
+	expectedBody, _ := runtime.Encode(testapi.Default.Codec(), status)
+	fakeHandler := utiltesting.FakeHandler{
+		StatusCode:   404,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+
+	c, err := restClient(testServer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	body, err := c.Get().Do().Raw()
 
-	if err == nil || body != nil {
+	if err == nil || body == nil {
 		t.Errorf("unexpected non-error: %#v", body)
 	}
 	ss, ok := err.(errors.APIStatus)
@@ -93,12 +132,8 @@ func TestDoRequestFailed(t *testing.T) {
 		t.Errorf("unexpected error type %v", err)
 	}
 	actual := ss.Status()
-	expected := *status
-	// The decoder will apply the default Version and Kind to the Status.
-	expected.APIVersion = "v1"
-	expected.Kind = "Status"
-	if !reflect.DeepEqual(&expected, &actual) {
-		t.Errorf("Unexpected mis-match: %s", diff.ObjectDiff(status, &actual))
+	if !reflect.DeepEqual(status, &actual) {
+		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, &actual))
 	}
 }
 

--- a/pkg/client/restclient/request_test.go
+++ b/pkg/client/restclient/request_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
 	"k8s.io/kubernetes/pkg/util/clock"
+	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -582,7 +583,8 @@ func TestTransformUnstructuredError(t *testing.T) {
 		Resource string
 		Name     string
 
-		ErrFn func(error) bool
+		ErrFn       func(error) bool
+		Transformed error
 	}{
 		{
 			Resource: "foo",
@@ -626,9 +628,46 @@ func TestTransformUnstructuredError(t *testing.T) {
 			},
 			ErrFn: apierrors.IsBadRequest,
 		},
+		{
+			// status in response overrides transformed result
+			Req:   &http.Request{},
+			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","code":404}`)))},
+			ErrFn: apierrors.IsBadRequest,
+			Transformed: &apierrors.StatusError{
+				ErrStatus: unversioned.Status{Status: unversioned.StatusFailure, Code: http.StatusNotFound},
+			},
+		},
+		{
+			// successful status is ignored
+			Req:   &http.Request{},
+			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","apiVersion":"v1","status":"Success","code":404}`)))},
+			ErrFn: apierrors.IsBadRequest,
+		},
+		{
+			// empty object does not change result
+			Req:   &http.Request{},
+			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: ioutil.NopCloser(bytes.NewReader([]byte(`{}`)))},
+			ErrFn: apierrors.IsBadRequest,
+		},
+		{
+			// we default apiVersion for backwards compatibility with old clients
+			// TODO: potentially remove in 1.7
+			Req:   &http.Request{},
+			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","status":"Failure","code":404}`)))},
+			ErrFn: apierrors.IsBadRequest,
+			Transformed: &apierrors.StatusError{
+				ErrStatus: unversioned.Status{Status: unversioned.StatusFailure, Code: http.StatusNotFound},
+			},
+		},
+		{
+			// we do not default kind
+			Req:   &http.Request{},
+			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"status":"Failure","code":404}`)))},
+			ErrFn: apierrors.IsBadRequest,
+		},
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		r := &Request{
 			content:      defaultContentConfig(),
 			serializers:  defaultSerializers(),
@@ -641,11 +680,39 @@ func TestTransformUnstructuredError(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			continue
 		}
+		if !apierrors.IsUnexpectedServerError(err) {
+			t.Errorf("%d: unexpected error type: %v", i, err)
+		}
 		if len(testCase.Name) != 0 && !strings.Contains(err.Error(), testCase.Name) {
 			t.Errorf("unexpected error string: %s", err)
 		}
 		if len(testCase.Resource) != 0 && !strings.Contains(err.Error(), testCase.Resource) {
 			t.Errorf("unexpected error string: %s", err)
+		}
+
+		// verify Error() properly transforms the error
+		transformed := result.Error()
+		expect := testCase.Transformed
+		if expect == nil {
+			expect = err
+		}
+		if !reflect.DeepEqual(expect, transformed) {
+			t.Errorf("%d: unexpected Error(): %s", i, diff.ObjectReflectDiff(expect, transformed))
+		}
+
+		// verify result.Get properly transforms the error
+		if _, err := result.Get(); !reflect.DeepEqual(expect, err) {
+			t.Errorf("%d: unexpected error on Get(): %s", i, diff.ObjectReflectDiff(expect, err))
+		}
+
+		// verify result.Into properly handles the error
+		if err := result.Into(&api.Pod{}); !reflect.DeepEqual(expect, err) {
+			t.Errorf("%d: unexpected error on Into(): %s", i, diff.ObjectReflectDiff(expect, err))
+		}
+
+		// verify result.Raw leaves the error in the untransformed state
+		if _, err := result.Raw(); !reflect.DeepEqual(result.err, err) {
+			t.Errorf("%d: unexpected error on Raw(): %s", i, diff.ObjectReflectDiff(expect, err))
 		}
 	}
 }

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -625,6 +625,17 @@ func TestConvertToVersion(t *testing.T) {
 				A: "test",
 			},
 		},
+		// unversioned type returned when not included in the target types
+		{
+			scheme: GetTestScheme(),
+			in:     &UnversionedType{A: "test"},
+			gv:     unversioned.GroupVersions{{Group: "other", Version: "v2"}},
+			same:   true,
+			out: &UnversionedType{
+				MyWeirdCustomEmbeddedVersionKindField: MyWeirdCustomEmbeddedVersionKindField{APIVersion: "v1", ObjectKind: "UnversionedType"},
+				A: "test",
+			},
+		},
 		// detected as already being in the target version
 		{
 			scheme: GetTestScheme(),


### PR DESCRIPTION
Fixes #35982 

The linked issue uncovered that we were always double decoding the response in restclient for get, list, update, create, and patch.  That's fairly expensive, most especially for list.  This PR refines the behavior of the rest client to avoid double decoding, and does so while minimizing the changes to rest client consumers.

restclient must be able to deal with multiple types of servers. Alter the behavior of restclient.Result#Raw() to not process the body on error, but instead to return the generic error (which still matches the error checking cases in api/error like IsBadRequest). If the caller uses
.Error(), .Into(), or .Get(), try decoding the body as a Status.

For older servers, continue to default apiVersion "v1" when calling restclient.Result#Error(). This was only for 1.1 servers and the extensions group, which we have since fixed.

This removes a double decode of very large objects (like LIST) - we were trying to DecodeInto status, but that ends up decoding the entire result and then throwing it away.  This makes the decode behavior specific to the type of action the user wants.

```release-note
The error handling behavior of `pkg/client/restclient.Result` has changed.  Calls to `Result.Raw()` will no longer parse the body, although they will still return errors that react to `pkg/api/errors.Is*()` as in previous releases.  Callers of `Get()` and `Into()` will continue to receive errors that are parsed from the body if the kind and apiVersion of the body match the `Status` object.

This more closely aligns rest client as a generic RESTful client, while preserving the special Kube API extended error handling for the `Get` and `Into` methods (which most Kube clients use).
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36001)
<!-- Reviewable:end -->