### PR TITLE
Use the new name for cassandra-statefulset.yaml in e2e tests.

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -253,12 +253,12 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			// have to change dns prefix because of the dynamic namespace
-			input, err := ioutil.ReadFile(mkpath("cassandra-petset.yaml"))
+			input, err := ioutil.ReadFile(mkpath("cassandra-statefulset.yaml"))
 			Expect(err).NotTo(HaveOccurred())
 
 			output := strings.Replace(string(input), "cassandra-0.cassandra.default.svc.cluster.local", "cassandra-0.cassandra."+ns+".svc.cluster.local", -1)
 
-			statefulsetYaml := "/tmp/cassandra-petset.yaml"
+			statefulsetYaml := "/tmp/cassandra-statefulset.yaml"
 
 			err = ioutil.WriteFile(statefulsetYaml, []byte(output), 0644)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes #36323.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36418)
<!-- Reviewable:end -->
