### PR TITLE
fix local resource output when `-f` not specified

### DIFF
--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -36,7 +36,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["set_image_test.go"],
+    srcs = [
+        "set_image_test.go",
+        "set_test.go",
+    ],
     data = [
         "//examples:config",
     ],
@@ -50,5 +53,6 @@ go_test(
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/resource:go_default_library",
+        "//vendor:github.com/spf13/cobra",
     ],
 )

--- a/pkg/kubectl/cmd/set/set_test.go
+++ b/pkg/kubectl/cmd/set/set_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	clientcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func TestLocalAndDryRunFlags(t *testing.T) {
+	out := &bytes.Buffer{}
+	errout := &bytes.Buffer{}
+	f := clientcmdutil.NewFactory(nil)
+	setCmd := NewCmdSet(f, out, errout)
+	ensureLocalAndDryRunFlagsOnChildren(t, setCmd, "")
+}
+
+func ensureLocalAndDryRunFlagsOnChildren(t *testing.T, c *cobra.Command, prefix string) {
+	for _, cmd := range c.Commands() {
+		name := prefix + cmd.Name()
+		if localFlag := cmd.Flag("local"); localFlag == nil {
+			t.Errorf("Command %s does not implement the --local flag", name)
+		}
+		if dryRunFlag := cmd.Flag("dry-run"); dryRunFlag == nil {
+			t.Errorf("Command %s does not implement the --dry-run flag", name)
+		}
+		ensureLocalAndDryRunFlagsOnChildren(t, cmd, name+".")
+	}
+}


### PR DESCRIPTION
**Release note**:
```release-note
release-note-none
```

`kubectl set image` does not have a `--dry-run` option. Although it offers a
`--local` flag, it does not support server request, limiting input to that of stdin
or that of a local file.

This patch adds a `--dry-run` option to the `kubectl set image` command,
allowing for resources from the server to be selected, without making any
mutations.

cc @ncdc 

Related PR: https://github.com/kubernetes/kubernetes/pull/36174

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36071)
<!-- Reviewable:end -->
