### PR TITLE
Don't add a HostName record if the cloudprovider did not return one

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -392,8 +392,10 @@ func (kl *Kubelet) setNodeAddress(node *api.Node) error {
 			}
 			return fmt.Errorf("failed to get node address from cloud provider that matches ip: %v", kl.nodeIP)
 		}
-		hostnameAddress := api.NodeAddress{Type: api.NodeHostName, Address: kl.GetHostname()}
-		node.Status.Addresses = append(nodeAddresses, hostnameAddress)
+
+		// We don't add a hostname if the cloudprovider didn't set it.
+		// The cloudprovider could easily add one if needed,
+		// and if we add it the cloudprovider has no way to say "don't add it"
 	} else {
 		var ipAddr net.IP
 		var err error


### PR DESCRIPTION
If we add a HostName to the records the cloudprovider returns, the
cloudprovider has no way to say "don't use HostName".  So we should not
add it - it is trivial for the cloudprovider to add it if needed.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36233)
<!-- Reviewable:end -->
