### PR TITLE
e2e.go/kops: Bump timeout to 20m, fix KUBERNETES_PROVIDER

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -60,6 +60,7 @@ var (
 	kopsKubeVersion = flag.String("kops-kubernetes-version", "", "(kops only) If set, the version of Kubernetes to deploy (can be a URL to a GCS path where the release is stored) (Defaults to kops default, latest stable release.).")
 	kopsZones       = flag.String("kops-zones", "us-west-2a", "(kops AWS only) AWS zones for kops deployment, comma delimited.")
 	kopsNodes       = flag.Int("kops-nodes", 2, "(kops only) Number of nodes to create.")
+	kopsUpTimeout   = flag.Duration("kops-up-timeout", 20*time.Minute, "(kops only) Time limit between 'kops config / kops update' and a response from the Kubernetes API.")
 
 	// Deprecated flags.
 	deprecatedPush   = flag.Bool("push", false, "Deprecated. Does nothing.")
@@ -524,7 +525,7 @@ func (k kops) Up() error {
 	// TODO(zmerlynn): More cluster validation. This should perhaps be
 	// added to kops and not here, but this is a fine place to loop
 	// for now.
-	for stop := time.Now().Add(10 * time.Minute); time.Now().Before(stop); time.Sleep(30 * time.Second) {
+	for stop := time.Now().Add(*kopsUpTimeout); time.Now().Before(stop); time.Sleep(30 * time.Second) {
 		n, err := clusterSize(k)
 		if err != nil {
 			log.Printf("Can't get cluster size, sleeping: %v", err)

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -49,7 +49,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 # ---- Do cloud-provider-specific setup
 if [[ -n "${KUBERNETES_CONFORMANCE_TEST:-}" ]]; then
     echo "Conformance test: not doing test setup."
-    KUBERNETES_PROVIDER="skeleton"
+    KUBERNETES_PROVIDER=${KUBERNETES_CONFORMANCE_PROVIDER:-"skeleton"}
 
     detect-master-from-kubeconfig
 

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -287,6 +287,7 @@ kops-kubernetes-version
 kops-nodes
 kops-ssh-key
 kops-state
+kops-up-timeout
 kops-zones
 kube-api-burst
 kube-api-content-type


### PR DESCRIPTION
**What this PR does / why we need it**: I don't have a ton of proof, but I think https://k8s-testgrid.appspot.com/google-aws#kops-aws-updown builds 4045-4047 are just AWS and DNS slowness.

In addition, my original PR was meant to change `KUBERNETES_PROVIDER` based on `KUBERNETES_CONFORMANCE_PROVIDER`.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36005)
<!-- Reviewable:end -->
