### PR TITLE
Bad conditional in vSphereLogin function

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -360,7 +360,7 @@ func vSphereLogin(vs *VSphere, ctx context.Context) error {
 	m := session.NewManager(vs.client.Client)
 	// retrieve client's current session
 	u, err := m.UserSession(ctx)
-	if err == nil && u == nil {
+	if err == nil && u != nil {
 		// current session is valid
 		return nil
 	}

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -360,8 +360,11 @@ func vSphereLogin(vs *VSphere, ctx context.Context) error {
 	m := session.NewManager(vs.client.Client)
 	// retrieve client's current session
 	u, err := m.UserSession(ctx)
-	if err == nil && u != nil {
-		// current session is valid
+	if err != nil {
+		glog.Errorf("Error while obtaining user session. err: %q", err)
+		return err
+	}
+	if u != nil {
 		return nil
 	}
 


### PR DESCRIPTION
```release-note
Fixes NotAuthenticated errors that appear in the kubelet and kube-controller-manager due to never logging in to vSphere
```

With this conditional being == instead of !=, a login would never actually be attempted by this provider, and disk attachments would fail with a NotAuthenticated error from vSphere.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36169)
<!-- Reviewable:end -->
