### PR TITLE
tighten and document the genericapiserver.Config 

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -334,7 +334,8 @@ func Run(s *options.ServerRunOptions) error {
 		ServiceNodePortRange:      s.GenericServerRunOptions.ServiceNodePortRange,
 		KubernetesServiceNodePort: s.GenericServerRunOptions.KubernetesServiceNodePort,
 
-		MasterCount: s.GenericServerRunOptions.MasterCount,
+		MasterCount:   s.GenericServerRunOptions.MasterCount,
+		RBACSuperUser: s.GenericServerRunOptions.AuthorizationRBACSuperUser,
 	}
 
 	if s.GenericServerRunOptions.EnableWatchCache {

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -90,7 +90,7 @@ func Run(s *options.ServerRunOptions) error {
 	if err != nil {
 		glog.Fatalf("Error determining service IP ranges: %v", err)
 	}
-	if err := genericConfig.MaybeGenerateServingCerts(apiServerServiceIP); err != nil {
+	if err := genericConfig.MaybeGenerateServingCerts(s.GenericServerRunOptions.AdvertiseAddress.String(), apiServerServiceIP); err != nil {
 		glog.Fatalf("Failed to generate service certificate: %v", err)
 	}
 
@@ -305,7 +305,6 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.Authorizer = apiAuthorizer
 	genericConfig.AdmissionControl = admissionController
-	genericConfig.APIResourceConfigSource = storageFactory.APIResourceConfigSource
 	genericConfig.OpenAPIConfig.Info.Title = "Kubernetes"
 	genericConfig.OpenAPIConfig.Definitions = generatedopenapi.OpenAPIDefinitions
 	genericConfig.EnableOpenAPISupport = true
@@ -316,6 +315,8 @@ func Run(s *options.ServerRunOptions) error {
 		GenericConfig: genericConfig.Config,
 
 		StorageFactory:          storageFactory,
+		APIResourceConfigSource: storageFactory.APIResourceConfigSource,
+		EnableGarbageCollection: s.GenericServerRunOptions.EnableGarbageCollection,
 		EnableWatchCache:        s.GenericServerRunOptions.EnableWatchCache,
 		EnableCoreControllers:   true,
 		DeleteCollectionWorkers: s.GenericServerRunOptions.DeleteCollectionWorkers,

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -68,7 +68,7 @@ func Run(serverOptions *genericoptions.ServerRunOptions, stopCh <-chan struct{})
 	genericvalidation.ValidateRunOptions(serverOptions)
 	genericvalidation.VerifyEtcdServersList(serverOptions)
 	config := genericapiserver.NewConfig().ApplyOptions(serverOptions).Complete()
-	if err := config.MaybeGenerateServingCerts(); err != nil {
+	if err := config.MaybeGenerateServingCerts(serverOptions.AdvertiseAddress.String()); err != nil {
 		// this wasn't treated as fatal for this process before
 		fmt.Printf("Error creating cert: %v", err)
 	}

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -73,7 +73,7 @@ func Run(s *options.ServerRunOptions) error {
 							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
 							Complete()                               // set default values based on the known values
 
-	if err := genericConfig.MaybeGenerateServingCerts(); err != nil {
+	if err := genericConfig.MaybeGenerateServingCerts(s.GenericServerRunOptions.AdvertiseAddress.String()); err != nil {
 		glog.Fatalf("Failed to generate service certificate: %v", err)
 	}
 
@@ -191,7 +191,6 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.Authorizer = apiAuthorizer
 	genericConfig.AdmissionControl = admissionController
-	genericConfig.APIResourceConfigSource = storageFactory.APIResourceConfigSource
 	genericConfig.OpenAPIConfig.Definitions = openapi.OpenAPIDefinitions
 	genericConfig.EnableOpenAPISupport = true
 	genericConfig.OpenAPIConfig.SecurityDefinitions = securityDefinitions

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -50,7 +50,6 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	etcdServer, _ := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 
 	config := NewConfig()
-	config.PublicAddress = net.ParseIP("192.168.10.4")
 	config.RequestContextMapper = api.NewRequestContextMapper()
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 
@@ -88,9 +87,6 @@ func TestNew(t *testing.T) {
 	assert.Equal(s.legacyAPIGroupPrefixes, config.LegacyAPIGroupPrefixes)
 	assert.Equal(s.admissionControl, config.AdmissionControl)
 	assert.Equal(s.RequestContextMapper(), config.RequestContextMapper)
-
-	// these values get defaulted
-	assert.Equal(s.ExternalAddress, net.JoinHostPort(config.PublicAddress.String(), "6443"))
 }
 
 // Verifies that AddGroupVersions works as expected.

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -100,7 +100,7 @@ func (c *Config) NewBootstrapController(legacyRESTStorage corerest.LegacyRESTSto
 		ServicePort:               c.APIServerServicePort,
 		ExtraServicePorts:         c.ExtraServicePorts,
 		ExtraEndpointPorts:        c.ExtraEndpointPorts,
-		PublicServicePort:         c.GenericConfig.ReadWritePort,
+		PublicServicePort:         c.GenericConfig.ExternalSecurePort,
 		KubernetesServiceNodePort: c.KubernetesServiceNodePort,
 	}
 }

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -19,6 +19,7 @@ package master
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -76,6 +77,15 @@ type Controller struct {
 
 // NewBootstrapController returns a controller for watching the core capabilities of the master
 func (c *Config) NewBootstrapController(legacyRESTStorage corerest.LegacyRESTStorage) *Controller {
+	publicServicePort := 6443
+	if c.GenericConfig.SecureServingInfo != nil {
+		if _, portStr, err := net.SplitHostPort(c.GenericConfig.SecureServingInfo.BindAddress); err == nil && len(portStr) > 0 {
+			if port, err := strconv.Atoi(portStr); err == nil {
+				publicServicePort = port
+			}
+		}
+	}
+
 	return &Controller{
 		NamespaceRegistry: legacyRESTStorage.NamespaceRegistry,
 		ServiceRegistry:   legacyRESTStorage.ServiceRegistry,
@@ -94,13 +104,13 @@ func (c *Config) NewBootstrapController(legacyRESTStorage corerest.LegacyRESTSto
 		ServiceNodePortRange:    c.ServiceNodePortRange,
 		ServiceNodePortInterval: 3 * time.Minute,
 
-		PublicIP: c.GenericConfig.PublicAddress,
+		PublicIP: c.PublicAddress,
 
 		ServiceIP:                 c.APIServerServiceIP,
 		ServicePort:               c.APIServerServicePort,
 		ExtraServicePorts:         c.ExtraServicePorts,
 		ExtraEndpointPorts:        c.ExtraEndpointPorts,
-		PublicServicePort:         c.GenericConfig.ExternalSecurePort,
+		PublicServicePort:         publicServicePort,
 		KubernetesServiceNodePort: c.KubernetesServiceNodePort,
 	}
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -76,7 +76,11 @@ const (
 type Config struct {
 	GenericConfig *genericapiserver.Config
 
-	StorageFactory           genericapiserver.StorageFactory
+	StorageFactory genericapiserver.StorageFactory
+	// APIResourceConfigSource controls which API GroupVersionResources should be enabled on this server.APIGroupPrefix.
+	APIResourceConfigSource genericapiserver.APIResourceConfigSource
+
+	EnableGarbageCollection  bool
 	EnableWatchCache         bool
 	EnableCoreControllers    bool
 	EndpointReconcilerConfig EndpointReconcilerConfig
@@ -97,6 +101,10 @@ type Config struct {
 	APIServerServiceIP net.IP
 	// Port for the apiserver service.
 	APIServerServicePort int
+	// PublicAddress is the IP address where members of the cluster (kubelet,
+	// kube-proxy, services, etc.) can reach the master API server.
+	// If nil or 0.0.0.0, the host's default interface will be used.
+	PublicAddress net.IP
 
 	// TODO, we can probably group service related items into a substruct to make it easier to configure
 	// the API server items and `Extra*` fields likely fit nicely together.
@@ -222,7 +230,7 @@ func (c completedConfig) New() (*Master, error) {
 
 	restOptionsFactory := restOptionsFactory{
 		deleteCollectionWorkers: c.DeleteCollectionWorkers,
-		enableGarbageCollection: c.GenericConfig.EnableGarbageCollection,
+		enableGarbageCollection: c.EnableGarbageCollection,
 		storageFactory:          c.StorageFactory,
 	}
 
@@ -233,7 +241,7 @@ func (c completedConfig) New() (*Master, error) {
 	}
 
 	// install legacy rest storage
-	if c.GenericConfig.APIResourceConfigSource.AnyResourcesForVersionEnabled(apiv1.SchemeGroupVersion) {
+	if c.APIResourceConfigSource.AnyResourcesForVersionEnabled(apiv1.SchemeGroupVersion) {
 		legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
 			StorageFactory:       c.StorageFactory,
 			ProxyTransport:       c.ProxyTransport,
@@ -258,7 +266,7 @@ func (c completedConfig) New() (*Master, error) {
 		rbacrest.RESTStorageProvider{RBACSuperUser: c.RBACSuperUser},
 		storagerest.RESTStorageProvider{},
 	}
-	m.InstallAPIs(c.Config.GenericConfig.APIResourceConfigSource, restOptionsFactory.NewFor, restStorageProviders...)
+	m.InstallAPIs(c.Config.APIResourceConfigSource, restOptionsFactory.NewFor, restStorageProviders...)
 
 	if c.Tunneler != nil {
 		m.installTunneler(c.Tunneler, coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig).Nodes())

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -121,6 +121,9 @@ type Config struct {
 	// Number of masters running; all masters must be started with the
 	// same value for this field. (Numbers > 1 currently untested.)
 	MasterCount int
+
+	// RBACSuperUser is used by the RBAC storage for escalation computation
+	RBACSuperUser string
 }
 
 // EndpointReconcilerConfig holds the endpoint reconciler and endpoint reconciliation interval to be
@@ -252,7 +255,7 @@ func (c completedConfig) New() (*Master, error) {
 		certificatesrest.RESTStorageProvider{},
 		extensionsrest.RESTStorageProvider{ResourceInterface: thirdparty.NewThirdPartyResourceServer(s, c.StorageFactory)},
 		policyrest.RESTStorageProvider{},
-		rbacrest.RESTStorageProvider{AuthorizerRBACSuperUser: c.GenericConfig.AuthorizerRBACSuperUser},
+		rbacrest.RESTStorageProvider{RBACSuperUser: c.RBACSuperUser},
 		storagerest.RESTStorageProvider{},
 	}
 	m.InstallAPIs(c.Config.GenericConfig.APIResourceConfigSource, restOptionsFactory.NewFor, restStorageProviders...)

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -69,6 +69,7 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 		GenericConfig:        genericapiserver.NewConfig(),
 		APIServerServicePort: 443,
 		MasterCount:          1,
+		PublicAddress:        net.ParseIP("192.168.10.4"),
 	}
 
 	resourceEncoding := genericapiserver.NewDefaultResourceEncodingConfig()
@@ -85,10 +86,8 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 	config.GenericConfig.Version = &kubeVersion
 	config.StorageFactory = storageFactory
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
-	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
-	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
-	config.GenericConfig.APIResourceConfigSource = DefaultAPIResourceConfigSource()
+	config.APIResourceConfigSource = DefaultAPIResourceConfigSource()
 	config.GenericConfig.RequestContextMapper = api.NewRequestContextMapper()
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: api.Codecs}}
 	config.GenericConfig.EnableMetrics = true
@@ -135,7 +134,7 @@ func limitedAPIResourceConfigSource() *genericapiserver.ResourceConfig {
 // newLimitedMaster only enables the core group, the extensions group, the batch group, and the autoscaling group.
 func newLimitedMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	_, etcdserver, config, assert := setUp(t)
-	config.GenericConfig.APIResourceConfigSource = limitedAPIResourceConfigSource()
+	config.APIResourceConfigSource = limitedAPIResourceConfigSource()
 	master, err := config.Complete().New()
 	if err != nil {
 		t.Fatalf("Error in bringing up the master: %v", err)

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -46,7 +46,7 @@ import (
 )
 
 type RESTStorageProvider struct {
-	AuthorizerRBACSuperUser string
+	RBACSuperUser string
 }
 
 var _ genericapiserver.RESTStorageProvider = RESTStorageProvider{}
@@ -83,19 +83,19 @@ func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource genericapis
 	storage := map[string]rest.Storage{}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("roles")) {
 		rolesStorage := roleetcd.NewREST(restOptionsGetter(rbac.Resource("roles")))
-		storage["roles"] = rolepolicybased.NewStorage(rolesStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["roles"] = rolepolicybased.NewStorage(rolesStorage, newRuleValidator(), p.RBACSuperUser)
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("rolebindings")) {
 		roleBindingsStorage := rolebindingetcd.NewREST(restOptionsGetter(rbac.Resource("rolebindings")))
-		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, newRuleValidator(), p.RBACSuperUser)
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterroles")) {
 		clusterRolesStorage := clusterroleetcd.NewREST(restOptionsGetter(rbac.Resource("clusterroles")))
-		storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, newRuleValidator(), p.RBACSuperUser)
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterrolebindings")) {
 		clusterRoleBindingsStorage := clusterrolebindingetcd.NewREST(restOptionsGetter(rbac.Resource("clusterrolebindings")))
-		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, newRuleValidator(), p.RBACSuperUser)
 	}
 	return storage
 }

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -341,7 +341,7 @@ func TestRBAC(t *testing.T) {
 		masterConfig := framework.NewIntegrationTestMasterConfig()
 		masterConfig.GenericConfig.Authorizer = newRBACAuthorizer(t, superUser, masterConfig)
 		masterConfig.GenericConfig.Authenticator = newFakeAuthenticator()
-		masterConfig.GenericConfig.RBACSuperUser = superUser
+		masterConfig.RBACSuperUser = superUser
 		_, s := framework.RunAMaster(masterConfig)
 		defer s.Close()
 
@@ -440,7 +440,7 @@ func TestBootstrapping(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authorizer = newRBACAuthorizer(t, superUser, masterConfig)
 	masterConfig.GenericConfig.Authenticator = newFakeAuthenticator()
-	masterConfig.GenericConfig.RBACSuperUser = superUser
+	masterConfig.RBACSuperUser = superUser
 	_, s := framework.RunAMaster(masterConfig)
 	defer s.Close()
 

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -341,7 +341,7 @@ func TestRBAC(t *testing.T) {
 		masterConfig := framework.NewIntegrationTestMasterConfig()
 		masterConfig.GenericConfig.Authorizer = newRBACAuthorizer(t, superUser, masterConfig)
 		masterConfig.GenericConfig.Authenticator = newFakeAuthenticator()
-		masterConfig.GenericConfig.AuthorizerRBACSuperUser = superUser
+		masterConfig.GenericConfig.RBACSuperUser = superUser
 		_, s := framework.RunAMaster(masterConfig)
 		defer s.Close()
 
@@ -440,7 +440,7 @@ func TestBootstrapping(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authorizer = newRBACAuthorizer(t, superUser, masterConfig)
 	masterConfig.GenericConfig.Authenticator = newFakeAuthenticator()
-	masterConfig.GenericConfig.AuthorizerRBACSuperUser = superUser
+	masterConfig.GenericConfig.RBACSuperUser = superUser
 	_, s := framework.RunAMaster(masterConfig)
 	defer s.Close()
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -348,19 +348,19 @@ func NewMasterConfig() *master.Config {
 	genericConfig := genericapiserver.NewConfig()
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
-	genericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
 	genericConfig.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
 	genericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	genericConfig.EnableMetrics = true
 
 	return &master.Config{
-		GenericConfig:         genericConfig,
-		StorageFactory:        storageFactory,
-		EnableCoreControllers: true,
-		EnableWatchCache:      true,
-		KubeletClientConfig:   kubeletclient.KubeletClientConfig{Port: 10250},
-		APIServerServicePort:  443,
-		MasterCount:           1,
+		GenericConfig:           genericConfig,
+		StorageFactory:          storageFactory,
+		APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
+		EnableCoreControllers:   true,
+		EnableWatchCache:        true,
+		KubeletClientConfig:     kubeletclient.KubeletClientConfig{Port: 10250},
+		APIServerServicePort:    443,
+		MasterCount:             1,
 	}
 }
 
@@ -368,8 +368,8 @@ func NewMasterConfig() *master.Config {
 func NewIntegrationTestMasterConfig() *master.Config {
 	masterConfig := NewMasterConfig()
 	masterConfig.EnableCoreControllers = true
-	masterConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
-	masterConfig.GenericConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
+	masterConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	masterConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
 	return masterConfig
 }
 


### PR DESCRIPTION
This re-organizes and documents the `genericapiserver.Config` in the order which composers are likely to need the fields.  The second commit further tightens the API to a spot that should be good for 1.5.

@ncdc @sttts

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36257)
<!-- Reviewable:end -->
