### PR TITLE
Fix startup script bug in kibana image

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/run.sh
@@ -17,7 +17,7 @@
 export ELASTICSEARCH_URL=${ELASTICSEARCH_URL:-"http://localhost:9200"}
 echo ELASTICSEARCH_URL=${ELASTICSEARCH_URL}
 
-export KIBANA_BASE_URL=${KIBANA_BASE_URL:-""}
+export KIBANA_BASE_URL=${KIBANA_BASE_URL:-"''"}
 echo "server.basePath: ${KIBANA_BASE_URL}"
 echo "server.basePath: ${KIBANA_BASE_URL}" >> /kibana/config/kibana.yml
 


### PR DESCRIPTION
Big thanks to @lhopki01 for noticing this!

As mention in discussion in https://github.com/kubernetes/kubernetes/pull/36103 current image crashes if we don't want to work behind proxy because of string interpolation in bash.

@piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36505)
<!-- Reviewable:end -->
