### PR TITLE
Improve quota performance for pvc by using shared informer

### DIFF
--- a/pkg/quota/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/evaluator/core/persistent_volume_claims.go
@@ -23,16 +23,42 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/controller/informers"
 	"k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/quota/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
+// listPersistentVolumeClaimsByNamespaceFuncUsingClient returns a pvc listing function based on the provided client.
+func listPersistentVolumeClaimsByNamespaceFuncUsingClient(kubeClient clientset.Interface) generic.ListFuncByNamespace {
+	// TODO: ideally, we could pass dynamic client pool down into this code, and have one way of doing this.
+	// unfortunately, dynamic client works with Unstructured objects, and when we calculate Usage, we require
+	// structured objects.
+	return func(namespace string, options api.ListOptions) ([]runtime.Object, error) {
+		itemList, err := kubeClient.Core().PersistentVolumeClaims(namespace).List(options)
+		if err != nil {
+			return nil, err
+		}
+		results := make([]runtime.Object, 0, len(itemList.Items))
+		for i := range itemList.Items {
+			results = append(results, &itemList.Items[i])
+		}
+		return results, nil
+	}
+}
+
 // NewPersistentVolumeClaimEvaluator returns an evaluator that can evaluate persistent volume claims
-func NewPersistentVolumeClaimEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+// if the specified shared informer factory is not nil, evaluator may use it to support listing functions.
+func NewPersistentVolumeClaimEvaluator(kubeClient clientset.Interface, f informers.SharedInformerFactory) quota.Evaluator {
 	allResources := []api.ResourceName{api.ResourcePersistentVolumeClaims, api.ResourceRequestsStorage}
+	listFuncByNamespace := listPersistentVolumeClaimsByNamespaceFuncUsingClient(kubeClient)
+	if f != nil {
+		listFuncByNamespace = generic.ListResourceUsingInformerFunc(f, unversioned.GroupResource{Resource: "persistentvolumeclaims"})
+	}
+
 	return &generic.GenericEvaluator{
 		Name:              "Evaluator.PersistentVolumeClaim",
 		InternalGroupKind: api.Kind("PersistentVolumeClaim"),
@@ -43,17 +69,7 @@ func NewPersistentVolumeClaimEvaluator(kubeClient clientset.Interface) quota.Eva
 		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
 		ConstraintsFunc:      PersistentVolumeClaimConstraintsFunc,
 		UsageFunc:            PersistentVolumeClaimUsageFunc,
-		ListFuncByNamespace: func(namespace string, options api.ListOptions) ([]runtime.Object, error) {
-			itemList, err := kubeClient.Core().PersistentVolumeClaims(namespace).List(options)
-			if err != nil {
-				return nil, err
-			}
-			results := make([]runtime.Object, 0, len(itemList.Items))
-			for i := range itemList.Items {
-				results = append(results, &itemList.Items[i])
-			}
-			return results, nil
-		},
+		ListFuncByNamespace:  listFuncByNamespace,
 	}
 }
 

--- a/pkg/quota/evaluator/core/persistent_volume_claims_test.go
+++ b/pkg/quota/evaluator/core/persistent_volume_claims_test.go
@@ -127,7 +127,7 @@ func TestPersistentVolumeClaimEvaluatorUsage(t *testing.T) {
 	})
 
 	kubeClient := fake.NewSimpleClientset()
-	evaluator := NewPersistentVolumeClaimEvaluator(kubeClient)
+	evaluator := NewPersistentVolumeClaimEvaluator(kubeClient, nil)
 	testCases := map[string]struct {
 		pvc   *api.PersistentVolumeClaim
 		usage api.ResourceList

--- a/pkg/quota/evaluator/core/registry.go
+++ b/pkg/quota/evaluator/core/registry.go
@@ -33,7 +33,7 @@ func NewRegistry(kubeClient clientset.Interface, f informers.SharedInformerFacto
 	resourceQuota := NewResourceQuotaEvaluator(kubeClient)
 	secret := NewSecretEvaluator(kubeClient)
 	configMap := NewConfigMapEvaluator(kubeClient)
-	persistentVolumeClaim := NewPersistentVolumeClaimEvaluator(kubeClient)
+	persistentVolumeClaim := NewPersistentVolumeClaimEvaluator(kubeClient, f)
 	return &generic.GenericRegistry{
 		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
 			pod.GroupKind():                   pod,


### PR DESCRIPTION
This avoids a list call for each namespace in the resource quota controller when syncing quota.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36316)
<!-- Reviewable:end -->
