### PR TITLE
Restore old apiserver cert CN

### DIFF
--- a/pkg/genericapiserver/BUILD
+++ b/pkg/genericapiserver/BUILD
@@ -65,6 +65,7 @@ go_library(
         "//pkg/util/net:go_default_library",
         "//pkg/util/runtime:go_default_library",
         "//pkg/util/sets:go_default_library",
+        "//pkg/util/validation:go_default_library",
         "//pkg/util/wait:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor:github.com/coreos/go-systemd/daemon",

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -138,7 +138,7 @@ func GenerateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
-			CommonName: host,
+			CommonName: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
 		},
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(time.Hour * 24 * 365),


### PR DESCRIPTION
This patch got lost during rebase of https://github.com/kubernetes/kubernetes/pull/35109:

- set `host@<unix-timestamp>` as CN in self-signed apiserver certs
- skip non-domain CN in getNamedCertificateMap

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36068)
<!-- Reviewable:end -->
