### PR TITLE
Update seccomp runtime/default to docker/default

### DIFF
--- a/docs/design/seccomp.md
+++ b/docs/design/seccomp.md
@@ -191,7 +191,7 @@ profiles to be opaque to kubernetes for now.
 
 The following format is scoped as follows:
 
-1.  `runtime/default` - the default profile for the container runtime
+1.  `docker/default` - the default profile for the container runtime
 2.  `unconfined` - unconfined profile, ie, no seccomp sandboxing
 3.  `localhost/<profile-name>` - the profile installed to the node's local seccomp profile root
 


### PR DESCRIPTION
The docs are not in alignment with the code and the code is correct:

https://github.com/kubernetes/kubernetes/blob/59caf07228231c7c78aae66f9c1ad60e2c42fc29/pkg/kubelet/dockertools/docker_manager.go#L1191

https://github.com/kubernetes/kubernetes/blob/59caf07228231c7c78aae66f9c1ad60e2c42fc29/pkg/api/validation/validation.go#L2122

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36086)
<!-- Reviewable:end -->
