### PR TITLE
Fix config file names inside fluentd-gcp image

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -53,8 +53,9 @@ RUN apt-get -qq update && \
 # Copy the Fluentd configuration files for logging Docker container logs.
 # Either configuration file can be used by specifying `-c <file>` as a command
 # line argument.
-COPY google-fluentd.conf /etc/td-agent/google-fluentd.conf
-COPY google-fluentd-journal.conf /etc/td-agent/google-fluentd-journal.conf
+RUN rm /etc/td-agent/td-agent.conf
+COPY google-fluentd.conf /etc/td-agent/td-agent.conf
+COPY google-fluentd-journal.conf /etc/td-agent/td-agent-journal.conf
 
 # Start Fluentd to pick up our config that watches Docker container logs.
-CMD /usr/sbin/td-agent "$FLUENTD_ARGS"
+CMD /usr/sbin/td-agent $FLUENTD_ARGS


### PR DESCRIPTION
Need this in order to merge https://github.com/kubernetes/kubernetes/pull/36358

Because on container-vm we need implicitly used configuration file

@piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36370)
<!-- Reviewable:end -->
