### PR TITLE
Get kernel logs with timestamps

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -132,7 +132,7 @@ function save-logs() {
     if log-dump-ssh "${node_name}" "sudo systemctl status kubelet.service" &> /dev/null; then
         log-dump-ssh "${node_name}" "sudo journalctl --output=cat -u kubelet.service" > "${dir}/kubelet.log" || true
         log-dump-ssh "${node_name}" "sudo journalctl --output=cat -u docker.service" > "${dir}/docker.log" || true
-        log-dump-ssh "${node_name}" "sudo journalctl --output=cat -k" > "${dir}/kern.log" || true
+        log-dump-ssh "${node_name}" "sudo journalctl --output=short-precise -k" > "${dir}/kern.log" || true
     else
         files="${kern_logfile} ${files} ${initd_logfiles} ${supervisord_logfiles}"
     fi


### PR DESCRIPTION
Without the timestamps, the log is not very useful.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36550)
<!-- Reviewable:end -->
