### PR TITLE
add default label to rbac bootstrap policy

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/install:go_default_library",
+        "//pkg/api/meta:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/apis/rbac/install:go_default_library",
@@ -50,5 +51,8 @@ go_test(
     srcs = ["controller_policy_test.go"],
     library = "go_default_library",
     tags = ["automanaged"],
-    deps = ["//pkg/util/sets:go_default_library"],
+    deps = [
+        "//pkg/api/meta:go_default_library",
+        "//pkg/util/sets:go_default_library",
+    ],
 )

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -46,8 +46,11 @@ func addControllerRole(role rbac.ClusterRole) {
 	}
 
 	controllerRoles = append(controllerRoles, role)
+	addClusterRoleLabel(controllerRoles)
+
 	controllerRoleBindings = append(controllerRoleBindings,
 		rbac.NewClusterBinding(role.Name).SAs("kube-system", role.Name[len(saRolePrefix):]).BindingOrDie())
+	addClusterRoleBindingLabel(controllerRoleBindings)
 }
 
 func eventsRule() rbac.PolicyRule {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package bootstrappolicy
 
 import (
+	"reflect"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -55,6 +57,32 @@ func TestNoStarsForControllers(t *testing.T) {
 					t.Errorf("%s.Rule[%d].Resources[%d] is star", role.Name, i, j)
 				}
 			}
+		}
+	}
+}
+
+func TestControllerRoleLabel(t *testing.T) {
+	roles := ControllerRoles()
+	for i := range roles {
+		role := roles[i]
+		accessor, err := meta.Accessor(&role)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := accessor.GetLabels(), map[string]string{"kubernetes.io/bootstrapping": "rbac-defaults"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("ClusterRole: %s GetLabels() = %s, want %s", accessor.GetName(), got, want)
+		}
+	}
+
+	rolebindings := ControllerRoleBindings()
+	for i := range rolebindings {
+		rolebinding := rolebindings[i]
+		accessor, err := meta.Accessor(&rolebinding)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := accessor.GetLabels(), map[string]string{"kubernetes.io/bootstrapping": "rbac-defaults"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("ClusterRoleBinding: %s GetLabels() = %s, want %s", accessor.GetName(), got, want)
 		}
 	}
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -4,6 +4,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: admin
   rules:
   - apiGroups:
@@ -170,6 +172,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: cluster-admin
   rules:
   - apiGroups:
@@ -188,6 +192,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: edit
   rules:
   - apiGroups:
@@ -332,6 +338,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:auth-delegator
   rules:
   - apiGroups:
@@ -352,6 +360,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:basic-user
   rules:
   - apiGroups:
@@ -365,6 +375,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:discovery
   rules:
   - attributeRestrictions: null
@@ -380,6 +392,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node
   rules:
   - apiGroups:
@@ -484,6 +498,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node-proxier
   rules:
   - apiGroups:
@@ -499,6 +515,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: view
   rules:
   - apiGroups:

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-role-bindings.yaml
@@ -4,6 +4,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:attachdetach-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -17,6 +19,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:cronjob-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -30,6 +34,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:daemon-set-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -43,6 +49,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:deployment-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -56,6 +64,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:disruption-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -69,6 +79,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:endpoint-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -82,6 +94,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:horizontal-pod-autoscaler
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -95,6 +109,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:job-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -108,6 +124,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:namespace-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -121,6 +139,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:persistent-volume-binder
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -134,6 +154,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:pod-garbage-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -147,6 +169,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:replicaset-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -160,6 +184,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:replication-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -173,6 +199,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:service-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -186,6 +214,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:statefulset-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -4,6 +4,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:attachdetach-controller
   rules:
   - apiGroups:
@@ -53,6 +55,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:cronjob-controller
   rules:
   - apiGroups:
@@ -96,6 +100,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:daemon-set-controller
   rules:
   - apiGroups:
@@ -152,6 +158,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:deployment-controller
   rules:
   - apiGroups:
@@ -206,6 +214,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:disruption-controller
   rules:
   - apiGroups:
@@ -252,6 +262,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:endpoint-controller
   rules:
   - apiGroups:
@@ -295,6 +307,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:horizontal-pod-autoscaler
   rules:
   - apiGroups:
@@ -361,6 +375,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:job-controller
   rules:
   - apiGroups:
@@ -405,6 +421,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:namespace-controller
   rules:
   - apiGroups:
@@ -439,6 +457,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:persistent-volume-binder
   rules:
   - apiGroups:
@@ -527,6 +547,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:pod-garbage-controller
   rules:
   - apiGroups:
@@ -542,6 +564,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:replicaset-controller
   rules:
   - apiGroups:
@@ -584,6 +608,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:replication-controller
   rules:
   - apiGroups:
@@ -626,6 +652,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:service-controller
   rules:
   - apiGroups:
@@ -665,6 +693,8 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:statefulset-controller
   rules:
   - apiGroups:


### PR DESCRIPTION
allow people to retrieve information of bootstrap policy by label :

`kubectl get clusterroles -l key=value` 
`kubectl get clusterrolebindings -l key=value`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36568)
<!-- Reviewable:end -->
