### PR TITLE
Curating Owners: pkg/apiserver

### DIFF
--- a/pkg/apiserver/OWNERS
+++ b/pkg/apiserver/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - lavalamp
 - nikhiljindal
 - smarterclayton
+- deads2k
 reviewers:
 - thockin
 - lavalamp
@@ -9,7 +10,6 @@ reviewers:
 - wojtek-t
 - bgrant0607
 - deads2k
-- brendandburns
 - derekwaynecarr
 - caesarxuchao
 - mikedanese
@@ -20,14 +20,12 @@ reviewers:
 - erictune
 - davidopp
 - sttts
-- dchen1107
 - zmerlynn
 - luxas
 - roberthbailey
 - ncdc
 - timstclair
 - yifan-gu
-- eparis
 - timothysc
 - feiskyer
 - soltysh
@@ -41,5 +39,4 @@ reviewers:
 - krousey
 - vmarmol
 - fgrzadkowski
-- satnam6502
 - xiang90

--- a/pkg/apiserver/OWNERS
+++ b/pkg/apiserver/OWNERS
@@ -1,4 +1,45 @@
-assignees:
-  - lavalamp
-  - nikhiljindal
-  - smarterclayton
+approvers:
+- lavalamp
+- nikhiljindal
+- smarterclayton
+reviewers:
+- thockin
+- lavalamp
+- smarterclayton
+- wojtek-t
+- bgrant0607
+- deads2k
+- brendandburns
+- derekwaynecarr
+- caesarxuchao
+- mikedanese
+- liggitt
+- nikhiljindal
+- bprashanth
+- gmarek
+- erictune
+- davidopp
+- sttts
+- dchen1107
+- zmerlynn
+- luxas
+- roberthbailey
+- ncdc
+- timstclair
+- yifan-gu
+- eparis
+- timothysc
+- feiskyer
+- soltysh
+- piosz
+- jbeda
+- dims
+- spxtr
+- errordeveloper
+- madhusudancs
+- hongchaodeng
+- krousey
+- vmarmol
+- fgrzadkowski
+- satnam6502
+- xiang90

--- a/pkg/apiserver/authenticator/OWNERS
+++ b/pkg/apiserver/authenticator/OWNERS
@@ -7,5 +7,4 @@ reviewers:
 - errordeveloper
 - resouer
 - cjcullen
-- david-mcmahon
 - ericchiang

--- a/pkg/apiserver/authenticator/OWNERS
+++ b/pkg/apiserver/authenticator/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+- smarterclayton
+- deads2k
+- liggitt
+- dims
+- spxtr
+- errordeveloper
+- resouer
+- cjcullen
+- david-mcmahon
+- ericchiang

--- a/pkg/apiserver/filters/OWNERS
+++ b/pkg/apiserver/filters/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- deads2k
+- sttts
+- soltysh

--- a/pkg/apiserver/metrics/OWNERS
+++ b/pkg/apiserver/metrics/OWNERS
@@ -1,4 +1,3 @@
 reviewers:
 - wojtek-t
-- david-mcmahon
 - jimmidyson

--- a/pkg/apiserver/metrics/OWNERS
+++ b/pkg/apiserver/metrics/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- wojtek-t
+- david-mcmahon
+- jimmidyson

--- a/pkg/apiserver/openapi/OWNERS
+++ b/pkg/apiserver/openapi/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- mbohlool

--- a/pkg/apiserver/request/OWNERS
+++ b/pkg/apiserver/request/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- sttts

--- a/pkg/apiserver/testing/OWNERS
+++ b/pkg/apiserver/testing/OWNERS
@@ -8,5 +8,4 @@ reviewers:
 - soltysh
 - mml
 - mbohlool
-- david-mcmahon
 - jianhuiz

--- a/pkg/apiserver/testing/OWNERS
+++ b/pkg/apiserver/testing/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+- smarterclayton
+- wojtek-t
+- caesarxuchao
+- liggitt
+- erictune
+- timothysc
+- soltysh
+- mml
+- mbohlool
+- david-mcmahon
+- jianhuiz


### PR DESCRIPTION
cc @lavalamp @smarterclayton @nikhiljindal

In an effort to expand the existing pool of reviewers and establish a
two-tiered review process (first someone lgtms and then someone
experienced in the project approves), we are adding new reviewers to
existing owners files.


If You Care About the Process:
------------------------------

We did this by algorithmically figuring out who’s contributed code to
the project and in what directories.  Unfortunately, that doesn’t work
well: people that have made mechanical code changes (e.g change the
copyright header across all directories) end up as reviewers in lots of
places.

Instead of using pure commit data, we generated an excessively large
list of reviewers and pruned based on all time commit data, recent
commit data and review data (number of PRs commented on).

At this point we have a decent list of reviewers, but it needs one last
pass for fine tuning.

Also, see https://github.com/kubernetes/contrib/issues/1389.

TLDR:
-----

As an owner of a sig/directory and a leader of the project, here’s what
we need from you:

1. Use PR https://github.com/kubernetes/kubernetes/pull/35715 as an example.

2. The pull-request is made editable, please edit the `OWNERS` file to
remove the names of people that shouldn't be reviewing code in the
future in the **reviewers** section. You probably do NOT need to modify
the **approvers** section. Names asre sorted by relevance, using some
secret statistics.

3. Notify me if you want some OWNERS file to be removed.  Being an
approver or reviewer of a parent directory makes you a reviewer/approver
of the subdirectories too, so not all OWNERS files may be necessary.

4. Please use ALIAS if you want to use the same list of people over and
over again (don't hesitate to ask me for help, or use the pull-request
above as an example)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36529)
<!-- Reviewable:end -->
