### PR TITLE
build-image fix for running integration-tests locally

### DIFF
--- a/build-tools/build-image/Dockerfile
+++ b/build-tools/build-image/Dockerfile
@@ -21,6 +21,10 @@ RUN touch /kube-build-image
 # To run as non-root we sometimes need to rebuild go stdlib packages.
 RUN chmod -R a+rwx /usr/local/go/pkg ${K8S_PATCHED_GOROOT}/pkg
 
+# For running integration tests /var/run/kubernetes is required
+# and should be writable by user
+RUN mkdir /var/run/kubernetes && chmod a+rwx /var/run/kubernetes
+
 # The kubernetes source is expected to be mounted here.  This will be the base
 # of operations.
 ENV HOME /go/src/k8s.io/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**: fix for running integration tests locally.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
current situation if users tries to run 
```console
$ make release
```
or 
```console
$ build-tools/run.sh make test-integration
```
output:
```console
+++ [1104 12:29:13] Stopping any currently running rsyncd container
+++ [1104 12:29:14] Running build command...
+++ [1104 12:29:26] Checking etcd is on PATH
/usr/local/bin/etcd
+++ [1104 12:29:26] Starting etcd instance
etcd --advertise-client-urls http://127.0.0.1:2379 --data-dir /tmp.k8s/tmp.FVPV9pGEWB --listen-client-urls http://127.0.0.1:2379 --debug > "/dev/null" 2>/dev/null
Waiting for etcd to come up.
+++ [1104 12:29:26] On try 1, etcd: : http://127.0.0.1:2379
{"action":"set","node":{"key":"/_test","value":"","modifiedIndex":4,"createdIndex":4}}
+++ [1104 12:29:26] Running integration test cases
Running tests for APIVersion: v1,apps/v1beta1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1beta1,autoscaling/v1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1alpha1,extensions/v1beta
1,imagepolicy.k8s.io/v1alpha1,policy/v1beta1,rbac.authorization.k8s.io/v1alpha1,storage.k8s.io/v1beta1
+++ [1104 12:29:30] Running tests without code coverage
ok      k8s.io/kubernetes/test/integration/auth 9.670s
ok      k8s.io/kubernetes/test/integration/client       11.181s
ok      k8s.io/kubernetes/test/integration/configmap    0.780s
setting up a handler for /apis
setting up a handler for /api
Server running on port 9090
Error creating cert: mkdir /var/run/kubernetes: permission deniedW1104 12:31:03.340082    7565 handlers.go:50] Authentication is disabled
[restful] 2016/11/04 12:31:03 log.go:30: [restful/swagger] listing is available at https:///swaggerapi/
[restful] 2016/11/04 12:31:03 log.go:30: [restful/swagger] https:///swaggerui/ is mapped to folder /swagger-ui/
F1104 12:31:03.367346    7565 genericapiserver.go:195] unable to load server certificate: open /var/run/kubernetes/apiserver.crt: no such file or directory
goroutine 90 [running]:
k8s.io/kubernetes/vendor/github.com/golang/glog.stacks(0x2200600, 0xc400000000, 0x9c, 0x198)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:766 +0xa5
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).output(0x21e0340, 0xc400000003, 0xc420160600, 0x2058e22, 0x13, 0xc3, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:717 +0x337
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).printDepth(0x21e0340, 0xc400000003, 0x1, 0xc420825b50, 0x1, 0x1)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:646 +0x126
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).print(0x21e0340, 0xc400000003, 0xc420825b50, 0x1, 0x1)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:637 +0x5a
k8s.io/kubernetes/vendor/github.com/golang/glog.Fatal(0xc420825b50, 0x1, 0x1)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:1125 +0x53
k8s.io/kubernetes/pkg/genericapiserver.preparedGenericAPIServer.Run(0xc42078eb40, 0xc4200d0a80)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go:195 +0x294
k8s.io/kubernetes/examples/apiserver.Run(0xc4204a5000, 0xc4200d0a80, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/examples/apiserver/apiserver.go:108 +0xb1f
k8s.io/kubernetes/test/integration/discoverysummarizer.runAPIServer.func1(0xc4204a5000, 0xc4200d0a80, 0xc4201603c0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/integration/discoverysummarizer/discoverysummarizer_test.go:74 +0x39
created by k8s.io/kubernetes/test/integration/discoverysummarizer.runAPIServer
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/integration/discoverysummarizer/discoverysummarizer_test.go:77 +0x82
FAIL    k8s.io/kubernetes/test/integration/discoverysummarizer  1.463s
```
and so on. few other tests would be failing with same symptoms, because directory missing and non-writable by regular user. 

**Release note**:
```release-note
NONE
```

Currently if developer tries to run integration tests locally,
it would be failing due to missing /var/run/kubernetes inside
cross container image. As tests are run by non-privileged
user, this directory must be pre-created and made user
writable at the time cross build/test container created.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36246)
<!-- Reviewable:end -->
