### PR TITLE
Extend test timeout for LB creation in large clusters

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -63,7 +63,7 @@ const (
 	// How long to wait for a load balancer to be created/modified.
 	//TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	loadBalancerCreateTimeoutDefault = 20 * time.Minute
-	loadBalancerCreateTimeoutLarge   = time.Hour
+	loadBalancerCreateTimeoutLarge   = 2 * time.Hour
 
 	largeClusterMinNodesNumber = 100
 


### PR DESCRIPTION
This will most probably be necessary to test 3000-node clusters.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36442)
<!-- Reviewable:end -->
