### PR TITLE
Curating Owners: cluster/vagrant

### DIFF
--- a/cluster/vagrant/OWNERS
+++ b/cluster/vagrant/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - derekwaynecarr
 reviewers:
+- ArtfulCoder
 - thockin
 - lavalamp
 - smarterclayton

--- a/cluster/vagrant/OWNERS
+++ b/cluster/vagrant/OWNERS
@@ -1,2 +1,38 @@
-assignees:
-  - derekwaynecarr
+approvers:
+- derekwaynecarr
+reviewers:
+- thockin
+- lavalamp
+- smarterclayton
+- derekwaynecarr
+- caesarxuchao
+- vishh
+- mikedanese
+- liggitt
+- nikhiljindal
+- erictune
+- dchen1107
+- zmerlynn
+- justinsb
+- roberthbailey
+- eparis
+- jlowdermilk
+- piosz
+- jsafrane
+- jbeda
+- spxtr
+- madhusudancs
+- jayunit100
+- satnam6502
+- cjcullen
+- david-mcmahon
+- mfojtik
+- pweil-
+- dcbw
+- ivan4th
+- filbranden
+- dshulyak
+- k82cn
+- caseydavenport
+- johscheuer
+- rjnagal


### PR DESCRIPTION
cc @derekwaynecarr

In an effort to expand the existing pool of reviewers and establish a
two-tiered review process (first someone lgtms and then someone
experienced in the project approves), we are adding new reviewers to
existing owners files.


If You Care About the Process:
------------------------------

We did this by algorithmically figuring out who’s contributed code to
the project and in what directories.  Unfortunately, that doesn’t work
well: people that have made mechanical code changes (e.g change the
copyright header across all directories) end up as reviewers in lots of
places.

Instead of using pure commit data, we generated an excessively large
list of reviewers and pruned based on all time commit data, recent
commit data and review data (number of PRs commented on).

At this point we have a decent list of reviewers, but it needs one last
pass for fine tuning.

Also, see https://github.com/kubernetes/contrib/issues/1389.

TLDR:
-----

As an owner of a sig/directory and a leader of the project, here’s what
we need from you:

1. Use PR https://github.com/kubernetes/kubernetes/pull/35715 as an example.

2. The pull-request is made editable, please edit the `OWNERS` file to
remove the names of people that shouldn't be reviewing code in the
future in the **reviewers** section. You probably do NOT need to modify
the **approvers** section. Names asre sorted by relevance, using some
secret statistics.

3. Notify me if you want some OWNERS file to be removed.  Being an
approver or reviewer of a parent directory makes you a reviewer/approver
of the subdirectories too, so not all OWNERS files may be necessary.

4. Please use ALIAS if you want to use the same list of people over and
over again (don't hesitate to ask me for help, or use the pull-request
above as an example)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36514)
<!-- Reviewable:end -->
