### PR TITLE
kubelet: don't print httplogs for redirects

### DIFF
--- a/pkg/httplog/log_test.go
+++ b/pkg/httplog/log_test.go
@@ -24,6 +24,20 @@ import (
 	"testing"
 )
 
+func TestDefaultStacktracePred(t *testing.T) {
+	for _, x := range []int{101, 200, 204, 302, 400, 404} {
+		if DefaultStacktracePred(x) {
+			t.Fatalf("should not log on %v by default", x)
+		}
+	}
+
+	for _, x := range []int{500, 100} {
+		if !DefaultStacktracePred(x) {
+			t.Fatalf("should log on %v by default", x)
+		}
+	}
+}
+
 func TestHandler(t *testing.T) {
 	want := &httptest.ResponseRecorder{
 		HeaderMap: make(http.Header),

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -675,6 +675,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer httplog.NewLogged(req, &w).StacktraceWhen(
 		httplog.StatusIsNot(
 			http.StatusOK,
+			http.StatusFound,
 			http.StatusMovedPermanently,
 			http.StatusTemporaryRedirect,
 			http.StatusBadRequest,


### PR DESCRIPTION
Goes with #36020, but can merge independently.

cc @timstclair

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36189)
<!-- Reviewable:end -->
