### PR TITLE
Set the annotation only if the test requires it.

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -391,7 +391,6 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			pst := statefulSetTester{c: c}
-			pst.saturate(ps)
 
 			nn := framework.TestContext.CloudConfig.NumNodes
 			nodeNames, err := framework.CheckNodesReady(f.ClientSet, framework.NodeReadyInitialTimeout, nn)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -114,6 +114,8 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 			petMounts := []api.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
 			podMounts := []api.VolumeMount{{Name: "home", MountPath: "/home"}}
 			ps := newStatefulSet(psName, ns, headlessSvcName, 3, petMounts, podMounts, labels)
+			setInitializedAnnotation(ps, "false")
+
 			_, err := c.Apps().StatefulSets(ns).Create(ps)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -147,6 +149,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 			petMounts := []api.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
 			podMounts := []api.VolumeMount{{Name: "home", MountPath: "/home"}}
 			ps := newStatefulSet(psName, ns, headlessSvcName, 2, petMounts, podMounts, labels)
+			setInitializedAnnotation(ps, "false")
 			_, err := c.Apps().StatefulSets(ns).Create(ps)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -897,10 +900,8 @@ func newStatefulSet(name, ns, governingSvcName string, replicas int32, petMounts
 			Replicas: replicas,
 			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Labels: labels,
-					Annotations: map[string]string{
-						"pod.alpha.kubernetes.io/initialized": "false",
-					},
+					Labels:      labels,
+					Annotations: map[string]string{},
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{
@@ -917,4 +918,8 @@ func newStatefulSet(name, ns, governingSvcName string, replicas int32, petMounts
 			ServiceName:          governingSvcName,
 		},
 	}
+}
+
+func setInitializedAnnotation(ss *apps.StatefulSet, value string) {
+	ss.Spec.Template.ObjectMeta.Annotations["pod.alpha.kubernetes.io/initialized"] = value
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes StatefulSet flake

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/36107

**Special notes for your reviewer**: We shouldn't be setting the debug annotation in all our tests, only the ones that bring statefulset pods up one after another. In the absence of the annotation, we have the new default behavior governed by https://github.com/kubernetes/kubernetes/pull/35739

**Release note**:
```release-note
NONE
```

cc @kubernetes/sig-apps @bprashanth @calebamiles

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36212)
<!-- Reviewable:end -->
