### PR TITLE
Read all resources for finalization and gc, not just preferred

### DIFF
--- a/pkg/client/typed/discovery/discovery_client_test.go
+++ b/pkg/client/typed/discovery/discovery_client_test.go
@@ -321,7 +321,7 @@ func TestGetSwaggerSchemaFail(t *testing.T) {
 	}
 }
 
-func TestGetServerPreferredResources(t *testing.T) {
+func TestServerPreferredResources(t *testing.T) {
 	stable := unversioned.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []unversioned.APIResource{
@@ -330,14 +330,6 @@ func TestGetServerPreferredResources(t *testing.T) {
 			{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
 		},
 	}
-	/*beta := unversioned.APIResourceList{
-		GroupVersion: "extensions/v1",
-		APIResources: []unversioned.APIResource{
-			{Name: "deployments", Namespaced: true, Kind: "Deployment"},
-			{Name: "ingresses", Namespaced: true, Kind: "Ingress"},
-			{Name: "jobs", Namespaced: true, Kind: "Job"},
-		},
-	}*/
 	tests := []struct {
 		resourcesList *unversioned.APIResourceList
 		response      func(w http.ResponseWriter, req *http.Request)
@@ -427,9 +419,6 @@ func TestGetServerPreferredResources(t *testing.T) {
 				w.Write(output)
 			},
 		},
-		/*{
-			resourcesList: &stable,
-		},*/
 	}
 	for _, test := range tests {
 		server := httptest.NewServer(http.HandlerFunc(test.response))
@@ -455,7 +444,7 @@ func TestGetServerPreferredResources(t *testing.T) {
 	}
 }
 
-func TestGetServerPreferredResourcesRetries(t *testing.T) {
+func TestServerPreferredResourcesRetries(t *testing.T) {
 	stable := unversioned.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []unversioned.APIResource{
@@ -549,6 +538,176 @@ func TestGetServerPreferredResourcesRetries(t *testing.T) {
 		}
 		if len(got) != tc.expectResources {
 			t.Errorf("case %d: expect %d resources, got %#v", i, tc.expectResources, got)
+		}
+		server.Close()
+	}
+}
+
+func TestServerPreferredNamespacedResources(t *testing.T) {
+	stable := unversioned.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []unversioned.APIResource{
+			{Name: "pods", Namespaced: true, Kind: "Pod"},
+			{Name: "services", Namespaced: true, Kind: "Service"},
+			{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
+		},
+	}
+	batchv1 := unversioned.APIResourceList{
+		GroupVersion: "batch/v1",
+		APIResources: []unversioned.APIResource{
+			{Name: "jobs", Namespaced: true, Kind: "Job"},
+		},
+	}
+	batchv2alpha1 := unversioned.APIResourceList{
+		GroupVersion: "batch/v2alpha1",
+		APIResources: []unversioned.APIResource{
+			{Name: "jobs", Namespaced: true, Kind: "Job"},
+			{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
+		},
+	}
+	batchv3alpha1 := unversioned.APIResourceList{
+		GroupVersion: "batch/v3alpha1",
+		APIResources: []unversioned.APIResource{
+			{Name: "jobs", Namespaced: true, Kind: "Job"},
+			{Name: "cronjobs", Namespaced: true, Kind: "CronJob"},
+		},
+	}
+	tests := []struct {
+		response func(w http.ResponseWriter, req *http.Request)
+		expected []unversioned.GroupVersionResource
+	}{
+		{
+			response: func(w http.ResponseWriter, req *http.Request) {
+				var list interface{}
+				switch req.URL.Path {
+				case "/api/v1":
+					list = &stable
+				case "/api":
+					list = &unversioned.APIVersions{
+						Versions: []string{
+							"v1",
+						},
+					}
+				default:
+					t.Logf("unexpected request: %s", req.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				output, err := json.Marshal(list)
+				if err != nil {
+					t.Errorf("unexpected encoding error: %v", err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(output)
+			},
+			expected: []unversioned.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "", Version: "v1", Resource: "services"},
+			},
+		},
+		{
+			response: func(w http.ResponseWriter, req *http.Request) {
+				var list interface{}
+				switch req.URL.Path {
+				case "/apis":
+					list = &unversioned.APIGroupList{
+						Groups: []unversioned.APIGroup{
+							{
+								Name: "batch",
+								Versions: []unversioned.GroupVersionForDiscovery{
+									{GroupVersion: "batch/v1", Version: "v1"},
+									{GroupVersion: "batch/v2alpha1", Version: "v2alpha1"},
+									{GroupVersion: "batch/v3alpha1", Version: "v3alpha1"},
+								},
+								PreferredVersion: unversioned.GroupVersionForDiscovery{GroupVersion: "batch/v1", Version: "v1"},
+							},
+						},
+					}
+				case "/apis/batch/v1":
+					list = &batchv1
+				case "/apis/batch/v2alpha1":
+					list = &batchv2alpha1
+				case "/apis/batch/v3alpha1":
+					list = &batchv3alpha1
+				default:
+					t.Logf("unexpected request: %s", req.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				output, err := json.Marshal(list)
+				if err != nil {
+					t.Errorf("unexpected encoding error: %v", err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(output)
+			},
+			expected: []unversioned.GroupVersionResource{
+				{Group: "batch", Version: "v1", Resource: "jobs"},
+				{Group: "batch", Version: "v2alpha1", Resource: "cronjobs"},
+			},
+		},
+		{
+			response: func(w http.ResponseWriter, req *http.Request) {
+				var list interface{}
+				switch req.URL.Path {
+				case "/apis":
+					list = &unversioned.APIGroupList{
+						Groups: []unversioned.APIGroup{
+							{
+								Name: "batch",
+								Versions: []unversioned.GroupVersionForDiscovery{
+									{GroupVersion: "batch/v1", Version: "v1"},
+									{GroupVersion: "batch/v2alpha1", Version: "v2alpha1"},
+									{GroupVersion: "batch/v3alpha1", Version: "v3alpha1"},
+								},
+								PreferredVersion: unversioned.GroupVersionForDiscovery{GroupVersion: "batch/v2alpha", Version: "v2alpha1"},
+							},
+						},
+					}
+				case "/apis/batch/v1":
+					list = &batchv1
+				case "/apis/batch/v2alpha1":
+					list = &batchv2alpha1
+				case "/apis/batch/v3alpha1":
+					list = &batchv3alpha1
+				default:
+					t.Logf("unexpected request: %s", req.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				output, err := json.Marshal(list)
+				if err != nil {
+					t.Errorf("unexpected encoding error: %v", err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(output)
+			},
+			expected: []unversioned.GroupVersionResource{
+				{Group: "batch", Version: "v2alpha1", Resource: "jobs"},
+				{Group: "batch", Version: "v2alpha1", Resource: "cronjobs"},
+			},
+		},
+	}
+	for _, test := range tests {
+		server := httptest.NewServer(http.HandlerFunc(test.response))
+		defer server.Close()
+
+		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+		got, err := client.ServerPreferredNamespacedResources()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		// we need deterministic order and since during processing in ServerPreferredNamespacedResources
+		// a map comes into play the result needs sorting
+		if !reflect.DeepEqual(got, test.expected) {
+			t.Errorf("expected:\n%v\ngot:\n%v\n", test.expected, got)
 		}
 		server.Close()
 	}


### PR DESCRIPTION
Fixes #31481. 

Currently when starting namespace controller or garbage collector we only gather preferred version resources, which in case of multiple versions (you guessed it `batch/v2alpha1.CronJobs` again) isn't sufficient. This PR adds additional method which actually retrieves all resources from all versions and works on them.

@kubernetes/sig-api-machinery ptal

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36444)
<!-- Reviewable:end -->
