### PR TITLE
kubeadm: Transition to using k8s.io/client-go

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -150,7 +150,8 @@ func (j *Join) Run(out io.Writer) error {
 		return err
 	}
 
-	err = kubeadmutil.WriteKubeconfigIfNotExists("kubelet", kubeconfig)
+	// TODO: use kubeadmutil.WriteKubeconfigIfNotExist() instead when csr.RequestNodeCertificate() is fixed
+	err = kubenode.WriteKubeconfigIfNotExists("kubelet", kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/master/addons.go
+++ b/cmd/kubeadm/app/master/addons.go
@@ -233,6 +233,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	SetMasterTaintTolerations(&kubeProxyDaemonSet.Spec.Template.ObjectMeta)
 	SetNodeAffinity(&kubeProxyDaemonSet.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if _, err := client.Extensions().DaemonSets(internal_api.NamespaceSystem).Create(kubeProxyDaemonSet); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-proxy addon [%v]", err)
 	}
@@ -243,6 +244,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	SetMasterTaintTolerations(&kubeDNSDeployment.Spec.Template.ObjectMeta)
 	SetNodeAffinity(&kubeDNSDeployment.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if _, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Create(kubeDNSDeployment); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-dns addon [%v]", err)
 	}
@@ -253,6 +255,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	}
 
 	kubeDNSService := NewService("kube-dns", *kubeDNSServiceSpec)
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if _, err := client.Services(internal_api.NamespaceSystem).Create(kubeDNSService); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-dns addon [%v]", err)
 	}

