### PR TITLE
Added config map with TTLs for apiservers.

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -120,7 +120,6 @@ go_test(
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/runtime:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
-        "//pkg/util/intstr:go_default_library",
         "//pkg/util/net:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/version:go_default_library",

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -17,911 +17,358 @@ limitations under the License.
 package master
 
 import (
-	"errors"
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	"k8s.io/kubernetes/pkg/client/testing/core"
-	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
-func TestReconcileEndpoints(t *testing.T) {
-	ns := api.NamespaceDefault
-	om := func(name string) api.ObjectMeta {
-		return api.ObjectMeta{Namespace: ns, Name: name}
-	}
-	reconcile_tests := []struct {
-		testName          string
-		serviceName       string
-		ip                string
-		endpointPorts     []api.EndpointPort
-		additionalMasters int
-		endpoints         *api.EndpointsList
-		expectUpdate      *api.Endpoints // nil means none expected
-		expectCreate      *api.Endpoints // nil means none expected
+var now = time.Now()
+
+const window = 3 * DefaultEndpointReconcilerInterval
+const format = "20060102 150405 MST"
+
+type Interface interface{}
+
+func TestDynamicReconciler(t *testing.T) {
+
+	cmTests := []struct {
+		testName       string
+		cmName         string
+		serviceName    string
+		ip             string
+		endpointPorts  []api.EndpointPort
+		reconcilePort  bool
+		cm             *api.ConfigMap
+		cmExpectUpdate Interface // nil means none expected
+		cmExpectCreate Interface // nil means none expected
+		ep             *api.EndpointsList
+		epExpectUpdate Interface // nil means none expected
+		epExpectCreate Interface // nil means none expected
 	}{
 		{
-			testName:      "no existing endpoints",
-			serviceName:   "foo",
+			testName:      "cm single create",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
 			ip:            "1.2.3.4",
 			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints:     nil,
-			expectCreate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+			cmExpectCreate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data:       map[string]string{"1.2.3.4": now.Add(window).Format(format)},
 			},
-		},
-		{
-			testName:      "existing endpoints satisfy",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
+			epExpectCreate: &api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+				Subsets: []api.EndpointSubset{
+					{
 						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
 						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
+					},
+				},
 			},
 		},
+
 		{
-			testName:      "existing endpoints satisfy but too many",
-			serviceName:   "foo",
+			testName:      "cm single update",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
 			ip:            "1.2.3.4",
 			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
+			cm: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data:       map[string]string{"1.2.3.4": now.Add(-window).Format(format)},
 			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+			cmExpectUpdate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data:       map[string]string{"1.2.3.4": now.Add(window).Format(format)},
+			},
+			epExpectCreate: &api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+				Subsets: []api.EndpointSubset{
+					{
+						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					},
+				},
 			},
 		},
+
 		{
-			testName:          "existing endpoints satisfy but too many + extra masters",
-			serviceName:       "foo",
-			ip:                "1.2.3.4",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
+			testName:      "cm multiple update",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
+			ip:            "1.2.3.4",
+			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			cm: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Format(format),
+					"1.2.3.5": now.Add(-2 * window).Format(format),
+					"1.2.3.6": now.Add(window / 2).Format(format),
+					"1.2.3.7": now.Add((3 * window) / 2).Format(format),
+				},
+			},
+			cmExpectUpdate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window).Format(format),
+					"1.2.3.6": now.Add(window / 2).Format(format),
+					"1.2.3.7": now.Add((3 * window) / 2).Format(format),
+				},
+			},
+			epExpectCreate: &api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+				Subsets: []api.EndpointSubset{
+					{
 						Addresses: []api.EndpointAddress{
 							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
+							{IP: "1.2.3.6"},
+							{IP: "1.2.3.7"},
 						},
 						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
-						{IP: "1.2.3.4"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+				},
 			},
 		},
