### PR TITLE
Admission controller to set Node Conditions

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//plugin/pkg/admission/namespace/autoprovision:go_default_library",
         "//plugin/pkg/admission/namespace/exists:go_default_library",
         "//plugin/pkg/admission/namespace/lifecycle:go_default_library",
+        "//plugin/pkg/admission/node/condition:go_default_library",
         "//plugin/pkg/admission/persistentvolume/label:go_default_library",
         "//plugin/pkg/admission/podnodeselector:go_default_library",
         "//plugin/pkg/admission/resourcequota:go_default_library",

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -36,6 +36,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/node/condition"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -389,6 +389,7 @@ no-suggestions
 no-suggestions
 node-cidr-mask-size
 node-eviction-rate
+node-initial-conditions
 node-instance-group
 node-ip
 node-labels

--- a/plugin/pkg/admission/node/condition/BUILD
+++ b/plugin/pkg/admission/node/condition/BUILD
@@ -1,0 +1,37 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+    "cgo_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/admission:go_default_library",
+        "//pkg/api:go_default_library",
+        "//pkg/api/errors:go_default_library",
+        "//pkg/api/unversioned:go_default_library",
+        "//pkg/client/clientset_generated/internalclientset:go_default_library",
+        "//pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/admission:go_default_library",
+        "//pkg/api:go_default_library",
+        "//pkg/runtime:go_default_library",
+    ],
+)

--- a/plugin/pkg/admission/node/condition/admission.go
+++ b/plugin/pkg/admission/node/condition/admission.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package condition contains a NodeCondition admission controller that sets Node Conditions on new Node.
+// This is useful because Node.Status.Conditions can be used to decouple our controllers, so that a new node
+// will not be ready until various processes have had the chance to run on it.
+// We want to ensure that a new node has a list of unhealthy Status Conditions set on creation, but we
+// can't hard-code a list of conditions into the kubelet, or else we have coupled things again.
+// Enter the NodeCondition admission controller: it will apply Status conditions on Node creation.
+package condition
+
+import (
+	"flag"
+	"io"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"strings"
+	"time"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+var (
+	flagNodeInitialConditions = flag.String("node-initial-conditions", "", "Comma-separated list of conditions to apply on newly created Nodes.")
+)
+
+const ReasonPending = "Pending"
+
+func init() {
+	admission.RegisterPlugin("NodeCondition", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		conditions := sets.NewString()
+		for _, s := range strings.Split(*flagNodeInitialConditions, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				conditions.Insert(s)
+			}
+		}
+		if conditions.Len() == 0 {
+			return nil, nil
+		}
+		return newNodeCondition(conditions.List()), nil
+	})
+}
+
+// nodeCondition is an implementation of admission.Interface.
+// It looks at all new Nodes and sets Conditions.
+type nodeCondition struct {
+	*admission.Handler
+	conditions []string
+}
+
+func (a *nodeCondition) Admit(attributes admission.Attributes) (err error) {
+	// Ignore all calls to subresources or resources other than Nodes.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("nodes") {
+		return nil
+	}
+	node, ok := attributes.GetObject().(*api.Node)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Node but was unable to be converted")
+	}
+
+	preexisting := sets.NewString()
+	for i := range node.Status.Conditions {
+		preexisting.Insert(string(node.Status.Conditions[i].Type))
+	}
+
+	for _, c := range a.conditions {
+		if preexisting.Has(c) {
+			continue
+		}
+
+		node.Status.Conditions = append(node.Status.Conditions, api.NodeCondition{
+			Type:               api.NodeConditionType(c),
+			Status:             api.ConditionTrue,
+			Reason:             ReasonPending,
+			Message:            "Condition automatically set on node creation",
+			LastTransitionTime: unversioned.NewTime(time.Now()),
+		})
+	}
+
+	return nil
+}
+
+// newNodeCondition creates a new NodeCondition admission control handler
+func newNodeCondition(conditions []string) admission.Interface {
+	return &nodeCondition{
+		Handler:    admission.NewHandler(admission.Create),
+		conditions: conditions,
+	}
+}

