### PR TITLE
modify the method name AddVersionInterfaces 

### DIFF
--- a/pkg/apimachinery/announced/group_factory.go
+++ b/pkg/apimachinery/announced/group_factory.go
@@ -213,7 +213,7 @@ func (gmf *GroupMetaFactory) Enable(m *registered.APIRegistrationManager, scheme
 	}
 	for _, v := range externalVersions {
 		gvf := gmf.VersionArgs[v.Version]
-		if err := groupMeta.AddVersionInterfaces(
+		if err := groupMeta.AddVersion(
 			schema.GroupVersion{Group: gvf.GroupName, Version: gvf.VersionName},
 			&meta.VersionInterfaces{
 				ObjectConvertor:  scheme,

--- a/pkg/apimachinery/types.go
+++ b/pkg/apimachinery/types.go
@@ -68,12 +68,10 @@ func (gm *GroupMeta) DefaultInterfacesFor(version schema.GroupVersion) (*meta.Ve
 	return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, gm.GroupVersions)
 }
 
-// AddVersionInterfaces adds the given version to the group. Only call during
+// AddVersion adds the given version to the group. Only call during
 // init, after that GroupMeta objects should be immutable. Not thread safe.
 // (If you use this, be sure to set .InterfacesFor = .DefaultInterfacesFor)
-// TODO: remove the "Interfaces" suffix and make this also maintain the
-// .GroupVersions member.
-func (gm *GroupMeta) AddVersionInterfaces(version schema.GroupVersion, interfaces *meta.VersionInterfaces) error {
+func (gm *GroupMeta) AddVersion(version schema.GroupVersion, interfaces *meta.VersionInterfaces) error {
 	if e, a := gm.GroupVersion.Group, version.Group; a != e {
 		return fmt.Errorf("got a version in group %v, but am in group %v", a, e)
 	}
@@ -82,12 +80,11 @@ func (gm *GroupMeta) AddVersionInterfaces(version schema.GroupVersion, interface
 	}
 	gm.InterfacesByVersion[version] = interfaces
 
-	// TODO: refactor to make the below error not possible, this function
-	// should *set* GroupVersions rather than depend on it.
 	for _, v := range gm.GroupVersions {
 		if v == version {
 			return nil
 		}
 	}
-	return fmt.Errorf("added a version interface without the corresponding version %v being in the list %#v", version, gm.GroupVersions)
+	gm.GroupVersions = append(gm.GroupVersions, version)
+	return nil
 }

--- a/pkg/apimachinery/types_test.go
+++ b/pkg/apimachinery/types_test.go
@@ -31,7 +31,7 @@ func TestAdd(t *testing.T) {
 		GroupVersions: []schema.GroupVersion{{Group: "test", Version: "v1"}},
 	}
 
-	gm.AddVersionInterfaces(schema.GroupVersion{Group: "test", Version: "v1"}, nil)
+	gm.AddVersion(schema.GroupVersion{Group: "test", Version: "v1"}, nil)
 	if e, a := 1, len(gm.InterfacesByVersion); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}


### PR DESCRIPTION


**What this PR does / why we need it**:
fix todo:
modify the  method name and refactor to make the below error not possible

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36345)
<!-- Reviewable:end -->
