### PR TITLE
Skip CLOSE_WAIT e2e test if server is 1.4.5

### DIFF
--- a/test/e2e/kube_proxy.go
+++ b/test/e2e/kube_proxy.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 
+	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/images/net/nat"
 
@@ -48,6 +49,10 @@ var _ = framework.KubeDescribe("Network", func() {
 	It("should set TCP CLOSE_WAIT timeout", func() {
 		nodes := framework.GetReadySchedulableNodesOrDie(fr.Client)
 		ips := collectAddresses(nodes, api.NodeInternalIP)
+
+		// The matching change is not present in kube-proxy 1.4.5
+		// release which will causes this test to always fail.
+		framework.SkipUnlessServerVersionGTE(version.MustParse("v1.4.6"), fr.Client)
 
 		if len(nodes.Items) < 2 {
 			framework.Skipf(


### PR DESCRIPTION
```release-note
Skip CLOSE_WAIT e2e test if server is 1.4.5
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36404)
<!-- Reviewable:end -->
