### PR TITLE
Fix LBaaS version detection in openstack cloudprovider

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -403,7 +403,7 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 	glog.V(1).Info("Claiming to support LoadBalancer")
 
-	if os.lbOpts.LBVersion == "v2" {
+	if lbversion == "v2" {
 		return &LbaasV2{LoadBalancer{network, compute, os.lbOpts}}, true
 	} else if lbversion == "v1" {
 		return &LbaasV1{LoadBalancer{network, compute, os.lbOpts}}, true


### PR DESCRIPTION
`lbversion` is the local variable used for version detection when `os.lbOpts.LBVersion` is not specified.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1391837

@ncdc @derekwaynecarr @anguslees

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36249)
<!-- Reviewable:end -->
