### PR TITLE
Uses a pair of locks as workaround to lock unfairness

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -162,6 +162,7 @@ func newServiceInfo(service proxy.ServicePortName) *serviceInfo {
 // Proxier is an iptables based proxy for connections between a localhost:lport
 // and services that provide the actual backends.
 type Proxier struct {
+	orderMu                     sync.Mutex // protects the following mutex as a workaround of lock unfairness
 	mu                          sync.Mutex // protects the following fields
 	serviceMap                  map[proxy.ServicePortName]*serviceInfo
 	endpointsMap                map[proxy.ServicePortName][]*endpointsInfo
@@ -394,9 +395,17 @@ func ipsEqual(lhs, rhs []string) bool {
 	return true
 }
 
+// lock acquires a pair of locks and releases the first lock once the second lock is acquired.
+// It is a workaround for lock unfairness.
+func (proxier *Proxier) lock() {
+	proxier.orderMu.Lock()
+	proxier.mu.Lock()
+	proxier.orderMu.Unlock()
+}
+
 // Sync is called to immediately synchronize the proxier state to iptables
 func (proxier *Proxier) Sync() {
-	proxier.mu.Lock()
+	proxier.lock()
 	defer proxier.mu.Unlock()
 	proxier.syncProxyRules()
 }
@@ -419,7 +428,8 @@ func (proxier *Proxier) OnServiceUpdate(allServices []api.Service) {
 	defer func() {
 		glog.V(4).Infof("OnServiceUpdate took %v for %d services", time.Since(start), len(allServices))
 	}()
-	proxier.mu.Lock()
+
+	proxier.lock()
 	defer proxier.mu.Unlock()
 	proxier.haveReceivedServiceUpdate = true
 
@@ -555,7 +565,7 @@ func (proxier *Proxier) OnEndpointsUpdate(allEndpoints []api.Endpoints) {
 		glog.V(4).Infof("OnEndpointsUpdate took %v for %d endpoints", time.Since(start), len(allEndpoints))
 	}()
 
-	proxier.mu.Lock()
+	proxier.lock()
 	defer proxier.mu.Unlock()
 	proxier.haveReceivedEndpointsUpdate = true
 


### PR DESCRIPTION
Attempt to fix #36281.

Instead of turning off `Proxy min sync period` introduced by #35334, this PR adds one more protecter lock for the original lock to handle golang's lock unfairness. This could make sure OnEndpointsUpdate() triggered by no-op endpoint updates don't starve OnServiceUpdate().

Ran on cluster and observed better behavior:
```
...
I1106 18:46:34.245327       6 proxier.go:433] [debug] OnServiceUpdate took 1.178257656s for lock()
...
I1106 18:46:36.245681       6 proxier.go:570] [debug] OnEndpointsUpdate took 2.000382123s for lock()
...
I1106 18:46:38.248147       6 proxier.go:570] [debug] OnEndpointsUpdate took 800ns for lock()
...
# A bunch of other OnEndpointsUpdate() calls
...
I1106 18:46:48.248739       6 proxier.go:433] [debug] OnServiceUpdate took 565.898529ms for lock()
...
```

@bprashanth @thockin @timothysc

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36320)
<!-- Reviewable:end -->
