### PR TITLE
Ensure verify-godep passes godep to godep-save

### DIFF
--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -34,6 +34,7 @@ REQUIRED_BINS=(
 )
 
 pushd "${KUBE_ROOT}" > /dev/null
+  "${GODEP}" version
   GO15VENDOREXPERIMENT=1 ${GODEP} save "${REQUIRED_BINS[@]}"
   # create a symlink in vendor directory pointing to the staging client. This
   # let other packages use the staging client as if it were vendored.

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -60,6 +60,7 @@ function cleanup {
     echo "Removing ${_tmpdir}"
     rm -rf "${_tmpdir}"
   fi
+  export GODEP=""
 }
 trap cleanup EXIT
 
@@ -76,7 +77,7 @@ export GOPATH="${_tmpdir}"
 pushd "${_kubetmp}" 2>&1 > /dev/null
   # Build the godep tool
   go get -u github.com/tools/godep 2>/dev/null
-  GODEP="${GOPATH}/bin/godep"
+  export GODEP="${GOPATH}/bin/godep"
   pin-godep() {
     pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
       git checkout "$1"


### PR DESCRIPTION
Ensure that `verify-godeps.sh` passes the `$GODEP` variable to `godep-save.sh`.

https://github.com/kubernetes/kubernetes/issues/36111

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36138)
<!-- Reviewable:end -->
