### PR TITLE
Fix Docker Registry image version to 2.5.1

### DIFF
--- a/cluster/addons/registry/registry-rc.yaml
+++ b/cluster/addons/registry/registry-rc.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: registry:2
+        image: registry:2.5.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
`registry:2` is constantly being updated with new versions. This means there's a possibility that the image may be changed unintentionally. For example, when the Pod is rescheduled on nodes that does not already have the image, depending on the time of the pull, `registry:2` may result in different images.

Fix this to the latest `registry:2.5.1` instead to avoid this problem.

@uluyol @freehan

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36537)
<!-- Reviewable:end -->
