### PR TITLE
Add the facility to return warnings from admission controllers.

### DIFF
--- a/pkg/admission/BUILD
+++ b/pkg/admission/BUILD
@@ -47,7 +47,9 @@ go_test(
     library = "go_default_library",
     tags = ["automanaged"],
     deps = [
+        "//pkg/api/unversioned:go_default_library",
         "//pkg/auth/authorizer:go_default_library",
         "//pkg/runtime/schema:go_default_library",
+        "//pkg/util/errors:go_default_library",
     ],
 )

--- a/pkg/admission/init_test.go
+++ b/pkg/admission/init_test.go
@@ -40,9 +40,9 @@ type WantAuthorizerAdmission struct {
 func (self *WantAuthorizerAdmission) SetAuthorizer(a authorizer.Authorizer) {
 	self.auth = a
 }
-func (self *WantAuthorizerAdmission) Admit(a Attributes) error { return nil }
-func (self *WantAuthorizerAdmission) Handles(o Operation) bool { return false }
-func (self *WantAuthorizerAdmission) Validate() error          { return nil }
+func (self *WantAuthorizerAdmission) Admit(a Attributes) (Warning, error) { return nil, nil }
+func (self *WantAuthorizerAdmission) Handles(o Operation) bool            { return false }
+func (self *WantAuthorizerAdmission) Validate() error                     { return nil }
 
 var _ Interface = &WantAuthorizerAdmission{}
 var _ WantsAuthorizer = &WantAuthorizerAdmission{}

--- a/pkg/admission/interfaces.go
+++ b/pkg/admission/interfaces.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/kubernetes/pkg/runtime/schema"
 )
 
