### PR TITLE
Hard code godep version to v74

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -84,7 +84,7 @@ pushd "${_kubetmp}" 2>&1 > /dev/null
     popd > /dev/null
   }
   # Use to following if we ever need to pin godep to a specific version again
-  #pin-godep 'v63'
+  pin-godep 'v74'
 
   # Fill out that nice clean place with the kube godeps
   echo "Starting to download all kubernetes godeps. This takes a while"


### PR DESCRIPTION
To fixes https://github.com/kubernetes/kubernetes/issues/36111

Latest version of godep has this change https://github.com/tools/godep/pull/522

Which causes this failure: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-verify-master/5744/

```release-note
Hard code godep version to v74
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36114)
<!-- Reviewable:end -->
