### PR TITLE
kubeadm: changed tests to be table driven

### DIFF
--- a/cmd/kubeadm/app/master/pki.go
+++ b/cmd/kubeadm/app/master/pki.go
@@ -49,7 +49,7 @@ func newCertificateAuthority() (*rsa.PrivateKey, *x509.Certificate, error) {
 func newServerKeyAndCert(cfg *kubeadmapi.MasterConfiguration, caCert *x509.Certificate, caKey *rsa.PrivateKey, altNames certutil.AltNames) (*rsa.PrivateKey, *x509.Certificate, error) {
 	key, err := certutil.NewPrivateKey()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unabel to create private key [%v]", err)
+		return nil, nil, fmt.Errorf("unable to create private key [%v]", err)
 	}
 
 	internalAPIServerFQDN := []string{

--- a/cmd/kubeadm/app/util/tokens_test.go
+++ b/cmd/kubeadm/app/util/tokens_test.go
@@ -38,44 +38,74 @@ func TestUsingEmptyTokenFails(t *testing.T) {
 }
 
 func TestTokenValidationFailures(t *testing.T) {
-	invalidTokens := []string{
-		"1234567890123456789012",
-		"12345.1234567890123456",
-		".1234567890123456",
-		"123456.1234567890.123456",
+	var tests = []struct {
+		t        string
+		expected bool
+	}{
+		{
+			t:        "1234567890123456789012",
+			expected: false,
+		},
+		{
+			t:        "12345.1234567890123456",
+			expected: false,
+		},
+		{
+			t:        ".1234567890123456",
+			expected: false,
+		},
+		{
+			t:        "123456.1234567890.123456",
+			expected: false,
+		},
 	}
 
-	for _, token := range invalidTokens {
-		s := newSecretsWithToken(token)
+	for _, rt := range tests {
+		s := newSecretsWithToken(rt.t)
 		_, err := UseGivenTokenIfValid(s)
-
-		if err == nil {
-			t.Errorf("UseGivenTokenIfValid did not return an error for this invalid token: [%s]", token)
+		if (err == nil) != rt.expected {
+			t.Errorf(
+				"failed UseGivenTokenIfValid and did not return an error for this invalid token: [%s]",
+				rt.t,
+			)
 		}
 	}
 }
 
 func TestValidTokenPopulatesSecrets(t *testing.T) {
-	s := newSecretsWithToken("123456.0123456789AbCdEf")
-	expectedToken := []byte("0123456789abcdef")
-	expectedTokenID := "123456"
-	expectedBearerToken := "0123456789abcdef"
+	var tests = []struct {
+		token               string
+		expectedToken       []byte
+		expectedTokenID     string
+		expectedBearerToken string
+	}{
+		{
+			token:               "123456.0123456789AbCdEf",
+			expectedToken:       []byte("0123456789abcdef"),
+			expectedTokenID:     "123456",
+			expectedBearerToken: "0123456789abcdef",
+		},
+	}
 
-	given, err := UseGivenTokenIfValid(s)
-	if err != nil {
-		t.Errorf("UseGivenTokenIfValid gave an error for a valid token: %v", err)
-	}
-	if !given {
-		t.Error("UseGivenTokenIfValid returned given = false when given a valid token")
-	}
-	if s.TokenID != expectedTokenID {
-		t.Errorf("UseGivenTokenIfValid did not populate the TokenID correctly; expected [%s] but got [%s]", expectedTokenID, s.TokenID)
-	}
-	if s.BearerToken != expectedBearerToken {
-		t.Errorf("UseGivenTokenIfValid did not populate the BearerToken correctly; expected [%s] but got [%s]", expectedBearerToken, s.BearerToken)
-	}
-	if !bytes.Equal(s.Token, expectedToken) {
-		t.Errorf("UseGivenTokenIfValid did not populate the Token correctly; expected %v but got %v", expectedToken, s.Token)
+	for _, rt := range tests {
+		s := newSecretsWithToken(rt.token)
+
+		given, err := UseGivenTokenIfValid(s)
+		if err != nil {
+			t.Errorf("UseGivenTokenIfValid gave an error for a valid token: %v", err)
+		}
+		if !given {
+			t.Error("UseGivenTokenIfValid returned given = false when given a valid token")
+		}
+		if s.TokenID != rt.expectedTokenID {
+			t.Errorf("UseGivenTokenIfValid did not populate the TokenID correctly; expected [%s] but got [%s]", rt.expectedTokenID, s.TokenID)
+		}
+		if s.BearerToken != rt.expectedBearerToken {
+			t.Errorf("UseGivenTokenIfValid did not populate the BearerToken correctly; expected [%s] but got [%s]", rt.expectedBearerToken, s.BearerToken)
+		}
+		if !bytes.Equal(s.Token, rt.expectedToken) {
+			t.Errorf("UseGivenTokenIfValid did not populate the Token correctly; expected %v but got %v", rt.expectedToken, s.Token)
+		}
 	}
 }
 


### PR DESCRIPTION
Small change to migrate tests in kubeadm/app/util/tokens_test.go to be table driven which should make adding more tests in the future easier and also have them match how other tests are being written. 

This PR is part of the ongoing effort to add tests (#35025)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36172)
<!-- Reviewable:end -->
