### PR TITLE
[kubectl] Don't require port for headless service expose

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -186,7 +186,9 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			}
 			switch len(ports) {
 			case 0:
-				return cmdutil.UsageError(cmd, "couldn't find port via --port flag or introspection")
+				if clusterIP, found := params["cluster-ip"]; !found || clusterIP != "None" {
+					return cmdutil.UsageError(cmd, "couldn't find port via --port flag or introspection")
+				}
 			case 1:
 				params["port"] = ports[0]
 			default:

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -429,6 +429,36 @@ func TestRunExposeService(t *testing.T) {
 			},
 			status: 200,
 		},
+		{
+			name: "expose-headless-service-without-port",
+			args: []string{"service", "baz"},
+			ns:   "test",
+			calls: map[string]string{
+				"GET":  "/namespaces/test/services/baz",
+				"POST": "/namespaces/test/services",
+			},
+			input: &api.Service{
+				ObjectMeta: api.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
+				Spec: api.ServiceSpec{
+					Selector: map[string]string{"app": "go"},
+				},
+			},
+			flags: map[string]string{"selector": "func=stream", "protocol": "UDP", "name": "foo", "labels": "svc=test", "cluster-ip": "None", "dry-run": "true"},
+			output: &api.Service{
+				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "", Labels: map[string]string{"svc": "test"}},
+				Spec: api.ServiceSpec{
+					Ports: []api.ServicePort{
+						{
+							Protocol: api.ProtocolUDP,
+						},
+					},
+					Selector:  map[string]string{"func": "stream"},
+					ClusterIP: api.ClusterIPNone,
+				},
+			},
+			expected: "service \"foo\" exposed",
+			status:   200,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -136,39 +136,41 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 		}
 	}
 
-	portStringSlice := strings.Split(portString, ",")
-	for i, stillPortString := range portStringSlice {
-		port, err := strconv.Atoi(stillPortString)
-		if err != nil {
-			return nil, err
-		}
-		name := servicePortName
-		// If we are going to assign multiple ports to a service, we need to
-		// generate a different name for each one.
-		if len(portStringSlice) > 1 {
-			name = fmt.Sprintf("port-%d", i+1)
-		}
-		protocol := params["protocol"]
-
-		switch {
-		case len(protocol) == 0 && len(portProtocolMap) == 0:
-			// Default to TCP, what the flag was doing previously.
-			protocol = "TCP"
-		case len(protocol) > 0 && len(portProtocolMap) > 0:
-			// User has specified the --protocol while exposing a multiprotocol resource
-			// We should stomp multiple protocols with the one specified ie. do nothing
-		case len(protocol) == 0 && len(portProtocolMap) > 0:
-			// no --protocol and we expose a multiprotocol resource
-			protocol = "TCP" // have the default so we can stay sane
-			if exposeProtocol, found := portProtocolMap[stillPortString]; found {
-				protocol = exposeProtocol
+	if len(portString) > 0 {
+		portStringSlice := strings.Split(portString, ",")
+		for i, stillPortString := range portStringSlice {
+			port, err := strconv.Atoi(stillPortString)
+			if err != nil {
+				return nil, err
 			}
+			name := servicePortName
+			// If we are going to assign multiple ports to a service, we need to
+			// generate a different name for each one.
+			if len(portStringSlice) > 1 {
+				name = fmt.Sprintf("port-%d", i+1)
+			}
+			protocol := params["protocol"]
+
+			switch {
+			case len(protocol) == 0 && len(portProtocolMap) == 0:
+				// Default to TCP, what the flag was doing previously.
+				protocol = "TCP"
+			case len(protocol) > 0 && len(portProtocolMap) > 0:
+				// User has specified the --protocol while exposing a multiprotocol resource
+				// We should stomp multiple protocols with the one specified ie. do nothing
+			case len(protocol) == 0 && len(portProtocolMap) > 0:
+				// no --protocol and we expose a multiprotocol resource
+				protocol = "TCP" // have the default so we can stay sane
+				if exposeProtocol, found := portProtocolMap[stillPortString]; found {
+					protocol = exposeProtocol
+				}
+			}
+			ports = append(ports, api.ServicePort{
+				Name:     name,
+				Port:     int32(port),
+				Protocol: api.Protocol(protocol),
+			})
 		}
-		ports = append(ports, api.ServicePort{
-			Name:     name,
-			Port:     int32(port),
-			Protocol: api.Protocol(protocol),
-		})
 	}
 
 	service := api.Service{


### PR DESCRIPTION
The validation for this is already done in API, but kubectl didn't allow that.
fixes #32795

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36434)
<!-- Reviewable:end -->