--- a/plugin/pkg/admission/node/condition/admission_test.go
+++ b/plugin/pkg/admission/node/condition/admission_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func simpleNodeCondition(t, reason string) api.NodeCondition {
+	return api.NodeCondition{
+		Type:   api.NodeConditionType(t),
+		Reason: reason,
+	}
+}
+
+// TestAdmission verifies all create requests for Node result in every conditions being set
+func TestAdmission(t *testing.T) {
+	tests := []struct {
+		admission   []string
+		preexisting []api.NodeCondition
+		expect      []api.NodeCondition
+	}{
+		{
+			admission: []string{"Foo", "Bar"},
+			expect: []api.NodeCondition{
+				simpleNodeCondition("Foo", ReasonPending),
+				simpleNodeCondition("Bar", ReasonPending),
+			},
+		},
+		{
+			admission: []string{"Foo", "Bar"},
+			preexisting: []api.NodeCondition{
+				simpleNodeCondition("Foo", "Foo"),
+				simpleNodeCondition("Ready", "Ready"),
+			},
+			expect: []api.NodeCondition{
+				simpleNodeCondition("Foo", "Foo"),
+				simpleNodeCondition("Ready", "Ready"),
+				simpleNodeCondition("Bar", ReasonPending),
+			},
+		},
+		{
+			preexisting: []api.NodeCondition{
+				simpleNodeCondition("Foo", "Foo"),
+				simpleNodeCondition("Ready", "Ready"),
+			},
+			expect: []api.NodeCondition{
+				simpleNodeCondition("Foo", "Foo"),
+				simpleNodeCondition("Ready", "Ready"),
+			},
+		},
+	}
+
+	for number, tc := range tests {
+		namespace := "test"
+		handler := newNodeCondition(tc.admission)
+		node := api.Node{
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+		}
+
+		for _, nc := range tc.preexisting {
+			node.Status.Conditions = append(node.Status.Conditions, nc)
+		}
+		err := handler.Admit(admission.NewAttributesRecord(&node, nil, api.Kind("Node").WithVersion("version"), node.Namespace, node.Name, api.Resource("nodes").WithVersion("version"), "", admission.Create, nil))
+		if err != nil {
+			t.Errorf("Unexpected error returned from admission handler (#%d)", number)
+		}
+
+		if len(node.Status.Conditions) != len(tc.expect) {
+			t.Errorf("expected %d conditions, got %d (#%d)", len(node.Status.Conditions), len(tc.expect), number)
+		}
+		for i := range node.Status.Conditions {
+			if node.Status.Conditions[i].Type != tc.expect[i].Type {
+				t.Errorf("expected %v, got %v (#%d)", len(node.Status.Conditions), len(tc.expect), number)
+			}
+			if node.Status.Conditions[i].Reason != tc.expect[i].Reason {
+				t.Errorf("expected %v, got %v (#%d)", len(node.Status.Conditions), len(tc.expect), number)
+			}
+		}
+	}
+}
+
+// TestOtherResources ensures that this admission controller is a no-op for other resources,
+// subresources, and non-pods.
+func TestOtherResources(t *testing.T) {
+	namespace := "testnamespace"
+	name := "testname"
+	node := &api.Node{
+		ObjectMeta: api.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	tests := []struct {
+		name        string
+		kind        string
+		resource    string
+		subresource string
+		object      runtime.Object
+		expectError bool
+	}{
+		{
+			name:     "non-node resource",
+			kind:     "Foo",
+			resource: "foos",
+			object:   node,
+		},
+		{
+			name:        "node subresource",
+			kind:        "Node",
+			resource:    "nodes",
+			subresource: "exec",
+			object:      node,
+		},
+		{
+			name:        "non-Node object",
+			kind:        "Node",
+			resource:    "nodes",
+			object:      &api.Service{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		handler := &nodeCondition{}
+
+		err := handler.Admit(admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
+
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("%s: unexpected nil error", tc.name)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+
+		if len(node.Status.Conditions) != 0 {
+			t.Errorf("%s: node conditions were set %v", tc.name, node.Status.Conditions)
+		}
+	}
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -845,6 +845,7 @@ k8s.io/kubernetes/plugin/pkg/admission/limitranger,ncdc,1
 k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision,derekwaynecarr,0
 k8s.io/kubernetes/plugin/pkg/admission/namespace/exists,derekwaynecarr,0
 k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle,derekwaynecarr,0
+k8s.io/kubernetes/plugin/pkg/admission/node/condition,justinsb,0
 k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label,jdef,1
 k8s.io/kubernetes/plugin/pkg/admission/podnodeselector,ixdy,1
 k8s.io/kubernetes/plugin/pkg/admission/resourcequota,fabioy,1


### PR DESCRIPTION
This controller allows us to set Node Conditions without needing to be
aware of all of them in the kubelet.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36209)
<!-- Reviewable:end -->
