### PR TITLE
Add use case to service affinity

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -715,6 +715,11 @@ func NewServiceAffinityPredicate(podLister algorithm.PodLister, serviceLister al
 // the same service are running on nodes with
 // the exact same ServiceAffinity.label values).
 //
+// For example:
+// If the first pod of a service was scheduled to a node with label "region=foo",
+// all the other subsequent pods belong to the same service will be schedule on
+// nodes with the same "region=foo" label.
+//
 // Details:
 //
 // If (the svc affinity labels are not a subset of pod's label selectors )


### PR DESCRIPTION
Also part of nits in refactoring predicates, I found the explanation of `serviceaffinity` in its comment is very hard to understand. So I added example instead here to help user/developer to digest it.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36060)
<!-- Reviewable:end -->
