### PR TITLE
Fixing spark e2e test failures.

### DIFF
--- a/examples/spark/spark-master-controller.yaml
+++ b/examples/spark/spark-master-controller.yaml
@@ -2,7 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-master-controller
-  namespace: spark-cluster
 spec:
   replicas: 1
   selector:

--- a/examples/spark/spark-master-service.yaml
+++ b/examples/spark/spark-master-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: spark-master
-  namespace: spark-cluster
 spec:
   ports:
     - port: 7077

--- a/examples/spark/spark-ui-proxy-controller.yaml
+++ b/examples/spark/spark-ui-proxy-controller.yaml
@@ -2,7 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-ui-proxy-controller
-  namespace: spark-cluster
 spec:
   replicas: 1
   selector:

--- a/examples/spark/spark-ui-proxy-service.yaml
+++ b/examples/spark/spark-ui-proxy-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: spark-ui-proxy
-  namespace: spark-cluster
 spec:
   ports:
     - port: 80

--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -2,7 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-worker-controller
-  namespace: spark-cluster
 spec:
   replicas: 2
   selector:

--- a/examples/spark/zeppelin-controller.yaml
+++ b/examples/spark/zeppelin-controller.yaml
@@ -2,7 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: zeppelin-controller
-  namespace: spark-cluster
 spec:
   replicas: 1
   selector:

--- a/examples/spark/zeppelin-service.yaml
+++ b/examples/spark/zeppelin-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: zeppelin
-  namespace: spark-cluster
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes e2e test failures in the spark tests. These failures were caused by an update to the examples in https://github.com/kubernetes/kubernetes/pull/33604

**Which issue this PR fixes** : fixes https://github.com/kubernetes/kubernetes/issues/36102

**Release note**:
```release-note
NONE
```

cc @calebamiles @elsonrodriguez @saad-ali 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36548)
<!-- Reviewable:end -->