--- a/cmd/kubeadm/app/master/addons.go
+++ b/cmd/kubeadm/app/master/addons.go
@@ -21,19 +21,20 @@ import (
 	"net"
 	"path"
 
+	clientset "k8s.io/client-go/kubernetes"
+	internal_api "k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/resource"
+	api "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/intstr"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
-	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
 func createKubeProxyPodSpec(cfg *kubeadmapi.MasterConfiguration) api.PodSpec {
 	privilegedTrue := true
 	return api.PodSpec{
-		SecurityContext: &api.PodSecurityContext{HostNetwork: true},
+		HostNetwork: true,
 		Containers: []api.Container{{
 			Name:            kubeProxy,
 			Image:           images.GetCoreImage(images.KubeProxyImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
@@ -232,7 +233,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	SetMasterTaintTolerations(&kubeProxyDaemonSet.Spec.Template.ObjectMeta)
 	SetNodeAffinity(&kubeProxyDaemonSet.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
-	if _, err := client.Extensions().DaemonSets(api.NamespaceSystem).Create(kubeProxyDaemonSet); err != nil {
+	if _, err := client.Extensions().DaemonSets(internal_api.NamespaceSystem).Create(kubeProxyDaemonSet); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-proxy addon [%v]", err)
 	}
 
@@ -242,7 +243,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	SetMasterTaintTolerations(&kubeDNSDeployment.Spec.Template.ObjectMeta)
 	SetNodeAffinity(&kubeDNSDeployment.Spec.Template.ObjectMeta, NativeArchitectureNodeAffinity())
 
-	if _, err := client.Extensions().Deployments(api.NamespaceSystem).Create(kubeDNSDeployment); err != nil {
+	if _, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Create(kubeDNSDeployment); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-dns addon [%v]", err)
 	}
 
@@ -252,7 +253,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	}
 
 	kubeDNSService := NewService("kube-dns", *kubeDNSServiceSpec)
-	if _, err := client.Services(api.NamespaceSystem).Create(kubeDNSService); err != nil {
+	if _, err := client.Services(internal_api.NamespaceSystem).Create(kubeDNSService); err != nil {
 		return fmt.Errorf("<master/addons> failed creating essential kube-dns addon [%v]", err)
 	}
 

--- a/cmd/kubeadm/app/master/apiclient.go
+++ b/cmd/kubeadm/app/master/apiclient.go
@@ -90,6 +90,7 @@ func CreateClientAndWaitForAPI(adminConfig *clientcmdapi.Config) (*clientset.Cli
 			return false, nil
 		}
 		n := &nodeList.Items[0]
+		// TODO: use api.IsNodeReady() once it is available in a versioned API
 		if !isNodeReady(n) {
 			fmt.Println("<master/apiclient> first node has registered, but is not ready yet")
 			return false, nil
@@ -104,6 +105,7 @@ func CreateClientAndWaitForAPI(adminConfig *clientcmdapi.Config) (*clientset.Cli
 	return client, nil
 }
 
+// TODO: remove this once api.IsNodeReady is available in a versioned API
 func isNodeReady(node *api.Node) bool {
 	for _, c := range node.Status.Conditions {
 		if c.Type == api.NodeReady {
@@ -179,11 +181,13 @@ func attemptToUpdateMasterRoleLabelsAndTaints(client *clientset.Clientset, sched
 	if err != nil {
 		return err
 	}
-
+	// TODO: use a versioned api in place of unversionedapi once NodeLabelKubeadmAlphaRole and NodeLabelRoleMaster
+	// are available
 	n.ObjectMeta.Labels[unversionedapi.NodeLabelKubeadmAlphaRole] = unversionedapi.NodeLabelRoleMaster
 
 	if !schedulable {
 		taintsAnnotation, _ := json.Marshal([]api.Taint{{Key: "dedicated", Value: "master", Effect: "NoSchedule"}})
+		// TODO: use a versioned API in place of internal_api once the TaintsAnnotationKey constant is available
 		n.ObjectMeta.Annotations[internal_api.TaintsAnnotationKey] = string(taintsAnnotation)
 	}
 
@@ -214,6 +218,7 @@ func SetMasterTaintTolerations(meta *api.ObjectMeta) {
 	if meta.Annotations == nil {
 		meta.Annotations = map[string]string{}
 	}
+	// TODO: use a versioned API in place of internal_api once the TolerationsAnnotationKey constant is available
 	meta.Annotations[internal_api.TolerationsAnnotationKey] = string(tolerationsAnnotation)
 }
 
@@ -228,12 +233,14 @@ func SetNodeAffinity(meta *api.ObjectMeta, expr ...api.NodeSelectorRequirement) 
 	if meta.Annotations == nil {
 		meta.Annotations = map[string]string{}
 	}
+	// TODO: use a versioned API in place of internal_api once the AffinityAnnotationKey constant is available
 	meta.Annotations[internal_api.AffinityAnnotationKey] = string(affinityAnnotation)
 }
 
 // MasterNodeAffinity returns api.NodeSelectorRequirement to be used with SetNodeAffinity to set affinity to master node
 func MasterNodeAffinity() api.NodeSelectorRequirement {
 	return api.NodeSelectorRequirement{
+		// TODO: use a versioned API instead of unversionedapi when the NodeLabel constants are available
 		Key:      unversionedapi.NodeLabelKubeadmAlphaRole,
 		Operator: api.NodeSelectorOpIn,
 		Values:   []string{unversionedapi.NodeLabelRoleMaster},
@@ -260,6 +267,7 @@ func createDummyDeployment(client *clientset.Clientset) {
 
 	wait.PollInfinite(apiCallRetryInterval, func() (bool, error) {
 		// TODO: we should check the error, as some cases may be fatal
+		// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 		if _, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Create(dummyDeployment); err != nil {
 			fmt.Printf("<master/apiclient> failed to create test deployment [%v] (will retry)", err)
 			return false, nil
@@ -268,6 +276,7 @@ func createDummyDeployment(client *clientset.Clientset) {
 	})
 
 	wait.PollInfinite(apiCallRetryInterval, func() (bool, error) {
+		// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 		d, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Get("dummy")
 		if err != nil {
 			fmt.Printf("<master/apiclient> failed to get test deployment [%v] (will retry)", err)
@@ -281,6 +290,7 @@ func createDummyDeployment(client *clientset.Clientset) {
 
 	fmt.Println("<master/apiclient> test deployment succeeded")
 
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if err := client.Extensions().Deployments(internal_api.NamespaceSystem).Delete("dummy", &api.DeleteOptions{}); err != nil {
 		fmt.Printf("<master/apiclient> failed to delete test deployment [%v] (will ignore)", err)
 	}

--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -121,9 +121,11 @@ func newKubeDiscovery(cfg *kubeadmapi.MasterConfiguration, caCert *x509.Certific
 func CreateDiscoveryDeploymentAndSecret(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset, caCert *x509.Certificate) error {
 	kd := newKubeDiscovery(cfg, caCert)
 
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if _, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Create(kd.Deployment); err != nil {
 		return fmt.Errorf("<master/discovery> failed to create %q deployment [%v]", kubeDiscoveryName, err)
 	}
+	// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 	if _, err := client.Secrets(internal_api.NamespaceSystem).Create(kd.Secret); err != nil {
 		return fmt.Errorf("<master/discovery> failed to create %q secret [%v]", kubeDiscoverySecretName, err)
 	}
@@ -132,6 +134,7 @@ func CreateDiscoveryDeploymentAndSecret(cfg *kubeadmapi.MasterConfiguration, cli
 
 	start := time.Now()
 	wait.PollInfinite(apiCallRetryInterval, func() (bool, error) {
+		// TODO: use a versioned API in place of internal_api once the NamespaceSystem constant is available
 		d, err := client.Extensions().Deployments(internal_api.NamespaceSystem).Get(kubeDiscoveryName)
 		if err != nil {
 			return false, nil

--- a/cmd/kubeadm/app/master/kubeconfig.go
+++ b/cmd/kubeadm/app/master/kubeconfig.go
@@ -21,11 +21,10 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	// TODO: "k8s.io/client-go/client/tools/clientcmd/api"
+	certutil "k8s.io/client-go/pkg/util/cert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
 func CreateCertsAndConfigForClients(cfg kubeadmapi.API, clientNames []string, caKey *rsa.PrivateKey, caCert *x509.Certificate) (map[string]*clientcmdapi.Config, error) {

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -24,13 +24,13 @@ import (
 	"path"
 	"strings"
 
+	"k8s.io/client-go/pkg/api/resource"
+	"k8s.io/client-go/pkg/api/unversioned"
+	api "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/intstr"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	api "k8s.io/kubernetes/pkg/api/v1"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
 // Static pod definitions in golang form are included below so that `kubeadm init` can get going.

--- a/cmd/kubeadm/app/master/pki.go
+++ b/cmd/kubeadm/app/master/pki.go
@@ -23,9 +23,9 @@ import (
 	"net"
 	"path"
 
+	certutil "k8s.io/client-go/pkg/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
+	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
 func newCertificateAuthority() (*rsa.PrivateKey, *x509.Certificate, error) {

--- a/cmd/kubeadm/app/master/tokens.go
+++ b/cmd/kubeadm/app/master/tokens.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"path"
 
+	"k8s.io/client-go/pkg/util/uuid"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/uuid"
 )
 
 func generateTokenIfNeeded(s *kubeadmapi.Secrets) error {

--- a/cmd/kubeadm/app/node/bootstrap.go
+++ b/cmd/kubeadm/app/node/bootstrap.go
@@ -22,14 +22,15 @@ import (
 	"sync"
 	"time"
 
-	clientset "k8s.io/client-go/kubernetes"
-	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1"
-	certificates "k8s.io/client-go/pkg/apis/certificates/v1alpha1"
-	"k8s.io/client-go/pkg/types"
 	"k8s.io/client-go/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	// TODO: replace the dependencies below with ones from k8s.io/client-go when csr.RequestNodeCertificate() is fixed
+	"k8s.io/kubernetes/pkg/apis/certificates"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	certclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 // ConnectionDetails represents a master API endpoint connection
@@ -107,9 +108,11 @@ func EstablishMasterConnection(s *kubeadmapi.NodeConfiguration, clusterInfo *kub
 
 // creates a set of clients for this endpoint
 func createClients(caCert []byte, endpoint, token string, nodeName types.NodeName) (*clientset.Clientset, error) {
-	bareClientConfig := kubeadmutil.CreateBasicClientConfig("kubernetes", endpoint, caCert)
+	// TODO: use kubeadmutil.CreateBasicClientConfig() instead when when csr.RequestNodeCertificate() is fixed
+	bareClientConfig := createBasicClientConfig("kubernetes", endpoint, caCert)
 	bootstrapClientConfig, err := clientcmd.NewDefaultClientConfig(
-		*kubeadmutil.MakeClientConfigWithToken(
+		// TODO: use kubeadmutil.MakeClientConfigWithToken() instead when when csr.RequestNodeCertificate() is fixed
+		*makeClientConfigWithToken(
 			bareClientConfig, "kubernetes", fmt.Sprintf("kubelet-%s", nodeName), token,
 		),
 		&clientcmd.ConfigOverrides{},

--- a/cmd/kubeadm/app/node/bootstrap.go
+++ b/cmd/kubeadm/app/node/bootstrap.go
@@ -22,14 +22,14 @@ import (
 	"sync"
 	"time"
 
+	clientset "k8s.io/client-go/kubernetes"
+	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1"
+	certificates "k8s.io/client-go/pkg/apis/certificates/v1alpha1"
+	"k8s.io/client-go/pkg/types"
+	"k8s.io/client-go/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	"k8s.io/kubernetes/pkg/apis/certificates"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	certclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
-	"k8s.io/kubernetes/pkg/types"
-	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 // ConnectionDetails represents a master API endpoint connection

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -17,12 +17,19 @@ limitations under the License.
 package node
 
 import (
+	"crypto/x509/pkix"
 	"fmt"
 
+	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1"
+	"k8s.io/client-go/pkg/api/unversioned"
+	api "k8s.io/client-go/pkg/api/v1"
+	certificates "k8s.io/client-go/pkg/apis/certificates/v1alpha1"
+	"k8s.io/client-go/pkg/fields"
+	"k8s.io/client-go/pkg/types"
+	certutil "k8s.io/client-go/pkg/util/cert"
+	"k8s.io/client-go/pkg/watch"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	"k8s.io/kubernetes/pkg/kubelet/util/csr"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
 // PerformTLSBootstrap executes a certificate signing request with the
@@ -36,7 +43,7 @@ func PerformTLSBootstrap(connection *ConnectionDetails) (*clientcmdapi.Config, e
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to generating private key [%v]", err)
 	}
-	cert, err := csr.RequestNodeCertificate(csrClient, key, connection.NodeName)
+	cert, err := RequestNodeCertificate(csrClient, key, connection.NodeName)
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to request signed certificate from the API server [%v]", err)
 	}
@@ -54,4 +61,72 @@ func PerformTLSBootstrap(connection *ConnectionDetails) (*clientcmdapi.Config, e
 	)
 
 	return finalConfig, nil
+}
+
+func RequestNodeCertificate(client certclient.CertificateSigningRequestInterface, privateKeyData []byte, nodeName types.NodeName) (certData []byte, err error) {
+	subject := &pkix.Name{
+		Organization: []string{"system:nodes"},
+		CommonName:   fmt.Sprintf("system:node:%s", nodeName),
+	}
+
+	privateKey, err := certutil.ParsePrivateKeyPEM(privateKeyData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
+	}
+	csr, err := certutil.MakeCSR(privateKey, subject, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
+	}
+
+	req, err := client.Create(&certificates.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta:   unversioned.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: api.ObjectMeta{GenerateName: "csr-"},
+
+		// TODO: For now, this is a request for a certificate with allowed usage of "TLS Web Client Authentication".
+		// Need to figure out whether/how to surface the allowed usage in the spec.
+		Spec: certificates.CertificateSigningRequestSpec{Request: csr},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create certificate signing request: %v", err)
+
+	}
+
+	// Make a default timeout = 3600s.
+	var defaultTimeoutSeconds int64 = 3600
+	resultCh, err := client.Watch(api.ListOptions{
+		Watch:          true,
+		TimeoutSeconds: &defaultTimeoutSeconds,
+		FieldSelector:  fields.OneTermEqualSelector("metadata.name", req.Name).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot watch on the certificate signing request: %v", err)
+	}
+
+	var status certificates.CertificateSigningRequestStatus
+	ch := resultCh.ResultChan()
+
+	for {
+		event, ok := <-ch
+		if !ok {
+			break
+		}
+
+		if event.Type == watch.Modified || event.Type == watch.Added {
+			if event.Object.(*certificates.CertificateSigningRequest).UID != req.UID {
+				continue
+			}
+			status = event.Object.(*certificates.CertificateSigningRequest).Status
+			for _, c := range status.Conditions {
+				if c.Type == certificates.CertificateDenied {
+					return nil, fmt.Errorf("certificate signing request is not approved, reason: %v, message: %v", c.Reason, c.Message)
+				}
+				if c.Type == certificates.CertificateApproved && status.Certificate != nil {
+					return status.Certificate, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("watch channel closed")
 }

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -17,19 +17,12 @@ limitations under the License.
 package node
 
 import (
-	"crypto/x509/pkix"
 	"fmt"
 
-	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1"
-	"k8s.io/client-go/pkg/api/unversioned"
-	api "k8s.io/client-go/pkg/api/v1"
-	certificates "k8s.io/client-go/pkg/apis/certificates/v1alpha1"
-	"k8s.io/client-go/pkg/fields"
-	"k8s.io/client-go/pkg/types"
-	certutil "k8s.io/client-go/pkg/util/cert"
-	"k8s.io/client-go/pkg/watch"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	// TODO: replace deps below with ones from k8s.io/client-go when csr.RequestNodeCertificate() is fixed
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/kubelet/util/csr"
+	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
 // PerformTLSBootstrap executes a certificate signing request with the
@@ -43,7 +36,9 @@ func PerformTLSBootstrap(connection *ConnectionDetails) (*clientcmdapi.Config, e
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to generating private key [%v]", err)
 	}
-	cert, err := RequestNodeCertificate(csrClient, key, connection.NodeName)
+	// TODO: fix csr.RequestNodeCertificate() to use a versioned client from k8s.io/client-go and such a client here,
+	// changing the client creation in kubeadm/app/node/bootstrap.go
+	cert, err := csr.RequestNodeCertificate(csrClient, key, connection.NodeName)
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to request signed certificate from the API server [%v]", err)
 	}
@@ -54,79 +49,13 @@ func PerformTLSBootstrap(connection *ConnectionDetails) (*clientcmdapi.Config, e
 	fmt.Printf("<node/csr> received signed certificate from the API server:\n%s\n", fmtCert)
 	fmt.Println("<node/csr> generating kubelet configuration")
 
-	bareClientConfig := kubeadmutil.CreateBasicClientConfig("kubernetes", connection.Endpoint, connection.CACert)
-	finalConfig := kubeadmutil.MakeClientConfigWithCerts(
+	// TODO: use kubeadmutil.CreateBasicClientConfig() instead when csr.RequestNodeCertificate() is fixed
+	bareClientConfig := createBasicClientConfig("kubernetes", connection.Endpoint, connection.CACert)
+	// TODO: use kubeadmutil.MakeClientConfigWithCerts() instead when csr.RequestNodeCertificate() is fixed
+	finalConfig := makeClientConfigWithCerts(
 		bareClientConfig, "kubernetes", fmt.Sprintf("kubelet-%s", connection.NodeName),
 		key, cert,
 	)
 
 	return finalConfig, nil
-}
-
-func RequestNodeCertificate(client certclient.CertificateSigningRequestInterface, privateKeyData []byte, nodeName types.NodeName) (certData []byte, err error) {
-	subject := &pkix.Name{
-		Organization: []string{"system:nodes"},
-		CommonName:   fmt.Sprintf("system:node:%s", nodeName),
-	}
-
-	privateKey, err := certutil.ParsePrivateKeyPEM(privateKeyData)
-	if err != nil {
-		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
-	}
-	csr, err := certutil.MakeCSR(privateKey, subject, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
-	}
-
-	req, err := client.Create(&certificates.CertificateSigningRequest{
-		// Username, UID, Groups will be injected by API server.
-		TypeMeta:   unversioned.TypeMeta{Kind: "CertificateSigningRequest"},
-		ObjectMeta: api.ObjectMeta{GenerateName: "csr-"},
-
-		// TODO: For now, this is a request for a certificate with allowed usage of "TLS Web Client Authentication".
-		// Need to figure out whether/how to surface the allowed usage in the spec.
-		Spec: certificates.CertificateSigningRequestSpec{Request: csr},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot create certificate signing request: %v", err)
-
-	}
-
-	// Make a default timeout = 3600s.
-	var defaultTimeoutSeconds int64 = 3600
-	resultCh, err := client.Watch(api.ListOptions{
-		Watch:          true,
-		TimeoutSeconds: &defaultTimeoutSeconds,
-		FieldSelector:  fields.OneTermEqualSelector("metadata.name", req.Name).String(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot watch on the certificate signing request: %v", err)
-	}
-
-	var status certificates.CertificateSigningRequestStatus
-	ch := resultCh.ResultChan()
-
-	for {
-		event, ok := <-ch
-		if !ok {
-			break
-		}
-
-		if event.Type == watch.Modified || event.Type == watch.Added {
-			if event.Object.(*certificates.CertificateSigningRequest).UID != req.UID {
-				continue
-			}
-			status = event.Object.(*certificates.CertificateSigningRequest).Status
-			for _, c := range status.Conditions {
-				if c.Type == certificates.CertificateDenied {
-					return nil, fmt.Errorf("certificate signing request is not approved, reason: %v, message: %v", c.Reason, c.Message)
-				}
-				if c.Type == certificates.CertificateApproved && status.Certificate != nil {
-					return status.Certificate, nil
-				}
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("watch channel closed")
 }

--- a/cmd/kubeadm/app/node/discovery.go
+++ b/cmd/kubeadm/app/node/discovery.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	jose "github.com/square/go-jose"
+	"k8s.io/client-go/pkg/util/wait"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 // the amount of time to wait between each request to the discovery API

--- a/cmd/kubeadm/app/node/temp_util.go
+++ b/cmd/kubeadm/app/node/temp_util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// TODO: this whole file is just a temporary solution until the transition to k8s.io/client-go is finished.
+// It contains copies of the functions in kubeadm/app/cmd/util/kubeconfig.go that work with a non-versioned client
+// and should be removed in favor of the original kubeconfig.go file once the signature of csr.RequestNodeCertificate() is fixed.
+
+package node
+
+import (
+	"os"
+	"path"
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+// TODO: remove this in favor of kubeadmutil.WriteKubeconfigIfNotExists() when csr.RequestNodeCertificate() is fixed
+func WriteKubeconfigIfNotExists(name string, kubeconfig *clientcmdapi.Config) error {
+	if err := os.MkdirAll(kubeadmapi.GlobalEnvParams.KubernetesDir, 0700); err != nil {
+		return fmt.Errorf("<util/kubeconfig> failed to create directory %q [%v]", kubeadmapi.GlobalEnvParams.KubernetesDir, err)
+	}
+
+	filename := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, fmt.Sprintf("%s.conf", name))
+	// Create and open the file, only if it does not already exist.
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
+	if err != nil {
+		return fmt.Errorf("<util/kubeconfig> failed to create %q, it already exists [%v]", filename, err)
+	}
+	f.Close()
+
+	if err := clientcmd.WriteToFile(*kubeconfig, filename); err != nil {
+		return fmt.Errorf("<util/kubeconfig> failed to write to %q [%v]", filename, err)
+	}
+
+	fmt.Printf("<util/kubeconfig> created %q\n", filename)
+	return nil
+}
+
+// TODO: remove this in favor of kubeadmutil.CreateBasicClientConfig() when csr.RequestNodeCertificate() is fixed
+func createBasicClientConfig(clusterName string, serverURL string, caCert []byte) *clientcmdapi.Config {
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = serverURL
+	cluster.CertificateAuthorityData = caCert
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters[clusterName] = cluster
+
+	return config
+}
+
+// TODO: remove this in favor of kubeadmutil.MakeClientConfigWithToken() when csr.RequestNodeCertificate() is fixed
+func makeClientConfigWithToken(config *clientcmdapi.Config, clusterName string, userName string, token string) *clientcmdapi.Config {
+	newConfig := config
+	name := fmt.Sprintf("%s@%s", userName, clusterName)
+
+	authInfo := clientcmdapi.NewAuthInfo()
+	authInfo.Token = token
+
+	context := clientcmdapi.NewContext()
+	context.Cluster = clusterName
+	context.AuthInfo = userName
+
+	newConfig.AuthInfos[userName] = authInfo
+	newConfig.Contexts[name] = context
+	newConfig.CurrentContext = name
+
+	return newConfig
+}
+
+// TODO: remove this in favor of kubeadmutil.MakeClientConfigWithCerts() when csr.RequestNodeCertificate() is fixed
+func makeClientConfigWithCerts(config *clientcmdapi.Config, clusterName string, userName string, clientKey []byte, clientCert []byte) *clientcmdapi.Config {
+	newConfig := config
+	name := fmt.Sprintf("%s@%s", userName, clusterName)
+
+	authInfo := clientcmdapi.NewAuthInfo()
+	authInfo.ClientKeyData = clientKey
+	authInfo.ClientCertificateData = clientCert
+
+	context := clientcmdapi.NewContext()
+	context.Cluster = clusterName
+	context.AuthInfo = userName
+
+	newConfig.AuthInfos[userName] = authInfo
+	newConfig.Contexts[name] = context
+	newConfig.CurrentContext = name
+
+	return newConfig
+}

--- a/cmd/kubeadm/app/util/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"path"
 
-	// TODO: "k8s.io/client-go/client/tools/clientcmd/api"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
 func CreateBasicClientConfig(clusterName string, serverURL string, caCert []byte) *clientcmdapi.Config {

--- a/cmd/kubeadm/app/util/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig_test.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
 const (

--- a/pkg/kubelet/util/csr/csr.go
+++ b/pkg/kubelet/util/csr/csr.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+// TODO: use a versioned client from k8s.io/client-go in this function, `kubeadm` depends on it
 // RequestNodeCertificate will create a certificate signing request and send it to API server,
 // then it will watch the object's status, once approved by API server, it will return the API
 // server's issued certificate (pem-encoded). If there is any errors, or the watch timeouts,


### PR DESCRIPTION
**What this PR does / why we need it**: in `kubeadm`, replace all internal API clients with versioned clients from the `k8s.io/client-go` package.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubernetes/issues/33914

**Special notes for your reviewer**:
I tried to use `k8s.io/client-go` everywhere where kubeadm uses some sort of API client to contact the API server.

For the certificate generation during a `join` command, resulting from a CSR, I had to copy over the  `RequestNodeCertificate` function from the `kubelet` code, as kubelet uses the internal API's and here I wanted to use the versioned `client-go` API client (otherwise the function signatures do not match). WDYT, is there a better way to do it right now?

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36425)
<!-- Reviewable:end -->
