### PR TITLE
Avoid setting S_ISGID on files in volumes

### DIFF
--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -71,7 +71,11 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 			mask = roMask
 		}
 
-		err = chmodRunner.Chmod(path, info.Mode()|mask|os.ModeSetgid)
+		if info.IsDir() {
+			mask |= os.ModeSetgid
+		}
+
+		err = chmodRunner.Chmod(path, info.Mode()|mask)
 		if err != nil {
 			glog.Errorf("Chmod failed on %v: %v", path, err)
 		}


### PR DESCRIPTION
Some applications are having issues with setting the S_ISGID bit on files in volumes.  We intend to do this for directories so that the group ID is inherited, but not files for which S_ISGID indicates madatory file locking https://linux.die.net/man/2/stat

xref https://bugzilla.redhat.com/show_bug.cgi?id=1387306

@ncdc @derekwaynecarr @pmorie 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36386)
<!-- Reviewable:end -->
