### PR TITLE
fix cross build for kubelet/cm

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -57,3 +57,19 @@ func (m *unsupportedCgroupManager) Create(_ *CgroupConfig) error {
 func (m *unsupportedCgroupManager) Pids(_ CgroupName) []int {
 	return nil
 }
+
+func (m *unsupportedCgroupManager) CgroupName(name string) CgroupName {
+	return ""
+}
+
+func (m *unsupportedCgroupManager) ReduceCPULimits(cgroupName CgroupName) error {
+	return nil
+}
+
+func ConvertCgroupFsNameToSystemd(cgroupfsName string) (string, error) {
+	return "", nil
+}
+
+func ConvertCgroupNameToSystemd(cgroupName CgroupName, outputToCgroupFs bool) string {
+	return ""
+}

--- a/pkg/kubelet/cm/container_manager_unsupported_test.go
+++ b/pkg/kubelet/cm/container_manager_unsupported_test.go
@@ -57,6 +57,10 @@ func (mi *fakeMountInterface) PathIsDevice(pathname string) (bool, error) {
 	return true, nil
 }
 
+func (mi *fakeMountInterface) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
+	return "", nil
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -1,0 +1,54 @@
+// +build !linux
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import "k8s.io/kubernetes/pkg/api"
+
+const (
+	MinShares     = 0
+	SharesPerCPU  = 0
+	MilliCPUToCPU = 0
+
+	QuotaPeriod    = 0
+	MinQuotaPeriod = 0
+)
+
+// MilliCPUToQuota converts milliCPU to CFS quota and period values.
+func MilliCPUToQuota(milliCPU int64) (int64, int64) {
+	return 0, 0
+}
+
+// MilliCPUToShares converts the milliCPU to CFS shares.
+func MilliCPUToShares(milliCPU int64) int64 {
+	return 0
+}
+
+// ResourceConfigForPod takes the input pod and outputs the cgroup resource config.
+func ResourceConfigForPod(pod *api.Pod) *ResourceConfig {
+	return nil
+}
+
+// GetCgroupSubsystems returns information about the mounted cgroup subsystems
+func GetCgroupSubsystems() (*CgroupSubsystems, error) {
+	return nil, nil
+}
+
+func getCgroupProcs(dir string) ([]int, error) {
+	return nil, nil
+}

--- a/pkg/kubelet/cm/pod_container_manager_unsupported.go
+++ b/pkg/kubelet/cm/pod_container_manager_unsupported.go
@@ -47,3 +47,7 @@ func (m *unsupportedPodContainerManager) ReduceCPULimits(_ CgroupName) error {
 func (m *unsupportedPodContainerManager) GetAllPodsFromCgroups() (map[types.UID]CgroupName, error) {
 	return nil, nil
 }
+
+func (m *unsupportedPodContainerManager) Destroy(name CgroupName) error {
+	return nil
+}


### PR DESCRIPTION
Fixes a break in the cross build:

```
pkg/kubelet/cm/cgroup_manager_unsupported.go:26: cannot use unsupportedCgroupManager literal (type *unsupportedCgroupManager) as type CgroupManager in assignment:
        *unsupportedCgroupManager does not implement CgroupManager (missing CgroupName method)
...
pkg/kubelet/cm/container_manager_unsupported.go:59: cannot use unsupportedPodContainerManager literal (type *unsupportedPodContainerManager) as type PodContainerManager in return argument:
        *unsupportedPodContainerManager does not implement PodContainerManager (missing Destroy method)
```
@derekwaynecarr @liggitt @ncdc

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36163)
<!-- Reviewable:end -->
