### PR TITLE
options, kube-apiserver: clarify scheme on etcd endpoints

### DIFF
--- a/pkg/genericapiserver/options/etcd_options.go
+++ b/pkg/genericapiserver/options/etcd_options.go
@@ -32,7 +32,7 @@ func (s *ServerRunOptions) AddEtcdStorageFlags(fs *pflag.FlagSet) {
 		"format: group/resource#servers, where servers are http://ip:port, semicolon separated.")
 
 	fs.StringSliceVar(&s.StorageConfig.ServerList, "etcd-servers", s.StorageConfig.ServerList,
-		"List of etcd servers to connect with (http://ip:port), comma separated.")
+		"List of etcd servers to connect with (scheme://ip:port), comma separated.")
 
 	fs.StringVar(&s.StorageConfig.Prefix, "etcd-prefix", s.StorageConfig.Prefix,
 		"The prefix for all resource paths in etcd.")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix typo in `kube-apiserver` flag.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None


<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36321)
<!-- Reviewable:end -->
