### PR TITLE
README: stop linking to a 18 month old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Kubernetes builds upon a [decade and a half of experience at Google running prod
 
 ### Kubernetes is ready for Production!
 
-With the [1.0.1 release](https://github.com/kubernetes/kubernetes/releases/tag/v1.0.1) Kubernetes is ready to serve your production workloads.
+Since the Kubernetes 1.0 release in July 2015 Kubernetes is ready for your production workloads.
 
 ### Kubernetes can run anywhere!
 


### PR DESCRIPTION

We are proud of the v1.0 release but lets give users context on the date
it was released and not drive them to the actual release since
they should be using the latest release instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36591)
<!-- Reviewable:end -->
