### PR TITLE
Use the correct time field to estimate progress in deployments

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -844,7 +844,7 @@ func DeploymentTimedOut(deployment *extensions.Deployment, newStatus *extensions
 	// Look at the difference in seconds between now and the last time we reported any
 	// progress or tried to create a replica set, or resumed a paused deployment and
 	// compare against progressDeadlineSeconds.
-	from := condition.LastTransitionTime
+	from := condition.LastUpdateTime
 	delta := time.Duration(*deployment.Spec.ProgressDeadlineSeconds) * time.Second
 	return from.Add(delta).Before(nowFn())
 }

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -1055,9 +1055,9 @@ func TestDeploymentTimedOut(t *testing.T) {
 			Status: extensions.DeploymentStatus{
 				Conditions: []extensions.DeploymentCondition{
 					{
-						Type:               condType,
-						Status:             status,
-						LastTransitionTime: unversioned.Time{Time: from},
+						Type:           condType,
+						Status:         status,
+						LastUpdateTime: unversioned.Time{Time: from},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/36427

@kubernetes/deployment

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36430)
<!-- Reviewable:end -->
