### PR TITLE
azure: loadbalancer rules use DSR

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -133,7 +133,7 @@ func (az *Cloud) EnsureLoadBalancer(clusterName string, service *api.Service, no
 		return nil, utilerrors.Flatten(errs)
 	}
 
-	glog.V(2).Infof("ensure(%s): FINISH - %s", service.Name, *pip.Properties.IPAddress)
+	glog.V(2).Infof("ensure(%s): FINISH - %s", serviceName, *pip.Properties.IPAddress)
 	return &api.LoadBalancerStatus{
 		Ingress: []api.LoadBalancerIngress{{IP: *pip.Properties.IPAddress}},
 	}, nil
@@ -362,8 +362,9 @@ func (az *Cloud) reconcileLoadBalancer(lb network.LoadBalancer, pip *network.Pub
 				Probe: &network.SubResource{
 					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, lbRuleName)),
 				},
-				FrontendPort: to.Int32Ptr(port.Port),
-				BackendPort:  to.Int32Ptr(port.NodePort),
+				FrontendPort:     to.Int32Ptr(port.Port),
+				BackendPort:      to.Int32Ptr(port.Port),
+				EnableFloatingIP: to.BoolPtr(true),
 			},
 		}
 	}
@@ -470,7 +471,7 @@ func (az *Cloud) reconcileSecurityGroup(sg network.SecurityGroup, clusterName st
 			Properties: &network.SecurityRulePropertiesFormat{
 				Protocol:                 securityProto,
 				SourcePortRange:          to.StringPtr("*"),
-				DestinationPortRange:     to.StringPtr(strconv.Itoa(int(port.NodePort))),
+				DestinationPortRange:     to.StringPtr(strconv.Itoa(int(port.Port))),
 				SourceAddressPrefix:      to.StringPtr("Internet"),
 				DestinationAddressPrefix: to.StringPtr("*"),
 				Access:    network.Allow,

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -217,7 +217,7 @@ func getTestLoadBalancer(services ...api.Service) network.LoadBalancer {
 				Name: to.StringPtr(ruleName),
 				Properties: &network.LoadBalancingRulePropertiesFormat{
 					FrontendPort: to.Int32Ptr(port.Port),
-					BackendPort:  to.Int32Ptr(port.NodePort),
+					BackendPort:  to.Int32Ptr(port.Port),
 				},
 			})
 			probes = append(probes, network.Probe{
@@ -248,7 +248,7 @@ func getTestSecurityGroup(services ...api.Service) network.SecurityGroup {
 			rules = append(rules, network.SecurityRule{
 				Name: to.StringPtr(ruleName),
 				Properties: &network.SecurityRulePropertiesFormat{
-					DestinationPortRange: to.StringPtr(fmt.Sprintf("%d", port.NodePort)),
+					DestinationPortRange: to.StringPtr(fmt.Sprintf("%d", port.Port)),
 				},
 			})
 		}
@@ -273,13 +273,13 @@ func validateLoadBalancer(t *testing.T, loadBalancer network.LoadBalancer, servi
 			for _, actualRule := range *loadBalancer.Properties.LoadBalancingRules {
 				if strings.EqualFold(*actualRule.Name, wantedRuleName) &&
 					*actualRule.Properties.FrontendPort == wantedRule.Port &&
-					*actualRule.Properties.BackendPort == wantedRule.NodePort {
+					*actualRule.Properties.BackendPort == wantedRule.Port {
 					foundRule = true
 					break
 				}
 			}
 			if !foundRule {
-				t.Errorf("Expected rule but didn't find it: %q", wantedRuleName)
+				t.Errorf("Expected load balancer rule but didn't find it: %q", wantedRuleName)
 			}
 
 			foundProbe := false
@@ -291,7 +291,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer network.LoadBalancer, servi
 				}
 			}
 			if !foundProbe {
-				t.Errorf("Expected probe but didn't find it: %q", wantedRuleName)
+				t.Errorf("Expected loadbalancer probe but didn't find it: %q", wantedRuleName)
 			}
 		}
 	}
@@ -315,13 +315,13 @@ func validateSecurityGroup(t *testing.T, securityGroup network.SecurityGroup, se
 			foundRule := false
 			for _, actualRule := range *securityGroup.Properties.SecurityRules {
 				if strings.EqualFold(*actualRule.Name, wantedRuleName) &&
-					*actualRule.Properties.DestinationPortRange == fmt.Sprintf("%d", wantedRule.NodePort) {
+					*actualRule.Properties.DestinationPortRange == fmt.Sprintf("%d", wantedRule.Port) {
 					foundRule = true
 					break
 				}
 			}
 			if !foundRule {
-				t.Errorf("Expected rule but didn't find it: %q", wantedRuleName)
+				t.Errorf("Expected security group rule but didn't find it: %q", wantedRuleName)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables "direct server return" on the load balancer in Azure, which causes the DIP to be preserved when traffic goes through the load balancer. This enables service traffic to go to the Service Port rather than having to go through the NodePort.

**Special notes for your reviewer**:
N/A.

**Tested with...**:
```shell
kubectl run nginx --image=nginx
kubectl run nginx2 --image=nginx
kubectl expose deployment nginx --port=80 --type=LoadBalancer
kubectl expose deployment nginx2 --port=80 --type=LoadBalancer
```
Ensuring that both services got external IPs and that the resources created looked correct.

**Release note**:
```release-note
azure: load balancer preserves destination ip address
```

CC: @brendandburns

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36256)
<!-- Reviewable:end -->
