### PR TITLE
Mention overflows when mistakenly call function FromInt

### DIFF
--- a/pkg/util/intstr/BUILD
+++ b/pkg/util/intstr/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/genericapiserver/openapi/common:go_default_library",
         "//vendor:github.com/go-openapi/spec",
         "//vendor:github.com/gogo/protobuf/proto",
+        "//vendor:github.com/golang/glog",
         "//vendor:github.com/google/gofuzz",
     ],
 )

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -20,12 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/genericapiserver/openapi/common"
 
 	"github.com/go-openapi/spec"
+	"github.com/golang/glog"
 	"github.com/google/gofuzz"
 )
 
@@ -57,6 +59,9 @@ const (
 // than int32.
 // TODO: convert to (val int32)
 func FromInt(val int) IntOrString {
+	if val > math.MaxInt32 || val < math.MinInt32 {
+		glog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
+	}
 	return IntOrString{Type: Int, IntVal: int32(val)}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When mistakenly call this method with a value that overflows int32 will causes strange behavior in some environment (maybe in amd64 system, i'm not sure but my test shows that).
For example, call FromInt(93333333333) would result in -1155947179 and not mention overflows.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36487)
<!-- Reviewable:end -->
