### PR TITLE
kubeadm: Let apiserver and controller-manager host-mount /etc/pki when required

### DIFF
--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -201,7 +201,7 @@ func TestK8sVolume(t *testing.T) {
 		{
 			cfg: &kubeadmapi.MasterConfiguration{},
 			expected: api.Volume{
-				Name: "pki",
+				Name: "k8s",
 				VolumeSource: api.VolumeSource{
 					HostPath: &api.HostPathVolumeSource{
 						Path: kubeadmapi.GlobalEnvParams.KubernetesDir},
@@ -234,7 +234,7 @@ func TestK8sVolumeMount(t *testing.T) {
 	}{
 		{
 			expected: api.VolumeMount{
-				Name:      "pki",
+				Name:      "k8s",
 				MountPath: "/etc/kubernetes/",
 				ReadOnly:  true,
 			},


### PR DESCRIPTION
#<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR checks if /etc/pki is present on the host machine and adds a host-mount to the apiserver and controller-manager manifest if required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #36150

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fix incompatible host mounts for SSL certificates when deploying on CentOS with kubeadm
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36373)
<!-- Reviewable:end -->
