### PR TITLE
Remove unnecessary prefixes from OperationIDs in OpenAPI spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -90,7 +90,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ComponentStatus",
+     "operationId": "listComponentStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -165,7 +165,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1ComponentStatus",
+     "operationId": "readComponentStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -215,7 +215,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ConfigMapForAllNamespaces",
+     "operationId": "listConfigMapForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -292,7 +292,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1EndpointsForAllNamespaces",
+     "operationId": "listEndpointsForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -369,7 +369,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1EventForAllNamespaces",
+     "operationId": "listEventForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -446,7 +446,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1LimitRangeForAllNamespaces",
+     "operationId": "listLimitRangeForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -523,7 +523,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1Namespace",
+     "operationId": "listNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -589,7 +589,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1Namespace",
+     "operationId": "createNamespace",
      "parameters": [
       {
        "name": "body",
@@ -628,7 +628,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespace",
+     "operationId": "deleteCollectionNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -705,7 +705,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedBinding",
+     "operationId": "createNamespacedBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -763,7 +763,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedConfigMap",
+     "operationId": "listNamespacedConfigMap",
      "parameters": [
       {
        "uniqueItems": true,
@@ -829,7 +829,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedConfigMap",
+     "operationId": "createNamespacedConfigMap",
      "parameters": [
       {
        "name": "body",
@@ -868,7 +868,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedConfigMap",
+     "operationId": "deleteCollectionNamespacedConfigMap",
      "parameters": [
       {
        "uniqueItems": true,
@@ -953,7 +953,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedConfigMap",
+     "operationId": "readNamespacedConfigMap",
      "parameters": [
       {
        "uniqueItems": true,
@@ -998,7 +998,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedConfigMap",
+     "operationId": "replaceNamespacedConfigMap",
      "parameters": [
       {
        "name": "body",
@@ -1037,7 +1037,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedConfigMap",
+     "operationId": "deleteNamespacedConfigMap",
      "parameters": [
       {
        "name": "body",
@@ -1078,7 +1078,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedConfigMap",
+     "operationId": "patchNamespacedConfigMap",
      "parameters": [
       {
        "name": "body",
@@ -1146,7 +1146,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedEndpoints",
+     "operationId": "listNamespacedEndpoints",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1212,7 +1212,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedEndpoints",
+     "operationId": "createNamespacedEndpoints",
      "parameters": [
       {
        "name": "body",
@@ -1251,7 +1251,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedEndpoints",
+     "operationId": "deleteCollectionNamespacedEndpoints",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1336,7 +1336,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedEndpoints",
+     "operationId": "readNamespacedEndpoints",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1381,7 +1381,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedEndpoints",
+     "operationId": "replaceNamespacedEndpoints",
      "parameters": [
       {
        "name": "body",
@@ -1420,7 +1420,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedEndpoints",
+     "operationId": "deleteNamespacedEndpoints",
      "parameters": [
       {
        "name": "body",
@@ -1461,7 +1461,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedEndpoints",
+     "operationId": "patchNamespacedEndpoints",
      "parameters": [
       {
        "name": "body",
@@ -1529,7 +1529,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedEvent",
+     "operationId": "listNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1595,7 +1595,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedEvent",
+     "operationId": "createNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -1634,7 +1634,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedEvent",
+     "operationId": "deleteCollectionNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1719,7 +1719,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedEvent",
+     "operationId": "readNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1764,7 +1764,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedEvent",
+     "operationId": "replaceNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -1803,7 +1803,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedEvent",
+     "operationId": "deleteNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -1844,7 +1844,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedEvent",
+     "operationId": "patchNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -1912,7 +1912,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedLimitRange",
+     "operationId": "listNamespacedLimitRange",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1978,7 +1978,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedLimitRange",
+     "operationId": "createNamespacedLimitRange",
      "parameters": [
       {
        "name": "body",
@@ -2017,7 +2017,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedLimitRange",
+     "operationId": "deleteCollectionNamespacedLimitRange",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2102,7 +2102,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedLimitRange",
+     "operationId": "readNamespacedLimitRange",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2147,7 +2147,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedLimitRange",
+     "operationId": "replaceNamespacedLimitRange",
      "parameters": [
       {
        "name": "body",
@@ -2186,7 +2186,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedLimitRange",
+     "operationId": "deleteNamespacedLimitRange",
      "parameters": [
       {
        "name": "body",
@@ -2227,7 +2227,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedLimitRange",
+     "operationId": "patchNamespacedLimitRange",
      "parameters": [
       {
        "name": "body",
@@ -2295,7 +2295,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "listNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2361,7 +2361,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "createNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "name": "body",
@@ -2400,7 +2400,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedPersistentVolumeClaim",
+     "operationId": "deleteCollectionNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2485,7 +2485,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "readNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2530,7 +2530,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "replaceNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "name": "body",
@@ -2569,7 +2569,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "deleteNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "name": "body",
@@ -2610,7 +2610,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "patchNamespacedPersistentVolumeClaim",
      "parameters": [
       {
        "name": "body",
@@ -2676,7 +2676,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPersistentVolumeClaimStatus",
+     "operationId": "readNamespacedPersistentVolumeClaimStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -2705,7 +2705,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedPersistentVolumeClaimStatus",
+     "operationId": "replaceNamespacedPersistentVolumeClaimStatus",
      "parameters": [
       {
        "name": "body",
@@ -2746,7 +2746,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedPersistentVolumeClaimStatus",
+     "operationId": "patchNamespacedPersistentVolumeClaimStatus",
      "parameters": [
       {
        "name": "body",
@@ -2814,7 +2814,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedPod",
+     "operationId": "listNamespacedPod",
      "parameters": [
       {
        "uniqueItems": true,
@@ -2880,7 +2880,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedPod",
+     "operationId": "createNamespacedPod",
      "parameters": [
       {
        "name": "body",
@@ -2919,7 +2919,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedPod",
+     "operationId": "deleteCollectionNamespacedPod",
      "parameters": [
       {
        "uniqueItems": true,
@@ -3004,7 +3004,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPod",
+     "operationId": "readNamespacedPod",
      "parameters": [
       {
        "uniqueItems": true,
@@ -3049,7 +3049,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedPod",
+     "operationId": "replaceNamespacedPod",
      "parameters": [
       {
        "name": "body",
@@ -3088,7 +3088,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedPod",
+     "operationId": "deleteNamespacedPod",
      "parameters": [
       {
        "name": "body",
@@ -3129,7 +3129,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedPod",
+     "operationId": "patchNamespacedPod",
      "parameters": [
       {
        "name": "body",
@@ -3193,7 +3193,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedPodAttach",
+     "operationId": "connectGetNamespacedPodAttach",
      "responses": {
       "200": {
        "description": "OK",
@@ -3220,7 +3220,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedPodAttach",
+     "operationId": "connectPostNamespacedPodAttach",
      "responses": {
       "200": {
        "description": "OK",
@@ -3304,7 +3304,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedBindingBinding",
+     "operationId": "createNamespacedBindingBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -3368,7 +3368,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedEvictionEviction",
+     "operationId": "createNamespacedEvictionEviction",
      "responses": {
       "200": {
        "description": "OK",
@@ -3430,7 +3430,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedPodExec",
+     "operationId": "connectGetNamespacedPodExec",
      "responses": {
       "200": {
        "description": "OK",
@@ -3457,7 +3457,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedPodExec",
+     "operationId": "connectPostNamespacedPodExec",
      "responses": {
       "200": {
        "description": "OK",
@@ -3549,7 +3549,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPodLog",
+     "operationId": "readNamespacedPodLog",
      "responses": {
       "200": {
        "description": "OK",
@@ -3659,7 +3659,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedPodPortforward",
+     "operationId": "connectGetNamespacedPodPortforward",
      "responses": {
       "200": {
        "description": "OK",
@@ -3686,7 +3686,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedPodPortforward",
+     "operationId": "connectPostNamespacedPodPortforward",
      "responses": {
       "200": {
        "description": "OK",
@@ -3733,7 +3733,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedPodProxy",
+     "operationId": "connectGetNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3760,7 +3760,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNamespacedPodProxy",
+     "operationId": "connectPutNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3787,7 +3787,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedPodProxy",
+     "operationId": "connectPostNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3814,7 +3814,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNamespacedPodProxy",
+     "operationId": "connectDeleteNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3841,7 +3841,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNamespacedPodProxy",
+     "operationId": "connectOptionsNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3868,7 +3868,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNamespacedPodProxy",
+     "operationId": "connectHeadNamespacedPodProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -3922,7 +3922,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedPodProxyWithPath",
+     "operationId": "connectGetNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -3949,7 +3949,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNamespacedPodProxyWithPath",
+     "operationId": "connectPutNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -3976,7 +3976,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedPodProxyWithPath",
+     "operationId": "connectPostNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -4003,7 +4003,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNamespacedPodProxyWithPath",
+     "operationId": "connectDeleteNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -4030,7 +4030,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNamespacedPodProxyWithPath",
+     "operationId": "connectOptionsNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -4057,7 +4057,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNamespacedPodProxyWithPath",
+     "operationId": "connectHeadNamespacedPodProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -4121,7 +4121,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPodStatus",
+     "operationId": "readNamespacedPodStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -4150,7 +4150,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedPodStatus",
+     "operationId": "replaceNamespacedPodStatus",
      "parameters": [
       {
        "name": "body",
@@ -4191,7 +4191,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedPodStatus",
+     "operationId": "patchNamespacedPodStatus",
      "parameters": [
       {
        "name": "body",
@@ -4259,7 +4259,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedPodTemplate",
+     "operationId": "listNamespacedPodTemplate",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4325,7 +4325,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedPodTemplate",
+     "operationId": "createNamespacedPodTemplate",
      "parameters": [
       {
        "name": "body",
@@ -4364,7 +4364,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedPodTemplate",
+     "operationId": "deleteCollectionNamespacedPodTemplate",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4449,7 +4449,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedPodTemplate",
+     "operationId": "readNamespacedPodTemplate",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4494,7 +4494,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedPodTemplate",
+     "operationId": "replaceNamespacedPodTemplate",
      "parameters": [
       {
        "name": "body",
@@ -4533,7 +4533,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedPodTemplate",
+     "operationId": "deleteNamespacedPodTemplate",
      "parameters": [
       {
        "name": "body",
@@ -4574,7 +4574,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedPodTemplate",
+     "operationId": "patchNamespacedPodTemplate",
      "parameters": [
       {
        "name": "body",
@@ -4642,7 +4642,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedReplicationController",
+     "operationId": "listNamespacedReplicationController",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4708,7 +4708,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedReplicationController",
+     "operationId": "createNamespacedReplicationController",
      "parameters": [
       {
        "name": "body",
@@ -4747,7 +4747,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedReplicationController",
+     "operationId": "deleteCollectionNamespacedReplicationController",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4832,7 +4832,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedReplicationController",
+     "operationId": "readNamespacedReplicationController",
      "parameters": [
       {
        "uniqueItems": true,
@@ -4877,7 +4877,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedReplicationController",
+     "operationId": "replaceNamespacedReplicationController",
      "parameters": [
       {
        "name": "body",
@@ -4916,7 +4916,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedReplicationController",
+     "operationId": "deleteNamespacedReplicationController",
      "parameters": [
       {
        "name": "body",
@@ -4957,7 +4957,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedReplicationController",
+     "operationId": "patchNamespacedReplicationController",
      "parameters": [
       {
        "name": "body",
@@ -5023,7 +5023,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedScaleScale",
+     "operationId": "readNamespacedScaleScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -5052,7 +5052,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedScaleScale",
+     "operationId": "replaceNamespacedScaleScale",
      "parameters": [
       {
        "name": "body",
@@ -5093,7 +5093,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedScaleScale",
+     "operationId": "patchNamespacedScaleScale",
      "parameters": [
       {
        "name": "body",
@@ -5159,7 +5159,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedReplicationControllerStatus",
+     "operationId": "readNamespacedReplicationControllerStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -5188,7 +5188,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedReplicationControllerStatus",
+     "operationId": "replaceNamespacedReplicationControllerStatus",
      "parameters": [
       {
        "name": "body",
@@ -5229,7 +5229,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedReplicationControllerStatus",
+     "operationId": "patchNamespacedReplicationControllerStatus",
      "parameters": [
       {
        "name": "body",
@@ -5297,7 +5297,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedResourceQuota",
+     "operationId": "listNamespacedResourceQuota",
      "parameters": [
       {
        "uniqueItems": true,
@@ -5363,7 +5363,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedResourceQuota",
+     "operationId": "createNamespacedResourceQuota",
      "parameters": [
       {
        "name": "body",
@@ -5402,7 +5402,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedResourceQuota",
+     "operationId": "deleteCollectionNamespacedResourceQuota",
      "parameters": [
       {
        "uniqueItems": true,
@@ -5487,7 +5487,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedResourceQuota",
+     "operationId": "readNamespacedResourceQuota",
      "parameters": [
       {
        "uniqueItems": true,
@@ -5532,7 +5532,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedResourceQuota",
+     "operationId": "replaceNamespacedResourceQuota",
      "parameters": [
       {
        "name": "body",
@@ -5571,7 +5571,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedResourceQuota",
+     "operationId": "deleteNamespacedResourceQuota",
      "parameters": [
       {
        "name": "body",
@@ -5612,7 +5612,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedResourceQuota",
+     "operationId": "patchNamespacedResourceQuota",
      "parameters": [
       {
        "name": "body",
@@ -5678,7 +5678,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedResourceQuotaStatus",
+     "operationId": "readNamespacedResourceQuotaStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -5707,7 +5707,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedResourceQuotaStatus",
+     "operationId": "replaceNamespacedResourceQuotaStatus",
      "parameters": [
       {
        "name": "body",
@@ -5748,7 +5748,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedResourceQuotaStatus",
+     "operationId": "patchNamespacedResourceQuotaStatus",
      "parameters": [
       {
        "name": "body",
@@ -5816,7 +5816,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedSecret",
+     "operationId": "listNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -5882,7 +5882,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedSecret",
+     "operationId": "createNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -5921,7 +5921,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedSecret",
+     "operationId": "deleteCollectionNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6006,7 +6006,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedSecret",
+     "operationId": "readNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6051,7 +6051,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedSecret",
+     "operationId": "replaceNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -6090,7 +6090,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedSecret",
+     "operationId": "deleteNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -6131,7 +6131,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedSecret",
+     "operationId": "patchNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -6199,7 +6199,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedServiceAccount",
+     "operationId": "listNamespacedServiceAccount",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6265,7 +6265,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedServiceAccount",
+     "operationId": "createNamespacedServiceAccount",
      "parameters": [
       {
        "name": "body",
@@ -6304,7 +6304,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedServiceAccount",
+     "operationId": "deleteCollectionNamespacedServiceAccount",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6389,7 +6389,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedServiceAccount",
+     "operationId": "readNamespacedServiceAccount",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6434,7 +6434,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedServiceAccount",
+     "operationId": "replaceNamespacedServiceAccount",
      "parameters": [
       {
        "name": "body",
@@ -6473,7 +6473,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedServiceAccount",
+     "operationId": "deleteNamespacedServiceAccount",
      "parameters": [
       {
        "name": "body",
@@ -6514,7 +6514,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedServiceAccount",
+     "operationId": "patchNamespacedServiceAccount",
      "parameters": [
       {
        "name": "body",
@@ -6582,7 +6582,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedService",
+     "operationId": "listNamespacedService",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6648,7 +6648,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedService",
+     "operationId": "createNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -6706,7 +6706,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedService",
+     "operationId": "readNamespacedService",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6751,7 +6751,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedService",
+     "operationId": "replaceNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -6790,7 +6790,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedService",
+     "operationId": "deleteNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -6821,7 +6821,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedService",
+     "operationId": "patchNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -6885,7 +6885,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedServiceProxy",
+     "operationId": "connectGetNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -6912,7 +6912,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNamespacedServiceProxy",
+     "operationId": "connectPutNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -6939,7 +6939,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedServiceProxy",
+     "operationId": "connectPostNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -6966,7 +6966,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNamespacedServiceProxy",
+     "operationId": "connectDeleteNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -6993,7 +6993,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNamespacedServiceProxy",
+     "operationId": "connectOptionsNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -7020,7 +7020,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNamespacedServiceProxy",
+     "operationId": "connectHeadNamespacedServiceProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -7074,7 +7074,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNamespacedServiceProxyWithPath",
+     "operationId": "connectGetNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7101,7 +7101,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNamespacedServiceProxyWithPath",
+     "operationId": "connectPutNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7128,7 +7128,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNamespacedServiceProxyWithPath",
+     "operationId": "connectPostNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7155,7 +7155,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNamespacedServiceProxyWithPath",
+     "operationId": "connectDeleteNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7182,7 +7182,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNamespacedServiceProxyWithPath",
+     "operationId": "connectOptionsNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7209,7 +7209,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNamespacedServiceProxyWithPath",
+     "operationId": "connectHeadNamespacedServiceProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -7273,7 +7273,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedServiceStatus",
+     "operationId": "readNamespacedServiceStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -7302,7 +7302,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedServiceStatus",
+     "operationId": "replaceNamespacedServiceStatus",
      "parameters": [
       {
        "name": "body",
@@ -7343,7 +7343,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedServiceStatus",
+     "operationId": "patchNamespacedServiceStatus",
      "parameters": [
       {
        "name": "body",
@@ -7409,7 +7409,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1Namespace",
+     "operationId": "readNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -7454,7 +7454,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1Namespace",
+     "operationId": "replaceNamespace",
      "parameters": [
       {
        "name": "body",
@@ -7493,7 +7493,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1Namespace",
+     "operationId": "deleteNamespace",
      "parameters": [
       {
        "name": "body",
@@ -7534,7 +7534,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1Namespace",
+     "operationId": "patchNamespace",
      "parameters": [
       {
        "name": "body",
@@ -7592,7 +7592,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespaceFinalize",
+     "operationId": "replaceNamespaceFinalize",
      "responses": {
       "200": {
        "description": "OK",
@@ -7648,7 +7648,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespaceStatus",
+     "operationId": "readNamespaceStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -7677,7 +7677,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespaceStatus",
+     "operationId": "replaceNamespaceStatus",
      "parameters": [
       {
        "name": "body",
@@ -7718,7 +7718,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespaceStatus",
+     "operationId": "patchNamespaceStatus",
      "parameters": [
       {
        "name": "body",
@@ -7778,7 +7778,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1Node",
+     "operationId": "listNode",
      "parameters": [
       {
        "uniqueItems": true,
@@ -7844,7 +7844,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1Node",
+     "operationId": "createNode",
      "parameters": [
       {
        "name": "body",
@@ -7883,7 +7883,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNode",
+     "operationId": "deleteCollectionNode",
      "parameters": [
       {
        "uniqueItems": true,
@@ -7960,7 +7960,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1Node",
+     "operationId": "readNode",
      "parameters": [
       {
        "uniqueItems": true,
@@ -8005,7 +8005,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1Node",
+     "operationId": "replaceNode",
      "parameters": [
       {
        "name": "body",
@@ -8044,7 +8044,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1Node",
+     "operationId": "deleteNode",
      "parameters": [
       {
        "name": "body",
@@ -8085,7 +8085,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1Node",
+     "operationId": "patchNode",
      "parameters": [
       {
        "name": "body",
@@ -8141,7 +8141,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNodeProxy",
+     "operationId": "connectGetNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8168,7 +8168,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNodeProxy",
+     "operationId": "connectPutNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8195,7 +8195,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNodeProxy",
+     "operationId": "connectPostNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8222,7 +8222,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNodeProxy",
+     "operationId": "connectDeleteNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8249,7 +8249,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNodeProxy",
+     "operationId": "connectOptionsNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8276,7 +8276,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNodeProxy",
+     "operationId": "connectHeadNodeProxy",
      "responses": {
       "200": {
        "description": "OK",
@@ -8322,7 +8322,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1GetNodeProxyWithPath",
+     "operationId": "connectGetNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8349,7 +8349,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PutNodeProxyWithPath",
+     "operationId": "connectPutNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8376,7 +8376,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1PostNodeProxyWithPath",
+     "operationId": "connectPostNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8403,7 +8403,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1DeleteNodeProxyWithPath",
+     "operationId": "connectDeleteNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8430,7 +8430,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1OptionsNodeProxyWithPath",
+     "operationId": "connectOptionsNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8457,7 +8457,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "connectCoreV1HeadNodeProxyWithPath",
+     "operationId": "connectHeadNodeProxyWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -8513,7 +8513,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NodeStatus",
+     "operationId": "readNodeStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -8542,7 +8542,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NodeStatus",
+     "operationId": "replaceNodeStatus",
      "parameters": [
       {
        "name": "body",
@@ -8583,7 +8583,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NodeStatus",
+     "operationId": "patchNodeStatus",
      "parameters": [
       {
        "name": "body",
@@ -8643,7 +8643,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1PersistentVolumeClaimForAllNamespaces",
+     "operationId": "listPersistentVolumeClaimForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -8720,7 +8720,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1PersistentVolume",
+     "operationId": "listPersistentVolume",
      "parameters": [
       {
        "uniqueItems": true,
@@ -8786,7 +8786,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1PersistentVolume",
+     "operationId": "createPersistentVolume",
      "parameters": [
       {
        "name": "body",
@@ -8825,7 +8825,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionPersistentVolume",
+     "operationId": "deleteCollectionPersistentVolume",
      "parameters": [
       {
        "uniqueItems": true,
@@ -8902,7 +8902,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1PersistentVolume",
+     "operationId": "readPersistentVolume",
      "parameters": [
       {
        "uniqueItems": true,
@@ -8947,7 +8947,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1PersistentVolume",
+     "operationId": "replacePersistentVolume",
      "parameters": [
       {
        "name": "body",
@@ -8986,7 +8986,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1PersistentVolume",
+     "operationId": "deletePersistentVolume",
      "parameters": [
       {
        "name": "body",
@@ -9027,7 +9027,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1PersistentVolume",
+     "operationId": "patchPersistentVolume",
      "parameters": [
       {
        "name": "body",
@@ -9085,7 +9085,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1PersistentVolumeStatus",
+     "operationId": "readPersistentVolumeStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -9114,7 +9114,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1PersistentVolumeStatus",
+     "operationId": "replacePersistentVolumeStatus",
      "parameters": [
       {
        "name": "body",
@@ -9155,7 +9155,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1PersistentVolumeStatus",
+     "operationId": "patchPersistentVolumeStatus",
      "parameters": [
       {
        "name": "body",
@@ -9215,7 +9215,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1PodForAllNamespaces",
+     "operationId": "listPodForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -9292,7 +9292,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1PodTemplateForAllNamespaces",
+     "operationId": "listPodTemplateForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -9365,7 +9365,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNamespacedPod",
+     "operationId": "proxyGETNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9392,7 +9392,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNamespacedPod",
+     "operationId": "proxyPUTNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9419,7 +9419,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNamespacedPod",
+     "operationId": "proxyPOSTNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9446,7 +9446,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENamespacedPod",
+     "operationId": "proxyDELETENamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9473,7 +9473,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNamespacedPod",
+     "operationId": "proxyOPTIONSNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9500,7 +9500,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNamespacedPod",
+     "operationId": "proxyHEADNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -9547,7 +9547,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNamespacedPodWithPath",
+     "operationId": "proxyGETNamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9574,7 +9574,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNamespacedPodWithPath",
+     "operationId": "proxyPUTNamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9601,7 +9601,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNamespacedPodWithPath",
+     "operationId": "proxyPOSTNamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9628,7 +9628,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENamespacedPodWithPath",
+     "operationId": "proxyDELETENamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9655,7 +9655,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNamespacedPodWithPath",
+     "operationId": "proxyOPTIONSNamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9682,7 +9682,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNamespacedPodWithPath",
+     "operationId": "proxyHEADNamespacedPodWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9737,7 +9737,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNamespacedService",
+     "operationId": "proxyGETNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9764,7 +9764,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNamespacedService",
+     "operationId": "proxyPUTNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9791,7 +9791,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNamespacedService",
+     "operationId": "proxyPOSTNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9818,7 +9818,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENamespacedService",
+     "operationId": "proxyDELETENamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9845,7 +9845,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNamespacedService",
+     "operationId": "proxyOPTIONSNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9872,7 +9872,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNamespacedService",
+     "operationId": "proxyHEADNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -9919,7 +9919,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNamespacedServiceWithPath",
+     "operationId": "proxyGETNamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9946,7 +9946,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNamespacedServiceWithPath",
+     "operationId": "proxyPUTNamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -9973,7 +9973,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNamespacedServiceWithPath",
+     "operationId": "proxyPOSTNamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10000,7 +10000,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENamespacedServiceWithPath",
+     "operationId": "proxyDELETENamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10027,7 +10027,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNamespacedServiceWithPath",
+     "operationId": "proxyOPTIONSNamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10054,7 +10054,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNamespacedServiceWithPath",
+     "operationId": "proxyHEADNamespacedServiceWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10109,7 +10109,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNode",
+     "operationId": "proxyGETNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10136,7 +10136,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNode",
+     "operationId": "proxyPUTNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10163,7 +10163,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNode",
+     "operationId": "proxyPOSTNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10190,7 +10190,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENode",
+     "operationId": "proxyDELETENode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10217,7 +10217,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNode",
+     "operationId": "proxyOPTIONSNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10244,7 +10244,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNode",
+     "operationId": "proxyHEADNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -10283,7 +10283,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1GETNodeWithPath",
+     "operationId": "proxyGETNodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10310,7 +10310,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1PUTNodeWithPath",
+     "operationId": "proxyPUTNodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10337,7 +10337,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1POSTNodeWithPath",
+     "operationId": "proxyPOSTNodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10364,7 +10364,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1DELETENodeWithPath",
+     "operationId": "proxyDELETENodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10391,7 +10391,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1OPTIONSNodeWithPath",
+     "operationId": "proxyOPTIONSNodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10418,7 +10418,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "proxyCoreV1HEADNodeWithPath",
+     "operationId": "proxyHEADNodeWithPath",
      "responses": {
       "200": {
        "description": "OK",
@@ -10469,7 +10469,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ReplicationControllerForAllNamespaces",
+     "operationId": "listReplicationControllerForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10546,7 +10546,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ResourceQuotaForAllNamespaces",
+     "operationId": "listResourceQuotaForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10623,7 +10623,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1SecretForAllNamespaces",
+     "operationId": "listSecretForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10700,7 +10700,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ServiceAccountForAllNamespaces",
+     "operationId": "listServiceAccountForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10777,7 +10777,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ServiceForAllNamespaces",
+     "operationId": "listServiceForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10854,7 +10854,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ConfigMapListForAllNamespaces",
+     "operationId": "watchConfigMapListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -10931,7 +10931,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1EndpointsListForAllNamespaces",
+     "operationId": "watchEndpointsListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -11008,7 +11008,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1EventListForAllNamespaces",
+     "operationId": "watchEventListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -11085,7 +11085,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1LimitRangeListForAllNamespaces",
+     "operationId": "watchLimitRangeListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -11162,7 +11162,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespaceList",
+     "operationId": "watchNamespaceList",
      "responses": {
       "200": {
        "description": "OK",
@@ -11239,7 +11239,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedConfigMapList",
+     "operationId": "watchNamespacedConfigMapList",
      "responses": {
       "200": {
        "description": "OK",
@@ -11324,7 +11324,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedConfigMap",
+     "operationId": "watchNamespacedConfigMap",
      "responses": {
       "200": {
        "description": "OK",
@@ -11417,7 +11417,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEndpointsList",
+     "operationId": "watchNamespacedEndpointsList",
      "responses": {
       "200": {
        "description": "OK",
@@ -11502,7 +11502,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEndpoints",
+     "operationId": "watchNamespacedEndpoints",
      "responses": {
       "200": {
        "description": "OK",
@@ -11595,7 +11595,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEventList",
+     "operationId": "watchNamespacedEventList",
      "responses": {
       "200": {
        "description": "OK",
@@ -11680,7 +11680,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEvent",
+     "operationId": "watchNamespacedEvent",
      "responses": {
       "200": {
        "description": "OK",
@@ -11773,7 +11773,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedLimitRangeList",
+     "operationId": "watchNamespacedLimitRangeList",
      "responses": {
       "200": {
        "description": "OK",
@@ -11858,7 +11858,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedLimitRange",
+     "operationId": "watchNamespacedLimitRange",
      "responses": {
       "200": {
        "description": "OK",
@@ -11951,7 +11951,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPersistentVolumeClaimList",
+     "operationId": "watchNamespacedPersistentVolumeClaimList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12036,7 +12036,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPersistentVolumeClaim",
+     "operationId": "watchNamespacedPersistentVolumeClaim",
      "responses": {
       "200": {
        "description": "OK",
@@ -12129,7 +12129,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPodList",
+     "operationId": "watchNamespacedPodList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12214,7 +12214,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPod",
+     "operationId": "watchNamespacedPod",
      "responses": {
       "200": {
        "description": "OK",
@@ -12307,7 +12307,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPodTemplateList",
+     "operationId": "watchNamespacedPodTemplateList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12392,7 +12392,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedPodTemplate",
+     "operationId": "watchNamespacedPodTemplate",
      "responses": {
       "200": {
        "description": "OK",
@@ -12485,7 +12485,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedReplicationControllerList",
+     "operationId": "watchNamespacedReplicationControllerList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12570,7 +12570,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedReplicationController",
+     "operationId": "watchNamespacedReplicationController",
      "responses": {
       "200": {
        "description": "OK",
@@ -12663,7 +12663,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedResourceQuotaList",
+     "operationId": "watchNamespacedResourceQuotaList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12748,7 +12748,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedResourceQuota",
+     "operationId": "watchNamespacedResourceQuota",
      "responses": {
       "200": {
        "description": "OK",
@@ -12841,7 +12841,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedSecretList",
+     "operationId": "watchNamespacedSecretList",
      "responses": {
       "200": {
        "description": "OK",
@@ -12926,7 +12926,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedSecret",
+     "operationId": "watchNamespacedSecret",
      "responses": {
       "200": {
        "description": "OK",
@@ -13019,7 +13019,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedServiceAccountList",
+     "operationId": "watchNamespacedServiceAccountList",
      "responses": {
       "200": {
        "description": "OK",
@@ -13104,7 +13104,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedServiceAccount",
+     "operationId": "watchNamespacedServiceAccount",
      "responses": {
       "200": {
        "description": "OK",
@@ -13197,7 +13197,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedServiceList",
+     "operationId": "watchNamespacedServiceList",
      "responses": {
       "200": {
        "description": "OK",
@@ -13282,7 +13282,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedService",
+     "operationId": "watchNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -13375,7 +13375,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1Namespace",
+     "operationId": "watchNamespace",
      "responses": {
       "200": {
        "description": "OK",
@@ -13460,7 +13460,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NodeList",
+     "operationId": "watchNodeList",
      "responses": {
       "200": {
        "description": "OK",
@@ -13537,7 +13537,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1Node",
+     "operationId": "watchNode",
      "responses": {
       "200": {
        "description": "OK",
@@ -13622,7 +13622,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1PersistentVolumeClaimListForAllNamespaces",
+     "operationId": "watchPersistentVolumeClaimListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -13699,7 +13699,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1PersistentVolumeList",
+     "operationId": "watchPersistentVolumeList",
      "responses": {
       "200": {
        "description": "OK",
@@ -13776,7 +13776,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1PersistentVolume",
+     "operationId": "watchPersistentVolume",
      "responses": {
       "200": {
        "description": "OK",
@@ -13861,7 +13861,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1PodListForAllNamespaces",
+     "operationId": "watchPodListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -13938,7 +13938,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1PodTemplateListForAllNamespaces",
+     "operationId": "watchPodTemplateListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14015,7 +14015,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ReplicationControllerListForAllNamespaces",
+     "operationId": "watchReplicationControllerListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14092,7 +14092,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ResourceQuotaListForAllNamespaces",
+     "operationId": "watchResourceQuotaListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14169,7 +14169,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1SecretListForAllNamespaces",
+     "operationId": "watchSecretListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14246,7 +14246,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ServiceAccountListForAllNamespaces",
+     "operationId": "watchServiceAccountListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14323,7 +14323,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ServiceListForAllNamespaces",
+     "operationId": "watchServiceListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -14499,7 +14499,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "listAppsV1beta1NamespacedStatefulSet",
+     "operationId": "listNamespacedStatefulSet",
      "parameters": [
       {
        "uniqueItems": true,
@@ -14565,7 +14565,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "createAppsV1beta1NamespacedStatefulSet",
+     "operationId": "createNamespacedStatefulSet",
      "parameters": [
       {
        "name": "body",
@@ -14604,7 +14604,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "deleteAppsV1beta1CollectionNamespacedStatefulSet",
+     "operationId": "deleteCollectionNamespacedStatefulSet",
      "parameters": [
       {
        "uniqueItems": true,
@@ -14689,7 +14689,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "readAppsV1beta1NamespacedStatefulSet",
+     "operationId": "readNamespacedStatefulSet",
      "parameters": [
       {
        "uniqueItems": true,
@@ -14734,7 +14734,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "replaceAppsV1beta1NamespacedStatefulSet",
+     "operationId": "replaceNamespacedStatefulSet",
      "parameters": [
       {
        "name": "body",
@@ -14773,7 +14773,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "deleteAppsV1beta1NamespacedStatefulSet",
+     "operationId": "deleteNamespacedStatefulSet",
      "parameters": [
       {
        "name": "body",
@@ -14814,7 +14814,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "patchAppsV1beta1NamespacedStatefulSet",
+     "operationId": "patchNamespacedStatefulSet",
      "parameters": [
       {
        "name": "body",
@@ -14880,7 +14880,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "readAppsV1beta1NamespacedStatefulSetStatus",
+     "operationId": "readNamespacedStatefulSetStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -14909,7 +14909,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "replaceAppsV1beta1NamespacedStatefulSetStatus",
+     "operationId": "replaceNamespacedStatefulSetStatus",
      "parameters": [
       {
        "name": "body",
@@ -14950,7 +14950,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "patchAppsV1beta1NamespacedStatefulSetStatus",
+     "operationId": "patchNamespacedStatefulSetStatus",
      "parameters": [
       {
        "name": "body",
@@ -15018,7 +15018,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "listAppsV1beta1StatefulSetForAllNamespaces",
+     "operationId": "listStatefulSetForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -15095,7 +15095,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "watchAppsV1beta1NamespacedStatefulSetList",
+     "operationId": "watchNamespacedStatefulSetList",
      "responses": {
       "200": {
        "description": "OK",
@@ -15180,7 +15180,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "watchAppsV1beta1NamespacedStatefulSet",
+     "operationId": "watchNamespacedStatefulSet",
      "responses": {
       "200": {
        "description": "OK",
@@ -15273,7 +15273,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "watchAppsV1beta1StatefulSetListForAllNamespaces",
+     "operationId": "watchStatefulSetListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -15414,7 +15414,7 @@
      "tags": [
       "authentication_v1beta1"
      ],
-     "operationId": "createAuthenticationV1beta1TokenReview",
+     "operationId": "createTokenReview",
      "responses": {
       "200": {
        "description": "OK",
@@ -15528,7 +15528,7 @@
      "tags": [
       "authorization_v1beta1"
      ],
-     "operationId": "createAuthorizationV1beta1NamespacedLocalSubjectAccessReview",
+     "operationId": "createNamespacedLocalSubjectAccessReview",
      "responses": {
       "200": {
        "description": "OK",
@@ -15584,7 +15584,7 @@
      "tags": [
       "authorization_v1beta1"
      ],
-     "operationId": "createAuthorizationV1beta1SelfSubjectAccessReview",
+     "operationId": "createSelfSubjectAccessReview",
      "responses": {
       "200": {
        "description": "OK",
@@ -15632,7 +15632,7 @@
      "tags": [
       "authorization_v1beta1"
      ],
-     "operationId": "createAuthorizationV1beta1SubjectAccessReview",
+     "operationId": "createSubjectAccessReview",
      "responses": {
       "200": {
        "description": "OK",
@@ -15748,7 +15748,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces",
+     "operationId": "listHorizontalPodAutoscalerForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -15825,7 +15825,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "listAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "listNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "uniqueItems": true,
@@ -15891,7 +15891,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "createAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "createNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "name": "body",
@@ -15930,7 +15930,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler",
+     "operationId": "deleteCollectionNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "uniqueItems": true,
@@ -16015,7 +16015,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "readAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "readNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "uniqueItems": true,
@@ -16060,7 +16060,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "replaceAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "replaceNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "name": "body",
@@ -16099,7 +16099,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "deleteAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "deleteNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "name": "body",
@@ -16140,7 +16140,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "patchAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "patchNamespacedHorizontalPodAutoscaler",
      "parameters": [
       {
        "name": "body",
@@ -16206,7 +16206,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
+     "operationId": "readNamespacedHorizontalPodAutoscalerStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -16235,7 +16235,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
+     "operationId": "replaceNamespacedHorizontalPodAutoscalerStatus",
      "parameters": [
       {
        "name": "body",
@@ -16276,7 +16276,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
+     "operationId": "patchNamespacedHorizontalPodAutoscalerStatus",
      "parameters": [
       {
        "name": "body",
@@ -16344,7 +16344,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "watchAutoscalingV1HorizontalPodAutoscalerListForAllNamespaces",
+     "operationId": "watchHorizontalPodAutoscalerListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -16421,7 +16421,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "watchAutoscalingV1NamespacedHorizontalPodAutoscalerList",
+     "operationId": "watchNamespacedHorizontalPodAutoscalerList",
      "responses": {
       "200": {
        "description": "OK",
@@ -16506,7 +16506,7 @@
      "tags": [
       "autoscaling_v1"
      ],
-     "operationId": "watchAutoscalingV1NamespacedHorizontalPodAutoscaler",
+     "operationId": "watchNamespacedHorizontalPodAutoscaler",
      "responses": {
       "200": {
        "description": "OK",
@@ -16665,7 +16665,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "listBatchV1JobForAllNamespaces",
+     "operationId": "listJobForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -16742,7 +16742,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "listBatchV1NamespacedJob",
+     "operationId": "listNamespacedJob",
      "parameters": [
       {
        "uniqueItems": true,
@@ -16808,7 +16808,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "createBatchV1NamespacedJob",
+     "operationId": "createNamespacedJob",
      "parameters": [
       {
        "name": "body",
@@ -16847,7 +16847,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "deleteBatchV1CollectionNamespacedJob",
+     "operationId": "deleteCollectionNamespacedJob",
      "parameters": [
       {
        "uniqueItems": true,
@@ -16932,7 +16932,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "readBatchV1NamespacedJob",
+     "operationId": "readNamespacedJob",
      "parameters": [
       {
        "uniqueItems": true,
@@ -16977,7 +16977,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "replaceBatchV1NamespacedJob",
+     "operationId": "replaceNamespacedJob",
      "parameters": [
       {
        "name": "body",
@@ -17016,7 +17016,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "deleteBatchV1NamespacedJob",
+     "operationId": "deleteNamespacedJob",
      "parameters": [
       {
        "name": "body",
@@ -17057,7 +17057,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "patchBatchV1NamespacedJob",
+     "operationId": "patchNamespacedJob",
      "parameters": [
       {
        "name": "body",
@@ -17123,7 +17123,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "readBatchV1NamespacedJobStatus",
+     "operationId": "readNamespacedJobStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -17152,7 +17152,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "replaceBatchV1NamespacedJobStatus",
+     "operationId": "replaceNamespacedJobStatus",
      "parameters": [
       {
        "name": "body",
@@ -17193,7 +17193,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "patchBatchV1NamespacedJobStatus",
+     "operationId": "patchNamespacedJobStatus",
      "parameters": [
       {
        "name": "body",
@@ -17261,7 +17261,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "watchBatchV1JobListForAllNamespaces",
+     "operationId": "watchJobListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -17338,7 +17338,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "watchBatchV1NamespacedJobList",
+     "operationId": "watchNamespacedJobList",
      "responses": {
       "200": {
        "description": "OK",
@@ -17423,7 +17423,7 @@
      "tags": [
       "batch_v1"
      ],
-     "operationId": "watchBatchV1NamespacedJob",
+     "operationId": "watchNamespacedJob",
      "responses": {
       "200": {
        "description": "OK",
@@ -17530,6 +17530,1708 @@
      }
     }
    },
+   "/apis/batch/v2alpha1/jobs": {
+    "get": {
+     "description": "list or watch objects of kind Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "listBatchV2alpha1JobForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.JobList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/jobs": {
+    "get": {
+     "description": "list or watch objects of kind Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "listBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.JobList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "post": {
+     "description": "create a Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "createBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "delete": {
+     "description": "delete collection of Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "deleteBatchV2alpha1CollectionNamespacedJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/jobs/{name}": {
+    "get": {
+     "description": "read the specified Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "readBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "name": "exact",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "name": "export",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "put": {
+     "description": "replace the specified Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "replaceBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "delete": {
+     "description": "delete a Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "deleteBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "patch": {
+     "description": "partially update the specified Job",
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "patchBatchV2alpha1NamespacedJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/unversioned.Patch"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the Job",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/jobs/{name}/status": {
+    "get": {
+     "description": "read status of the specified Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "readBatchV2alpha1NamespacedJobStatus",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "put": {
+     "description": "replace status of the specified Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "replaceBatchV2alpha1NamespacedJobStatus",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "patch": {
+     "description": "partially update status of the specified Job",
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "patchBatchV2alpha1NamespacedJobStatus",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/unversioned.Patch"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.Job"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the Job",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/scheduledjobs": {
+    "get": {
+     "description": "list or watch objects of kind ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "listBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJobList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "post": {
+     "description": "create a ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "createBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "delete": {
+     "description": "delete collection of ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "deleteBatchV2alpha1CollectionNamespacedScheduledJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/scheduledjobs/{name}": {
+    "get": {
+     "description": "read the specified ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "readBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "name": "exact",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "name": "export",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "put": {
+     "description": "replace the specified ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "replaceBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "delete": {
+     "description": "delete a ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "deleteBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "patch": {
+     "description": "partially update the specified ScheduledJob",
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "patchBatchV2alpha1NamespacedScheduledJob",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/unversioned.Patch"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the ScheduledJob",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/namespaces/{namespace}/scheduledjobs/{name}/status": {
+    "get": {
+     "description": "read status of the specified ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "readBatchV2alpha1NamespacedScheduledJobStatus",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "put": {
+     "description": "replace status of the specified ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "replaceBatchV2alpha1NamespacedScheduledJobStatus",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "patch": {
+     "description": "partially update status of the specified ScheduledJob",
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "patchBatchV2alpha1NamespacedScheduledJobStatus",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/unversioned.Patch"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJob"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the ScheduledJob",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/scheduledjobs": {
+    "get": {
+     "description": "list or watch objects of kind ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "listBatchV2alpha1ScheduledJobForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v2alpha1.ScheduledJobList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/jobs": {
+    "get": {
+     "description": "watch individual changes to a list of Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1JobListForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/namespaces/{namespace}/jobs": {
+    "get": {
+     "description": "watch individual changes to a list of Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1NamespacedJobList",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/namespaces/{namespace}/jobs/{name}": {
+    "get": {
+     "description": "watch changes to an object of kind Job",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1NamespacedJob",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the Job",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/namespaces/{namespace}/scheduledjobs": {
+    "get": {
+     "description": "watch individual changes to a list of ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1NamespacedScheduledJobList",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/namespaces/{namespace}/scheduledjobs/{name}": {
+    "get": {
+     "description": "watch changes to an object of kind ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1NamespacedScheduledJob",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the ScheduledJob",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/batch/v2alpha1/watch/scheduledjobs": {
+    "get": {
+     "description": "watch individual changes to a list of ScheduledJob",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "batch_v2alpha1"
+     ],
+     "operationId": "watchBatchV2alpha1ScheduledJobListForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
    "/apis/certificates.k8s.io/": {
     "get": {
      "description": "get information of a group",
@@ -17615,7 +19317,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "listCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "listCertificateSigningRequest",
      "parameters": [
       {
        "uniqueItems": true,
@@ -17681,7 +19383,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "createCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "createCertificateSigningRequest",
      "parameters": [
       {
        "name": "body",
@@ -17720,7 +19422,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "deleteCertificatesV1alpha1CollectionCertificateSigningRequest",
+     "operationId": "deleteCollectionCertificateSigningRequest",
      "parameters": [
       {
        "uniqueItems": true,
@@ -17797,7 +19499,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "readCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "readCertificateSigningRequest",
      "parameters": [
       {
        "uniqueItems": true,
@@ -17842,7 +19544,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "replaceCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "replaceCertificateSigningRequest",
      "parameters": [
       {
        "name": "body",
@@ -17881,7 +19583,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "deleteCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "deleteCertificateSigningRequest",
      "parameters": [
       {
        "name": "body",
@@ -17922,7 +19624,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "patchCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "patchCertificateSigningRequest",
      "parameters": [
       {
        "name": "body",
@@ -17980,7 +19682,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "replaceCertificatesV1alpha1CertificateSigningRequestApproval",
+     "operationId": "replaceCertificateSigningRequestApproval",
      "responses": {
       "200": {
        "description": "OK",
@@ -18036,7 +19738,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "replaceCertificatesV1alpha1CertificateSigningRequestStatus",
+     "operationId": "replaceCertificateSigningRequestStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -18094,7 +19796,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "watchCertificatesV1alpha1CertificateSigningRequestList",
+     "operationId": "watchCertificateSigningRequestList",
      "responses": {
       "200": {
        "description": "OK",
@@ -18171,7 +19873,7 @@
      "tags": [
       "certificates_v1alpha1"
      ],
-     "operationId": "watchCertificatesV1alpha1CertificateSigningRequest",
+     "operationId": "watchCertificateSigningRequest",
      "responses": {
       "200": {
        "description": "OK",
@@ -25210,7 +26912,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "listPolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "listNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "uniqueItems": true,
@@ -25276,7 +26978,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "createPolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "createNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "name": "body",
@@ -25315,7 +27017,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget",
+     "operationId": "deleteCollectionNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "uniqueItems": true,
@@ -25400,7 +27102,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "readPolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "readNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "uniqueItems": true,
@@ -25445,7 +27147,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "replacePolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "replaceNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "name": "body",
@@ -25484,7 +27186,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "deletePolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "deleteNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "name": "body",
@@ -25525,7 +27227,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "patchPolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "patchNamespacedPodDisruptionBudget",
      "parameters": [
       {
        "name": "body",
@@ -25591,7 +27293,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "readPolicyV1beta1NamespacedPodDisruptionBudgetStatus",
+     "operationId": "readNamespacedPodDisruptionBudgetStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -25620,7 +27322,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus",
+     "operationId": "replaceNamespacedPodDisruptionBudgetStatus",
      "parameters": [
       {
        "name": "body",
@@ -25661,7 +27363,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus",
+     "operationId": "patchNamespacedPodDisruptionBudgetStatus",
      "parameters": [
       {
        "name": "body",
@@ -25729,7 +27431,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "listPolicyV1beta1PodDisruptionBudgetForAllNamespaces",
+     "operationId": "listPodDisruptionBudgetForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -25806,7 +27508,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "watchPolicyV1beta1NamespacedPodDisruptionBudgetList",
+     "operationId": "watchNamespacedPodDisruptionBudgetList",
      "responses": {
       "200": {
        "description": "OK",
@@ -25891,7 +27593,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "watchPolicyV1beta1NamespacedPodDisruptionBudget",
+     "operationId": "watchNamespacedPodDisruptionBudget",
      "responses": {
       "200": {
        "description": "OK",
@@ -25984,7 +27686,7 @@
      "tags": [
       "policy_v1beta1"
      ],
-     "operationId": "watchPolicyV1beta1PodDisruptionBudgetListForAllNamespaces",
+     "operationId": "watchPodDisruptionBudgetListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -26127,7 +27829,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "listClusterRoleBinding",
      "parameters": [
       {
        "uniqueItems": true,
@@ -26193,7 +27895,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "createRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "createClusterRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -26232,7 +27934,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1CollectionClusterRoleBinding",
+     "operationId": "deleteCollectionClusterRoleBinding",
      "parameters": [
       {
        "uniqueItems": true,
@@ -26309,7 +28011,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "readRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "readClusterRoleBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -26338,7 +28040,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "replaceRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "replaceClusterRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -26377,7 +28079,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "deleteClusterRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -26418,7 +28120,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "patchRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "patchClusterRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -26478,7 +28180,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "listClusterRole",
      "parameters": [
       {
        "uniqueItems": true,
@@ -26544,7 +28246,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "createRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "createClusterRole",
      "parameters": [
       {
        "name": "body",
@@ -26583,7 +28285,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1CollectionClusterRole",
+     "operationId": "deleteCollectionClusterRole",
      "parameters": [
       {
        "uniqueItems": true,
@@ -26660,7 +28362,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "readRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "readClusterRole",
      "responses": {
       "200": {
        "description": "OK",
@@ -26689,7 +28391,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "replaceRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "replaceClusterRole",
      "parameters": [
       {
        "name": "body",
@@ -26728,7 +28430,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "deleteClusterRole",
      "parameters": [
       {
        "name": "body",
@@ -26769,7 +28471,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "patchRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "patchClusterRole",
      "parameters": [
       {
        "name": "body",
@@ -26829,7 +28531,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "listNamespacedRoleBinding",
      "parameters": [
       {
        "uniqueItems": true,
@@ -26895,7 +28597,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "createRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "createNamespacedRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -26934,7 +28636,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding",
+     "operationId": "deleteCollectionNamespacedRoleBinding",
      "parameters": [
       {
        "uniqueItems": true,
@@ -27019,7 +28721,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "readRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "readNamespacedRoleBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -27048,7 +28750,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "replaceRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "replaceNamespacedRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -27087,7 +28789,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "deleteNamespacedRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -27128,7 +28830,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "patchRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "patchNamespacedRoleBinding",
      "parameters": [
       {
        "name": "body",
@@ -27196,7 +28898,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "listNamespacedRole",
      "parameters": [
       {
        "uniqueItems": true,
@@ -27262,7 +28964,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "createRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "createNamespacedRole",
      "parameters": [
       {
        "name": "body",
@@ -27301,7 +29003,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1CollectionNamespacedRole",
+     "operationId": "deleteCollectionNamespacedRole",
      "parameters": [
       {
        "uniqueItems": true,
@@ -27386,7 +29088,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "readRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "readNamespacedRole",
      "responses": {
       "200": {
        "description": "OK",
@@ -27415,7 +29117,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "replaceRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "replaceNamespacedRole",
      "parameters": [
       {
        "name": "body",
@@ -27454,7 +29156,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "deleteRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "deleteNamespacedRole",
      "parameters": [
       {
        "name": "body",
@@ -27495,7 +29197,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "patchRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "patchNamespacedRole",
      "parameters": [
       {
        "name": "body",
@@ -27563,7 +29265,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1RoleBindingForAllNamespaces",
+     "operationId": "listRoleBindingForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -27640,7 +29342,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "listRbacAuthorizationV1alpha1RoleForAllNamespaces",
+     "operationId": "listRoleForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -27717,7 +29419,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1ClusterRoleBindingList",
+     "operationId": "watchClusterRoleBindingList",
      "responses": {
       "200": {
        "description": "OK",
@@ -27794,7 +29496,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1ClusterRoleBinding",
+     "operationId": "watchClusterRoleBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -27879,7 +29581,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1ClusterRoleList",
+     "operationId": "watchClusterRoleList",
      "responses": {
       "200": {
        "description": "OK",
@@ -27956,7 +29658,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1ClusterRole",
+     "operationId": "watchClusterRole",
      "responses": {
       "200": {
        "description": "OK",
@@ -28041,7 +29743,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1NamespacedRoleBindingList",
+     "operationId": "watchNamespacedRoleBindingList",
      "responses": {
       "200": {
        "description": "OK",
@@ -28126,7 +29828,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1NamespacedRoleBinding",
+     "operationId": "watchNamespacedRoleBinding",
      "responses": {
       "200": {
        "description": "OK",
@@ -28219,7 +29921,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1NamespacedRoleList",
+     "operationId": "watchNamespacedRoleList",
      "responses": {
       "200": {
        "description": "OK",
@@ -28304,7 +30006,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1NamespacedRole",
+     "operationId": "watchNamespacedRole",
      "responses": {
       "200": {
        "description": "OK",
@@ -28397,7 +30099,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1RoleBindingListForAllNamespaces",
+     "operationId": "watchRoleBindingListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -28474,7 +30176,7 @@
      "tags": [
       "rbacAuthorization_v1alpha1"
      ],
-     "operationId": "watchRbacAuthorizationV1alpha1RoleListForAllNamespaces",
+     "operationId": "watchRoleListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -28617,7 +30319,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "listStorageV1beta1StorageClass",
+     "operationId": "listStorageClass",
      "parameters": [
       {
        "uniqueItems": true,
@@ -28683,7 +30385,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "createStorageV1beta1StorageClass",
+     "operationId": "createStorageClass",
      "parameters": [
       {
        "name": "body",
@@ -28722,7 +30424,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "deleteStorageV1beta1CollectionStorageClass",
+     "operationId": "deleteCollectionStorageClass",
      "parameters": [
       {
        "uniqueItems": true,
@@ -28799,7 +30501,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "readStorageV1beta1StorageClass",
+     "operationId": "readStorageClass",
      "parameters": [
       {
        "uniqueItems": true,
@@ -28844,7 +30546,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "replaceStorageV1beta1StorageClass",
+     "operationId": "replaceStorageClass",
      "parameters": [
       {
        "name": "body",
@@ -28883,7 +30585,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "deleteStorageV1beta1StorageClass",
+     "operationId": "deleteStorageClass",
      "parameters": [
       {
        "name": "body",
@@ -28924,7 +30626,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "patchStorageV1beta1StorageClass",
+     "operationId": "patchStorageClass",
      "parameters": [
       {
        "name": "body",
@@ -28984,7 +30686,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "watchStorageV1beta1StorageClassList",
+     "operationId": "watchStorageClassList",
      "responses": {
       "200": {
        "description": "OK",
@@ -29061,7 +30763,7 @@
      "tags": [
       "storage_v1beta1"
      ],
-     "operationId": "watchStorageV1beta1StorageClass",
+     "operationId": "watchStorageClass",
      "responses": {
       "200": {
        "description": "OK",
@@ -34053,6 +35755,240 @@
      "username": {
       "description": "The name that uniquely identifies this user among all active users.",
       "type": "string"
+     }
+    }
+   },
+   "v2alpha1.Job": {
+    "description": "Job represents the configuration of a single job.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/v2alpha1.JobSpec"
+     },
+     "status": {
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/v2alpha1.JobStatus"
+     }
+    }
+   },
+   "v2alpha1.JobCondition": {
+    "description": "JobCondition describes current state of a job.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "description": "Last time the condition was checked.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "lastTransitionTime": {
+      "description": "Last time the condition transit from one status to another.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "message": {
+      "description": "Human readable message indicating details about last transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "(brief) reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of job condition, Complete or Failed.",
+      "type": "string"
+     }
+    }
+   },
+   "v2alpha1.JobList": {
+    "description": "JobList is a collection of jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of Job.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v2alpha1.Job"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/unversioned.ListMeta"
+     }
+    }
+   },
+   "v2alpha1.JobSpec": {
+    "description": "JobSpec describes how the job execution will look like.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "activeDeadlineSeconds": {
+      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+      "type": "integer",
+      "format": "int64"
+     },
+     "completions": {
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "manualSelector": {
+      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
+      "type": "boolean"
+     },
+     "parallelism": {
+      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/unversioned.LabelSelector"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "v2alpha1.JobStatus": {
+    "description": "JobStatus represents the current state of a Job.",
+    "properties": {
+     "active": {
+      "description": "Active is the number of actively running pods.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "completionTime": {
+      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "conditions": {
+      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v2alpha1.JobCondition"
+      }
+     },
+     "failed": {
+      "description": "Failed is the number of pods which reached Phase Failed.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "startTime": {
+      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "succeeded": {
+      "description": "Succeeded is the number of pods which reached Phase Succeeded.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "v2alpha1.JobTemplateSpec": {
+    "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata of the jobs created from this template. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Specification of the desired behavior of the job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/v2alpha1.JobSpec"
+     }
+    }
+   },
+   "v2alpha1.ScheduledJob": {
+    "description": "ScheduledJob represents the configuration of a single scheduled job.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is a structure defining the expected behavior of a job, including the schedule. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/v2alpha1.ScheduledJobSpec"
+     },
+     "status": {
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/v2alpha1.ScheduledJobStatus"
+     }
+    }
+   },
+   "v2alpha1.ScheduledJobList": {
+    "description": "ScheduledJobList is a collection of scheduled jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of ScheduledJob.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v2alpha1.ScheduledJob"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/unversioned.ListMeta"
+     }
+    }
+   },
+   "v2alpha1.ScheduledJobSpec": {
+    "description": "ScheduledJobSpec describes how the job execution will look like and when it will actually run.",
+    "required": [
+     "schedule",
+     "jobTemplate"
+    ],
+    "properties": {
+     "concurrencyPolicy": {
+      "description": "ConcurrencyPolicy specifies how to treat concurrent executions of a Job.",
+      "type": "string"
+     },
+     "jobTemplate": {
+      "description": "JobTemplate is the object that describes the job that will be created when executing a ScheduledJob.",
+      "$ref": "#/definitions/v2alpha1.JobTemplateSpec"
+     },
+     "schedule": {
+      "description": "Schedule contains the schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+      "type": "string"
+     },
+     "startingDeadlineSeconds": {
+      "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "suspend": {
+      "description": "Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "v2alpha1.ScheduledJobStatus": {
+    "description": "ScheduledJobStatus represents the current state of a Job.",
+    "properties": {
+     "active": {
+      "description": "Active holds pointers to currently running jobs.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v1.ObjectReference"
+      }
+     },
+     "lastScheduleTime": {
+      "description": "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+      "$ref": "#/definitions/unversioned.Time"
      }
     }
    },

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -65,6 +65,80 @@
      }
     }
    },
+   "/api/v1/configmaps": {
+    "get": {
+     "description": "list or watch objects of kind ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "listConfigMapForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMapList"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
    "/api/v1/events": {
     "get": {
      "description": "list or watch objects of kind Event",
@@ -74,7 +148,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -82,7 +158,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1EventForAllNamespaces",
+     "operationId": "listEventForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -146,7 +222,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -154,7 +232,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1Namespace",
+     "operationId": "listNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -217,7 +295,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1Namespace",
+     "operationId": "createNamespace",
      "parameters": [
       {
        "name": "body",
@@ -253,7 +331,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespace",
+     "operationId": "deleteCollectionNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -310,9 +388,74 @@
      }
     ]
    },
-   "/api/v1/namespaces/{namespace}/events": {
+   "/api/v1/namespaces/{namespace}/configmaps": {
     "get": {
-     "description": "list or watch objects of kind Event",
+     "description": "list or watch objects of kind ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "listNamespacedConfigMap",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMapList"
+       }
+      }
+     }
+    },
+    "post": {
+     "description": "create a ConfigMap",
      "consumes": [
       "*/*"
      ],
@@ -327,7 +470,306 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedEvent",
+     "operationId": "createNamespacedConfigMap",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     }
+    },
+    "delete": {
+     "description": "delete collection of ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "deleteCollectionNamespacedConfigMap",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "name": "fieldSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "name": "labelSelector",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "string",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "name": "resourceVersion",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "integer",
+       "description": "Timeout for the list/watch call.",
+       "name": "timeoutSeconds",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "name": "watch",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/api/v1/namespaces/{namespace}/configmaps/{name}": {
+    "get": {
+     "description": "read the specified ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "readNamespacedConfigMap",
+     "parameters": [
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "name": "exact",
+       "in": "query"
+      },
+      {
+       "uniqueItems": true,
+       "type": "boolean",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.`",
+       "name": "export",
+       "in": "query"
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     }
+    },
+    "put": {
+     "description": "replace the specified ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "replaceNamespacedConfigMap",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     }
+    },
+    "delete": {
+     "description": "delete a ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "deleteNamespacedConfigMap",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.Status"
+       }
+      }
+     }
+    },
+    "patch": {
+     "description": "partially update the specified ConfigMap",
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "patchNamespacedConfigMap",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/unversioned.Patch"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.ConfigMap"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the ConfigMap",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/api/v1/namespaces/{namespace}/events": {
+    "get": {
+     "description": "list or watch objects of kind Event",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "listNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -375,7 +817,7 @@
      }
     },
     "post": {
-     "description": "create a Event",
+     "description": "create an Event",
      "consumes": [
       "*/*"
      ],
@@ -390,7 +832,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedEvent",
+     "operationId": "createNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -426,7 +868,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedEvent",
+     "operationId": "deleteCollectionNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -508,7 +950,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedEvent",
+     "operationId": "readNamespacedEvent",
      "parameters": [
       {
        "uniqueItems": true,
@@ -550,7 +992,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedEvent",
+     "operationId": "replaceNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -571,7 +1013,7 @@
      }
     },
     "delete": {
-     "description": "delete a Event",
+     "description": "delete an Event",
      "consumes": [
       "*/*"
      ],
@@ -586,7 +1028,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedEvent",
+     "operationId": "deleteNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -624,7 +1066,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedEvent",
+     "operationId": "patchNamespacedEvent",
      "parameters": [
       {
        "name": "body",
@@ -679,7 +1121,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -687,7 +1131,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedSecret",
+     "operationId": "listNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -750,7 +1194,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedSecret",
+     "operationId": "createNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -786,7 +1230,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedSecret",
+     "operationId": "deleteCollectionNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -868,7 +1312,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedSecret",
+     "operationId": "readNamespacedSecret",
      "parameters": [
       {
        "uniqueItems": true,
@@ -910,7 +1354,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedSecret",
+     "operationId": "replaceNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -946,7 +1390,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedSecret",
+     "operationId": "deleteNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -984,7 +1428,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedSecret",
+     "operationId": "patchNamespacedSecret",
      "parameters": [
       {
        "name": "body",
@@ -1039,7 +1483,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -1047,7 +1493,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1NamespacedService",
+     "operationId": "listNamespacedService",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1110,7 +1556,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedService",
+     "operationId": "createNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -1146,7 +1592,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1CollectionNamespacedService",
+     "operationId": "deleteCollectionNamespacedService",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1228,7 +1674,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedService",
+     "operationId": "readNamespacedService",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1270,7 +1716,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedService",
+     "operationId": "replaceNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -1306,7 +1752,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1NamespacedService",
+     "operationId": "deleteNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -1344,7 +1790,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedService",
+     "operationId": "patchNamespacedService",
      "parameters": [
       {
        "name": "body",
@@ -1407,7 +1853,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedServiceStatus",
+     "operationId": "readNamespacedServiceStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -1433,7 +1879,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedServiceStatus",
+     "operationId": "replaceNamespacedServiceStatus",
      "parameters": [
       {
        "name": "body",
@@ -1471,7 +1917,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedServiceStatus",
+     "operationId": "patchNamespacedServiceStatus",
      "parameters": [
       {
        "name": "body",
@@ -1534,7 +1980,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1Namespace",
+     "operationId": "readNamespace",
      "parameters": [
       {
        "uniqueItems": true,
@@ -1576,7 +2022,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1Namespace",
+     "operationId": "replaceNamespace",
      "parameters": [
       {
        "name": "body",
@@ -1612,7 +2058,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "deleteCoreV1Namespace",
+     "operationId": "deleteNamespace",
      "parameters": [
       {
        "name": "body",
@@ -1650,7 +2096,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1Namespace",
+     "operationId": "patchNamespace",
      "parameters": [
       {
        "name": "body",
@@ -1705,7 +2151,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespaceFinalize",
+     "operationId": "replaceNamespaceFinalize",
      "responses": {
       "200": {
        "description": "OK",
@@ -1758,7 +2204,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespaceStatus",
+     "operationId": "readNamespaceStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -1784,7 +2230,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespaceStatus",
+     "operationId": "replaceNamespaceStatus",
      "parameters": [
       {
        "name": "body",
@@ -1822,7 +2268,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespaceStatus",
+     "operationId": "patchNamespaceStatus",
      "parameters": [
       {
        "name": "body",
@@ -1869,7 +2315,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -1877,7 +2325,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1SecretForAllNamespaces",
+     "operationId": "listSecretForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -1941,7 +2389,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -1949,12 +2399,86 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "listCoreV1ServiceForAllNamespaces",
+     "operationId": "listServiceForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
        "schema": {
         "$ref": "#/definitions/v1.ServiceList"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/api/v1/watch/configmaps": {
+    "get": {
+     "description": "watch individual changes to a list of ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "watchConfigMapListForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
        }
       }
      }
@@ -2012,8 +2536,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2022,7 +2547,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1EventListForAllNamespaces",
+     "operationId": "watchEventListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -2085,8 +2610,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2095,7 +2621,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespaceList",
+     "operationId": "watchNamespaceList",
      "responses": {
       "200": {
        "description": "OK",
@@ -2150,16 +2676,17 @@
      }
     ]
    },
-   "/api/v1/watch/namespaces/{namespace}/events": {
+   "/api/v1/watch/namespaces/{namespace}/configmaps": {
     "get": {
-     "description": "watch individual changes to a list of Event",
+     "description": "watch individual changes to a list of ConfigMap",
      "consumes": [
       "*/*"
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2168,7 +2695,179 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEventList",
+     "operationId": "watchNamespacedConfigMapList",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/api/v1/watch/namespaces/{namespace}/configmaps/{name}": {
+    "get": {
+     "description": "watch changes to an object of kind ConfigMap",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "watchNamespacedConfigMap",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/versioned.Event"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+      "name": "fieldSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+      "name": "labelSelector",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the ConfigMap",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+      "name": "resourceVersion",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "integer",
+      "description": "Timeout for the list/watch call.",
+      "name": "timeoutSeconds",
+      "in": "query"
+     },
+     {
+      "uniqueItems": true,
+      "type": "boolean",
+      "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+      "name": "watch",
+      "in": "query"
+     }
+    ]
+   },
+   "/api/v1/watch/namespaces/{namespace}/events": {
+    "get": {
+     "description": "watch individual changes to a list of Event",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "core_v1"
+     ],
+     "operationId": "watchNamespacedEventList",
      "responses": {
       "200": {
        "description": "OK",
@@ -2239,8 +2938,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2249,7 +2949,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedEvent",
+     "operationId": "watchNamespacedEvent",
      "responses": {
       "200": {
        "description": "OK",
@@ -2328,8 +3028,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2338,7 +3039,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedSecretList",
+     "operationId": "watchNamespacedSecretList",
      "responses": {
       "200": {
        "description": "OK",
@@ -2409,8 +3110,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2419,7 +3121,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedSecret",
+     "operationId": "watchNamespacedSecret",
      "responses": {
       "200": {
        "description": "OK",
@@ -2498,8 +3200,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2508,7 +3211,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedServiceList",
+     "operationId": "watchNamespacedServiceList",
      "responses": {
       "200": {
        "description": "OK",
@@ -2579,8 +3282,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2589,7 +3293,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1NamespacedService",
+     "operationId": "watchNamespacedService",
      "responses": {
       "200": {
        "description": "OK",
@@ -2668,8 +3372,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2678,7 +3383,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1Namespace",
+     "operationId": "watchNamespace",
      "responses": {
       "200": {
        "description": "OK",
@@ -2749,8 +3454,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2759,7 +3465,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1SecretListForAllNamespaces",
+     "operationId": "watchSecretListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -2822,8 +3528,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -2832,7 +3539,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "watchCoreV1ServiceListForAllNamespaces",
+     "operationId": "watchServiceListForAllNamespaces",
      "responses": {
       "200": {
        "description": "OK",
@@ -2986,7 +3693,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -3058,7 +3767,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -3130,7 +3841,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -3202,7 +3915,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -3689,7 +4404,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -4364,7 +5081,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -4420,7 +5139,7 @@
      }
     },
     "post": {
-     "description": "create a Ingress",
+     "description": "create an Ingress",
      "consumes": [
       "*/*"
      ],
@@ -4616,7 +5335,7 @@
      }
     },
     "delete": {
-     "description": "delete a Ingress",
+     "description": "delete an Ingress",
      "consumes": [
       "*/*"
      ],
@@ -4851,7 +5570,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -5465,7 +6186,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -5536,8 +6259,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -5609,8 +6333,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -5682,8 +6407,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -5755,8 +6481,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -5836,8 +6563,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -5925,8 +6653,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6006,8 +6735,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6095,8 +6825,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6176,8 +6907,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6265,8 +6997,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6346,8 +7079,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6435,8 +7169,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6569,7 +7304,9 @@
      "produces": [
       "application/json",
       "application/yaml",
-      "application/vnd.kubernetes.protobuf"
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
       "https"
@@ -6577,7 +7314,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "listFederationV1beta1Cluster",
+     "operationId": "listCluster",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6640,7 +7377,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "createFederationV1beta1Cluster",
+     "operationId": "createCluster",
      "parameters": [
       {
        "name": "body",
@@ -6676,7 +7413,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "deleteFederationV1beta1CollectionCluster",
+     "operationId": "deleteCollectionCluster",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6750,7 +7487,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "readFederationV1beta1Cluster",
+     "operationId": "readCluster",
      "parameters": [
       {
        "uniqueItems": true,
@@ -6792,7 +7529,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "replaceFederationV1beta1Cluster",
+     "operationId": "replaceCluster",
      "parameters": [
       {
        "name": "body",
@@ -6828,7 +7565,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "deleteFederationV1beta1Cluster",
+     "operationId": "deleteCluster",
      "parameters": [
       {
        "name": "body",
@@ -6866,7 +7603,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "patchFederationV1beta1Cluster",
+     "operationId": "patchCluster",
      "parameters": [
       {
        "name": "body",
@@ -6921,7 +7658,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "replaceFederationV1beta1ClusterStatus",
+     "operationId": "replaceClusterStatus",
      "responses": {
       "200": {
        "description": "OK",
@@ -6965,8 +7702,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -6975,7 +7713,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "watchFederationV1beta1ClusterList",
+     "operationId": "watchClusterList",
      "responses": {
       "200": {
        "description": "OK",
@@ -7038,8 +7776,9 @@
      ],
      "produces": [
       "application/json",
-      "application/json;stream=watch",
+      "application/yaml",
       "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
       "application/vnd.kubernetes.protobuf;stream=watch"
      ],
      "schemes": [
@@ -7048,7 +7787,7 @@
      "tags": [
       "federation_v1beta1"
      ],
-     "operationId": "watchFederationV1beta1Cluster",
+     "operationId": "watchCluster",
      "responses": {
       "200": {
        "description": "OK",
@@ -7330,6 +8069,49 @@
      }
     }
    },
+   "unversioned.LabelSelector": {
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchExpressions": {
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/unversioned.LabelSelectorRequirement"
+      }
+     },
+     "matchLabels": {
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "unversioned.LabelSelectorRequirement": {
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "description": "key is the label key that the selector applies to.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
+      "type": "string"
+     },
+     "values": {
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
    "unversioned.ListMeta": {
     "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
     "properties": {
@@ -7462,6 +8244,22 @@
      }
     }
    },
+   "v1.ConfigMap": {
+    "description": "ConfigMap holds configuration data for pods to consume.",
+    "properties": {
+     "data": {
+      "description": "Data contains the configuration data. Each key must be a valid DNS_SUBDOMAIN with an optional leading dot.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     }
+    }
+   },
    "v1.ConfigMapKeySelector": {
     "description": "Selects a key from a ConfigMap.",
     "required": [
@@ -7471,6 +8269,25 @@
      "key": {
       "description": "The key to select.",
       "type": "string"
+     }
+    }
+   },
+   "v1.ConfigMapList": {
+    "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of ConfigMaps.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v1.ConfigMap"
+      }
+     },
+     "metadata": {
+      "description": "More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/unversioned.ListMeta"
      }
     }
    },
@@ -8743,7 +9560,7 @@
     "properties": {
      "selector": {
       "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1beta1.LabelSelector"
+      "$ref": "#/definitions/unversioned.LabelSelector"
      },
      "template": {
       "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
@@ -8799,6 +9616,43 @@
      }
     }
    },
+   "v1beta1.DeploymentCondition": {
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "required": [
+     "type",
+     "status",
+     "lastUpdateTime",
+     "lastTransitionTime",
+     "reason",
+     "message"
+    ],
+    "properties": {
+     "lastTransitionTime": {
+      "description": "Last time the condition transitioned from one status to another.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "lastUpdateTime": {
+      "description": "The last time this condition was updated.",
+      "$ref": "#/definitions/unversioned.Time"
+     },
+     "message": {
+      "description": "A human readable message indicating details about the transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "The reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of deployment condition.",
+      "type": "string"
+     }
+    }
+   },
    "v1beta1.DeploymentList": {
     "description": "DeploymentList is a list of Deployments.",
     "required": [
@@ -8845,7 +9699,8 @@
    "v1beta1.DeploymentSpec": {
     "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
-     "template"
+     "template",
+     "progressDeadlineSeconds"
     ],
     "properties": {
      "minReadySeconds": {
@@ -8856,6 +9711,11 @@
      "paused": {
       "description": "Indicates that the deployment is paused and will not be processed by the deployment controller.",
       "type": "boolean"
+     },
+     "progressDeadlineSeconds": {
+      "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default.",
+      "type": "integer",
+      "format": "int32"
      },
      "replicas": {
       "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
@@ -8873,7 +9733,7 @@
      },
      "selector": {
       "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-      "$ref": "#/definitions/v1beta1.LabelSelector"
+      "$ref": "#/definitions/unversioned.LabelSelector"
      },
      "strategy": {
       "description": "The deployment strategy to use to replace existing pods with new ones.",
@@ -8887,11 +9747,21 @@
    },
    "v1beta1.DeploymentStatus": {
     "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "required": [
+     "conditions"
+    ],
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
       "type": "integer",
       "format": "int32"
+     },
+     "conditions": {
+      "description": "Represents the latest available observations of a deployment's current state.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v1beta1.DeploymentCondition"
+      }
      },
      "observedGeneration": {
       "description": "The generation observed by the deployment controller.",
@@ -9038,49 +9908,6 @@
      }
     }
    },
-   "v1beta1.LabelSelector": {
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
-    "properties": {
-     "matchExpressions": {
-      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.LabelSelectorRequirement"
-      }
-     },
-     "matchLabels": {
-      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1beta1.LabelSelectorRequirement": {
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-    "required": [
-     "key",
-     "operator"
-    ],
-    "properties": {
-     "key": {
-      "description": "key is the label key that the selector applies to.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
-      "type": "string"
-     },
-     "values": {
-      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
    "v1beta1.ReplicaSet": {
     "description": "ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
@@ -9161,7 +9988,7 @@
      },
      "selector": {
       "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1beta1.LabelSelector"
+      "$ref": "#/definitions/unversioned.LabelSelector"
      },
      "template": {
       "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
         "//pkg/apiserver/authenticator:go_default_library",
+        "//pkg/apiserver/openapi:go_default_library",
         "//pkg/auth/authorizer/union:go_default_library",
         "//pkg/auth/user:go_default_library",
         "//pkg/cloudprovider/providers:go_default_library",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apiserver/authenticator"
+	apiserveropenapi "k8s.io/kubernetes/pkg/apiserver/openapi"
 	authorizerunion "k8s.io/kubernetes/pkg/auth/authorizer/union"
 	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/controller/informers"
@@ -72,6 +73,11 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig := genericapiserver.NewConfig(). // create the new config
 							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
 							Complete()                               // set default values based on the known values
+
+	// Avoid duplicate OpenAPI operation IDs and add GroupVersion tags to all operation definitions.
+	genericConfig.OpenAPIConfig.GetOperationIDAndTags = apiserveropenapi.GetOperationIDAndTagsFunc(
+		[]string{"extensions_v1beta1", "batch_v2alpha1"},
+		[]string{"getAPIResources", "getAPIGroup", "getAPIVersions"})
 
 	if err := genericConfig.MaybeGenerateServingCerts(); err != nil {
 		glog.Fatalf("Failed to generate service certificate: %v", err)

--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -63,6 +63,7 @@ kube::log::status "Starting kube-apiserver"
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \
+  --runtime-config=api/all=true \
   --token-auth-file=$TMP_DIR/tokenauth.csv \
   --service-cluster-ip-range="10.0.0.0/24" >/tmp/openapi-api-server.log 2>&1 &
 APISERVER_PID=$!

--- a/pkg/genericapiserver/BUILD
+++ b/pkg/genericapiserver/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//pkg/apimachinery/registered:go_default_library",
         "//pkg/apiserver:go_default_library",
         "//pkg/apiserver/filters:go_default_library",
-        "//pkg/apiserver/openapi:go_default_library",
         "//pkg/apiserver/request:go_default_library",
         "//pkg/auth/authenticator:go_default_library",
         "//pkg/auth/authorizer:go_default_library",

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiserverfilters "k8s.io/kubernetes/pkg/apiserver/filters"
-	apiserveropenapi "k8s.io/kubernetes/pkg/apiserver/openapi"
 	"k8s.io/kubernetes/pkg/apiserver/request"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
@@ -244,7 +243,6 @@ func NewConfig() *Config {
 					Description: "Default Response.",
 				},
 			},
-			GetOperationIDAndTags: apiserveropenapi.GetOperationIDAndTags,
 		},
 		LongRunningFunc: genericfilters.BasicLongRunningRequestCheck(longRunningRE, map[string]string{"watch": "true"}),
 	}

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//pkg/apis/rbac/v1alpha1:go_default_library",
         "//pkg/apis/storage/install:go_default_library",
         "//pkg/apis/storage/v1beta1:go_default_library",
+        "//pkg/apiserver/openapi:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//pkg/genericapiserver:go_default_library",
         "//pkg/healthz:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -35,6 +35,7 @@ import (
 	policyapiv1beta1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 	rbacapi "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 	storageapiv1beta1 "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
+	"k8s.io/kubernetes/pkg/apiserver/openapi"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/healthz"
@@ -104,6 +105,12 @@ type completedConfig struct {
 
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() completedConfig {
+	if c.GenericConfig.OpenAPIConfig != nil && c.GenericConfig.OpenAPIConfig.GetOperationIDAndTags == nil {
+		// Avoid duplicate OpenAPI operation IDs and add GroupVersion tags to all operation definitions.
+		c.GenericConfig.OpenAPIConfig.GetOperationIDAndTags = openapi.GetOperationIDAndTagsFunc(
+			[]string{"extensions_v1beta1", "batch_v2alpha1"},
+			[]string{"getAPIResources", "getAPIGroup", "getAPIVersions"})
+	}
 	c.GenericConfig.Complete()
 
 	// enable swagger UI only if general UI support is on


### PR DESCRIPTION
When we moved to one spec (to rule them all #35388), we added prefix to all Operation IDs in OpenAPI spec (to be precise, the prefix is added after the verb, for example a listPod converted to listCoreV1Pods). These prefixes are not necessary for all GroupVersions and OperationIDs. Some Operation IDs such as getAPIResources defined for more than one GroupVersions and some GroupVersions such as extensions_v1beta1 defined duplicate operation IDs because their operation are release in v1 and still exists in v1beta1. This PR will try to minimize adding prefixes to have a more readable operation IDs. These IDs will be used as method names in clients so it is important to keep them as short as possible.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36002)
<!-- Reviewable:end -->
