### PR TITLE
Fix flunetd-gcp image Dockerfile

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get -qq update && \
 # Copy the Fluentd configuration files for logging Docker container logs.
 # Either configuration file can be used by specifying `-c <file>` as a command
 # line argument.
-RUN rm /etc/td-agent/td-agent.conf
 COPY google-fluentd.conf /etc/td-agent/td-agent.conf
 COPY google-fluentd-journal.conf /etc/td-agent/td-agent-journal.conf
 


### PR DESCRIPTION
A mistake was made during rebasing this PR: https://github.com/kubernetes/kubernetes/pull/36370

One line, earlier deleted, was restored and broke the image build.

@piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36443)
<!-- Reviewable:end -->
