### PR TITLE
Disable the test-owners verify step until the merge conflicts are resolved

### DIFF
--- a/hack/verify-test-owners.sh
+++ b/hack/verify-test-owners.sh
@@ -20,8 +20,10 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
+
 cd "${KUBE_ROOT}"
 if ! hack/update_owners.py --check; then
     echo 'Run ./hack/update_owners.py to fix it'
+    exit  # TODO(rmmh): fix Github merging to respect .gitattributes
     exit 1
 fi


### PR DESCRIPTION
It's causing more pain than it's preventing currently. There should be some simpler ways to fix this.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36096)
<!-- Reviewable:end -->
