### PR TITLE
fix verify-bazel.sh on mac and windows

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -21,7 +21,7 @@ export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 go get -u github.com/mikedanese/gazel
-if [[ $("${GOPATH}/bin/gazel" -dry-run -root="$(kube::realpath ${KUBE_ROOT})" |& tee /dev/stderr | wc -l) != 0 ]]; then
+if [[ $("${GOPATH}/bin/gazel" -dry-run -root="$(kube::realpath ${KUBE_ROOT})" 2>&1 | tee /dev/stderr | wc -l | tr -d '[:space:]') != 0 ]]; then
   echo
   echo "BUILD files are not up to date"
   echo "Run ./hack/update-bazel.sh"


### PR DESCRIPTION
mac bash doesn't like |& because mac bash is really old. the formating of wc
is also slightly different then on linux.


```console
$ # on linux
$ echo -n | wc -l
0
$ # on mac
$ echo -n | wc -l
       0
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36089)
<!-- Reviewable:end -->
