### PR TITLE
Remove stray file added to docker vendor folder

### DIFF
--- a/vendor/github.com/docker/docker/project/CONTRIBUTORS.md
+++ b/vendor/github.com/docker/docker/project/CONTRIBUTORS.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/36124

Removing file in docker vendor folder. We do not vendor `docker/docker/project`

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36127)
<!-- Reviewable:end -->
