### PR TITLE
Fix flake resize node test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1404,27 +1404,6 @@ func WaitForRCToStabilize(c clientset.Interface, ns, name string, timeout time.D
 	return err
 }
 
-// WaitForPodAddition waits for pods to be added within the timeout.
-func WaitForPodAddition(c clientset.Interface, ns string, timeout time.Duration) error {
-	options := api.ListOptions{FieldSelector: fields.Set{
-		"metadata.namespace": ns,
-	}.AsSelector()}
-
-	w, err := c.Core().Pods(ns).Watch(options)
-	if err != nil {
-		return err
-	}
-	_, err = watch.Until(timeout, w, func(event watch.Event) (bool, error) {
-		switch event.Type {
-		case watch.Added:
-			return true, nil
-		}
-		Logf("Waiting for pod(s) to be added in namespace %v", ns)
-		return false, nil
-	})
-	return err
-}
-
 func WaitForPodToDisappear(c clientset.Interface, ns, podName string, label labels.Selector, interval, timeout time.Duration) error {
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		Logf("Waiting for pod %s to disappear", podName)

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -307,8 +307,9 @@ var _ = framework.KubeDescribe("Nodes [Disruptive]", func() {
 			err = framework.WaitForClusterSize(c, int(replicas-1), 10*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("waiting for podGC to remove/recreate any pods scheduled on the now non-existent node")
-			framework.WaitForPodAddition(c, ns, 2*time.Minute)
+			By("waiting 1 minute for the watch in the podGC to catch up, remove any pods scheduled on " +
+				"the now non-existent node and the RC to recreate it")
+			time.Sleep(time.Minute)
 
 			By("verifying whether the pods from the removed node are recreated")
 			err = framework.VerifyPods(c, ns, name, true, replicas)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes flake blocking cutting of the release branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/27233

**Special notes for your reviewer**:

Previously, the NC would watch for deleted instances and clean up up pods and nodes together when it found one. Now (as part of https://github.com/kubernetes/kubernetes/issues/35145), we simply wait for the PodGC to see that the node is now deleted and clean up the pods. This may take a while and hence we add a 1 minute timeout. 
P1 because it is blocking @saad-ali from cutting a 1.5 branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

cc @saad-ali

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36199)
<!-- Reviewable:end -->
