### PR TITLE
Switch cluster autoscaler to 0.4.0-beta1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.3.0",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.4.0-beta1",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
Switch Kubernetes to new 0.4.0-beta1 Cluster Autoscaler. The release contains mainly bugfixes:
* unschedulable nodes don't stop cluster autoscaler
* better logging
* events for deltions
* bulk delete for empty nodes

cc: @fgrzadkowski @piosz @jszczepkowski

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36431)
<!-- Reviewable:end -->
