### PR TITLE
Enable NFS volume test

### DIFF
--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -370,7 +370,7 @@ var _ = framework.KubeDescribe("Volumes [Feature:Volumes]", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "nfs",
-				serverImage: "gcr.io/google_containers/volume-nfs:0.6",
+				serverImage: "gcr.io/google_containers/volume-nfs:0.8",
 				serverPorts: []int{2049},
 			}
 

--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -20,6 +20,8 @@ ADD run_nfs.sh /usr/local/bin/
 ADD index.html /tmp/index.html
 RUN chmod 644 /tmp/index.html
 
+# mark /exports as a mount point
+VOLUME /exports
 # expose mountd 20048/tcp and nfsd 2049/tcp
 EXPOSE 2049/tcp 20048/tcp
 

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.7
+TAG = 0.8
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/volumes-tester/nfs/run_nfs.sh
+++ b/test/images/volumes-tester/nfs/run_nfs.sh
@@ -49,13 +49,12 @@ function start()
 
     mount -t nfsd nfds /proc/fs/nfsd
 
-    # -N 4.x: disable NFSv4
     # -V 3: enable NFSv3
-    /usr/sbin/rpc.mountd -N 2 -V 3 -N 4 -N 4.1
+    /usr/sbin/rpc.mountd -N 2 -V 3
 
     /usr/sbin/exportfs -r
     # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
-    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3 -N 4 -N 4.1 2
+    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3
     /usr/sbin/rpc.statd --no-notify
     echo "NFS started"
 }


### PR DESCRIPTION
This PR fixes the dockerfile for NFS server image and enable NFSv4.
After using containeried mounts approach on GCI, this test should pass.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36175)
<!-- Reviewable:end -->
