### PR TITLE
Kubeadm unit tests for kubeadm/app/master package

### DIFF
--- a/cmd/kubeadm/app/master/BUILD
+++ b/cmd/kubeadm/app/master/BUILD
@@ -60,7 +60,6 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/util/cert:go_default_library",
         "//pkg/util/intstr:go_default_library",

--- a/cmd/kubeadm/app/master/BUILD
+++ b/cmd/kubeadm/app/master/BUILD
@@ -44,3 +44,25 @@ go_library(
         "//pkg/util/wait:go_default_library",
     ],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "addons_test.go",
+        "apiclient_test.go",
+        "discovery_test.go",
+        "kubeconfig_test.go",
+        "manifests_test.go",
+        "pki_test.go",
+        "tokens_test.go",
+    ],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//pkg/api:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//pkg/util/cert:go_default_library",
+        "//pkg/util/intstr:go_default_library",
+    ],
+)

--- a/cmd/kubeadm/app/master/addons_test.go
+++ b/cmd/kubeadm/app/master/addons_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestCreateKubeProxyPodSpec(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected bool
+	}{
+		{
+			cfg:      &kubeadmapi.MasterConfiguration{},
+			expected: true,
+		},
+	}
+
+	for _, rt := range tests {
+		actual := createKubeProxyPodSpec(rt.cfg)
+		if (actual.Containers[0].Name != "") != rt.expected {
+			t.Errorf(
+				"failed createKubeProxyPodSpec:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual.Containers[0].Name != ""),
+			)
+		}
+	}
+}
+
+func TestCreateKubeDNSPodSpec(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected string
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{DNSDomain: "localhost"},
+			},
+			expected: "--domain=localhost",
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{DNSDomain: "foo"},
+			},
+			expected: "--domain=foo",
+		},
+	}
+
+	for _, rt := range tests {
+		actual := createKubeDNSPodSpec(rt.cfg)
+		if actual.Containers[0].Args[0] != rt.expected {
+			t.Errorf(
+				"failed createKubeDNSPodSpec:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Containers[0].Args[0],
+			)
+		}
+	}
+}
+
+func TestCreateKubeDNSServiceSpec(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected bool
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "foo"},
+			},
+			expected: false,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/24"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, rt := range tests {
+		_, actual := createKubeDNSServiceSpec(rt.cfg)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed createKubeDNSServiceSpec:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/apiclient_test.go
+++ b/cmd/kubeadm/app/master/apiclient_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestCreateClientAndWaitForAPI(t *testing.T) {
+	cfg := &kubeadmapi.MasterConfiguration{
+		Networking: kubeadm.Networking{DNSDomain: "localhost"},
+	}
+	fmt.Println(cfg)
+
+}
+
+func TestStandardLabels(t *testing.T) {
+	var tests = []struct {
+		n        string
+		expected string
+	}{
+		{
+			n:        "foo",
+			expected: "foo",
+		},
+		{
+			n:        "bar",
+			expected: "bar",
+		},
+	}
+
+	for _, rt := range tests {
+		actual := standardLabels(rt.n)
+		if actual["component"] != rt.expected {
+			t.Errorf(
+				"failed standardLabels:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual["component"],
+			)
+		}
+		if actual["name"] != rt.expected {
+			t.Errorf(
+				"failed standardLabels:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual["name"],
+			)
+		}
+		if actual["k8s-app"] != rt.expected {
+			t.Errorf(
+				"failed standardLabels:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual["k8s-app"],
+			)
+		}
+	}
+}
+
+func TestNewDaemonSet(t *testing.T) {
+	var tests = []struct {
+		dn       string
+		expected string
+	}{
+		{
+			dn:       "foo",
+			expected: "foo",
+		},
+		{
+			dn:       "bar",
+			expected: "bar",
+		},
+	}
+
+	for _, rt := range tests {
+		p := api.PodSpec{}
+		actual := NewDaemonSet(rt.dn, p)
+		if actual.Spec.Selector.MatchLabels["k8s-app"] != rt.expected {
+			t.Errorf(
+				"failed NewDaemonSet:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["k8s-app"],
+			)
+		}
+		if actual.Spec.Selector.MatchLabels["component"] != rt.expected {
+			t.Errorf(
+				"failed NewDaemonSet:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["component"],
+			)
+		}
+		if actual.Spec.Selector.MatchLabels["name"] != rt.expected {
+			t.Errorf(
+				"failed NewDaemonSet:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["name"],
+			)
+		}
+	}
+}
+
+func TestNewService(t *testing.T) {
+	var tests = []struct {
+		dn       string
+		expected string
+	}{
+		{
+			dn:       "foo",
+			expected: "foo",
+		},
+		{
+			dn:       "bar",
+			expected: "bar",
+		},
+	}
+
+	for _, rt := range tests {
+		p := api.ServiceSpec{}
+		actual := NewService(rt.dn, p)
+		if actual.ObjectMeta.Labels["k8s-app"] != rt.expected {
+			t.Errorf(
+				"failed NewService:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.ObjectMeta.Labels["k8s-app"],
+			)
+		}
+		if actual.ObjectMeta.Labels["component"] != rt.expected {
+			t.Errorf(
+				"failed NewService:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.ObjectMeta.Labels["component"],
+			)
+		}
+		if actual.ObjectMeta.Labels["name"] != rt.expected {
+			t.Errorf(
+				"failed NewService:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.ObjectMeta.Labels["name"],
+			)
+		}
+	}
+}
+
+func TestNewDeployment(t *testing.T) {
+	var tests = []struct {
+		dn       string
+		expected string
+	}{
+		{
+			dn:       "foo",
+			expected: "foo",
+		},
+		{
+			dn:       "bar",
+			expected: "bar",
+		},
+	}
+
+	for _, rt := range tests {
+		p := api.PodSpec{}
+		actual := NewDeployment(rt.dn, 1, p)
+		if actual.Spec.Selector.MatchLabels["k8s-app"] != rt.expected {
+			t.Errorf(
+				"failed NewDeployment:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["k8s-app"],
+			)
+		}
+		if actual.Spec.Selector.MatchLabels["component"] != rt.expected {
+			t.Errorf(
+				"failed NewDeployment:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["component"],
+			)
+		}
+		if actual.Spec.Selector.MatchLabels["name"] != rt.expected {
+			t.Errorf(
+				"failed NewDeployment:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actual.Spec.Selector.MatchLabels["name"],
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/apiclient_test.go
+++ b/cmd/kubeadm/app/master/apiclient_test.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/pkg/api"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
 func TestCreateClientAndWaitForAPI(t *testing.T) {
@@ -90,7 +90,7 @@ func TestNewDaemonSet(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		p := api.PodSpec{}
+		p := apiv1.PodSpec{}
 		actual := NewDaemonSet(rt.dn, p)
 		if actual.Spec.Selector.MatchLabels["k8s-app"] != rt.expected {
 			t.Errorf(
@@ -132,7 +132,7 @@ func TestNewService(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		p := api.ServiceSpec{}
+		p := apiv1.ServiceSpec{}
 		actual := NewService(rt.dn, p)
 		if actual.ObjectMeta.Labels["k8s-app"] != rt.expected {
 			t.Errorf(
@@ -174,7 +174,7 @@ func TestNewDeployment(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		p := api.PodSpec{}
+		p := apiv1.PodSpec{}
 		actual := NewDeployment(rt.dn, 1, p)
 		if actual.Spec.Selector.MatchLabels["k8s-app"] != rt.expected {
 			t.Errorf(

--- a/cmd/kubeadm/app/master/discovery_test.go
+++ b/cmd/kubeadm/app/master/discovery_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"crypto/x509"
+	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestEncodeKubeDiscoverySecretData(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected bool
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadmapi.API{BindPort: 123, AdvertiseAddresses: []string{"10.0.0.1"}},
+				Networking: kubeadmapi.Networking{ServiceSubnet: "10.0.0.1/1"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, rt := range tests {
+		caCert := &x509.Certificate{}
+		actual := encodeKubeDiscoverySecretData(rt.cfg, caCert)
+		if (actual != nil) != rt.expected {
+			t.Errorf(
+				"failed encodeKubeDiscoverySecretData, return map[string][]byte was nil",
+			)
+		}
+	}
+}
+
+func TestNewKubeDiscoveryPodSpec(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		p        int32
+		expected bool
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Discovery: kubeadmapi.Discovery{BindPort: 123},
+			},
+			p: 123,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Discovery: kubeadmapi.Discovery{BindPort: 456},
+			},
+			p: 456,
+		},
+	}
+	for _, rt := range tests {
+		actual := newKubeDiscoveryPodSpec(rt.cfg)
+		if actual.Containers[0].Ports[0].HostPort != rt.p {
+			t.Errorf(
+				"failed newKubeDiscoveryPodSpec:\n\texpected: %d\n\t  actual: %d",
+				rt.p,
+				actual.Containers[0].Ports[0].HostPort,
+			)
+		}
+	}
+}
+
+func TestNewKubeDiscovery(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		caCert   *x509.Certificate
+		expected bool
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadmapi.API{BindPort: 123, AdvertiseAddresses: []string{"10.0.0.1"}},
+				Networking: kubeadmapi.Networking{ServiceSubnet: "10.0.0.1/1"},
+			},
+			caCert: &x509.Certificate{},
+		},
+	}
+	for _, rt := range tests {
+		actual := newKubeDiscovery(rt.cfg, rt.caCert)
+		if actual.Deployment == nil || actual.Secret == nil {
+			t.Errorf(
+				"failed newKubeDiscovery, kubeDiscovery was nil",
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/kubeconfig_test.go
+++ b/cmd/kubeadm/app/master/kubeconfig_test.go
@@ -61,7 +61,7 @@ func TestCreateCertsAndConfigForClients(t *testing.T) {
 		_, actual := CreateCertsAndConfigForClients(rt.a, rt.cn, caKey, caCert)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
-				"failed UseGivenTokenIfValid:\n\texpected: %t\n\t  actual: %t",
+				"failed CreateCertsAndConfigForClients:\n\texpected: %t\n\t  actual: %t",
 				rt.expected,
 				(actual == nil),
 			)

--- a/cmd/kubeadm/app/master/kubeconfig_test.go
+++ b/cmd/kubeadm/app/master/kubeconfig_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestCreateCertsAndConfigForClients(t *testing.T) {
+	var tests = []struct {
+		a         kubeadmapi.API
+		cn        []string
+		caKeySize int
+		expected  bool
+	}{
+		{
+			a:         kubeadmapi.API{AdvertiseAddresses: []string{"foo"}},
+			cn:        []string{"localhost"},
+			caKeySize: 128,
+			expected:  false,
+		},
+		{
+			a:         kubeadmapi.API{AdvertiseAddresses: []string{"foo"}},
+			cn:        []string{},
+			caKeySize: 128,
+			expected:  true,
+		},
+		{
+			a:         kubeadmapi.API{AdvertiseAddresses: []string{"foo"}},
+			cn:        []string{"localhost"},
+			caKeySize: 2048,
+			expected:  true,
+		},
+	}
+
+	for _, rt := range tests {
+		caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
+		if err != nil {
+			t.Fatalf("Couldn't create rsa Private Key")
+		}
+		caCert := &x509.Certificate{}
+		_, actual := CreateCertsAndConfigForClients(rt.a, rt.cn, caKey, caCert)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed UseGivenTokenIfValid:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -1,0 +1,577 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/util/intstr"
+)
+
+func TestWriteStaticPodManifests(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+
+	// set up tmp GlobalEnvParams values for testing
+	oldEnv := kubeadmapi.GlobalEnvParams
+	kubeadmapi.GlobalEnvParams.KubernetesDir = fmt.Sprintf("%s/etc/kubernetes", tmpdir)
+	defer func() { kubeadmapi.GlobalEnvParams = oldEnv }()
+
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected bool
+	}{
+		{
+			cfg:      &kubeadmapi.MasterConfiguration{},
+			expected: true,
+		},
+	}
+	for _, rt := range tests {
+		actual := WriteStaticPodManifests(rt.cfg)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed WriteStaticPodManifests with an error:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}
+
+func TestEtcdVolume(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected api.Volume
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: api.Volume{
+				Name: "etcd",
+				VolumeSource: api.VolumeSource{
+					HostPath: &api.HostPathVolumeSource{
+						Path: kubeadmapi.GlobalEnvParams.HostEtcdPath},
+				}},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := etcdVolume(rt.cfg)
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed etcdVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.VolumeSource.HostPath.Path != rt.expected.VolumeSource.HostPath.Path {
+			t.Errorf(
+				"failed etcdVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.VolumeSource.HostPath.Path,
+				actual.VolumeSource.HostPath.Path,
+			)
+		}
+	}
+}
+
+func TestEtcdVolumeMount(t *testing.T) {
+	var tests = []struct {
+		expected api.VolumeMount
+	}{
+		{
+			expected: api.VolumeMount{
+				Name:      "etcd",
+				MountPath: "/var/etcd",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := etcdVolumeMount()
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed etcdVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.MountPath != rt.expected.MountPath {
+			t.Errorf(
+				"failed etcdVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.MountPath,
+				actual.MountPath,
+			)
+		}
+	}
+}
+
+func TestCertsVolume(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected api.Volume
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: api.Volume{
+				Name: "certs",
+				VolumeSource: api.VolumeSource{
+					HostPath: &api.HostPathVolumeSource{
+						Path: "/etc/ssl/certs"},
+				}},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := certsVolume(rt.cfg)
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed certsVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.VolumeSource.HostPath.Path != rt.expected.VolumeSource.HostPath.Path {
+			t.Errorf(
+				"failed certsVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.VolumeSource.HostPath.Path,
+				actual.VolumeSource.HostPath.Path,
+			)
+		}
+	}
+}
+
+func TestCertsVolumeMount(t *testing.T) {
+	var tests = []struct {
+		expected api.VolumeMount
+	}{
+		{
+			expected: api.VolumeMount{
+				Name:      "certs",
+				MountPath: "/etc/ssl/certs",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := certsVolumeMount()
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed certsVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.MountPath != rt.expected.MountPath {
+			t.Errorf(
+				"failed certsVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.MountPath,
+				actual.MountPath,
+			)
+		}
+	}
+}
+
+func TestK8sVolume(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected api.Volume
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: api.Volume{
+				Name: "pki",
+				VolumeSource: api.VolumeSource{
+					HostPath: &api.HostPathVolumeSource{
+						Path: kubeadmapi.GlobalEnvParams.KubernetesDir},
+				}},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := k8sVolume(rt.cfg)
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed k8sVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.VolumeSource.HostPath.Path != rt.expected.VolumeSource.HostPath.Path {
+			t.Errorf(
+				"failed k8sVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.VolumeSource.HostPath.Path,
+				actual.VolumeSource.HostPath.Path,
+			)
+		}
+	}
+}
+
+func TestK8sVolumeMount(t *testing.T) {
+	var tests = []struct {
+		expected api.VolumeMount
+	}{
+		{
+			expected: api.VolumeMount{
+				Name:      "pki",
+				MountPath: "/etc/kubernetes/",
+				ReadOnly:  true,
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := k8sVolumeMount()
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed k8sVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.MountPath != rt.expected.MountPath {
+			t.Errorf(
+				"failed k8sVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.MountPath,
+				actual.MountPath,
+			)
+		}
+		if actual.ReadOnly != rt.expected.ReadOnly {
+			t.Errorf(
+				"failed k8sVolumeMount:\n\texpected: %t\n\t  actual: %t",
+				rt.expected.ReadOnly,
+				actual.ReadOnly,
+			)
+		}
+	}
+}
+
+func TestComponentResources(t *testing.T) {
+	a := componentResources("250m")
+	if a.Requests == nil {
+		t.Errorf(
+			"failed componentResources, return value was nil",
+		)
+	}
+}
+
+func TestComponentProbe(t *testing.T) {
+	var tests = []struct {
+		port int
+		path string
+	}{
+		{
+			port: 1,
+			path: "foo",
+		},
+	}
+	for _, rt := range tests {
+		actual := componentProbe(rt.port, rt.path)
+		if actual.Handler.HTTPGet.Port != intstr.FromInt(rt.port) {
+			t.Errorf(
+				"failed componentProbe:\n\texpected: %v\n\t  actual: %v",
+				rt.port,
+				actual.Handler.HTTPGet.Port,
+			)
+		}
+		if actual.Handler.HTTPGet.Path != rt.path {
+			t.Errorf(
+				"failed componentProbe:\n\texpected: %s\n\t  actual: %s",
+				rt.path,
+				actual.Handler.HTTPGet.Path,
+			)
+		}
+	}
+}
+
+func TestComponentPod(t *testing.T) {
+	var tests = []struct {
+		n string
+	}{
+		{
+			n: "foo",
+		},
+	}
+
+	for _, rt := range tests {
+		c := api.Container{Name: rt.n}
+		v := api.Volume{}
+		actual := componentPod(c, v)
+		if actual.ObjectMeta.Name != rt.n {
+			t.Errorf(
+				"failed componentPod:\n\texpected: %s\n\t  actual: %s",
+				rt.n,
+				actual.ObjectMeta.Name,
+			)
+		}
+	}
+}
+
+func TestGetComponentBaseCommand(t *testing.T) {
+	var tests = []struct {
+		c        string
+		expected []string
+	}{
+		{
+			c:        "foo",
+			expected: []string{"kube-foo", "--v=2"},
+		},
+		{
+			c:        "bar",
+			expected: []string{"kube-bar", "--v=2"},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := getComponentBaseCommand(rt.c)
+		for i := range actual {
+			if actual[i] != rt.expected[i] {
+				t.Errorf(
+					"failed getComponentBaseCommand:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					actual[i],
+				)
+			}
+		}
+	}
+}
+
+func TestGetAPIServerCommand(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected []string
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadm.API{BindPort: 123},
+				Networking: kubeadm.Networking{ServiceSubnet: "bar"},
+			},
+			expected: []string{
+				"kube-apiserver",
+				"--v=2",
+				"--insecure-bind-address=127.0.0.1",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
+				"--service-cluster-ip-range=bar",
+				"--service-account-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--client-ca-file=" + pkiDir + "/ca.pem",
+				"--tls-cert-file=" + pkiDir + "/apiserver.pem",
+				"--tls-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--token-auth-file=" + pkiDir + "/tokens.csv",
+				fmt.Sprintf("--secure-port=%d", 123),
+				"--allow-privileged",
+				"--etcd-servers=http://127.0.0.1:2379",
+			},
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadm.API{BindPort: 123, AdvertiseAddresses: []string{"foo"}},
+				Networking: kubeadm.Networking{ServiceSubnet: "bar"},
+			},
+			expected: []string{
+				"kube-apiserver",
+				"--v=2",
+				"--insecure-bind-address=127.0.0.1",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
+				"--service-cluster-ip-range=bar",
+				"--service-account-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--client-ca-file=" + pkiDir + "/ca.pem",
+				"--tls-cert-file=" + pkiDir + "/apiserver.pem",
+				"--tls-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--token-auth-file=" + pkiDir + "/tokens.csv",
+				fmt.Sprintf("--secure-port=%d", 123),
+				"--allow-privileged",
+				"--advertise-address=foo",
+				"--etcd-servers=http://127.0.0.1:2379",
+			},
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadm.API{BindPort: 123},
+				Networking: kubeadm.Networking{ServiceSubnet: "bar"},
+				Etcd:       kubeadm.Etcd{CertFile: "fiz", KeyFile: "faz"},
+			},
+			expected: []string{
+				"kube-apiserver",
+				"--v=2",
+				"--insecure-bind-address=127.0.0.1",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
+				"--service-cluster-ip-range=bar",
+				"--service-account-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--client-ca-file=" + pkiDir + "/ca.pem",
+				"--tls-cert-file=" + pkiDir + "/apiserver.pem",
+				"--tls-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--token-auth-file=" + pkiDir + "/tokens.csv",
+				fmt.Sprintf("--secure-port=%d", 123),
+				"--allow-privileged",
+				"--etcd-servers=http://127.0.0.1:2379",
+				"--etcd-certfile=fiz",
+				"--etcd-keyfile=faz",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := getAPIServerCommand(rt.cfg)
+		for i := range actual {
+			if actual[i] != rt.expected[i] {
+				t.Errorf(
+					"failed getAPIServerCommand:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					actual[i],
+				)
+			}
+		}
+	}
+}
+
+func TestGetControllerManagerCommand(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected []string
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: []string{
+				"kube-controller-manager",
+				"--v=2",
+				"--address=127.0.0.1",
+				"--leader-elect",
+				"--master=127.0.0.1:8080",
+				"--cluster-name=" + DefaultClusterName,
+				"--root-ca-file=" + pkiDir + "/ca.pem",
+				"--service-account-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--cluster-signing-cert-file=" + pkiDir + "/ca.pem",
+				"--cluster-signing-key-file=" + pkiDir + "/ca-key.pem",
+				"--insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap",
+			},
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{CloudProvider: "foo"},
+			expected: []string{
+				"kube-controller-manager",
+				"--v=2",
+				"--address=127.0.0.1",
+				"--leader-elect",
+				"--master=127.0.0.1:8080",
+				"--cluster-name=" + DefaultClusterName,
+				"--root-ca-file=" + pkiDir + "/ca.pem",
+				"--service-account-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--cluster-signing-cert-file=" + pkiDir + "/ca.pem",
+				"--cluster-signing-key-file=" + pkiDir + "/ca-key.pem",
+				"--insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap",
+				"--cloud-provider=foo",
+			},
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{Networking: kubeadm.Networking{PodSubnet: "bar"}},
+			expected: []string{
+				"kube-controller-manager",
+				"--v=2",
+				"--address=127.0.0.1",
+				"--leader-elect",
+				"--master=127.0.0.1:8080",
+				"--cluster-name=" + DefaultClusterName,
+				"--root-ca-file=" + pkiDir + "/ca.pem",
+				"--service-account-private-key-file=" + pkiDir + "/apiserver-key.pem",
+				"--cluster-signing-cert-file=" + pkiDir + "/ca.pem",
+				"--cluster-signing-key-file=" + pkiDir + "/ca-key.pem",
+				"--insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap",
+				"--allocate-node-cidrs=true",
+				"--cluster-cidr=bar",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := getControllerManagerCommand(rt.cfg)
+		for i := range actual {
+			if actual[i] != rt.expected[i] {
+				t.Errorf(
+					"failed getControllerManagerCommand:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					actual[i],
+				)
+			}
+		}
+	}
+}
+
+func TestGetSchedulerCommand(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected []string
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: []string{
+				"kube-scheduler",
+				"--v=2",
+				"--address=127.0.0.1",
+				"--leader-elect",
+				"--master=127.0.0.1:8080",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := getSchedulerCommand(rt.cfg)
+		for i := range actual {
+			if actual[i] != rt.expected[i] {
+				t.Errorf(
+					"failed getSchedulerCommand:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					actual[i],
+				)
+			}
+		}
+	}
+}
+
+func TestGetProxyCommand(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected []string
+	}{
+		{
+			cfg: &kubeadmapi.MasterConfiguration{},
+			expected: []string{
+				"kube-proxy",
+				"--v=2",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := getProxyCommand(rt.cfg)
+		for i := range actual {
+			if actual[i] != rt.expected[i] {
+				t.Errorf(
+					"failed getProxyCommand:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					actual[i],
+				)
+			}
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/pki_test.go
+++ b/cmd/kubeadm/app/master/pki_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	certutil "k8s.io/kubernetes/pkg/util/cert"
+)
+
+func TestNewCertificateAuthority(t *testing.T) {
+	r, x, err := newCertificateAuthority()
+
+	if r == nil {
+		t.Errorf(
+			"failed newCertificateAuthority, rsa key == nil",
+		)
+	}
+	if x == nil {
+		t.Errorf(
+			"failed newCertificateAuthority, x509 cert == nil",
+		)
+	}
+	if err != nil {
+		t.Errorf(
+			"failed newCertificateAuthority with an error: %v",
+			err,
+		)
+	}
+}
+
+func TestNewServerKeyAndCert(t *testing.T) {
+	var tests = []struct {
+		cfg       *kubeadmapi.MasterConfiguration
+		caKeySize int
+		expected  bool
+	}{
+		{
+			// given CIDR too small
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/1"},
+			},
+			caKeySize: 2048,
+			expected:  false,
+		},
+		{
+			// bad CIDR
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "foo"},
+			},
+			caKeySize: 2048,
+			expected:  false,
+		},
+		{
+			// RSA key too small
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/24"},
+			},
+			caKeySize: 128,
+			expected:  false,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/24"},
+			},
+			caKeySize: 2048,
+			expected:  true,
+		},
+	}
+
+	for _, rt := range tests {
+		caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
+		if err != nil {
+			t.Fatalf("Couldn't create rsa Private Key")
+		}
+		caCert := &x509.Certificate{}
+		altNames := certutil.AltNames{}
+		_, _, actual := newServerKeyAndCert(rt.cfg, caCert, caKey, altNames)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed newServerKeyAndCert:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}
+
+func TestNewClientKeyAndCert(t *testing.T) {
+	var tests = []struct {
+		caKeySize int
+		expected  bool
+	}{
+		{
+			// RSA key too small
+			caKeySize: 128,
+			expected:  false,
+		},
+		{
+			caKeySize: 2048,
+			expected:  true,
+		},
+	}
+
+	for _, rt := range tests {
+		caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
+		if err != nil {
+			t.Fatalf("Couldn't create rsa Private Key")
+		}
+		caCert := &x509.Certificate{}
+		_, _, actual := newClientKeyAndCert(caCert, caKey)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed newClientKeyAndCert:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}
+
+func TestWriteKeysAndCert(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Couldn't create rsa Private Key")
+	}
+	caCert := &x509.Certificate{}
+	actual := writeKeysAndCert(tmpdir, "foo", caKey, caCert)
+	if actual != nil {
+		t.Errorf(
+			"failed writeKeysAndCert with an error: %v",
+			actual,
+		)
+	}
+}
+
+func TestPathsKeysCerts(t *testing.T) {
+	var tests = []struct {
+		pkiPath  string
+		name     string
+		expected []string
+	}{
+		{
+			pkiPath:  "foo",
+			name:     "bar",
+			expected: []string{"foo/bar-pub.pem", "foo/bar-key.pem", "foo/bar.pem"},
+		},
+		{
+			pkiPath:  "bar",
+			name:     "foo",
+			expected: []string{"bar/foo-pub.pem", "bar/foo-key.pem", "bar/foo.pem"},
+		},
+	}
+
+	for _, rt := range tests {
+		a, b, c := pathsKeysCerts(rt.pkiPath, rt.name)
+		all := []string{a, b, c}
+		for i := range all {
+			if all[i] != rt.expected[i] {
+				t.Errorf(
+					"failed pathsKeysCerts:\n\texpected: %s\n\t  actual: %s",
+					rt.expected[i],
+					all[i],
+				)
+			}
+		}
+	}
+}
+
+func TestNewServiceAccountKey(t *testing.T) {
+	r, err := newServiceAccountKey()
+	if r == nil {
+		t.Errorf(
+			"failed newServiceAccountKey, rsa key == nil",
+		)
+	}
+	if err != nil {
+		t.Errorf(
+			"failed newServiceAccountKey with an error: %v",
+			err,
+		)
+	}
+}
+
+func TestCreatePKIAssets(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+
+	// set up tmp GlobalEnvParams values for testing
+	oldEnv := kubeadmapi.GlobalEnvParams
+	kubeadmapi.GlobalEnvParams.HostPKIPath = fmt.Sprintf("%s/etc/kubernetes/pki", tmpdir)
+	defer func() { kubeadmapi.GlobalEnvParams = oldEnv }()
+
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		expected bool
+	}{
+		{
+			cfg:      &kubeadmapi.MasterConfiguration{},
+			expected: false,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadm.API{AdvertiseAddresses: []string{"10.0.0.1"}},
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:        kubeadm.API{AdvertiseAddresses: []string{"10.0.0.1"}},
+				Networking: kubeadm.Networking{ServiceSubnet: "10.0.0.1/24"},
+			},
+			expected: true,
+		},
+	}
+	for _, rt := range tests {
+		_, _, actual := CreatePKIAssets(rt.cfg)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed CreatePKIAssets with an error:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/master/tokens_test.go
+++ b/cmd/kubeadm/app/master/tokens_test.go
@@ -38,8 +38,6 @@ func TestGenerateTokenIfNeeded(t *testing.T) {
 
 	for _, rt := range tests {
 		actual := generateTokenIfNeeded(&rt.s)
-		fmt.Println("here is a run:")
-		fmt.Println(actual)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed UseGivenTokenIfValid:\n\texpected: %t\n\t  actual: %t\n\t token:%s",
@@ -57,7 +55,6 @@ func TestCreateTokenAuthFile(t *testing.T) {
 		t.Fatalf("Couldn't create tmpdir")
 	}
 	defer os.Remove(tmpdir)
-	fmt.Println(tmpdir)
 
 	// set up tmp GlobalEnvParams values for testing
 	oldEnv := kubeadmapi.GlobalEnvParams

--- a/cmd/kubeadm/app/master/tokens_test.go
+++ b/cmd/kubeadm/app/master/tokens_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestGenerateTokenIfNeeded(t *testing.T) {
+	var tests = []struct {
+		s        kubeadmapi.Secrets
+		expected bool
+	}{
+		{kubeadmapi.Secrets{GivenToken: "noperiod"}, false}, // not 2-part '.' format
+		{kubeadmapi.Secrets{GivenToken: "abcd.a"}, false},   // len(tokenID) != 6
+		{kubeadmapi.Secrets{GivenToken: "abcdef.a"}, true},
+		{kubeadmapi.Secrets{GivenToken: ""}, true},
+	}
+
+	for _, rt := range tests {
+		actual := generateTokenIfNeeded(&rt.s)
+		fmt.Println("here is a run:")
+		fmt.Println(actual)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed UseGivenTokenIfValid:\n\texpected: %t\n\t  actual: %t\n\t token:%s",
+				rt.expected,
+				(actual == nil),
+				rt.s.GivenToken,
+			)
+		}
+	}
+}
+
+func TestCreateTokenAuthFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+	fmt.Println(tmpdir)
+
+	// set up tmp GlobalEnvParams values for testing
+	oldEnv := kubeadmapi.GlobalEnvParams
+	kubeadmapi.GlobalEnvParams.HostPKIPath = fmt.Sprintf("%s/etc/kubernetes/pki", tmpdir)
+	defer func() { kubeadmapi.GlobalEnvParams = oldEnv }()
+
+	var tests = []struct {
+		s        kubeadmapi.Secrets
+		expected bool
+	}{
+		{kubeadmapi.Secrets{GivenToken: "noperiod"}, false}, // not 2-part '.' format
+		{kubeadmapi.Secrets{GivenToken: "abcd.a"}, false},   // len(tokenID) != 6
+		{kubeadmapi.Secrets{GivenToken: "abcdef.a"}, true},
+		{kubeadmapi.Secrets{GivenToken: ""}, true},
+	}
+	for _, rt := range tests {
+		actual := CreateTokenAuthFile(&rt.s)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed WriteKubeconfigIfNotExists with an error:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -506,6 +506,7 @@ k8s.io/kubernetes/cmd/kube-proxy/app,luxas,1
 k8s.io/kubernetes/cmd/kubeadm/app/cmd,caesarxuchao,1
 k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/node,apprenda,0
+k8s.io/kubernetes/cmd/kubeadm/app/master,apprenda,0
 k8s.io/kubernetes/cmd/kubeadm/app/preflight,apprenda,0
 k8s.io/kubernetes/cmd/kubeadm/app/util,krousey,1
 k8s.io/kubernetes/cmd/kubeadm/test,pipejakob,0


### PR DESCRIPTION
Added unit tests for the kubeadm/app/master package testing functionality of tokens.go, kubeconfig.go, manifests.go, pki.go, discovery.go, addons.go, and apiclient.go.

This PR is part of the ongoing effort to add tests (#35025)

/cc @pires @jbeda

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36263)
<!-- Reviewable:end -->
