### PR TITLE
Fix doc links in Federation readme

### DIFF
--- a/federation/README.md
+++ b/federation/README.md
@@ -1,8 +1,8 @@
 # Cluster Federation
 
 Kubernetes Cluster Federation enables users to federate multiple
-Kubernetes clusters. Please see the [user guide](http://kubernetes.io/docs/admin/federation/)
-and the [admin guide](http://kubernetes.io/docs/user-guide/federation/federated-services/)
+Kubernetes clusters. Please see the [user guide](http://kubernetes.io/docs/user-guide/federation/federated-services/)
+and the [admin guide](http://kubernetes.io/docs/admin/federation/)
 for more details about setting up and using the Cluster Federation.
 
 # Building Kubernetes Cluster Federation


### PR DESCRIPTION
**What this PR does / why we need it**:

The user guide and admin guide links were swapped round

**Release note**: NONE

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36354)
<!-- Reviewable:end -->
