### PR TITLE
Revert "cr2 e2e: remove experimental-mounter-rootfs flag"

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
@@ -5,5 +5,5 @@ GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
 SETUP_NODE=false
-TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true --experimental-mounter-path=""'
+TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true --experimental-mounter-path="" --experimental-mounter-rootfs-path=""'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
@@ -5,4 +5,4 @@ GCE_PROJECT=k8s-jkns-pr-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
 SETUP_NODE=false
-TEST_ARGS='--runtime-integration-type=cri --experimental-mounter-path=""'
+TEST_ARGS='--runtime-integration-type=cri --experimental-mounter-path="" --experimental-mounter-rootfs-path=""'

--- a/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
@@ -5,6 +5,6 @@ GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
 SETUP_NODE=false
-TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true --experimental-mounter-path=""'
+TEST_ARGS='--runtime-integration-type=cri --feature-gates=DynamicKubeletConfig=true --experimental-mounter-path="" --experimental-mounter-rootfs-path=""'
 PARALLELISM=1
 TIMEOUT=3h

--- a/test/e2e_node/jenkins/cri_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-validation.properties
@@ -5,4 +5,4 @@ GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
 SETUP_NODE=false
-TEST_ARGS='--runtime-integration-type=cri  --experimental-mounter-path=""'
+TEST_ARGS='--runtime-integration-type=cri  --experimental-mounter-path="" --experimental-mounter-rootfs-path=""'


### PR DESCRIPTION
Reverts kubernetes/kubernetes#36166

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36239)
<!-- Reviewable:end -->
