### PR TITLE
Fix typo in local-up-cluster

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -552,7 +552,7 @@ kind: Namespace
 metadata:
   name: kube-system
 EOF
-        ${KUBECTL} config set-cluster local --server=https://${API_HOST}:${API_SECURE_PORT} --certificate-authority=$(ROOT_CA_FILE)
+        ${KUBECTL} config set-cluster local --server=https://${API_HOST}:${API_SECURE_PORT} --certificate-authority=${ROOT_CA_FILE}
         ${KUBECTL} config set-context local --cluster=local
         ${KUBECTL} config use-context local
 


### PR DESCRIPTION
Use curly braces instead of round ones for bash variable expansion. The
script complains about unknown ROOT_CA_FILE when running with
KUBE_ENABLE_CLUSTER_DNS=true.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36147)
<!-- Reviewable:end -->
