### PR TITLE
Fix wrong comparison var in e2e_node density test

### DIFF
--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -469,8 +469,8 @@ func verifyPodStartupLatency(expect, actual framework.LatencyMetric) error {
 	if actual.Perc90 > expect.Perc90 {
 		return fmt.Errorf("too high pod startup latency 90th percentile: %v", actual.Perc90)
 	}
-	if actual.Perc99 > actual.Perc99 {
-		return fmt.Errorf("too high pod startup latency 99th percentil: %v", actual.Perc99)
+	if actual.Perc99 > expect.Perc99 {
+		return fmt.Errorf("too high pod startup latency 99th percentile: %v", actual.Perc99)
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36594)
<!-- Reviewable:end -->
