### PR TITLE
Add rescheduler logs to the fluentd-elasticsearch configuration

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -218,6 +218,19 @@
   tag kube-scheduler
 </source>
 
+# Example:
+# I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
+<source>
+  type tail
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/rescheduler.log
+  pos_file /var/log/es-rescheduler.log.pos
+  tag rescheduler
+</source>
+
 #<filter kubernetes.**>
 #  type kubernetes_metadata
 #</filter>


### PR DESCRIPTION
Same as https://github.com/kubernetes/kubernetes/pull/36359 for elasticsearch plugin

@piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36384)
<!-- Reviewable:end -->
