### PR TITLE
Add traces to etcd3 code

### DIFF
--- a/pkg/storage/etcd3/BUILD
+++ b/pkg/storage/etcd3/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//pkg/runtime:go_default_library",
         "//pkg/storage:go_default_library",
         "//pkg/storage/etcd:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/watch:go_default_library",
         "//vendor:github.com/coreos/etcd/clientv3",
         "//vendor:github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",


### PR DESCRIPTION
This is to confirm that long PUT nodes we observe are really on the etcd "server+client" side and not somewhere in the middle in apiserver side.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36496)
<!-- Reviewable:end -->
