### PR TITLE
eliminate redundant map construction from function GetAddonImage

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -45,6 +45,15 @@ const (
 	pauseVersion       = "3.0"
 )
 
+var (
+	addonImages = map[string]string{
+		KubeDNSImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kubedns", runtime.GOARCH, kubeDNSVersion),
+		KubeDNSmasqImage:     fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-dnsmasq", runtime.GOARCH, dnsmasqVersion),
+		KubeExechealthzImage: fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "exechealthz", runtime.GOARCH, exechealthzVersion),
+		Pause:                fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "pause", runtime.GOARCH, pauseVersion),
+	}
+)
+
 func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideImage string) string {
 	if overrideImage != "" {
 		return overrideImage
@@ -60,10 +69,5 @@ func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideIma
 }
 
 func GetAddonImage(image string) string {
-	return map[string]string{
-		KubeDNSImage:         fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kubedns", runtime.GOARCH, kubeDNSVersion),
-		KubeDNSmasqImage:     fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-dnsmasq", runtime.GOARCH, dnsmasqVersion),
-		KubeExechealthzImage: fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "exechealthz", runtime.GOARCH, exechealthzVersion),
-		Pause:                fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "pause", runtime.GOARCH, pauseVersion),
-	}[image]
+	return addonImages[image]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`GetAddonImage` function is invoked 3 times in `kubeadm/app/master/addons.go` and 1 time in `kubeadm/app/master/apiclient.go`.
everytime `GetAddonImage` is invoked a new anonymous map will be newed ,but actually image names in this anonymous map is independant of kubernetes' version. and even when more extra image names are added into this map in the future, i think they will be independant of kubernetes' version.

this PR extracted that  anonymous map to a variable `addonImages`

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36142)
<!-- Reviewable:end -->