+// Warning describes a warning to a user about an activity that they are taking.
+// A warning could be a deprecation message, it could be advice about an object, etc.
+type Warning interface {
+	error
+}
+
 // Attributes is an interface used by AdmissionController to get information about a request
 // that is used to make an admission decision.
 type Attributes interface {
@@ -52,7 +58,7 @@ type Attributes interface {
 // Interface is an abstract, pluggable interface for Admission Control decisions.
 type Interface interface {
 	// Admit makes an admission decision based on the request attributes
-	Admit(a Attributes) (err error)
+	Admit(a Attributes) (warning Warning, err error)
 
 	// Handles returns true if this admission controller can handle the given operation
 	// where operation can be one of CREATE, UPDATE, DELETE, or CONNECT

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -18,6 +18,7 @@ package resttest
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -44,6 +45,8 @@ type Tester struct {
 	generatesName       bool
 	returnDeletedObject bool
 	namer               func(int) string
+	methods             []string
+	handler             http.Handler
 }
 
 func New(t *testing.T, storage rest.Storage) *Tester {
@@ -63,6 +66,18 @@ func defaultNamer(i int) string {
 func (t *Tester) Namer(namer func(int) string) *Tester {
 	t.namer = namer
 	return t
+}
+
+func (t *Tester) Connect(ctx api.Context, id string, options runtime.Object, r rest.Responder) (http.Handler, error) {
+	return t.handler, nil
+}
+
+func (t *Tester) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (t *Tester) ConnectMethods() []string {
+	return t.methods
 }
 
 func (t *Tester) ClusterScope() *Tester {

--- a/pkg/apiserver/BUILD
+++ b/pkg/apiserver/BUILD
@@ -101,6 +101,7 @@ go_test(
         "//pkg/runtime/serializer/streaming:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/util/diff:go_default_library",
+        "//pkg/util/errors:go_default_library",
         "//pkg/util/net:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/util/strategicpatch:go_default_library",

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/util"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
 
@@ -87,6 +88,24 @@ type RequestScope struct {
 
 func (scope *RequestScope) err(err error, w http.ResponseWriter, req *http.Request) {
 	errorNegotiated(err, scope.Serializer, scope.Kind.GroupVersion(), w, req)
+}
+
+func addWarningHeaders(warning admission.Warning, source string, res *restful.Response) {
+	if warning == nil {
+		return
+	}
+	aggregate, ok := warning.(utilerrors.Aggregate)
+	var errs []error
+	if ok {
+		errs = aggregate.Errors()
+	} else {
+		errs = []error{warning}
+	}
+	for ix := range errs {
+		// HTTP 'Warning' Header: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46
+		// 199 is a status code indicating "Miscellaneous warning"
+		res.AddHeader("Warning", fmt.Sprintf("199 %s %s", source, errs[ix].Error()))
+	}
 }
 
 // getterFunc performs a get request with the given context and object name. The request
@@ -201,7 +220,8 @@ func ConnectResource(connecter rest.Connecter, scope RequestScope, admit admissi
 			}
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(connectRequest, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, userInfo))
+			warn, err := admit.Admit(admission.NewAttributesRecord(connectRequest, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, userInfo))
+			addWarningHeaders(warn, scope.Kind.String(), res)
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -392,7 +412,8 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 		if admit != nil && admit.Handles(admission.Create) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(obj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, userInfo))
+			warn, err := admit.Admit(admission.NewAttributesRecord(obj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, userInfo))
+			addWarningHeaders(warn, scope.Kind.String(), res)
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -495,7 +516,9 @@ func PatchResource(r rest.Patcher, scope RequestScope, typer runtime.ObjectTyper
 		updateAdmit := func(updatedObject runtime.Object, currentObject runtime.Object) error {
 			if admit != nil && admit.Handles(admission.Update) {
 				userInfo, _ := api.UserFrom(ctx)
-				return admit.Admit(admission.NewAttributesRecord(updatedObject, currentObject, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
+				warn, err := admit.Admit(admission.NewAttributesRecord(updatedObject, currentObject, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
+				addWarningHeaders(warn, scope.Kind.String(), res)
+				return err
 			}
 
 			return nil
@@ -708,7 +731,9 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 		if admit != nil && admit.Handles(admission.Update) {
 			transformers = append(transformers, func(ctx api.Context, newObj, oldObj runtime.Object) (runtime.Object, error) {
 				userInfo, _ := api.UserFrom(ctx)
-				return newObj, admit.Admit(admission.NewAttributesRecord(newObj, oldObj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
+				warn, err := admit.Admit(admission.NewAttributesRecord(newObj, oldObj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
+				addWarningHeaders(warn, scope.Kind.String(), res)
+				return newObj, err
 			})
 		}
 
@@ -795,7 +820,8 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope RequestSco
 		if admit != nil && admit.Handles(admission.Delete) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Delete, userInfo))
+			warn, err := admit.Admit(admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Delete, userInfo))
+			addWarningHeaders(warn, scope.Kind.String(), res)
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -856,7 +882,8 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope RequestSco
 		if admit != nil && admit.Handles(admission.Delete) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, "", scope.Resource, scope.Subresource, admission.Delete, userInfo))
+			warn, err := admit.Admit(admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, "", scope.Resource, scope.Subresource, admission.Delete, userInfo))
+			addWarningHeaders(warn, scope.Kind.String(), res)
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return

--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -34,8 +34,8 @@ func init() {
 // It is useful in tests and when using kubernetes in an open manner.
 type alwaysAdmit struct{}
 
-func (alwaysAdmit) Admit(a admission.Attributes) (err error) {
-	return nil
+func (alwaysAdmit) Admit(a admission.Attributes) (warn admission.Warning, err error) {
+	return nil, nil
 }
 
 func (alwaysAdmit) Handles(operation admission.Operation) bool {

--- a/plugin/pkg/admission/admit/admission_test.go
+++ b/plugin/pkg/admission/admit/admission_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAdmission(t *testing.T) {
 	handler := NewAlwaysAdmit()
-	err := handler.Admit(nil)
+	_, err := handler.Admit(nil)
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -46,14 +46,14 @@ type alwaysPullImages struct {
 	*admission.Handler
 }
 
-func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
+func (a *alwaysPullImages) Admit(attributes admission.Attributes) (warn admission.Warning, err error) {
 	// Ignore all calls to subresources or resources other than pods.
 	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	pod, ok := attributes.GetObject().(*api.Pod)
 	if !ok {
-		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+		return nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
 	for i := range pod.Spec.InitContainers {
@@ -64,7 +64,7 @@ func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
 		pod.Spec.Containers[i].ImagePullPolicy = api.PullAlways
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewAlwaysPullImages creates a new always pull images admission control handler

--- a/plugin/pkg/admission/alwayspullimages/admission_test.go
+++ b/plugin/pkg/admission/alwayspullimages/admission_test.go
@@ -46,7 +46,7 @@ func TestAdmission(t *testing.T) {
 			},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -108,7 +108,7 @@ func TestOtherResources(t *testing.T) {
 	for _, tc := range tests {
 		handler := &alwaysPullImages{}
 
-		err := handler.Admit(admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
 
 		if tc.expectError {
 			if err == nil {

--- a/plugin/pkg/admission/antiaffinity/admission_test.go
+++ b/plugin/pkg/admission/antiaffinity/admission_test.go
@@ -214,7 +214,7 @@ func TestInterPodAffinityAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		pod.ObjectMeta.Annotations = test.affinity
-		err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 
 		if test.errorExpected && err == nil {
 			t.Errorf("Expected error for Anti Affinity %+v but did not get an error", test.affinity)
@@ -282,7 +282,7 @@ func TestOtherResources(t *testing.T) {
 	for _, tc := range tests {
 		handler := &plugin{}
 
-		err := handler.Admit(admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
 
 		if tc.expectError {
 			if err == nil {

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -35,8 +35,8 @@ func init() {
 // It is useful in unit tests to force an operation to be forbidden.
 type alwaysDeny struct{}
 
-func (alwaysDeny) Admit(a admission.Attributes) (err error) {
-	return admission.NewForbidden(a, errors.New("Admission control is denying all modifications"))
+func (alwaysDeny) Admit(a admission.Attributes) (warn admission.Warning, err error) {
+	return nil, admission.NewForbidden(a, errors.New("Admission control is denying all modifications"))
 }
 
 func (alwaysDeny) Handles(operation admission.Operation) bool {

--- a/plugin/pkg/admission/deny/admission_test.go
+++ b/plugin/pkg/admission/deny/admission_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAdmission(t *testing.T) {
 	handler := NewAlwaysDeny()
-	err := handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("kind").WithVersion("version"), "namespace", "name", api.Resource("resource").WithVersion("version"), "subresource", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("kind").WithVersion("version"), "namespace", "name", api.Resource("resource").WithVersion("version"), "subresource", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error returned from admission handler")
 	}

--- a/plugin/pkg/admission/exec/admission_test.go
+++ b/plugin/pkg/admission/exec/admission_test.go
@@ -125,7 +125,7 @@ func testAdmission(t *testing.T, pod *api.Pod, handler *denyExec, shouldAccept b
 	// pods/exec
 	{
 		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/exec"}
-		err := handler.Admit(admission.NewAttributesRecord(req, nil, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "exec", admission.Connect, nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(req, nil, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "exec", admission.Connect, nil))
 		if shouldAccept && err != nil {
 			t.Errorf("Unexpected error returned from admission handler: %v", err)
 		}
@@ -137,7 +137,7 @@ func testAdmission(t *testing.T, pod *api.Pod, handler *denyExec, shouldAccept b
 	// pods/attach
 	{
 		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/attach"}
-		err := handler.Admit(admission.NewAttributesRecord(req, nil, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "attach", admission.Connect, nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(req, nil, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "attach", admission.Connect, nil))
 		if shouldAccept && err != nil {
 			t.Errorf("Unexpected error returned from admission handler: %v", err)
 		}

--- a/plugin/pkg/admission/gc/gc_admission.go
+++ b/plugin/pkg/admission/gc/gc_admission.go
@@ -43,10 +43,10 @@ type gcPermissionsEnforcement struct {
 	authorizer authorizer.Authorizer
 }
 
-func (a *gcPermissionsEnforcement) Admit(attributes admission.Attributes) (err error) {
+func (a *gcPermissionsEnforcement) Admit(attributes admission.Attributes) (warn admission.Warning, err error) {
 	// if we aren't changing owner references, then the edit is always allowed
 	if !isChangingOwnerReference(attributes.GetObject(), attributes.GetOldObject()) {
-		return nil
+		return nil, nil
 	}
 
 	deleteAttributes := authorizer.AttributesRecord{
@@ -63,10 +63,10 @@ func (a *gcPermissionsEnforcement) Admit(attributes admission.Attributes) (err e
 	}
 	allowed, reason, err := a.authorizer.Authorize(deleteAttributes)
 	if allowed {
-		return nil
+		return nil, nil
 	}
 
-	return admission.NewForbidden(attributes, fmt.Errorf("cannot set an ownerRef on a resource you can't delete: %v, %v", reason, err))
+	return nil, admission.NewForbidden(attributes, fmt.Errorf("cannot set an ownerRef on a resource you can't delete: %v, %v", reason, err))
 }
 
 func isChangingOwnerReference(newObj, oldObj runtime.Object) bool {

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -203,7 +203,7 @@ func TestGCAdmission(t *testing.T) {
 		user := &user.DefaultInfo{Name: tc.username}
 		attributes := admission.NewAttributesRecord(tc.newObj, tc.oldObj, schema.GroupVersionKind{}, api.NamespaceDefault, "foo", tc.resource, "", operation, user)
 
-		err := gcAdmit.Admit(attributes)
+		_, err := gcAdmit.Admit(attributes)
 		switch {
 		case err != nil && !tc.expectedAllowed:
 		case err != nil && tc.expectedAllowed:

--- a/plugin/pkg/admission/imagepolicy/admission_test.go
+++ b/plugin/pkg/admission/imagepolicy/admission_test.go
@@ -475,7 +475,7 @@ func TestTLSConfig(t *testing.T) {
 			// Allow all and see if we get an error.
 			service.Allow()
 
-			err = wh.Admit(attr)
+			_, err = wh.Admit(attr)
 			if tt.wantAllowed {
 				if err != nil {
 					t.Errorf("expected successful admission")
@@ -497,7 +497,7 @@ func TestTLSConfig(t *testing.T) {
 			}
 
 			service.Deny()
-			if err := wh.Admit(attr); err == nil {
+			if _, err := wh.Admit(attr); err == nil {
 				t.Errorf("%s: incorrectly admitted with DenyAll policy", tt.test)
 			}
 		}()
@@ -514,7 +514,7 @@ type webhookCacheTestCase struct {
 func testWebhookCacheCases(t *testing.T, serv *mockService, wh *imagePolicyWebhook, attr admission.Attributes, tests []webhookCacheTestCase) {
 	for _, test := range tests {
 		serv.statusCode = test.statusCode
-		err := wh.Admit(attr)
+		_, err := wh.Admit(attr)
 		authorized := err == nil
 
 		if test.expectedErr && err == nil {
@@ -747,7 +747,7 @@ func TestContainerCombinations(t *testing.T) {
 
 			attr := admission.NewAttributesRecord(tt.pod, nil, api.Kind("Pod").WithVersion("version"), "namespace", "", api.Resource("pods").WithVersion("version"), "", admission.Create, &user.DefaultInfo{})
 
-			err = wh.Admit(attr)
+			_, err = wh.Admit(attr)
 			if tt.wantAllowed {
 				if err != nil {
 					t.Errorf("expected successful admission: %s", tt.test)
@@ -825,7 +825,7 @@ func TestDefaultAllow(t *testing.T) {
 
 			attr := admission.NewAttributesRecord(tt.pod, nil, api.Kind("Pod").WithVersion("version"), "namespace", "", api.Resource("pods").WithVersion("version"), "", admission.Create, &user.DefaultInfo{})
 
-			err = wh.Admit(attr)
+			_, err = wh.Admit(attr)
 			if tt.wantAllowed {
 				if err != nil {
 					t.Errorf("expected successful admission")
@@ -917,7 +917,7 @@ func TestAnnotationFiltering(t *testing.T) {
 
 			attr := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "namespace", "", api.Resource("pods").WithVersion("version"), "", admission.Create, &user.DefaultInfo{})
 
-			err = wh.Admit(attr)
+			_, err = wh.Admit(attr)
 			if err != nil {
 				t.Errorf("expected successful admission")
 			}

--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -73,18 +73,18 @@ func newInitialResources(source dataSource, percentile int64, nsOnly bool) admis
 	}
 }
 
-func (ir initialResources) Admit(a admission.Attributes) (err error) {
+func (ir initialResources) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	// Ignore all calls to subresources or resources other than pods.
 	if a.GetSubresource() != "" || a.GetResource().GroupResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	pod, ok := a.GetObject().(*api.Pod)
 	if !ok {
-		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+		return nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
 	ir.estimateAndFillResourcesIfNotSet(pod)
-	return nil
+	return nil, nil
 }
 
 // The method veryfies whether resources should be set for the given pod and

--- a/plugin/pkg/admission/initialresources/admission_test.go
+++ b/plugin/pkg/admission/initialresources/admission_test.go
@@ -111,7 +111,7 @@ func expectNoAnnotation(t *testing.T, pod *api.Pod) {
 func admit(t *testing.T, ir admission.Interface, pods []*api.Pod) {
 	for i := range pods {
 		p := pods[i]
-		if err := ir.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "test", p.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil)); err != nil {
+		if _, err := ir.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "test", p.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil)); err != nil {
 			t.Error(err)
 		}
 	}

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -535,12 +535,12 @@ func TestLimitRangerIgnoresSubresource(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	testPod := validPod("testPod", 1, api.ResourceRequirements{})
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}
@@ -557,12 +557,12 @@ func TestLimitRangerAdmitPod(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	testPod := validPod("testPod", 1, api.ResourceRequirements{})
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&testPod, nil, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -98,7 +98,7 @@ func TestAdmission(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}
@@ -118,7 +118,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}
@@ -139,7 +139,7 @@ func TestIgnoreAdmission(t *testing.T) {
 	chainHandler := admission.NewChainHandler(handler)
 
 	pod := newPod(namespace)
-	err = chainHandler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	_, err = chainHandler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}
@@ -161,7 +161,7 @@ func TestAdmissionWithLatentCache(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -47,17 +47,17 @@ type exists struct {
 
 var _ = admission.WantsInformerFactory(&exists{})
 
-func (e *exists) Admit(a admission.Attributes) (err error) {
+func (e *exists) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
 	if len(a.GetNamespace()) == 0 || a.GetKind().GroupKind() == api.Kind("Namespace") {
-		return nil
+		return nil, nil
 	}
 
 	// we need to wait for our caches to warm
 	if !e.WaitForReady() {
-		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 	namespace := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{
@@ -68,22 +68,22 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 	}
 	_, exists, err := e.namespaceInformer.GetStore().Get(namespace)
 	if err != nil {
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 	if exists {
-		return nil
+		return nil, nil
 	}
 
 	// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
 	_, err = e.client.Core().Namespaces().Get(a.GetNamespace())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return err
+			return nil, err
 		}
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewExists creates a new namespace exists admission control handler

--- a/plugin/pkg/admission/namespace/exists/admission_test.go
+++ b/plugin/pkg/admission/namespace/exists/admission_test.go
@@ -87,7 +87,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}
@@ -107,7 +107,7 @@ func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		actions := ""
 		for _, action := range mockClient.Actions() {

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -81,10 +81,10 @@ func makeNamespaceKey(namespace string) *api.Namespace {
 	}
 }
 
-func (l *lifecycle) Admit(a admission.Attributes) error {
+func (l *lifecycle) Admit(a admission.Attributes) (admission.Warning, error) {
 	// prevent deletion of immortal namespaces
 	if a.GetOperation() == admission.Delete && a.GetKind().GroupKind() == api.Kind("Namespace") && l.immortalNamespaces.Has(a.GetName()) {
-		return errors.NewForbidden(a.GetResource().GroupResource(), a.GetName(), fmt.Errorf("this namespace may not be deleted"))
+		return nil, errors.NewForbidden(a.GetResource().GroupResource(), a.GetName(), fmt.Errorf("this namespace may not be deleted"))
 	}
 
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
@@ -98,12 +98,12 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 		if a.GetOperation() == admission.Delete {
 			l.forceLiveLookupCache.Add(a.GetName(), true, forceLiveLookupTTL)
 		}
-		return nil
+		return nil, nil
 	}
 
 	// we need to wait for our caches to warm
 	if !l.WaitForReady() {
-		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 
 	var (
@@ -115,7 +115,7 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 	key := makeNamespaceKey(a.GetNamespace())
 	namespaceObj, exists, err = l.namespaceInformer.GetStore().Get(key)
 	if err != nil {
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 
 	if !exists && a.GetOperation() == admission.Create {
@@ -124,7 +124,7 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 		time.Sleep(missingNamespaceWait)
 		namespaceObj, exists, err = l.namespaceInformer.GetStore().Get(key)
 		if err != nil {
-			return errors.NewInternalError(err)
+			return nil, errors.NewInternalError(err)
 		}
 		if exists {
 			glog.V(4).Infof("found %s in cache after waiting", a.GetNamespace())
@@ -144,9 +144,9 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 		namespaceObj, err = l.client.Core().Namespaces().Get(a.GetNamespace())
 		if err != nil {
 			if errors.IsNotFound(err) {
-				return err
+				return nil, err
 			}
-			return errors.NewInternalError(err)
+			return nil, errors.NewInternalError(err)
 		}
 		glog.V(4).Infof("found %s via storage lookup", a.GetNamespace())
 	}
@@ -155,14 +155,14 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 	if a.GetOperation() == admission.Create {
 		namespace := namespaceObj.(*api.Namespace)
 		if namespace.Status.Phase != api.NamespaceTerminating {
-			return nil
+			return nil, nil
 		}
 
 		// TODO: This should probably not be a 403
-		return admission.NewForbidden(a, fmt.Errorf("unable to create new content in namespace %s because it is being terminated.", a.GetNamespace()))
+		return nil, admission.NewForbidden(a, fmt.Errorf("unable to create new content in namespace %s because it is being terminated", a.GetNamespace()))
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewLifecycle creates a new namespace lifecycle admission control handler

--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -105,7 +105,7 @@ func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		actions := ""
 		for _, action := range mockClient.Actions() {
@@ -129,7 +129,7 @@ func TestAdmissionNamespaceActive(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	pod := newPod(namespace)
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("unexpected error returned from admission handler")
 	}
@@ -150,31 +150,31 @@ func TestAdmissionNamespaceTerminating(t *testing.T) {
 
 	pod := newPod(namespace)
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
 	}
 
 	// verify update operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete of namespace default can never proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", api.NamespaceDefault, api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", api.NamespaceDefault, api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
 	if err == nil {
 		t.Errorf("Expected an error that this namespace can never be deleted")
 	}
 
 	// verify delete of namespace other than default can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", "other", api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", "other", api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error %v", err)
 	}
@@ -201,7 +201,7 @@ func TestAdmissionNamespaceForceLiveLookup(t *testing.T) {
 
 	pod := newPod(namespace)
 	// verify create operations in the namespace is allowed
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error rejecting creates in an active namespace")
 	}
@@ -211,7 +211,7 @@ func TestAdmissionNamespaceForceLiveLookup(t *testing.T) {
 	getCalls = 0
 
 	// verify delete of namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", namespace, api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Namespace").WithVersion("version"), "", namespace, api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Expected namespace deletion to be allowed")
 	}
@@ -224,7 +224,7 @@ func TestAdmissionNamespaceForceLiveLookup(t *testing.T) {
 	phases[namespace] = api.NamespaceTerminating
 
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace right after deleting it")
 	}
@@ -237,7 +237,7 @@ func TestAdmissionNamespaceForceLiveLookup(t *testing.T) {
 	fakeClock.Step(forceLiveLookupTTL)
 
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace right after deleting it")
 	}

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -59,31 +59,31 @@ func NewPersistentVolumeLabel() *persistentVolumeLabel {
 	}
 }
 
-func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
+func (l *persistentVolumeLabel) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	if a.GetResource().GroupResource() != api.Resource("persistentvolumes") {
-		return nil
+		return nil, nil
 	}
 	obj := a.GetObject()
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
 	volume, ok := obj.(*api.PersistentVolume)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	var volumeLabels map[string]string
 	if volume.Spec.AWSElasticBlockStore != nil {
 		labels, err := l.findAWSEBSLabels(volume)
 		if err != nil {
-			return admission.NewForbidden(a, fmt.Errorf("error querying AWS EBS volume %s: %v", volume.Spec.AWSElasticBlockStore.VolumeID, err))
+			return nil, admission.NewForbidden(a, fmt.Errorf("error querying AWS EBS volume %s: %v", volume.Spec.AWSElasticBlockStore.VolumeID, err))
 		}
 		volumeLabels = labels
 	}
 	if volume.Spec.GCEPersistentDisk != nil {
 		labels, err := l.findGCEPDLabels(volume)
 		if err != nil {
-			return admission.NewForbidden(a, fmt.Errorf("error querying GCE PD volume %s: %v", volume.Spec.GCEPersistentDisk.PDName, err))
+			return nil, admission.NewForbidden(a, fmt.Errorf("error querying GCE PD volume %s: %v", volume.Spec.GCEPersistentDisk.PDName, err))
 		}
 		volumeLabels = labels
 	}
@@ -100,7 +100,7 @@ func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (l *persistentVolumeLabel) findAWSEBSLabels(volume *api.PersistentVolume) (map[string]string, error) {

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -100,20 +100,20 @@ func TestAdmission(t *testing.T) {
 	}
 
 	// Non-cloud PVs are ignored
-	err := handler.Admit(admission.NewAttributesRecord(&ignoredPV, nil, api.Kind("PersistentVolume").WithVersion("version"), ignoredPV.Namespace, ignoredPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(&ignoredPV, nil, api.Kind("PersistentVolume").WithVersion("version"), ignoredPV.Namespace, ignoredPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler (on ignored pv): %v", err)
 	}
 
 	// We only add labels on creation
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler (when deleting aws pv):  %v", err)
 	}
 
 	// Errors from the cloudprovider block creation of the volume
 	pvHandler.ebsVolumes = mockVolumeFailure(fmt.Errorf("invalid volume"))
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error when aws pv info fails")
 	}
@@ -121,7 +121,7 @@ func TestAdmission(t *testing.T) {
 	// Don't add labels if the cloudprovider doesn't return any
 	labels := make(map[string]string)
 	pvHandler.ebsVolumes = mockVolumeLabels(labels)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}
@@ -131,7 +131,7 @@ func TestAdmission(t *testing.T) {
 
 	// Don't panic if the cloudprovider returns nil, nil
 	pvHandler.ebsVolumes = mockVolumeFailure(nil)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when cloud provider returns empty labels")
 	}
@@ -141,7 +141,7 @@ func TestAdmission(t *testing.T) {
 	labels["a"] = "1"
 	labels["b"] = "2"
 	pvHandler.ebsVolumes = mockVolumeLabels(labels)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}
@@ -153,7 +153,7 @@ func TestAdmission(t *testing.T) {
 	awsPV.ObjectMeta.Labels = make(map[string]string)
 	awsPV.ObjectMeta.Labels["a"] = "not1"
 	awsPV.ObjectMeta.Labels["c"] = "3"
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(&awsPV, nil, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -84,25 +84,25 @@ func readConfig(config io.Reader) *pluginConfig {
 }
 
 // Admit enforces that pod and its namespace node label selectors matches at least a node in the cluster.
-func (p *podNodeSelector) Admit(a admission.Attributes) error {
+func (p *podNodeSelector) Admit(a admission.Attributes) (admission.Warning, error) {
 	resource := a.GetResource().GroupResource()
 	if resource != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	if a.GetSubresource() != "" {
 		// only run the checks below on pods proper and not subresources
-		return nil
+		return nil, nil
 	}
 
 	obj := a.GetObject()
 	pod, ok := obj.(*api.Pod)
 	if !ok {
 		glog.Errorf("expected pod but got %s", a.GetKind().Kind)
-		return nil
+		return nil, nil
 	}
 
 	if !p.WaitForReady() {
-		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 
 	name := pod.Name
@@ -116,7 +116,7 @@ func (p *podNodeSelector) Admit(a admission.Attributes) error {
 		},
 	})
 	if err != nil {
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 	if exists {
 		namespace = namespaceObj.(*api.Namespace)
@@ -124,23 +124,23 @@ func (p *podNodeSelector) Admit(a admission.Attributes) error {
 		namespace, err = p.defaultGetNamespace(nsName)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				return err
+				return nil, err
 			}
-			return errors.NewInternalError(err)
+			return nil, errors.NewInternalError(err)
 		}
 	}
 	namespaceNodeSelector, err := p.getNodeSelectorMap(namespace)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if labels.Conflicts(namespaceNodeSelector, labels.Set(pod.Spec.NodeSelector)) {
-		return errors.NewForbidden(resource, name, fmt.Errorf("pod node label selector conflicts with its namespace node label selector"))
+		return nil, errors.NewForbidden(resource, name, fmt.Errorf("pod node label selector conflicts with its namespace node label selector"))
 	}
 
 	whitelist, err := labels.ConvertSelectorToLabelsMap(p.clusterNodeSelectors[namespace.Name])
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Merge pod node selector = namespace node selector + current pod node selector
@@ -148,12 +148,12 @@ func (p *podNodeSelector) Admit(a admission.Attributes) error {
 
 	// whitelist verification
 	if !labels.AreLabelsInWhiteList(podNodeSelectorLabels, whitelist) {
-		return errors.NewForbidden(resource, name, fmt.Errorf("pod node label selector labels conflict with its namespace whitelist"))
+		return nil, errors.NewForbidden(resource, name, fmt.Errorf("pod node label selector labels conflict with its namespace whitelist"))
 	}
 
 	// Updated pod node selector = namespace node selector + current pod node selector
 	pod.Spec.NodeSelector = map[string]string(podNodeSelectorLabels)
-	return nil
+	return nil, nil
 }
 
 func NewPodNodeSelector(client clientset.Interface, clusterNodeSelectors map[string]string) *podNodeSelector {

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -149,7 +149,7 @@ func TestPodAdmission(t *testing.T) {
 		handler.clusterNodeSelectors[namespace.Name] = test.whitelist
 		pod.Spec = api.PodSpec{NodeSelector: test.podNodeSelector}
 
-		err := handler.Admit(admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "testNamespace", namespace.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "testNamespace", namespace.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 		if test.admit && err != nil {
 			t.Errorf("Test: %s, expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -69,11 +69,11 @@ func NewResourceQuota(client clientset.Interface, registry quota.Registry, numEv
 }
 
 // Admit makes admission decisions while enforcing quota
-func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
+func (q *quotaAdmission) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	// ignore all operations that correspond to sub-resource actions
 	if a.GetSubresource() != "" {
-		return nil
+		return nil, nil
 	}
 
-	return q.evaluator.Evaluate(a)
+	return nil, q.evaluator.Evaluate(a)
 }

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -131,7 +131,7 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 		t.Errorf("Unexpected error %v", err)
 	}
 	namespace := "default"
-	err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), namespace, "name", api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), namespace, "name", api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("ResourceQuota should admit all deletes: %v", err)
 	}
@@ -166,11 +166,11 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 	}
 	indexer.Add(resourceQuota)
 	newPod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod exceeded allowed quota")
 	}
-	err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "subresource", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "subresource", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error because the action went to a subresource: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 	}
 	indexer.Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 			Ports: []api.ServicePort{{Port: 1234}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(newService, existingService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newService, existingService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 			Ports: []api.ServicePort{{Port: 1234}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(newService, oldService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newService, oldService, api.Kind("Service").WithVersion("version"), newService.Namespace, newService.Name, api.Resource("services").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 	}
 	indexer.Add(resourceQuota)
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error exceeding quota")
 	}
@@ -524,13 +524,13 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	indexer.Add(resourceQuota)
 	// verify all values are specified as required on the quota
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod does not specify a memory limit")
 	}
 	// verify the requests and limits are actually valid (in this case, we fail because the limits < requests)
 	newPod = validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("200m", "2Gi"), getResourceList("100m", "1Gi")))
-	err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod does not specify a memory limit")
 	}
@@ -579,7 +579,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
 	// Add to the lru cache so we do not do a live client lookup
 	liveLookupCache.Add(newPod.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(30 * time.Second)), items: []*api.ResourceQuota{}})
-	err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error because the pod is in a different namespace than the quota")
 	}
@@ -646,7 +646,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
 	activeDeadlineSeconds := int64(30)
 	newPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -748,7 +748,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 
 	// create a pod that is best effort because it does not make a request for anything
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -836,7 +836,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	}
 	indexer.Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -958,7 +958,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 	// unset the namespace
 	newPod.ObjectMeta.Namespace = ""
 
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -999,14 +999,14 @@ func TestAdmitRejectsNegativeUsage(t *testing.T) {
 	indexer.Add(resourceQuota)
 	// verify quota rejects negative pvc storage requests
 	newPvc := validPersistentVolumeClaim("not-allowed-pvc", getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("-1Gi")}, api.ResourceList{}))
-	err := handler.Admit(admission.NewAttributesRecord(newPvc, nil, api.Kind("PersistentVolumeClaim").WithVersion("version"), newPvc.Namespace, newPvc.Name, api.Resource("persistentvolumeclaims").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPvc, nil, api.Kind("PersistentVolumeClaim").WithVersion("version"), newPvc.Namespace, newPvc.Name, api.Resource("persistentvolumeclaims").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pvc has negative storage usage")
 	}
 
 	// verify quota accepts non-negative pvc storage requests
 	newPvc = validPersistentVolumeClaim("not-allowed-pvc", getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("1Gi")}, api.ResourceList{}))
-	err = handler.Admit(admission.NewAttributesRecord(newPvc, nil, api.Kind("PersistentVolumeClaim").WithVersion("version"), newPvc.Namespace, newPvc.Name, api.Resource("persistentvolumeclaims").WithVersion("version"), "", admission.Create, nil))
+	_, err = handler.Admit(admission.NewAttributesRecord(newPvc, nil, api.Kind("PersistentVolumeClaim").WithVersion("version"), newPvc.Namespace, newPvc.Name, api.Resource("persistentvolumeclaims").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1045,7 +1045,7 @@ func TestAdmitWhenUnrelatedResourceExceedsQuota(t *testing.T) {
 
 	// create a pod that should pass existing quota
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	_, err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -1351,7 +1351,7 @@ func testPSPAdmit(testCaseName string, psps []*extensions.PodSecurityPolicy, pod
 	plugin := NewTestAdmission(store, tc)
 
 	attrs := kadmission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion("version"), "namespace", "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
-	err := plugin.Admit(attrs)
+	_, err := plugin.Admit(attrs)
 
 	if shouldPass && err != nil {
 		t.Errorf("%s: expected no errors but received %v", testCaseName, err)

--- a/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
@@ -82,7 +82,7 @@ func TestAdmission(t *testing.T) {
 		p.Spec.SecurityContext = tc.podSc
 		p.Spec.Containers[0].SecurityContext = tc.sc
 
-		err := handler.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 		if err != nil && !tc.expectError {
 			t.Errorf("%v: unexpected error: %v", tc.name, err)
 		} else if err == nil && tc.expectError {
@@ -96,7 +96,7 @@ func TestAdmission(t *testing.T) {
 		p.Spec.InitContainers = p.Spec.Containers
 		p.Spec.Containers = nil
 
-		err = handler.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
+		_, err = handler.Admit(admission.NewAttributesRecord(p, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 		if err != nil && !tc.expectError {
 			t.Errorf("%v: unexpected error: %v", tc.name, err)
 		} else if err == nil && tc.expectError {
@@ -140,7 +140,7 @@ func TestPodSecurityContextAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		pod.Spec.SecurityContext = &test.securityContext
-		err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
+		_, err := handler.Admit(admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 
 		if test.errorExpected && err == nil {
 			t.Errorf("Expected error for security context %+v but did not get an error", test.securityContext)

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -158,17 +158,17 @@ func (s *serviceAccount) Stop() {
 	}
 }
 
-func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
+func (s *serviceAccount) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	if a.GetResource().GroupResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	obj := a.GetObject()
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
 	pod, ok := obj.(*api.Pod)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// Don't modify the spec of mirror pods.
@@ -176,14 +176,14 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 	// That said, don't allow mirror pods to reference ServiceAccounts or SecretVolumeSources either
 	if _, isMirrorPod := pod.Annotations[kubelet.ConfigMirrorAnnotationKey]; isMirrorPod {
 		if len(pod.Spec.ServiceAccountName) != 0 {
-			return admission.NewForbidden(a, fmt.Errorf("a mirror pod may not reference service accounts"))
+			return nil, admission.NewForbidden(a, fmt.Errorf("a mirror pod may not reference service accounts"))
 		}
 		for _, volume := range pod.Spec.Volumes {
 			if volume.VolumeSource.Secret != nil {
-				return admission.NewForbidden(a, fmt.Errorf("a mirror pod may not reference secrets"))
+				return nil, admission.NewForbidden(a, fmt.Errorf("a mirror pod may not reference secrets"))
 			}
 		}
-		return nil
+		return nil, nil
 	}
 
 	// Set the default service account if needed
@@ -194,25 +194,25 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 	// Ensure the referenced service account exists
 	serviceAccount, err := s.getServiceAccount(a.GetNamespace(), pod.Spec.ServiceAccountName)
 	if err != nil {
-		return admission.NewForbidden(a, fmt.Errorf("error looking up service account %s/%s: %v", a.GetNamespace(), pod.Spec.ServiceAccountName, err))
+		return nil, admission.NewForbidden(a, fmt.Errorf("error looking up service account %s/%s: %v", a.GetNamespace(), pod.Spec.ServiceAccountName, err))
 	}
 	if serviceAccount == nil {
 		// TODO: convert to a ServerTimeout error (or other error that sends a Retry-After header)
-		return admission.NewForbidden(a, fmt.Errorf("service account %s/%s was not found, retry after the service account is created", a.GetNamespace(), pod.Spec.ServiceAccountName))
+		return nil, admission.NewForbidden(a, fmt.Errorf("service account %s/%s was not found, retry after the service account is created", a.GetNamespace(), pod.Spec.ServiceAccountName))
 	}
 
 	if s.enforceMountableSecrets(serviceAccount) {
 		if err := s.limitSecretReferences(serviceAccount, pod); err != nil {
-			return admission.NewForbidden(a, err)
+			return nil, admission.NewForbidden(a, err)
 		}
 	}
 
 	if s.MountServiceAccountToken {
 		if err := s.mountServiceAccountToken(serviceAccount, pod); err != nil {
 			if _, ok := err.(errors.APIStatus); ok {
-				return err
+				return nil, err
 			}
-			return admission.NewForbidden(a, err)
+			return nil, admission.NewForbidden(a, err)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 		copy(pod.Spec.ImagePullSecrets, serviceAccount.ImagePullSecrets)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // enforceMountableSecrets indicates whether mountable secrets should be enforced for a particular service account

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -34,7 +34,7 @@ func TestIgnoresNonCreate(t *testing.T) {
 	for _, op := range []admission.Operation{admission.Update, admission.Delete, admission.Connect} {
 		attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", op, nil)
 		handler := admission.NewChainHandler(NewServiceAccount(nil))
-		err := handler.Admit(attrs)
+		_, err := handler.Admit(attrs)
 		if err != nil {
 			t.Errorf("Expected %s operation allowed, got err: %v", op, err)
 		}
@@ -44,7 +44,7 @@ func TestIgnoresNonCreate(t *testing.T) {
 func TestIgnoresNonPodResource(t *testing.T) {
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("CustomResource").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non-pod resource allowed, got err: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestIgnoresNonPodResource(t *testing.T) {
 
 func TestIgnoresNilObject(t *testing.T) {
 	attrs := admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected nil object allowed allowed, got err: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestIgnoresNilObject(t *testing.T) {
 func TestIgnoresNonPodObject(t *testing.T) {
 	obj := &api.Namespace{}
 	attrs := admission.NewAttributesRecord(obj, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non pod object allowed, got err: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestIgnoresMirrorPod(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected mirror pod without service account or secrets allowed, got err: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestRejectsMirrorPodWithServiceAccount(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a service account")
 	}
@@ -119,7 +119,7 @@ func TestRejectsMirrorPodWithSecretVolumes(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := NewServiceAccount(nil).Admit(attrs)
+	_, err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a secret volume")
 	}
@@ -142,7 +142,7 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestAssignsDefaultServiceAccountAndRejectsMissingAPIToken(t *testing.T) {
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err == nil || !errors.IsServerTimeout(err) {
 		t.Errorf("Expected server timeout error for missing API token: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestFetchesUncachedServiceAccount(t *testing.T) {
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestDeniesInvalidServiceAccount(t *testing.T) {
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected error for missing service account, got none")
 	}
@@ -272,7 +272,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err != nil {
+	if _, err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
@@ -378,7 +378,7 @@ func TestRespectsExistingMount(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestRespectsExistingMount(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err != nil {
+	if _, err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
@@ -451,7 +451,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod1, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err != nil {
+	if _, err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -475,7 +475,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err != nil {
+	if _, err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -499,7 +499,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err != nil {
+	if _, err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }
@@ -527,7 +527,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod1, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err == nil {
+	if _, err := admit.Admit(attrs); err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
 	}
 
@@ -551,7 +551,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err == nil || !strings.Contains(err.Error(), "with envVar") {
+	if _, err := admit.Admit(attrs); err == nil || !strings.Contains(err.Error(), "with envVar") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -575,7 +575,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	if err := admit.Admit(attrs); err == nil || !strings.Contains(err.Error(), "with envVar") {
+	if _, err := admit.Admit(attrs); err == nil || !strings.Contains(err.Error(), "with envVar") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }
@@ -604,7 +604,7 @@ func TestAllowUnreferencedSecretVolumesForPermissiveSAs(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
 	}
@@ -634,7 +634,7 @@ func TestAllowsReferencedImagePullSecrets(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -661,7 +661,7 @@ func TestRejectsUnreferencedImagePullSecrets(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
 	}
@@ -692,7 +692,7 @@ func TestDoNotAddImagePullSecrets(t *testing.T) {
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -724,7 +724,7 @@ func TestAddImagePullSecrets(t *testing.T) {
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-	err := admit.Admit(attrs)
+	_, err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/plugin/pkg/admission/storageclass/default/admission_test.go
+++ b/plugin/pkg/admission/storageclass/default/admission_test.go
@@ -208,7 +208,7 @@ func TestAdmission(t *testing.T) {
 			admission.Create,
 			nil, // userInfo
 		)
-		err = ctrl.Admit(attrs)
+		_, err = ctrl.Admit(attrs)
 		glog.Infof("Got %v", err)
 		if err != nil && !test.expectError {
 			t.Errorf("Test %q: unexpected error received: %v", test.name, err)

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -162,6 +162,10 @@ Federation deployments Federated Deployment should be deleted from underlying cl
 Federation deployments Federated Deployment should create and update matching deployments in underling clusters,soltysh,1
 Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
 Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
+Federation daemonsets DaemonSet objects should be created and deleted successfully,nikhiljindal,0
+Federation daemonsets DaemonSet objects should be created and deleted successfully,brendandburns,0
+Federation deployments Deployment objects should be created and deleted successfully,brendandburns,0
+Federation deployments Federated Deployment should create and update matching deployments in underling clusters,brendandburns,0
 Federation events Event objects should be created and deleted successfully,karlkfi,1
 Federation namespace Namespace objects all resources in the namespace should be deleted when namespace is deleted,nikhiljindal,0
 Federation namespace Namespace objects should be created and deleted successfully,xiang90,1


### PR DESCRIPTION
@smarterclayton @lavalamp @deads2k @kubernetes/sig-api-machinery 

This is a reprise of https://github.com/kubernetes/kubernetes/pull/19534 which I let drop.

No real code changes from that review, just updated and rebased.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36325)
<!-- Reviewable:end -->
