### PR TITLE
Recycle Pod Template Check

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -183,6 +183,9 @@ func AttemptToLoadRecycler(path string, config *volume.VolumeConfig) error {
 		if err != nil {
 			return err
 		}
+		if err = volume.ValidateRecyclerPodTemplate(recyclerPod); err != nil {
+			return fmt.Errorf("Pod specification (%v): %v", path, err)
+		}
 		config.RecyclerPodTemplate = recyclerPod
 	}
 	return nil

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -563,3 +563,15 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
 	}
 	return pod
 }
+
+// Check validity of recycle pod template
+// List of checks:
+// - at least one volume is defined in the recycle pod template
+// If successful, returns nil
+// if unsuccessful, returns an error.
+func ValidateRecyclerPodTemplate(pod *v1.Pod) error {
+	if len(pod.Spec.Volumes) < 1 {
+		return fmt.Errorf("does not contain any volume(s)")
+	}
+	return nil
+}

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -104,3 +104,41 @@ func TestVolumePluginMgrFunc(t *testing.T) {
 		t.Errorf("Wrong name: %s", plug.GetPluginName())
 	}
 }
+
+func Test_ValidatePodTemplate(t *testing.T) {
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name:         "vol",
+					VolumeSource: v1.VolumeSource{},
+				},
+			},
+		},
+	}
+	var want error
+	if got := ValidateRecyclerPodTemplate(pod); got != want {
+		t.Errorf("isPodTemplateValid(%v) returned (%v), want (%v)", pod.String(), got.Error(), want)
+	}
+
+	// Check that the default recycle pod template is valid
+	pod = NewPersistentVolumeRecyclerPodTemplate()
+	want = nil
+	if got := ValidateRecyclerPodTemplate(pod); got != want {
+		t.Errorf("isPodTemplateValid(%v) returned (%v), want (%v)", pod.String(), got.Error(), want)
+	}
+
+	pod = &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "pv-recycler",
+				},
+			},
+		},
+	}
+	// want = an error
+	if got := ValidateRecyclerPodTemplate(pod); got == nil {
+		t.Errorf("isPodTemplateValid(%v) returned (%v), want (%v)", pod.String(), got, "Error: pod specification does not contain any volume(s).")
+	}
+}


### PR DESCRIPTION
The kube-controller-manager has two command line arguments (--pv-recycler-pod-template-filepath-hostpath and --pv-recycler-pod-template-filepath-nfs) that specify a recycle pod template. The recycle pod template may not contain the volume that shall be recycled.

A check is added to make sure that the recycle pod template contains at least a volume.

cc: @jsafrane

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36221)
<!-- Reviewable:end -->
