### PR TITLE
 Deprecate extensions/v1beta1.Jobs related stuff

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -33555,7 +33555,7 @@
     }
    },
    "v1beta1.Job": {
-    "description": "Job represents the configuration of a single job.",
+    "description": "Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.",
     "properties": {
      "metadata": {
       "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
@@ -33605,7 +33605,7 @@
     }
    },
    "v1beta1.JobList": {
-    "description": "JobList is a collection of jobs.",
+    "description": "JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.",
     "required": [
      "items"
     ],

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -10194,7 +10194,7 @@
    },
    "v1beta1.JobList": {
     "id": "v1beta1.JobList",
-    "description": "JobList is a collection of jobs.",
+    "description": "JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.",
     "required": [
      "items"
     ],
@@ -10222,7 +10222,7 @@
    },
    "v1beta1.Job": {
     "id": "v1beta1.Job",
-    "description": "Job represents the configuration of a single job.",
+    "description": "Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.",
     "properties": {
      "kind": {
       "type": "string",

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -557,7 +557,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_job">v1beta1.Job</h3>
 <div class="paragraph">
-<p>Job represents the configuration of a single job.</p>
+<p>Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4942,7 +4942,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_joblist">v1beta1.JobList</h3>
 <div class="paragraph">
-<p>JobList is a collection of jobs.</p>
+<p>JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6770,7 +6770,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-11-03 15:10:21 UTC
+Last updated 2016-11-07 11:40:35 UTC
 </div>
 </div>
 </body>

--- a/pkg/apis/extensions/v1beta1/generated.proto
+++ b/pkg/apis/extensions/v1beta1/generated.proto
@@ -550,6 +550,7 @@ message IngressTLS {
 }
 
 // Job represents the configuration of a single job.
+// DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.
 message Job {
   // Standard object's metadata.
   // More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
@@ -593,6 +594,7 @@ message JobCondition {
 }
 
 // JobList is a collection of jobs.
+// DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.
 message JobList {
   // Standard list metadata
   // More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -617,6 +617,7 @@ type ThirdPartyResourceDataList struct {
 // +genclient=true
 
 // Job represents the configuration of a single job.
+// DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.
 type Job struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -636,6 +637,7 @@ type Job struct {
 }
 
 // JobList is a collection of jobs.
+// DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.
 type JobList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -377,7 +377,7 @@ func (IngressTLS) SwaggerDoc() map[string]string {
 }
 
 var map_Job = map[string]string{
-	"":         "Job represents the configuration of a single job.",
+	"":         "Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.",
 	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
 	"spec":     "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
 	"status":   "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
@@ -402,7 +402,7 @@ func (JobCondition) SwaggerDoc() map[string]string {
 }
 
 var map_JobList = map[string]string{
-	"":         "JobList is a collection of jobs.",
+	"":         "JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.",
 	"metadata": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
 	"items":    "Items is the list of Job.",
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -16436,7 +16436,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 	"v1beta1.Job": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Job represents the configuration of a single job.",
+				Description: "Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.",
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
@@ -16517,7 +16517,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 	"v1beta1.JobList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "JobList is a collection of jobs.",
+				Description: "JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.",
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -228,6 +228,9 @@ func Run(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobr
 			generatorName = "run-pod/v1"
 		}
 	}
+	if generatorName == "job/v1beta1" {
+		fmt.Fprintf(cmdErr, "DEPRECATED: --generator=job/v1beta1 is deprecated, use job/v1 instead.\n")
+	}
 	generators := f.Generators("run")
 	generator, found := generators[generatorName]
 	if !found {


### PR DESCRIPTION
This PR supersedes https://github.com/kubernetes/kubernetes/pull/33861, it's a pre-req for removing `extensions/v1beta1.Jobs` (#32763) in the next release. 

@kubernetes/kubectl @kubernetes/api-review-team ptal
@bgrant0607 @erictune @janetkuo fyi

```release-note
Deprecate extensions/v1beta1.Jobs
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36355)
<!-- Reviewable:end -->
