### PR TITLE
Fix godep to v73 in verify-godeps

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -84,7 +84,8 @@ pushd "${_kubetmp}" 2>&1 > /dev/null
     popd > /dev/null
   }
   # Use to following if we ever need to pin godep to a specific version again
-  pin-godep 'v74'
+  pin-godep 'v73'
+  "${GODEP}" version
 
   # Fill out that nice clean place with the kube godeps
   echo "Starting to download all kubernetes godeps. This takes a while"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/36111

Latest version (and v74 suprisingly) of godep has this change https://github.com/tools/godep/pull/522 which causes this failure: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-verify-master/5744/

This PR sets the version to v73 of `godep` which does not care about AUTHOR or CONTRIBUTOR files.

The reason we don't want to upgrade to the latest `godep` version yet is that one of our dependencies, `github.com/docker/docker/project`, contains a CONTRIBUTOR file that is a symlink to `github.com/docker/docker/CONTRIBUTING.md`. The former is picked up by `godep`, the later is not. And `verify-godep` fails when diffing the symlink. Until those issues are resolved this is our best approach.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36132)
<!-- Reviewable:end -->
