### PR TITLE
fix nodeport service no endpoints

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1119,6 +1119,8 @@ func (proxier *Proxier) syncProxyRules() {
 		if svcInfo.nodePort != 0 {
 			// Hold the local port open so no other process can open it
 			// (because the socket might open but it would never work).
+			// Even if NodePort type service don't have any endpoints, we should hold the
+			// port open as we don't want someone coming along later thinking they can use it.
 			lp := localPort{
 				desc:     "nodePort for " + svcName.String(),
 				ip:       "",
@@ -1139,22 +1141,33 @@ func (proxier *Proxier) syncProxyRules() {
 				}
 				replacementPortsMap[lp] = socket
 			} // We're holding the port, so it's OK to install iptables rules.
-
-			args := []string{
-				"-A", string(kubeNodePortsChain),
-				"-m", "comment", "--comment", svcName.String(),
-				"-m", protocol, "-p", protocol,
-				"--dport", fmt.Sprintf("%d", svcInfo.nodePort),
-			}
-			if !svcInfo.onlyNodeLocalEndpoints {
-				// Nodeports need SNAT, unless they're local.
-				writeLine(natRules, append(args, "-j", string(KubeMarkMasqChain))...)
-				// Jump to the service chain.
-				writeLine(natRules, append(args, "-j", string(svcChain))...)
+			if len(proxier.endpointsMap[svcName]) != 0 {
+				args := []string{
+					"-A", string(kubeNodePortsChain),
+					"-m", "comment", "--comment", svcName.String(),
+					"-m", protocol, "-p", protocol,
+					"--dport", fmt.Sprintf("%d", svcInfo.nodePort),
+				}
+				if !svcInfo.onlyNodeLocalEndpoints {
+					// Nodeports need SNAT, unless they're local.
+					writeLine(natRules, append(args, "-j", string(KubeMarkMasqChain))...)
+					// Jump to the service chain.
+					writeLine(natRules, append(args, "-j", string(svcChain))...)
+				} else {
+					// TODO: Make all nodePorts jump to the firewall chain.
+					// Currently we only create it for loadbalancers (#33586).
+					writeLine(natRules, append(args, "-j", string(svcXlbChain))...)
+				}
 			} else {
-				// TODO: Make all nodePorts jump to the firewall chain.
-				// Currently we only create it for loadbalancers (#33586).
-				writeLine(natRules, append(args, "-j", string(svcXlbChain))...)
+				// If the NodePort type service has no endpoints then reject packets.
+				glog.V(3).Infof("Reject NodePort type service %s has no endpoints", svcName.String())
+				writeLine(filterRules,
+					"-A", string(kubeServicesChain),
+					"-m", "comment", "--comment", fmt.Sprintf(`"NodePort type service %s has no endpoints"`, svcName.String()),
+					"-m", protocol, "-p", protocol,
+					"--dport", fmt.Sprintf("%d", svcInfo.nodePort),
+					"-j", "REJECT",
+				)
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**Which issue this PR fixes:**

Fixes #31435

Sorry for the delay :)

**Special notes for your reviewer:**

This PR is ready for review but needs more UT and e2e test, I will implement test cases if reviewers agree with this fix.

**Updated**

I added some e2e test case but hit some issues when try to add UT, see #36043 

BTW, as @freehan suggested in #31435(comments), perhaps I need to add another iptables util chain for Reject in kubelet `syncNetworkUtil()`.

@thockin @bprashanth @zhulinhong

Please take a look first.

Thanks!

**TODO:**

Reject LoadBalancer type services that has no endpoints as well?

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36130)
<!-- Reviewable:end -->
