### PR TITLE
Node Conformance & E2E: Get node name from node object.

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -122,33 +122,37 @@ func (c *PodClient) DeleteSync(name string, options *api.DeleteOptions, timeout 
 
 // mungeSpec apply test-suite specific transformations to the pod spec.
 func (c *PodClient) mungeSpec(pod *api.Pod) {
-	if TestContext.NodeName != "" {
-		Expect(pod.Spec.NodeName).To(Or(BeZero(), Equal(TestContext.NodeName)), "Test misconfigured")
-		pod.Spec.NodeName = TestContext.NodeName
-		// Node e2e does not support the default DNSClusterFirst policy. Set
-		// the policy to DNSDefault, which is configured per node.
-		pod.Spec.DNSPolicy = api.DNSDefault
+	if !TestContext.NodeE2E {
+		return
+	}
 
-		if !TestContext.PrepullImages {
-			return
+	Expect(pod.Spec.NodeName).To(Or(BeZero(), Equal(TestContext.NodeName)), "Test misconfigured")
+	pod.Spec.NodeName = TestContext.NodeName
+	// Node e2e does not support the default DNSClusterFirst policy. Set
+	// the policy to DNSDefault, which is configured per node.
+	pod.Spec.DNSPolicy = api.DNSDefault
+
+	// PrepullImages only works for node e2e now. For cluster e2e, image prepull is not enforced,
+	// we should not munge ImagePullPolicy for cluster e2e pods.
+	if !TestContext.PrepullImages {
+		return
+	}
+	// If prepull is enabled, munge the container spec to make sure the images are not pulled
+	// during the test.
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.ImagePullPolicy == api.PullAlways {
+			// If the image pull policy is PullAlways, the image doesn't need to be in
+			// the white list or pre-pulled, because the image is expected to be pulled
+			// in the test anyway.
+			continue
 		}
-		// If prepull is enabled, munge the container spec to make sure the images are not pulled
-		// during the test.
-		for i := range pod.Spec.Containers {
-			c := &pod.Spec.Containers[i]
-			if c.ImagePullPolicy == api.PullAlways {
-				// If the image pull policy is PullAlways, the image doesn't need to be in
-				// the white list or pre-pulled, because the image is expected to be pulled
-				// in the test anyway.
-				continue
-			}
-			// If the image policy is not PullAlways, the image must be in the white list and
-			// pre-pulled.
-			Expect(ImageWhiteList.Has(c.Image)).To(BeTrue(), "Image %q is not in the white list, consider adding it to CommonImageWhiteList in test/e2e/common/util.go or NodeImageWhiteList in test/e2e_node/image_list.go", c.Image)
-			// Do not pull images during the tests because the images in white list should have
-			// been prepulled.
-			c.ImagePullPolicy = api.PullNever
-		}
+		// If the image policy is not PullAlways, the image must be in the white list and
+		// pre-pulled.
+		Expect(ImageWhiteList.Has(c.Image)).To(BeTrue(), "Image %q is not in the white list, consider adding it to CommonImageWhiteList in test/e2e/common/util.go or NodeImageWhiteList in test/e2e_node/image_list.go", c.Image)
+		// Do not pull images during the tests because the images in white list should have
+		// been prepulled.
+		c.ImagePullPolicy = api.PullNever
 	}
 }
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -100,7 +100,9 @@ type TestContextType struct {
 
 // NodeTestContextType is part of TestContextType, it is shared by all node e2e test.
 type NodeTestContextType struct {
-	// Name of the node to run tests on (node e2e suite only).
+	// NodeE2E indicates whether it is running node e2e.
+	NodeE2E bool
+	// Name of the node to run tests on.
 	NodeName string
 	// NodeConformance indicates whether the test is running in node conformance mode.
 	NodeConformance bool
@@ -210,7 +212,9 @@ func RegisterClusterFlags() {
 
 // Register flags specific to the node e2e test suite.
 func RegisterNodeFlags() {
-	flag.StringVar(&TestContext.NodeName, "node-name", "", "Name of the node to run tests on (node e2e suite only).")
+	// Mark the test as node e2e when node flags are registered.
+	TestContext.NodeE2E = true
+	flag.StringVar(&TestContext.NodeName, "node-name", "", "Name of the node to run tests on.")
 	// TODO(random-liu): Move kubelet start logic out of the test.
 	// TODO(random-liu): Move log fetch logic out of the test.
 	// There are different ways to start kubelet (systemd, initd, docker, rkt, manually started etc.)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1789,7 +1789,7 @@ func restclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 type ClientConfigGetter func() (*restclient.Config, error)
 
 func LoadConfig() (*restclient.Config, error) {
-	if TestContext.NodeName != "" {
+	if TestContext.NodeE2E {
 		// This is a node e2e test, apply the node e2e configuration
 		return &restclient.Config{Host: TestContext.Host}, nil
 	}

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -195,7 +195,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--address", "0.0.0.0",
 		"--port", kubeletPort,
 		"--read-only-port", kubeletReadOnlyPort,
-		"--hostname-override", framework.TestContext.NodeName, // Required because hostname is inconsistent across hosts
 		"--volume-stats-agg-period", "10s", // Aggregate volumes frequently so tests don't need to wait as long
 		"--allow-privileged", "true",
 		"--serialize-image-pulls", "false",
@@ -211,7 +210,9 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		// "--experimental-mounter-path", framework.TestContext.MounterPath,
 		// "--experimental-mounter-rootfs-path", framework.TestContext.MounterRootfsPath,
 	)
-
+	if framework.TestContext.NodeName != "" { // If node name is specified, set hostname override.
+		cmdArgs = append(cmdArgs, "--hostname-override", framework.TestContext.NodeName)
+	}
 	if framework.TestContext.EnableCRI {
 		cmdArgs = append(cmdArgs, "--experimental-cri", "true") // Whether to use experimental cri integration.
 	}


### PR DESCRIPTION
This PR changes the node e2e test framework to get node name from apiserver instead of test flags.

When a user tried out the node conformance test, he found that node conformance test will not work properly if kubelet is started with `hostname-override`.

The reason is that node conformance test is using [the default node name - `os.Hostname`](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/e2e_node_suite_test.go#L124), which may be different from `hostname-override`. This will cause test pods not scheduled, and eventually test timeout.

We can expose a flag from node conformance test, and let user set node name themselves if they are using `hostname-override` on kubelet. However, let the framework automatically detect it from apiserver is more user friendly.

/cc @kubernetes/sig-node 
This PR 1) only changes node e2e test framework; 2) fixes a problem in node conformance test which is a 1.5 feature. @saad-ali Can we have this in 1.5?

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36479)
<!-- Reviewable:end -->
