### PR TITLE
Cleanup leaking goroutine

### DIFF
--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -49,23 +49,8 @@ func (r *streamingRuntime) exec(containerID string, cmd []string, in io.Reader, 
 		return err
 	}
 
-	// TODO(timstclair): Clean this up once PR#33366 merges.
-	if timeout <= 0 {
-		// Run until command exits.
-		return r.execHandler.ExecInContainer(r.client, container, cmd, in, out, errw, tty, resize)
-	}
-
-	errCh := make(chan error)
-	go func() {
-		errCh <- r.execHandler.ExecInContainer(r.client, container, cmd, in, out, errw, tty, resize)
-	}()
-
-	select {
-	case err := <-errCh:
-		return err
-	case <-time.After(timeout):
-		return streaming.ErrorTimeout("exec", timeout)
-	}
+	// TODO(timstclair): Add timeout once PR#33366 merges.
+	return r.execHandler.ExecInContainer(r.client, container, cmd, in, out, errw, tty, resize)
 }
 
 func (r *streamingRuntime) Attach(containerID string, in io.Reader, out, errw io.WriteCloser, resize <-chan term.Size) error {


### PR DESCRIPTION
Cleanup potential go-routine leak in ExecSync path by removing timeout support. Timeout support is added in https://github.com/kubernetes/kubernetes/pull/33366 and https://github.com/kubernetes/kubernetes/pull/35893, and until those merge this is consistent with current behavior.

/cc @rhcarvalho

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36100)
<!-- Reviewable:end -->
