### PR TITLE
Use available informers in quota replenishment

### DIFF
--- a/pkg/controller/resourcequota/replenishment_controller.go
+++ b/pkg/controller/resourcequota/replenishment_controller.go
@@ -113,8 +113,21 @@ func NewReplenishmentControllerFactoryFromClient(kubeClient clientset.Interface)
 	return NewReplenishmentControllerFactory(nil, kubeClient)
 }
 
-func (r *replenishmentControllerFactory) NewController(options *ReplenishmentControllerOptions) (cache.ControllerInterface, error) {
-	var result cache.ControllerInterface
+// controllerFor returns a replenishment controller for the specified group resource.
+func controllerFor(
+	groupResource unversioned.GroupResource,
+	f informers.SharedInformerFactory,
+	handlerFuncs cache.ResourceEventHandlerFuncs) (cache.ControllerInterface, error) {
+	genericInformer, err := f.ForResource(groupResource)
+	if err != nil {
+		return nil, err
+	}
+	informer := genericInformer.Informer()
+	informer.AddEventHandler(handlerFuncs)
+	return informer.GetController(), nil
+}
+
+func (r *replenishmentControllerFactory) NewController(options *ReplenishmentControllerOptions) (result cache.ControllerInterface, err error) {
 	if r.kubeClient != nil && r.kubeClient.Core().RESTClient().GetRateLimiter() != nil {
 		metrics.RegisterMetricAndTrackRateLimiterUsage("replenishment_controller", r.kubeClient.Core().RESTClient().GetRateLimiter())
 	}
@@ -122,16 +135,15 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 	switch options.GroupKind {
 	case api.Kind("Pod"):
 		if r.sharedInformerFactory != nil {
-			podInformer := r.sharedInformerFactory.Pods().Informer()
-			podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			result, err = controllerFor(api.Resource("pods"), r.sharedInformerFactory, cache.ResourceEventHandlerFuncs{
 				UpdateFunc: PodReplenishmentUpdateFunc(options),
 				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
 			})
-			result = podInformer.GetController()
 			break
 		}
 		result = informers.NewPodInformer(r.kubeClient, options.ResyncPeriod())
 	case api.Kind("Service"):
+		// TODO move to informer when defined
 		_, result = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -149,6 +161,7 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 			},
 		)
 	case api.Kind("ReplicationController"):
+		// TODO move to informer when defined
 		_, result = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -165,6 +178,13 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 			},
 		)
 	case api.Kind("PersistentVolumeClaim"):
+		if r.sharedInformerFactory != nil {
+			result, err = controllerFor(api.Resource("persistentvolumeclaims"), r.sharedInformerFactory, cache.ResourceEventHandlerFuncs{
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			})
+			break
+		}
+		// TODO (derekwaynecarr) remove me when we can require a sharedInformerFactory in all code paths...
 		_, result = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -181,6 +201,7 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 			},
 		)
 	case api.Kind("Secret"):
+		// TODO move to informer when defined
 		_, result = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -197,6 +218,7 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 			},
 		)
 	case api.Kind("ConfigMap"):
+		// TODO move to informer when defined
 		_, result = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -215,7 +237,7 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 	default:
 		return nil, NewUnhandledGroupKindError(options.GroupKind)
 	}
-	return result, nil
+	return result, err
 }
 
 // ServiceReplenishmentUpdateFunc will replenish if the service was quota tracked has changed service type


### PR DESCRIPTION
more iteration on the goal to use informers where available in quota system.  this time adding persistent volume claims so the same informer is used here and https://github.com/kubernetes/kubernetes/pull/36316

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36329)
<!-- Reviewable:end -->
