### PR TITLE
Remove duplicate describer errs

### DIFF
--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var (
@@ -133,17 +134,26 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		allErrs = append(allErrs, err)
 	}
 
+	errs := sets.NewString()
 	first := true
 	for _, info := range infos {
 		mapping := info.ResourceMapping()
 		describer, err := f.Describer(mapping)
 		if err != nil {
+			if errs.Has(err.Error()) {
+				continue
+			}
 			allErrs = append(allErrs, err)
+			errs.Insert(err.Error())
 			continue
 		}
 		s, err := describer.Describe(info.Namespace, info.Name, *describerSettings)
 		if err != nil {
+			if errs.Has(err.Error()) {
+				continue
+			}
 			allErrs = append(allErrs, err)
+			errs.Insert(err.Error())
 			continue
 		}
 		if first {


### PR DESCRIPTION
Downstream issue https://github.com/openshift/origin/issues/11846

**Release note**:
```release-note
release-note-none
```

The `describe` command iterates through a list of infos received from
the server and aggregates a list of errors while attempting to call each
resource's respective describer. When a resource exists, but does not
have a describer set, such as `Event`, the `describe` command outputs
the same error `error: no description has been implemented for "Event"`
for each info.

```
$ kubectl describe events
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
no description has been implemented for "Event"
```

@kubernetes/kubectl @fabianofranz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36541)
<!-- Reviewable:end -->
