### PR TITLE
Fix setNodeAddress in combination with cloud providers

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -404,10 +404,11 @@ func (kl *Kubelet) setNodeAddress(node *api.Node) error {
 		}
 		if addressNodeHostName == nil {
 			hostnameAddress := api.NodeAddress{Type: api.NodeHostName, Address: kl.GetHostname()}
-			node.Status.Addresses = append(nodeAddresses, hostnameAddress)
+			nodeAddresses = append(nodeAddresses, hostnameAddress)
 		} else {
 			glog.V(2).Infof("Using Node Hostname from cloudprovider: %q", addressNodeHostName.Address)
 		}
+		node.Status.Addresses = nodeAddresses
 	} else {
 		var ipAddr net.IP
 		var err error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Fixes a follow-up bug introduced by https://github.com/kubernetes/kubernetes/pull/36231
The PR missed to update node.Status.Addresses in case the host name was already set by the cloud provider.

fixes #36234

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36362)
<!-- Reviewable:end -->
