### PR TITLE
Add `clusterid`, an optional parameter to storageclass.

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -74,6 +74,7 @@ metadata:
 provisioner: kubernetes.io/glusterfs
 parameters:
   resturl: "http://127.0.0.1:8081"
+  clusterid: "630372ccdc720a92c681fb928f27b53f"
   restuser: "admin"
   secretNamespace: "default"
   secretName: "heketi-secret"
@@ -85,8 +86,9 @@ parameters:
 * `restuser` : Gluster REST service/Heketi user who has access to create volumes in the Gluster Trusted Pool.
 * `restuserkey` : Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of `secretNamespace` + `secretName`.
 * `secretNamespace` + `secretName` : Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both `secretNamespace` and `secretName` are omitted. The provided secret must have type "kubernetes.io/glusterfs".
-
 When both `restuserkey` and `secretNamespace` + `secretName` is specified, the secret will be used.
+* `clusterid`: `630372ccdc720a92c681fb928f27b53f` is the ID of the cluster which will be used by Heketi when provisioning the volume. It can also be a list of clusterids, for ex:
+"8452344e2becec931ece4e33c4674e4e,42982310de6c63381718ccfa6d8cf397". This is an optional parameter.
 
 Example of a secret can be found in [glusterfs-provisioning-secret.yaml](glusterfs-provisioning-secret.yaml).
 

--- a/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -5,6 +5,7 @@ metadata:
 provisioner: kubernetes.io/glusterfs
 parameters:
   resturl: "http://127.0.0.1:8081"
+  clusterid: "630372ccdc720a92c681fb928f27b53f"
   restuser: "admin"
   secretNamespace: "default"
   secretName: "heketi-secret"


### PR DESCRIPTION
At present, admin doesn't have the privilege to chose the
trusted storage pool from which persistent gluster volume
has to be provided.

This patch introduce a new storage class parameter which allows
the admin to specify storage pool/cluster if required.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36437)
<!-- Reviewable:end -->
