### PR TITLE
Move .gitattributes annotation to the root, so GitHub will respect them.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+hack/verify-flags/known-flags.txt merge=union
+test/test_owners.csv merge=union

--- a/hack/verify-flags/.gitattributes
+++ b/hack/verify-flags/.gitattributes
@@ -1,1 +1,0 @@
-known-flags.txt merge=union

--- a/test/.gitattributes
+++ b/test/.gitattributes
@@ -1,1 +1,0 @@
-test_owners.csv merge=union


### PR DESCRIPTION
This should fix the merge conflicts by letting GitHub use the simpler line-by-line algorithm for this file. Having .gitattributes in a sub-directory would work for local merging, but would show conflicts on the web UI.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36075)
<!-- Reviewable:end -->
