### PR TITLE
Fix find command added by f85ac90 on certain OS

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -70,7 +70,7 @@ pkg/api
 pkg/api/v1
 $(
   cd ${KUBE_ROOT}
-  find pkg/apis -name types.go | xargs dirname | sort
+  find pkg/apis -name types.go | xargs -I{} dirname {} | sort
 )
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `find` command executed in `hack/update-codegen.sh` and added by f85ac90 that fail on certain platforms such as Darwin.

```
Updating codegen
+++ [1103 15:39:34] Building go targets for darwin/amd64:
    cmd/libs/go2idl/client-gen
    cmd/libs/go2idl/set-gen
    cmd/libs/go2idl/lister-gen
usage: dirname path
!!! Error in ./hack/../hack/update-codegen.sh:75
  'LISTERGEN_APIS=(pkg/api pkg/api/v1 $(
  cd ${KUBE_ROOT}
  find pkg/apis -name types.go | xargs dirname | sort
))' exited with status 1
Call stack:
  1: ./hack/../hack/update-codegen.sh:75 main(...)
Exiting with status 1
```

```
$ find pkg/apis -name types.go | xargs dirname | sort
usage: dirname path
```

```
$ find pkg/apis -name types.go | xargs -I{} dirname {} | sort
pkg/apis/abac
pkg/apis/abac/v0
[...]
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36164)
<!-- Reviewable:end -->
