### PR TITLE
kube-up/down: support for dynamic addition and deletion of nodes in a cluster

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -29,6 +29,12 @@ export roles_array=($roles)
 
 # Define minion numbers
 export NUM_NODES=${NUM_NODES:-3}
+
+# Define master of cluster when "a" or "ai" is not appear in $roles
+# Note: this will be ignore when "a" or "ai" exist in $roles
+MASTER=${MASTER:-"vcap@10.10.103.250"}
+MASTER_IP="${MASTER#*@}"
+
 # define the IP range used for service cluster IPs.
 # according to rfc 1918 ref: https://tools.ietf.org/html/rfc1918 choose a private ip range here.
 export SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-192.168.3.0/24}  # formerly PORTAL_NET


### PR DESCRIPTION
What this PR does / why we need it:
	I can't dynamically added node to or removed node from the existed k8s-cluster, but i think it's very important in some scenarios, so do something for this under ubuntu OS

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36475)
<!-- Reviewable:end -->
