### PR TITLE
etcd3: have prefix always prepended

### DIFF
--- a/pkg/genericapiserver/options/etcd.go
+++ b/pkg/genericapiserver/options/etcd.go
@@ -70,7 +70,7 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 		"List of etcd servers to connect with (scheme://ip:port), comma separated.")
 
 	fs.StringVar(&s.StorageConfig.Prefix, "etcd-prefix", s.StorageConfig.Prefix,
-		"The prefix for all resource paths in etcd.")
+		"The prefix to prepend to all resource paths in etcd.")
 
 	fs.StringVar(&s.StorageConfig.KeyFile, "etcd-keyfile", s.StorageConfig.KeyFile,
 		"SSL key file used to secure etcd communication.")


### PR DESCRIPTION
ref: #36290

Previously, the prefix behavior is "sometimes prefixing". If the prefix already exists for the resource path, it will ignore.
With this PR, we make sure that prefix is always prepended in etcd3 storage backend. See the discussion in #36290

**release note**:
```
etcd3: have prefix always prepended
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36374)
<!-- Reviewable:end -->