+
 		{
-			testName:          "existing endpoints satisfy but too many + extra masters + delete first",
-			serviceName:       "foo",
-			ip:                "4.3.2.4",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
+			testName:      "ep multiple update",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
+			ip:            "1.2.3.4",
+			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			cm: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Format(format),
+					"1.2.3.5": now.Add(-2 * window).Format(format),
+					"1.2.3.6": now.Add(window / 2).Format(format),
+					"1.2.3.7": now.Add((3 * window) / 2).Format(format),
+				},
+			},
+			cmExpectUpdate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window).Format(format),
+					"1.2.3.6": now.Add(window / 2).Format(format),
+					"1.2.3.7": now.Add((3 * window) / 2).Format(format),
+				},
+			},
+			ep: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+						Subsets: []api.EndpointSubset{
+							{
+								Addresses: []api.EndpointAddress{
+									{IP: "1.2.3.4"},
+									{IP: "1.2.3.5"},
+									{IP: "1.2.3.7"},
+								},
+								Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							},
+						},
+					},
+				},
+			},
+			epExpectUpdate: &api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+				Subsets: []api.EndpointSubset{
+					{
 						Addresses: []api.EndpointAddress{
 							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
+							{IP: "1.2.3.6"},
+							{IP: "1.2.3.7"},
 						},
 						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+				},
 			},
 		},
+
 		{
-			testName:          "existing endpoints satisfy and endpoint addresses length less than master count",
-			serviceName:       "foo",
-			ip:                "4.3.2.2",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
+			testName:      "ep do reconcile port",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
+			ip:            "1.2.3.4",
+			endpointPorts: []api.EndpointPort{{Name: "bar", Port: 9090, Protocol: "TCP"}},
+			reconcilePort: true,
+			cm: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window / 2).Format(format),
+					"1.2.3.5": now.Add(window / 2).Format(format),
+				},
+			},
+			cmExpectUpdate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window).Format(format),
+					"1.2.3.5": now.Add(window / 2).Format(format),
+				},
+			},
+			ep: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+						Subsets: []api.EndpointSubset{
+							{
+								Addresses: []api.EndpointAddress{
+									{IP: "1.2.3.4"},
+									{IP: "1.2.3.5"},
+								},
+								Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							},
+						},
+					},
+				},
+			},
+			epExpectUpdate: &api.Endpoints{
+				ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+				Subsets: []api.EndpointSubset{
+					{
 						Addresses: []api.EndpointAddress{
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
+							{IP: "1.2.3.4"},
+							{IP: "1.2.3.5"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: nil,
-		},
-		{
-			testName:          "existing endpoints current IP missing and address length less than master count",
-			serviceName:       "foo",
-			ip:                "4.3.2.2",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
-							{IP: "4.3.2.1"},
-						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
+						Ports: []api.EndpointPort{{Name: "bar", Port: 9090, Protocol: "TCP"}},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+				},
 			},
 		},
+
 		{
-			testName:      "existing endpoints wrong name",
-			serviceName:   "foo",
+			testName:      "ep don't reconcile port",
+			cmName:        "apiservers",
+			serviceName:   "kubernetes",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("bar"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
+			endpointPorts: []api.EndpointPort{{Name: "bar", Port: 9090, Protocol: "TCP"}},
+			reconcilePort: false,
+			cm: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window / 2).Format(format),
+					"1.2.3.5": now.Add(window / 2).Format(format),
+				},
 			},
-			expectCreate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
+			cmExpectUpdate: &api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{Name: "apiservers", Namespace: "kube-system"},
+				Data: map[string]string{
+					"1.2.3.4": now.Add(window).Format(format),
+					"1.2.3.5": now.Add(window / 2).Format(format),
+				},
 			},
-		},
-		{
-			testName:      "existing endpoints wrong IP",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-		{
-			testName:      "existing endpoints wrong port",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-		{
-			testName:      "existing endpoints wrong protocol",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-		{
-			testName:      "existing endpoints wrong port name",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-		{
-			testName:    "existing endpoints extra service ports satisfy",
-			serviceName: "foo",
-			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
-				{Name: "foo", Port: 8080, Protocol: "TCP"},
-				{Name: "bar", Port: 1000, Protocol: "TCP"},
-				{Name: "baz", Port: 1010, Protocol: "TCP"},
-			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports: []api.EndpointPort{
-							{Name: "foo", Port: 8080, Protocol: "TCP"},
-							{Name: "bar", Port: 1000, Protocol: "TCP"},
-							{Name: "baz", Port: 1010, Protocol: "TCP"},
+			ep: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						ObjectMeta: api.ObjectMeta{Name: "kubernetes", Namespace: "default"},
+						Subsets: []api.EndpointSubset{
+							{
+								Addresses: []api.EndpointAddress{
+									{IP: "1.2.3.4"},
+									{IP: "1.2.3.5"},
+								},
+								Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							},
 						},
-					}},
-				}},
-			},
-		},
-		{
-			testName:    "existing endpoints extra service ports missing port",
-			serviceName: "foo",
-			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
-				{Name: "foo", Port: 8080, Protocol: "TCP"},
-				{Name: "bar", Port: 1000, Protocol: "TCP"},
-			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports: []api.EndpointPort{
-						{Name: "foo", Port: 8080, Protocol: "TCP"},
-						{Name: "bar", Port: 1000, Protocol: "TCP"},
 					},
-				}},
+				},
 			},
 		},
 	}
