### PR TITLE
kubeadm: unit test for app/apis/kubeadm/env.go

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/BUILD
@@ -25,3 +25,11 @@ go_library(
         "//pkg/runtime:go_default_library",
     ],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["env_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [],
+)

--- a/cmd/kubeadm/app/apis/kubeadm/env_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import "testing"
+
+func TestSetEnvParams(t *testing.T) {
+	oldEnv := GlobalEnvParams
+	GlobalEnvParams = &EnvParams{}
+	GlobalEnvParams = SetEnvParams()
+
+	// verify that it gets back to its defaults after being changed to nil
+	if oldEnv.KubernetesDir != GlobalEnvParams.KubernetesDir {
+		t.Errorf(
+			"failed KubernetesDir:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.KubernetesDir,
+			GlobalEnvParams.KubernetesDir,
+		)
+	}
+	if oldEnv.HostPKIPath != GlobalEnvParams.HostPKIPath {
+		t.Errorf(
+			"failed HostPKIPath:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.HostPKIPath,
+			GlobalEnvParams.HostPKIPath,
+		)
+	}
+	if oldEnv.HostEtcdPath != GlobalEnvParams.HostEtcdPath {
+		t.Errorf(
+			"failed HostEtcdPath:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.HostEtcdPath,
+			GlobalEnvParams.HostEtcdPath,
+		)
+	}
+	if oldEnv.HyperkubeImage != GlobalEnvParams.HyperkubeImage {
+		t.Errorf(
+			"failed HyperkubeImage:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.HyperkubeImage,
+			GlobalEnvParams.HyperkubeImage,
+		)
+	}
+	if oldEnv.DiscoveryImage != GlobalEnvParams.DiscoveryImage {
+		t.Errorf(
+			"failed DiscoveryImage:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.DiscoveryImage,
+			GlobalEnvParams.DiscoveryImage,
+		)
+	}
+	if oldEnv.EtcdImage != GlobalEnvParams.EtcdImage {
+		t.Errorf(
+			"failed EtcdImage:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.EtcdImage,
+			GlobalEnvParams.EtcdImage,
+		)
+	}
+	if oldEnv.ComponentLoglevel != GlobalEnvParams.ComponentLoglevel {
+		t.Errorf(
+			"failed ComponentLoglevel:\n\texpected: %s\n\t  actual: %s",
+			oldEnv.ComponentLoglevel,
+			GlobalEnvParams.ComponentLoglevel,
+		)
+	}
+	defer func() { GlobalEnvParams = oldEnv }()
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -461,6 +461,7 @@ k8s.io/kubernetes/cmd/kube-apiserver/app,nikhiljindal,0
 k8s.io/kubernetes/cmd/kube-apiserver/app/options,nikhiljindal,0
 k8s.io/kubernetes/cmd/kube-discovery/app,pmorie,1
 k8s.io/kubernetes/cmd/kube-proxy/app,luxas,1
+k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm,apprenda,0
 k8s.io/kubernetes/cmd/kubeadm/app/cmd,caesarxuchao,1
 k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/preflight,apprenda,0


### PR DESCRIPTION
Added unit test for the kubeadm/apis/kubeadm package testing functionality of env.go

This PR is part of the ongoing effort to add tests (#35025)

/cc @pires @jbeda

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36176)
<!-- Reviewable:end -->
