### PR TITLE
[Part 2] Adding s390x cross-compilation support for gcr.io images in this repo

### DIFF
--- a/build-tools/common.sh
+++ b/build-tools/common.sh
@@ -120,6 +120,13 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,ppc64le/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v4
         );;
+    "s390x")
+        local targets=(
+          kube-apiserver,s390x/busybox
+          kube-controller-manager,s390x/busybox
+          kube-scheduler,s390x/busybox
+          kube-proxy,gcr.io/google_containers/debian-iptables-s390x:v4
+        );;		
   esac
 
   echo "${targets[@]}"

--- a/build-tools/debian-iptables/Makefile
+++ b/build-tools/debian-iptables/Makefile
@@ -35,6 +35,10 @@ ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/debian:jessie
 	QEMUARCH=ppc64le
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:jessie
+	QEMUARCH=s390x
+endif
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/build-tools/debian-iptables/README.md
+++ b/build-tools/debian-iptables/README.md
@@ -21,6 +21,9 @@ $ make push ARCH=arm64
 
 $ make push ARCH=ppc64le
 # ---> gcr.io/google_containers/debian-iptables-ppc64le:TAG
+
+$ make push ARCH=s390x
+# ---> gcr.io/google_containers/debian-iptables-s390x:TAG
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/build-tools/kube-dns/Makefile
+++ b/build-tools/kube-dns/Makefile
@@ -41,6 +41,9 @@ endif
 ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/busybox
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/busybox
+endif
 
 
 all: container

--- a/build-tools/kube-dns/RELEASES.md
+++ b/build-tools/kube-dns/RELEASES.md
@@ -35,6 +35,9 @@ make container PREFIX=<your-docker-hub> TAG=rc
 
 	$ make push ARCH=ppc64le
 	# ---> gcr.io/google_containers/kube-dns-ppc64le:TAG