-	for _, test := range reconcile_tests {
-		fakeClient := fake.NewSimpleClientset()
-		if test.endpoints != nil {
-			fakeClient = fake.NewSimpleClientset(test.endpoints)
+
+	for _, test := range cmTests {
+
+		fakeCMClient := fake.NewSimpleClientset()
+		if test.cm != nil {
+			fakeCMClient = fake.NewSimpleClientset(test.cm)
 		}
-		reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.Core())
-		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
+
+		fakeEPClient := fake.NewSimpleClientset()
+		if test.ep != nil {
+			fakeEPClient = fake.NewSimpleClientset(test.ep)
+		}
+		reconciler := NewDynamicEndpointReconciler(fakeEPClient.Core(), fakeCMClient.Core())
+		err := reconciler.ReconcileEndpoints(test.cmName, test.serviceName, net.ParseIP(test.ip), test.endpointPorts, test.reconcilePort, now)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
 
-		updates := []core.UpdateAction{}
-		for _, action := range fakeClient.Actions() {
-			if action.GetVerb() != "update" {
-				continue
-			}
-			updates = append(updates, action.(core.UpdateAction))
-		}
-		if test.expectUpdate != nil {
-			if len(updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, updates)
-			} else if e, a := test.expectUpdate, updates[0].GetObject(); !reflect.DeepEqual(e, a) {
-				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
-			}
-		}
-		if test.expectUpdate == nil && len(updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, updates)
-		}
-
-		creates := []core.CreateAction{}
-		for _, action := range fakeClient.Actions() {
+		// handle config map
+		cmCreates := []core.CreateAction{}
+		for _, action := range fakeCMClient.Actions() {
 			if action.GetVerb() != "create" {
 				continue
 			}
-			creates = append(creates, action.(core.CreateAction))
+			cmCreates = append(cmCreates, action.(core.CreateAction))
 		}
-		if test.expectCreate != nil {
-			if len(creates) != 1 {
-				t.Errorf("case %q: unexpected creates: %v", test.testName, creates)
-			} else if e, a := test.expectCreate, creates[0].GetObject(); !reflect.DeepEqual(e, a) {
+		if test.cmExpectCreate != nil {
+			if len(cmCreates) == 0 {
+				t.Errorf("case %q: unexpected creates: %v", test.testName, test.cmExpectCreate)
+			} else if e, a := test.cmExpectCreate, cmCreates[0].GetObject(); !reflect.DeepEqual(e, a) { // compare the first create
 				t.Errorf("case %q: expected create:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}
 		}
-		if test.expectCreate == nil && len(creates) > 0 {
-			t.Errorf("case %q: no create expected, yet saw: %v", test.testName, creates)
+		if test.cmExpectCreate == nil && len(cmCreates) > 0 {
+			t.Errorf("case %q: no create expected, yet saw: %v", test.testName, cmCreates)
 		}
 
-	}
-
-	non_reconcile_tests := []struct {
-		testName          string
-		serviceName       string
-		ip                string
-		endpointPorts     []api.EndpointPort
-		additionalMasters int
-		endpoints         *api.EndpointsList
-		expectUpdate      *api.Endpoints // nil means none expected
-		expectCreate      *api.Endpoints // nil means none expected
-	}{
-		{
-			testName:    "existing endpoints extra service ports missing port no update",
-			serviceName: "foo",
-			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
-				{Name: "foo", Port: 8080, Protocol: "TCP"},
-				{Name: "bar", Port: 1000, Protocol: "TCP"},
-			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: nil,
-		},
-		{
-			testName:    "existing endpoints extra service ports, wrong ports, wrong IP",
-			serviceName: "foo",
-			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
-				{Name: "foo", Port: 8080, Protocol: "TCP"},
-				{Name: "bar", Port: 1000, Protocol: "TCP"},
-			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
-					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				}},
-			},
-			expectUpdate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-		{
-			testName:      "no existing endpoints",
-			serviceName:   "foo",
-			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints:     nil,
-			expectCreate: &api.Endpoints{
-				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
-		},
-	}
-	for _, test := range non_reconcile_tests {
-		fakeClient := fake.NewSimpleClientset()
-		if test.endpoints != nil {
-			fakeClient = fake.NewSimpleClientset(test.endpoints)
-		}
-		reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.Core())
-		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
-		if err != nil {
-			t.Errorf("case %q: unexpected error: %v", test.testName, err)
-		}
-
-		updates := []core.UpdateAction{}
-		for _, action := range fakeClient.Actions() {
+		cmUpdates := []core.UpdateAction{}
+		for _, action := range fakeCMClient.Actions() {
 			if action.GetVerb() != "update" {
 				continue
 			}
-			updates = append(updates, action.(core.UpdateAction))
+			cmUpdates = append(cmUpdates, action.(core.UpdateAction))
 		}
-		if test.expectUpdate != nil {
-			if len(updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, updates)
-			} else if e, a := test.expectUpdate, updates[0].GetObject(); !reflect.DeepEqual(e, a) {
+		if test.cmExpectUpdate != nil {
+			if len(cmUpdates) == 0 {
+				t.Errorf("case %q: unexpected updates: %v", test.testName, cmUpdates)
+			} else if e, a := test.cmExpectUpdate, cmUpdates[0].GetObject(); !reflect.DeepEqual(e, a) { // compare the first update
 				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}
 		}
-		if test.expectUpdate == nil && len(updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, updates)
+		if test.cmExpectUpdate == nil && len(cmUpdates) > 0 {
+			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, cmUpdates)
 		}
 
-		creates := []core.CreateAction{}
-		for _, action := range fakeClient.Actions() {
+		// handle endpoints
+		epCreates := []core.CreateAction{}
+		for _, action := range fakeEPClient.Actions() {
 			if action.GetVerb() != "create" {
 				continue
 			}
-			creates = append(creates, action.(core.CreateAction))
+			epCreates = append(epCreates, action.(core.CreateAction))
 		}
-		if test.expectCreate != nil {
-			if len(creates) != 1 {
-				t.Errorf("case %q: unexpected creates: %v", test.testName, creates)
-			} else if e, a := test.expectCreate, creates[0].GetObject(); !reflect.DeepEqual(e, a) {
+		if test.epExpectCreate != nil {
+			if len(epCreates) == 0 {
+				t.Errorf("case %q: unexpected creates: %v", test.testName, test.epExpectCreate)
+			} else if e, a := test.epExpectCreate, epCreates[0].GetObject(); !reflect.DeepEqual(e, a) { // compare the first create
 				t.Errorf("case %q: expected create:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}
 		}
-		if test.expectCreate == nil && len(creates) > 0 {
-			t.Errorf("case %q: no create expected, yet saw: %v", test.testName, creates)
+		if test.epExpectCreate == nil && len(epCreates) > 0 {
+			t.Errorf("case %q: no create expected, yet saw: %v", test.testName, cmCreates)
 		}
 
-	}
-
-}
-
-func TestCreateOrUpdateMasterService(t *testing.T) {
-	ns := api.NamespaceDefault
-	om := func(name string) api.ObjectMeta {
-		return api.ObjectMeta{Namespace: ns, Name: name}
-	}
-
-	create_tests := []struct {
-		testName     string
-		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		expectCreate *api.Service // nil means none expected
-	}{
-		{
-			testName:    "service does not exist",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			expectCreate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-	}
-	for _, test := range create_tests {
-		master := Controller{}
-		registry := &registrytest.ServiceRegistry{
-			Err: errors.New("unable to get svc"),
-		}
-		master.ServiceRegistry = registry
-		master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
-		if test.expectCreate != nil {
-			if len(registry.List.Items) != 1 {
-				t.Errorf("case %q: unexpected creations: %v", test.testName, registry.List.Items)
-			} else if e, a := test.expectCreate.Spec, registry.List.Items[0].Spec; !reflect.DeepEqual(e, a) {
-				t.Errorf("case %q: expected create:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+		epUpdates := []core.UpdateAction{}
+		for _, action := range fakeEPClient.Actions() {
+			if action.GetVerb() != "update" {
+				continue
 			}
+			epUpdates = append(epUpdates, action.(core.UpdateAction))
 		}
-		if test.expectCreate == nil && len(registry.List.Items) > 1 {
-			t.Errorf("case %q: no create expected, yet saw: %v", test.testName, registry.List.Items)
-		}
-	}
-
-	reconcile_tests := []struct {
-		testName     string
-		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		service      *api.Service
-		expectUpdate *api.Service // nil means none expected
-	}{
-		{
-			testName:    "service definition wrong port",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8000, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition missing port",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-				{Name: "baz", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-						{Name: "baz", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition incorrect port",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "bar", Port: 1000, Protocol: "UDP", TargetPort: intstr.FromInt(1000)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition incorrect port name",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 1000, Protocol: "UDP", TargetPort: intstr.FromInt(1000)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition incorrect target port",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition incorrect protocol",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "UDP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition has incorrect type",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeNodePort,
-				},
-			},
-			expectUpdate: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-		},
-		{
-			testName:    "service definition satisfies",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: nil,
-		},
-	}
-	for _, test := range reconcile_tests {
-		master := Controller{}
-		registry := &registrytest.ServiceRegistry{
-			Service: test.service,
-		}
-		master.ServiceRegistry = registry
-		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, true)
-		if err != nil {
-			t.Errorf("case %q: unexpected error: %v", test.testName, err)
-		}
-		if test.expectUpdate != nil {
-			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+		if test.epExpectUpdate != nil {
+			if len(epUpdates) == 0 {
+				t.Errorf("case %q: unexpected updates: %v", test.testName, epUpdates)
+			} else if e, a := test.epExpectUpdate, epUpdates[0].GetObject(); !reflect.DeepEqual(e, a) { // compare the first update
 				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}
 		}
-		if test.expectUpdate == nil && len(registry.Updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
-		}
-	}
-
-	non_reconcile_tests := []struct {
-		testName     string
-		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		service      *api.Service
-		expectUpdate *api.Service // nil means none expected
-	}{
-		{
-			testName:    "service definition wrong port, no expected update",
-			serviceName: "foo",
-			servicePorts: []api.ServicePort{
-				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
-			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
-				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
-						{Name: "foo", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
-					},
-					Selector:        nil,
-					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityClientIP,
-					Type:            api.ServiceTypeClusterIP,
-				},
-			},
-			expectUpdate: nil,
-		},
-	}
-	for _, test := range non_reconcile_tests {
-		master := Controller{}
-		registry := &registrytest.ServiceRegistry{
-			Service: test.service,
-		}
-		master.ServiceRegistry = registry
-		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
-		if err != nil {
-			t.Errorf("case %q: unexpected error: %v", test.testName, err)
-		}
-		if test.expectUpdate != nil {
-			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
-				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
-			}
-		}
-		if test.expectUpdate == nil && len(registry.Updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
+		if test.epExpectUpdate == nil && len(epUpdates) > 0 {
+			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, epUpdates)
 		}
 	}
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -69,7 +69,7 @@ import (
 const (
 	// DefaultEndpointReconcilerInterval is the default amount of time for how often the endpoints for
 	// the kubernetes Service are reconciled.
-	DefaultEndpointReconcilerInterval = 10 * time.Second
+	DefaultEndpointReconcilerInterval = 5 * time.Second
 )
 
 type Config struct {
@@ -177,7 +177,7 @@ func (c *Config) Complete() completedConfig {
 	if c.EndpointReconcilerConfig.Reconciler == nil {
 		// use a default endpoint reconciler if nothing is set
 		endpointClient := coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-		c.EndpointReconcilerConfig.Reconciler = NewMasterCountEndpointReconciler(c.MasterCount, endpointClient)
+		c.EndpointReconcilerConfig.Reconciler = NewDynamicEndpointReconciler(endpointClient, endpointClient)
 	}
 
 	// this has always been hardcoded true in the past


### PR DESCRIPTION
Added config map with TTLs for apiservers.
Reconciliation of running apiservers is now based on the map.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36057)
<!-- Reviewable:end -->
