### PR TITLE
Fix how we iterate over active jobs when removing them for Replace policy

### DIFF
--- a/pkg/controller/scheduledjob/controller.go
+++ b/pkg/controller/scheduledjob/controller.go
@@ -203,8 +203,7 @@ func SyncOne(sj batch.ScheduledJob, js []batch.Job, now time.Time, jc jobControl
 		return
 	}
 	if sj.Spec.ConcurrencyPolicy == batch.ReplaceConcurrent {
-		for i := range sj.Status.Active {
-			j := sj.Status.Active[i]
+		for _, j := range sj.Status.Active {
 			// TODO: this should be replaced with server side job deletion
 			// currently this mimics JobReaper from pkg/kubectl/stop.go
 			glog.V(4).Infof("Deleting job %s of %s that was still running at next scheduled start time", j.Name, nameForLog)


### PR DESCRIPTION
When fixing the Replace Active removal I used wrong for loop construct which panics :/ This PR fixes that by using for range.

@janetkuo ptal

@jessfraz this will also be a cherry-pick candidate for 1.4, I remember we've picked the aforementioned fix as well

```release-note
Fix how we iterate over active jobs when removing them for Replace policy
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36161)
<!-- Reviewable:end -->
