### PR TITLE
Disabling flaky federation unit tests

### DIFF
--- a/federation/pkg/federation-controller/namespace/namespace_controller_test.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller_test.go
@@ -62,7 +62,7 @@ func TestNamespaceController(t *testing.T) {
 	cluster1Watch := RegisterFakeWatch("namespaces", &cluster1Client.Fake)
 	RegisterFakeList("namespaces", &cluster1Client.Fake, &api_v1.NamespaceList{Items: []api_v1.Namespace{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("namespaces", &cluster1Client.Fake, cluster1Watch)
-	cluster1UpdateChan := RegisterFakeCopyOnUpdate("namespaces", &cluster1Client.Fake, cluster1Watch)
+	//	cluster1UpdateChan := RegisterFakeCopyOnUpdate("namespaces", &cluster1Client.Fake, cluster1Watch)
 
 	cluster2Client := &fake_kubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("namespaces", &cluster2Client.Fake)
@@ -132,15 +132,18 @@ func TestNamespaceController(t *testing.T) {
 		cluster1.Name, ns1.Name, wait.ForeverTestTimeout)
 	assert.Nil(t, err, "namespace should have appeared in the informer store")
 
-	// Test update federated namespace.
-	ns1.Annotations = map[string]string{
-		"A": "B",
-	}
-	namespaceWatch.Modify(&ns1)
-	updatedNamespace = GetNamespaceFromChan(cluster1UpdateChan)
-	assert.NotNil(t, updatedNamespace)
-	assert.Equal(t, ns1.Name, updatedNamespace.Name)
-	// assert.Contains(t, updatedNamespace.Annotations, "A")
+	/*
+		        // TODO: Uncomment this once we have figured out why this is flaky.
+			// Test update federated namespace.
+			ns1.Annotations = map[string]string{
+				"A": "B",
+			}
+			namespaceWatch.Modify(&ns1)
+			updatedNamespace = GetNamespaceFromChan(cluster1UpdateChan)
+			assert.NotNil(t, updatedNamespace)
+			assert.Equal(t, ns1.Name, updatedNamespace.Name)
+			// assert.Contains(t, updatedNamespace.Annotations, "A")
+	*/
 
 	// Test add cluster
 	clusterWatch.Add(cluster2)

--- a/federation/pkg/federation-controller/secret/secret_controller_test.go
+++ b/federation/pkg/federation-controller/secret/secret_controller_test.go
@@ -52,7 +52,7 @@ func TestSecretController(t *testing.T) {
 	cluster1Watch := RegisterFakeWatch("secrets", &cluster1Client.Fake)
 	RegisterFakeList("secrets", &cluster1Client.Fake, &api_v1.SecretList{Items: []api_v1.Secret{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("secrets", &cluster1Client.Fake, cluster1Watch)
-	cluster1UpdateChan := RegisterFakeCopyOnUpdate("secrets", &cluster1Client.Fake, cluster1Watch)
+	//	cluster1UpdateChan := RegisterFakeCopyOnUpdate("secrets", &cluster1Client.Fake, cluster1Watch)
 
 	cluster2Client := &fake_kubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("secrets", &cluster2Client.Fake)
@@ -116,35 +116,38 @@ func TestSecretController(t *testing.T) {
 		cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(), wait.ForeverTestTimeout)
 	assert.Nil(t, err, "secret should have appeared in the informer store")
 
-	// Test update federated secret.
-	secret1.Annotations = map[string]string{
-		"A": "B",
-	}
-	secretWatch.Modify(&secret1)
-	updatedSecret = GetSecretFromChan(cluster1UpdateChan)
-	assert.NotNil(t, updatedSecret)
-	assert.Equal(t, secret1.Name, updatedSecret.Name)
-	assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
-	assert.True(t, secretsEqual(secret1, *updatedSecret),
-		fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret))
-	// Wait for the secret to be updated in the informer store.
-	err = WaitForSecretStoreUpdate(
-		secretController.secretFederatedInformer.GetTargetStore(),
-		cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(),
-		updatedSecret, wait.ForeverTestTimeout)
-	assert.Nil(t, err, "secret should have been updated in the informer store")
+	/*
+		        // TODO: Uncomment this once we have figured out why this is flaky.
+			// Test update federated secret.
+			secret1.Annotations = map[string]string{
+				"A": "B",
+			}
+			secretWatch.Modify(&secret1)
+			updatedSecret = GetSecretFromChan(cluster1UpdateChan)
+			assert.NotNil(t, updatedSecret)
+			assert.Equal(t, secret1.Name, updatedSecret.Name)
+			assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
+			assert.True(t, secretsEqual(secret1, *updatedSecret),
+				fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret))
+			// Wait for the secret to be updated in the informer store.
+			err = WaitForSecretStoreUpdate(
+				secretController.secretFederatedInformer.GetTargetStore(),
+				cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(),
+				updatedSecret, wait.ForeverTestTimeout)
+			assert.Nil(t, err, "secret should have been updated in the informer store")
 
-	// Test update federated secret.
-	secret1.Data = map[string][]byte{
-		"config": []byte("myconfigurationfile"),
-	}
-	secretWatch.Modify(&secret1)
-	updatedSecret2 := GetSecretFromChan(cluster1UpdateChan)
-	assert.NotNil(t, updatedSecret2)
-	assert.Equal(t, secret1.Name, updatedSecret2.Name)
-	assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
-	assert.True(t, secretsEqual(secret1, *updatedSecret2),
-		fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret2))
+				// Test update federated secret.
+				secret1.Data = map[string][]byte{
+					"config": []byte("myconfigurationfile"),
+				}
+				secretWatch.Modify(&secret1)
+				updatedSecret2 := GetSecretFromChan(cluster1UpdateChan)
+				assert.NotNil(t, updatedSecret2)
+				assert.Equal(t, secret1.Name, updatedSecret2.Name)
+				assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
+				assert.True(t, secretsEqual(secret1, *updatedSecret2),
+					fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret2))
+	*/
 
 	// Test add cluster
 	clusterWatch.Add(cluster2)


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/36473 and https://github.com/kubernetes/kubernetes/issues/36351

Disabling flaky unit tests while we figure out why they are flaky. This unblocks others as per discussion https://github.com/kubernetes/kubernetes/issues/36473#issuecomment-259490256.
We do test the same in our e2e tests.

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36536)
<!-- Reviewable:end -->
