### PR TITLE
add master address into kubeadm join help message and some validations

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -55,7 +55,7 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 	var cfgPath string
 
 	cmd := &cobra.Command{
-		Use:   "join",
+		Use:   "join <master address>",
 		Short: "Run this on any machine you wish to join an existing cluster",
 		Run: func(cmd *cobra.Command, args []string) {
 			j, err := NewJoin(cfgPath, args, &cfg, skipPreFlight)
@@ -104,11 +104,13 @@ func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, s
 		}
 	}
 
-	// TODO(phase1+) this we are missing args from the help text, there should be a way to tell cobra about it
 	if len(args) == 0 && len(cfg.MasterAddresses) == 0 {
-		return nil, fmt.Errorf("must specify master IP address (see --help)")
+		return nil, fmt.Errorf("must specify master address (see --help)")
 	}
 	cfg.MasterAddresses = append(cfg.MasterAddresses, args...)
+	if len(cfg.MasterAddresses) > 1 {
+		return nil, fmt.Errorf("Must not specify more than one master address  (see --help)")
+	}
 
 	if !skipPreFlight {
 		fmt.Println("Running pre-flight checks")


### PR DESCRIPTION
**What this PR does / why we need it**:

1, add master address into kubeadm join help message. looks like :

>Usage:
>  kubeadm join <master address> [flags]

2, when user provides more than one master address, return an error.

3, since `kubeadm join` not only support ip addresses but also host names or domain names, so i delete the word `ip` from error message `must specify master ip address (see --help)`


Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36040)
<!-- Reviewable:end -->
