### PR TITLE
kubectl: enhancements for deployment progress deadline

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -2161,6 +2161,13 @@ func (dd *DeploymentDescriber) Describe(namespace, name string, describerSetting
 			ru := d.Spec.Strategy.RollingUpdate
 			fmt.Fprintf(out, "RollingUpdateStrategy:\t%s max unavailable, %s max surge\n", ru.MaxUnavailable.String(), ru.MaxSurge.String())
 		}
+		if len(d.Status.Conditions) > 0 {
+			fmt.Fprint(out, "Conditions:\n  Type\tStatus\tReason\n")
+			fmt.Fprint(out, "  ----\t------\t------\n")
+			for _, c := range d.Status.Conditions {
+				fmt.Fprintf(out, "  %v \t%v\t%v\n", c.Type, c.Status, c.Reason)
+			}
+		}
 		oldRSs, _, newRS, err := deploymentutil.GetAllReplicaSets(d, dd)
 		if err == nil {
 			fmt.Fprintf(out, "OldReplicaSets:\t%s\n", printReplicaSetsByLabels(oldRSs))

--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -59,6 +59,10 @@ func (s *DeploymentStatusViewer) Status(namespace, name string, revision int64) 
 		}
 	}
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
+		cond := util.GetDeploymentCondition(deployment.Status, extensions.DeploymentProgressing)
+		if cond != nil && cond.Reason == util.TimedOutReason {
+			return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", name)
+		}
 		if deployment.Status.UpdatedReplicas < deployment.Spec.Replicas {
 			return fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Status.UpdatedReplicas, deployment.Spec.Replicas), false, nil
 		}


### PR DESCRIPTION
Changes:
* add deployment conditions in the describer
* abort 'rollout status' for deployments that have exceeded their
progress deadline

Depends on https://github.com/kubernetes/kubernetes/pull/35691.

@kubernetes/kubectl @kubernetes/deployment

Fixes https://github.com/kubernetes/kubernetes/issues/31319

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36171)
<!-- Reviewable:end -->
