### PR TITLE
fix forbid clusterrole with namespace

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1749,6 +1749,9 @@ func printRoleBindingList(list *rbac.RoleBindingList, w io.Writer, options Print
 }
 
 func printClusterRole(clusterRole *rbac.ClusterRole, w io.Writer, options PrintOptions) error {
+	if options.WithNamespace {
+		return fmt.Errorf("clusterRole is not namespaced")
+	}
 	return printObjectMeta(clusterRole.ObjectMeta, w, options, false)
 }
 


### PR DESCRIPTION
run `kubectl get clusterroles --all-namespaces`
old version
return error message:
```
NAMESPACE   NAME      AGE
clusterRole is not namespaced
clusterRole is not namespaced
clusterRole is not namespaced
clusterRole is not namespaced
clusterRole is not namespaced
clusterRole is not namespaced
clusterRole is not namespaced
```


```release-note

Add error message when trying to use clusterrole with namespace in kubectl

```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36424)
<!-- Reviewable:end -->
