### PR TITLE
Close tunnels after failed healthchecks.

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -377,15 +377,18 @@ func (l *SSHTunnelList) healthCheck(e sshTunnelEntry) error {
 func (l *SSHTunnelList) removeAndReAdd(e sshTunnelEntry) {
 	// Find the entry to replace.
 	l.tunnelsLock.Lock()
-	defer l.tunnelsLock.Unlock()
 	for i, entry := range l.entries {
 		if entry.Tunnel == e.Tunnel {
 			l.entries = append(l.entries[:i], l.entries[i+1:]...)
 			l.adding[e.Address] = true
-			go l.createAndAddTunnel(e.Address)
-			return
+			break
 		}
 	}
+	l.tunnelsLock.Unlock()
+	if err := e.Tunnel.Close(); err != nil {
+		glog.Infof("Failed to close removed tunnel: %v", err)
+	}
+	go l.createAndAddTunnel(e.Address)
 }
 
 func (l *SSHTunnelList) Dial(net, addr string) (net.Conn, error) {


### PR DESCRIPTION
When we fail an ssh-tunnel healthcheck, we currently leak a file descriptor keeping the SSH connection open.

This closes the underlying tunnel before removing our pointer to it. It is possible that the tunnel was functional, but the healthcheck failed for some other reason (e.g. kubelet healthz down), which could close an in-use tunnel, but I think that is acceptable.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36549)
<!-- Reviewable:end -->
