### PR TITLE
Do not handle AlreadyExists errors yet

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -301,6 +301,7 @@ func (dc *DeploymentController) handleErr(err error, key interface{}) {
 	}
 
 	utilruntime.HandleError(err)
+	glog.V(2).Infof("Dropping deployment %q out of the queue: %v", key, err)
 	dc.queue.Forget(key)
 }
 

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -357,8 +357,10 @@ func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployme
 	createdRS, err := dc.client.Extensions().ReplicaSets(namespace).Create(&newRS)
 	switch {
 	// We may end up hitting this due to a slow cache or a fast resync of the deployment.
-	case errors.IsAlreadyExists(err):
-		return dc.rsLister.ReplicaSets(namespace).Get(newRS.Name)
+	// TODO: Restore once https://github.com/kubernetes/kubernetes/issues/29735 is fixed
+	// ie. we start using a new hashing algorithm.
+	// case errors.IsAlreadyExists(err):
+	//	return dc.rsLister.ReplicaSets(namespace).Get(newRS.Name)
 	case err != nil:
 		msg := fmt.Sprintf("Failed to create new replica set %q: %v", newRS.Name, err)
 		if deployment.Spec.ProgressDeadlineSeconds != nil {


### PR DESCRIPTION
Until we fix https://github.com/kubernetes/kubernetes/issues/29735 (use a new hashing algo) we should not handle AlreadyExists (was added recently in the perma-failed PR).

@kubernetes/deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36584)
<!-- Reviewable:end -->
