### PR TITLE
[Federation] Make federation etcd PVC size configurable

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -356,7 +356,6 @@ func createControllerManagerKubeconfigSecret(clientset *client.Clientset, namesp
 }
 
 func createPVC(clientset *client.Clientset, namespace, svcName, etcdPVCapacity string) (*api.PersistentVolumeClaim, error) {
-
 	capacity, err := resource.ParseQuantity(etcdPVCapacity)
 	if err != nil {
 		return nil, err

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -119,6 +119,7 @@ func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 	cmd.Flags().String("dns-zone-name", "", "DNS suffix for this federation. Federated Service DNS names are published with this suffix.")
 	cmd.Flags().String("image", defaultImage, "Image to use for federation API server and controller manager binaries.")
 	cmd.Flags().String("dns-provider", "google-clouddns", "Dns provider to be used for this deployment.")
+	cmd.Flags().String("etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
 	return cmd
 }
 
@@ -140,6 +141,7 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	dnsZoneName := cmdutil.GetFlagString(cmd, "dns-zone-name")
 	image := cmdutil.GetFlagString(cmd, "image")
 	dnsProvider := cmdutil.GetFlagString(cmd, "dns-provider")
+	etcdPVCapacity := cmdutil.GetFlagString(cmd, "etcd-pv-capacity")
 
 	hostFactory := config.HostFactory(initFlags.Host, initFlags.Kubeconfig)
 	hostClientset, err := hostFactory.ClientSet()
@@ -188,7 +190,7 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	// 5. Create a persistent volume and a claim to store the federation
 	// API server's state. This is where federation API server's etcd
 	// stores its data.
-	pvc, err := createPVC(hostClientset, initFlags.FederationSystemNamespace, svc.Name)
+	pvc, err := createPVC(hostClientset, initFlags.FederationSystemNamespace, svc.Name, etcdPVCapacity)
 	if err != nil {
 		return err
 	}
@@ -353,8 +355,9 @@ func createControllerManagerKubeconfigSecret(clientset *client.Clientset, namesp
 	return util.CreateKubeconfigSecret(clientset, config, namespace, kubeconfigName, false)
 }
 
-func createPVC(clientset *client.Clientset, namespace, svcName string) (*api.PersistentVolumeClaim, error) {
-	capacity, err := resource.ParseQuantity("10Gi")
+func createPVC(clientset *client.Clientset, namespace, svcName, etcdPVCapacity string) (*api.PersistentVolumeClaim, error) {
+
+	capacity, err := resource.ParseQuantity(etcdPVCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -403,12 +403,9 @@ func fakeInitHostFactory(federationName, namespaceName, ip, dnsZoneName, image, 
 	svcUrlPrefix := "/api/v1/namespaces/federation-system/services"
 	credSecretName := svcName + "-credentials"
 	cmKubeconfigSecretName := federationName + "-controller-manager-kubeconfig"
-	pvCap := ""
-
-	if "" != etcdPVCapacity {
+	pvCap := "10Gi"
+	if etcdPVCapacity != "" {
 		pvCap = etcdPVCapacity
-	} else {
-		pvCap = "10Gi" //test for default value
 	}
 
 	capacity, err := resource.ParseQuantity(pvCap)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -169,6 +169,7 @@ etcd-config
 etcd-keyfile
 etcd-mutation-timeout
 etcd-prefix
+etcd-pv-capacity
 etcd-quorum-read
 etcd-server
 etcd-servers


### PR DESCRIPTION
This one implements one of the many TODO items pending in the previous set of kubefed PRs.
The design doc PR is at https://github.com/kubernetes/kubernetes/pull/34484

cc  @kubernetes/sig-cluster-federation  @madhusudancs

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36310)
<!-- Reviewable:end -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
``` 
[Federation] kubefed init now has a new flag, --etcd-pv-capacity, which can be used to configure the persistent volume capacity for etcd.  
```
