### PR TITLE
Plumb through OUT_DIR for build-tools

### DIFF
--- a/build-tools/common.sh
+++ b/build-tools/common.sh
@@ -62,7 +62,8 @@ readonly KUBE_BUILD_IMAGE_VERSION="${KUBE_BUILD_IMAGE_VERSION_BASE}-${KUBE_BUILD
 #                    is really remote, this is the stuff that has to be copied
 #                    back.
 # OUT_DIR can come in from the Makefile, so honor it.
-readonly LOCAL_OUTPUT_ROOT="${KUBE_ROOT}/${OUT_DIR:-_output}"
+readonly OUT_DIR="${OUT_DIR:-_output}"
+readonly LOCAL_OUTPUT_ROOT="${KUBE_ROOT}/${OUT_DIR}"
 readonly LOCAL_OUTPUT_SUBPATH="${LOCAL_OUTPUT_ROOT}/dockerized"
 readonly LOCAL_OUTPUT_BINPATH="${LOCAL_OUTPUT_SUBPATH}/bin"
 readonly LOCAL_OUTPUT_GOPATH="${LOCAL_OUTPUT_SUBPATH}/go"
@@ -72,7 +73,7 @@ readonly LOCAL_OUTPUT_IMAGE_STAGING="${LOCAL_OUTPUT_ROOT}/images"
 readonly THIS_PLATFORM_BIN="${LOCAL_OUTPUT_ROOT}/bin"
 
 readonly REMOTE_ROOT="/go/src/${KUBE_GO_PACKAGE}"
-readonly REMOTE_OUTPUT_ROOT="${REMOTE_ROOT}/_output"
+readonly REMOTE_OUTPUT_ROOT="${REMOTE_ROOT}/${OUT_DIR}"
 readonly REMOTE_OUTPUT_SUBPATH="${REMOTE_OUTPUT_ROOT}/dockerized"
 readonly REMOTE_OUTPUT_BINPATH="${REMOTE_OUTPUT_SUBPATH}/bin"
 readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
@@ -159,7 +160,7 @@ function kube::build::verify_prereqs() {
     "${DOCKER[@]}" version | kube::log::info_from_stdin
   fi
 
-  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${KUBE_ROOT}")
+  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${KUBE_ROOT}:${OUT_DIR}")
   KUBE_BUILD_IMAGE_TAG_BASE="build-${KUBE_ROOT_HASH}"
   KUBE_BUILD_IMAGE_TAG="${KUBE_BUILD_IMAGE_TAG_BASE}-${KUBE_BUILD_IMAGE_VERSION}"
   KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
@@ -557,10 +558,11 @@ function kube::build::run_build_command_ex() {
   done
 
   docker_run_opts+=(
+    --env "OUT_DIR"
     --env "KUBE_FASTBUILD=${KUBE_FASTBUILD:-false}"
     --env "KUBE_BUILDER_OS=${OSTYPE:-notdetected}"
-    --env "KUBE_BUILD_PPC64LE=${KUBE_BUILD_PPC64LE}"  # TODO(IBM): remove
-    --env "KUBE_VERBOSE=${KUBE_VERBOSE}"
+    --env "KUBE_BUILD_PPC64LE"  # TODO(IBM): remove
+    --env "KUBE_VERBOSE"
   )
 
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'
@@ -669,7 +671,7 @@ function kube::build::sync_to_container() {
     --filter='- /.git/' \
     --filter='- /.make/' \
     --filter='- /_tmp/' \
-    --filter='- /_output/' \
+    --filter="- /${OUT_DIR}/" \
     --filter='- /' \
     "${KUBE_ROOT}/" "rsync://k8s@${KUBE_RSYNC_ADDR}/k8s/"
 
@@ -702,7 +704,7 @@ function kube::build::copy_output() {
     --password-file="${LOCAL_OUTPUT_BUILD_CONTEXT}/rsyncd.password" \
     --filter='- /vendor/' \
     --filter='- /_temp/' \
-    --filter='+ /_output/dockerized/bin/**' \
+    --filter="+ /${OUT_DIR}/dockerized/bin/"'**' \
     --filter='+ zz_generated.*' \
     --filter='+ generated.proto' \
     --filter='+ *.pb.go' \


### PR DESCRIPTION
The makefile and the hack dir still have a bunch of hard coded _output dirs but at least the dockerized build seems to plumb this through now.

Note that this will create a unique build image per unique OUT_DIR.  This is needed as the rsync password is encoded in the image.  We could fix that by passing that password in on the command line or env var in the docker run command for the rsync.

Helps with #23839.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36078)
<!-- Reviewable:end -->