+
+	$ make push ARCH=s390x
+	# ---> gcr.io/google_containers/kube-dns-s390x:TAG
 	```
 
 6. Manually deploy this to your own cluster by updating the replication

--- a/build-tools/pause/Makefile
+++ b/build-tools/pause/Makefile
@@ -20,10 +20,10 @@ LEGACY_AMD64_IMAGE = $(REGISTRY)/pause
 
 TAG = 3.0
 
-# Architectures supported: amd64, arm, arm64 and ppc64le
+# Architectures supported: amd64, arm, arm64, ppc64le and s390x
 ARCH ?= amd64
 
-ALL_ARCH = amd64 arm arm64 ppc64le
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 CFLAGS = -Os -Wall -static
 KUBE_CROSS_IMAGE ?= gcr.io/google_containers/kube-cross
@@ -46,6 +46,10 @@ endif
 
 ifeq ($(ARCH),ppc64le)
 	TRIPLE ?= powerpc64le-linux-gnu
+endif
+
+ifeq ($(ARCH),s390x)
+	TRIPLE ?= s390x-linux-gnu
 endif
 
 # If you want to build AND push all containers, see the 'all-push' rule.

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -30,6 +30,9 @@ endif
 ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/debian
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian
+endif
 
 .PHONY: build push
 

--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -29,6 +29,9 @@ $ make push ARCH=arm64
 
 $ make push ARCH=ppc64le
 # ---> gcr.io/google-containers/kube-addon-manager-ppc64le:VERSION
+
+$ make push ARCH=s390x
+# ---> gcr.io/google-containers/kube-addon-manager-s390x:VERSION
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -27,6 +27,7 @@
 #    * arm
 #    * arm64
 #    * ppc64le
+#    * s390x
 #
 #  Set KUBERNETES_SKIP_CONFIRM to skip the installation confirmation prompt.
 #  Set KUBERNETES_RELEASE_URL to choose where to download binaries from.
@@ -86,9 +87,12 @@ function detect_client_info() {
     i?86*)
       CLIENT_ARCH="386"
       ;;
+    s390x*)
+      CLIENT_ARCH="s390x"
+      ;;	  
     *)
       echo "Unknown, unsupported architecture (${machine})." >&2
-      echo "Supported architectures x86_64, i686, arm, arm64." >&2
+      echo "Supported architectures x86_64, i686, arm, arm64, s390x." >&2
       echo "Bailing out." >&2
       exit 3
       ;;

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -46,6 +46,9 @@ endif
 ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/busybox
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/busybox
+endif
 
 build:
 	# Copy the content in this dir to the temp dir,

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -21,6 +21,9 @@ $ make push ARCH=arm64
 
 $ make push ARCH=ppc64le
 # ---> gcr.io/google_containers/etcd-ppc64le:TAG
+
+$ make push ARCH=s390x
+# ---> gcr.io/google_containers/etcd-s390x:TAG
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -45,6 +45,10 @@ ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/debian:jessie
 	QEMUARCH=ppc64le
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:jessie
+	QEMUARCH=s390x
+endif
 
 all: build
 

--- a/cluster/images/hyperkube/README.md
+++ b/cluster/images/hyperkube/README.md
@@ -25,6 +25,9 @@ $ make push VERSION={target_version} ARCH=arm64
 
 $ make push VERSION={target_version} ARCH=ppc64le
 # ---> gcr.io/google_containers/hyperkube-ppc64le:VERSION
+
+$ make push VERSION={target_version} ARCH=s390x
+# ---> gcr.io/google_containers/hyperkube-s390x:VERSION
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/images/kube-discovery/Makefile
+++ b/cluster/images/kube-discovery/Makefile
@@ -37,6 +37,10 @@ endif
 ifeq ($(ARCH),ppc64le)
 	BASEIMAGE?=ppc64le/debian:jessie
 endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:jessie
+endif
+
 
 all: build
 

--- a/cluster/juju/layers/kubernetes/reactive/k8s.py
+++ b/cluster/juju/layers/kubernetes/reactive/k8s.py
@@ -478,7 +478,7 @@ def arch():
     # Convert the binary result into a string.
     architecture = architecture.decode('utf-8')
     # Validate the architecture is supported by kubernetes.
-    if architecture not in ['amd64', 'arm', 'arm64', 'ppc64le']:
+    if architecture not in ['amd64', 'arm', 'arm64', 'ppc64le', 's390x']:
         message = 'Unsupported machine architecture: {0}'.format(architecture)
         status_set('blocked', message)
         raise Exception(message)

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -61,6 +61,7 @@ else
     linux/amd64
     linux/arm
     linux/arm64
+    linux/s390x
   )
   if [[ "${KUBE_BUILD_PPC64LE:-}" =~ ^[yY]$ ]]; then
     KUBE_SERVER_PLATFORMS+=(linux/ppc64le)
@@ -78,6 +79,7 @@ else
     darwin/386
     windows/amd64
     windows/386
+    linux/s390x
   )
   if [[ "${KUBE_BUILD_PPC64LE:-}" =~ ^[yY]$ ]]; then
     KUBE_CLIENT_PLATFORMS+=(linux/ppc64le)
@@ -233,18 +235,32 @@ kube::golang::set_platform_envs() {
 
     # Dynamic CGO linking for other server architectures than linux/amd64 goes here
     # If you want to include support for more server platforms than these, add arch-specific gcc names here
-    if [[ ${platform} == "linux/arm" ]]; then
-      export CGO_ENABLED=1
-      export CC=arm-linux-gnueabi-gcc
-      # See https://github.com/kubernetes/kubernetes/issues/29904
-      export GOROOT=${K8S_PATCHED_GOROOT}
-    elif [[ ${platform} == "linux/arm64" ]]; then
-      export CGO_ENABLED=1
-      export CC=aarch64-linux-gnu-gcc
-    elif [[ ${platform} == "linux/ppc64le" ]]; then
-      export CGO_ENABLED=1
-      export CC=powerpc64le-linux-gnu-gcc
-    fi
+    case "${platform}" in
+      "linux/amd64")
+        ;;
+      "linux/arm")
+        export CGO_ENABLED=1
+        export CC=arm-linux-gnueabi-gcc
+        # See https://github.com/kubernetes/kubernetes/issues/29904
+        export GOROOT=${K8S_PATCHED_GOROOT}
+        ;;
+      "linux/arm64")
+        export CGO_ENABLED=1
+        export CC=aarch64-linux-gnu-gcc
+        ;;
+      "linux/ppc64le")
+        export CGO_ENABLED=1
+        export CC=powerpc64le-linux-gnu-gcc
+        ;;
+      "linux/s390x")
+        export CGO_ENABLED=1
+        export CC=s390x-linux-gnu-gcc
+        ;;
+      *)
+        echo "Unsupported architecture to cross-compile from linux/amd64." >&2
+        exit 1
+        ;;
+    esac
   fi
 }
 

--- a/test/images/serve_hostname/Makefile
+++ b/test/images/serve_hostname/Makefile
@@ -24,10 +24,10 @@ TAG ?= v1.5
 REGISTRY ?= gcr.io/google_containers
 TEST_REGISTRY ?= b.gcr.io/k8s_authenticated_test
 
-# Architectures supported: amd64, arm, arm64 and ppc64le
+# Architectures supported: amd64, arm, arm64, ppc64le and s390x
 ARCH ?= amd64
 
-ALL_ARCH = amd64 arm arm64 ppc64le
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 GOARM=6
 TEMP_DIR := $(shell mktemp -d)
@@ -51,6 +51,9 @@ ifeq ($(ARCH),arm64)
 endif
 ifeq ($(ARCH),ppc64le)
         BASEIMAGE?=ppc64le/busybox
+endif
+ifeq ($(ARCH),s390x)
+        BASEIMAGE?=s390x/busybox
 endif
 
 # If you want to build AND push all containers, see the 'all-push' rule.

--- a/test/images/serve_hostname/README.md
+++ b/test/images/serve_hostname/README.md
@@ -25,6 +25,9 @@ $ make push ARCH=arm64
 
 $ make push ARCH=ppc64le
 # ---> gcr.io/google_containers/serve_hostname-ppc64le:TAG
+
+$ make push ARCH=s390x
+# ---> gcr.io/google_containers/serve_hostname-s390x:TAG
 ```
 
 Of course, if you don't want to push the images, run `make all-container` or `make container ARCH={target_arch}` instead.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: This PR enables s390x support to kube-dns , pause, addon-manager, etcd, hyperkube, kube-discovery etc. This PR also includes the changes due to which it can be cross compiled on x86 host architecture.

**Which issue this PR fixes #34328

**Special notes for your reviewer**:  In existing file "build-tools/build-image/cross/Dockerfile" the repository mentioned for installing cross build tool chains for supporting architecture does not have a tool chain for s390x hence in my PR I am changing the repository so that it will be cross compiled for s390x.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
Allows cross compilation of Kubernetes on x86 host for s390x also enables s390x support to kube-dns , pause, addon-manager, etcd, hyperkube, kube-discovery etc  
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36050)
<!-- Reviewable:end -->
