### PR TITLE
support ThirdPartyResourceData in StrategicMergePatch

### DIFF
--- a/pkg/util/strategicpatch/patch_test.go
+++ b/pkg/util/strategicpatch/patch_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 type SortMergeListTestCases struct {
@@ -1968,6 +1969,79 @@ func jsonToYAML(j []byte) ([]byte, error) {
 	}
 
 	return y, nil
+}
+
+func TestStrategicMergePatchOnThirdPartyResourceData(t *testing.T) {
+	testCases := []struct {
+		Original       []byte
+		Patch          []byte
+		ExpectedResult string
+	}{
+		{
+			Original:       nil,
+			Patch:          nil,
+			ExpectedResult: "{}",
+		},
+		{
+			Original: []byte(`{
+  "kind": "My",
+  "apiVersion": "my.com/v1",
+  "metadata": {
+    "name": "s"
+  },
+  "data": "v1",
+  "spec": "v2",
+  "hello": "v3"
+}`),
+			Patch: []byte(`{
+  "hello": "v4"
+}`),
+			ExpectedResult: `{"apiVersion":"my.com/v1","data":"v1","hello":"v4","kind":"My","metadata":{"name":"s"},"spec":"v2"}`,
+		},
+		{
+			Original: []byte(`{
+  "kind": "My",
+  "apiVersion": "my.com/v1",
+  "metadata": {
+    "name": "s"
+  },
+  "data": "v1",
+  "spec": "v2",
+  "hello": "v3"
+}`),
+			Patch: []byte(`{
+  "hello": "v4"
+}`),
+			ExpectedResult: `{"apiVersion":"my.com/v1","data":"v1","hello":"v4","kind":"My","metadata":{"name":"s"},"spec":"v2"}`,
+		},
+		{
+			Original: []byte(`{
+  "kind": "My",
+  "apiVersion": "my.com/v1",
+  "metadata": {
+    "name": "s"
+  },
+  "data": "v1",
+  "spec": "v2"
+}`),
+			Patch: []byte(`{
+  "hello": "v4"
+}`),
+			ExpectedResult: `{"apiVersion":"my.com/v1","data":"v1","hello":"v4","kind":"My","metadata":{"name":"s"},"spec":"v2"}`,
+		},
+	}
+
+	var r extensions.ThirdPartyResourceData
+
+	for i, testCase := range testCases {
+		out, err := StrategicMergePatch(testCase.Original, testCase.Patch, r)
+		if err != nil {
+			t.Fatal("%d: unexpected error: %v", i, err)
+		}
+		if string(out) != testCase.ExpectedResult {
+			t.Errorf("%d: expected %s got %s", i, testCase.ExpectedResult, string(out))
+		}
+	}
 }
 
 func TestHasConflicts(t *testing.T) {

--- a/third_party/forked/golang/json/fields.go
+++ b/third_party/forked/golang/json/fields.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"unicode"
 	"unicode/utf8"
+
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // Finds the patchStrategy and patchMergeKey struct tag fields on a given
@@ -28,6 +30,10 @@ func LookupPatchMetadata(t reflect.Type, jsonField string) (reflect.Type, string
 		return nil, "", "", fmt.Errorf("merging an object in json but data type is not map or struct, instead is: %s",
 			t.Kind().String())
 	}
+	if t == reflect.TypeOf(extensions.ThirdPartyResourceData{}) {
+		return t, "", "", nil
+	}
+
 	jf := []byte(jsonField)
 	// Find the field that the JSON library would use.
 	var f *field


### PR DESCRIPTION
In a ThirdPartyResource object:

resource.yaml
```
metadata:
  name: new-object.test.com
apiVersion: extensions/v1beta1
kind: ThirdPartyResource
description: "A New Object"
versions:
- name: v1
```

1.yaml
```
{
  "kind": "NewObject",
  "apiVersion": "test.com/v1",
  "metadata": {
    "name": "a"
  },
  "data": "v1",
  "spec": "v2",
  "hello": "v3"
}
```

2.yaml
```
{
  "kind": "NewObject",
  "apiVersion": "test.com/v1",
  "metadata": {
    "name": "a"
  },
  "data": "v1",
  "spec": "v2",
  "hello": "v4"
}
```

I create the resource and object:
```
$ kubectl create -f resource.yaml
$ kubectl apply -f 1.yaml
```

But when I apply for an update:
```
$ kubectl apply -f 2.yaml
for: "2.yaml": unable to find api field in struct ThirdPartyResourceData for the json field "spec"
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36044)
<!-- Reviewable:end -->
