### PR TITLE
fix e2e delete namespace bug

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -445,7 +445,10 @@ func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (
 		createTestingNS = CreateTestingNS
 	}
 	ns, err := createTestingNS(baseName, f.ClientSet, labels)
-	if err == nil {
+	// check ns instead of err to see if it's nil as we may
+	// fail to create serviceAccount in it.
+	// In this case, we should not forget to delete the namespace.
+	if ns != nil {
 		f.namespacesToDelete = append(f.namespacesToDelete, ns)
 	}
 	return ns, err

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -912,7 +912,10 @@ func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]s
 
 	if TestContext.VerifyServiceAccount {
 		if err := WaitForDefaultServiceAccountInNamespace(c, got.Name); err != nil {
-			return nil, err
+			// Even if we fail to create serviceAccount in the namespace,
+			// we have successfully create a namespace.
+			// So, return the created namespace.
+			return got, err
 		}
 	}
 	return got, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What:**

Fix `CreateNamespace()` bug in `test/e2e/framework/framework.go`.

**Why:**

If we successfully create a namespace but fail to create a ServiceAccount in it, we should delete the namespace after test.

The current implement of `CreateNamespace()` int e2e test will forget to delete the namespace which we fail to create serviceAccount in it(but the namespace has been successfully created!).

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36154)
<!-- Reviewable:end -->
