### PR TITLE
Retry "godep restore" once in verify-dockerized.sh

### DIFF
--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -39,7 +39,8 @@ export LOG_LEVEL=4
 cd /go/src/k8s.io/kubernetes
 
 # hack/verify-client-go.sh requires all dependencies exist in the GOPATH.
-godep restore
+# the retry helps avoid flakes while keeping total time bounded.
+godep restore || godep restore
 
 ./hack/install-etcd.sh
 make verify


### PR DESCRIPTION
This should fix #36110. The current flake rate is 0.5%, so with the
unrealistic assumption of uncorrelated flakes, a single retry will bring
it down to <0.01% flake rate.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36119)
<!-- Reviewable:end -->
