### PR TITLE
 refactor  pkg/util/intstr/intstr.go change signature of func FromInt

### DIFF
--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -55,9 +55,8 @@ const (
 // FromInt creates an IntOrString object with an int32 value. It is
 // your responsibility not to call this method with a value greater
 // than int32.
-// TODO: convert to (val int32)
-func FromInt(val int) IntOrString {
-	return IntOrString{Type: Int, IntVal: int32(val)}
+func FromInt(val int32) IntOrString {
+	return IntOrString{Type: Int, IntVal: val}
 }
 
 // FromString creates an IntOrString object with a string value.


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the signature of util function  "FromInt" as the former annotation says.
If don't , when mistakenly call this method  with a value greater than int32 will causes strange behavior in some environment. 
For example, call FromInt(93333333333) would result in -1155947179.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36145)
<!-- Reviewable:end -->
