### PR TITLE
add kubectl get rolebindings/clusterrolebindings -o wide

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -97,6 +97,32 @@ func NonResourceURLMatches(rule PolicyRule, requestedURL string) bool {
 	return false
 }
 
+// subjectsStrings returns users, groups, serviceaccounts, unknown for display purposes.
+func SubjectsStrings(subjects []Subject) ([]string, []string, []string, []string) {
+	users := []string{}
+	groups := []string{}
+	sas := []string{}
+	others := []string{}
+
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case ServiceAccountKind:
+			sas = append(sas, fmt.Sprintf("%s/%s", subject.Namespace, subject.Name))
+
+		case UserKind:
+			users = append(users, subject.Name)
+
+		case GroupKind:
+			groups = append(groups, subject.Name)
+
+		default:
+			others = append(others, fmt.Sprintf("%s/%s/%s", subject.Kind, subject.Namespace, subject.Name))
+		}
+	}
+
+	return users, groups, sas, others
+}
+
 // +k8s:deepcopy-gen=false
 // PolicyRuleBuilder let's us attach methods.  A no-no for API types.
 // We use it to construct rules in code.  It's more compact than trying to write them


### PR DESCRIPTION
Use "-o wide" to get more information of roleRef/subjects
`kubectl get rolebindings -o wide`

|NAME | AGE | ROLE | USERS | GROUPS | SERVICEACCOUNTS|
|:-------|:-------|:-------|:-------|:-------|:-------|
|admin-resource-binding |1s | Role/admin-resource-role | test | | |


`kubectl get clusterrolebindings -o wide`

|NAME|AGE|ROLE|USERS|GROUPS|SERVICEACCOUNTS|
|:-------|:-------|:-------|:-------|:-------|:-------|
|cluster-admin|27s|cluster-admin| |system:masters| |
|system:basic-user|27s|system:basic-user| |system:authenticated, system:unauthenticated | |
|system:controller:replication-controller|27s|system:controller:replication-controller | | |kube-system/replication-controller|
|system:discovery |27s|system:discovery| |system:authenticated, system:unauthenticated| |

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36217)
<!-- Reviewable:end -->
