### PR TITLE
Add rescheduler logs to the fluentd-gcp configuration

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
@@ -172,6 +172,20 @@
 </source>
 
 # Example:
+# I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/rescheduler.log
+  pos_file /var/log/gcp-rescheduler.log.pos
+  tag rescheduler
+</source>
+
+# Example:
 # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
 <source>
   type tail

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -173,6 +173,20 @@
 </source>
 
 # Example:
+# I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/rescheduler.log
+  pos_file /var/log/gcp-rescheduler.log.pos
+  tag rescheduler
+</source>
+
+# Example:
 # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
 <source>
   type tail


### PR DESCRIPTION
Fix #36227

Allows fluentd-gcp plugin to collect rescheduler logs from master node and store in the logging backend.

@piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36359)
<!-- Reviewable:end -->
