### PR TITLE
Use curl -f in cluster/get-kube.sh

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -117,7 +117,7 @@ function download_tarball() {
   url="${DOWNLOAD_URL_PREFIX}/${file}"
   mkdir -p "${download_path}"
   if [[ $(which curl) ]]; then
-    curl -L --retry 3 --keepalive-time 2 "${url}" -o "${download_path}/${file}"
+    curl -fL --retry 3 --keepalive-time 2 "${url}" -o "${download_path}/${file}"
   elif [[ $(which wget) ]]; then
     wget "${url}" -O "${download_path}/${file}"
   else

--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -18,7 +18,7 @@
 # Usage:
 #   wget -q -O - https://get.k8s.io | bash
 # or
-#   curl -sS https://get.k8s.io | bash
+#   curl -fsSL https://get.k8s.io | bash
 #
 # Advanced options
 #  Set KUBERNETES_PROVIDER to choose between different providers:
@@ -115,7 +115,7 @@ function get_latest_version_number {
   if [[ $(which wget) ]]; then
     wget -qO- "${latest_url}"
   elif [[ $(which curl) ]]; then
-    curl -Ssf --retry 3 --keepalive-time 2 "${latest_url}"
+    curl -sSfL --retry 3 --keepalive-time 2 "${latest_url}"
   else
     echo "Couldn't find curl or wget.  Bailing out." >&2
     exit 4
@@ -203,7 +203,7 @@ fi
 
 if "${need_download}"; then
   if [[ $(which curl) ]]; then
-    curl -L --retry 3 --keepalive-time 2 "${release_url}" -o "${file}"
+    curl -fL --retry 3 --keepalive-time 2 "${release_url}" -o "${file}"
   elif [[ $(which wget) ]]; then
     wget "${release_url}"
   else


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `curl` explicitly fail if there are HTTP errors. This makes things more obvious than tar mysteriously failing. x-ref https://github.com/kubernetes/test-infra/issues/990

(I also added -L so HTTP redirects work, in case we eventually want to use them.)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36252)
<!-- Reviewable:end -->
