### PR TITLE
README: Link to the real links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,19 @@ Kubernetes documentation is organized into several categories.
 
   - **Getting started guides**
     - for people who want to create a Kubernetes cluster
-      - in [Creating a Kubernetes Cluster](docs/getting-started-guides/README.md)
+      - in [Creating a Kubernetes Cluster](http://kubernetes.github.io/docs/getting-started-guides/)
     - for people who want to port Kubernetes to a new environment
-      - in [Getting Started from Scratch](docs/getting-started-guides/scratch.md)
+      - in [Getting Started from Scratch](http://kubernetes.github.io/docs/getting-started-guides/scratch/)
   - **User documentation**
     - for people who want to run programs on an existing Kubernetes cluster
-    - in the [Kubernetes User Guide: Managing Applications](docs/user-guide/README.md)
+    - in the [Kubernetes User Guide: Managing Applications](http://kubernetes.github.io/docs/user-guide/)
 	*Tip: You can also view help documentation out on [http://kubernetes.io/docs/](http://kubernetes.io/docs/).*
-    - the [Kubectl Command Line Interface](docs/user-guide/kubectl/kubectl.md) is a detailed reference on
+    - the [Kubectl Command Line Interface](http://kubernetes.io/docs/user-guide/kubectl-overview/) is a detailed reference on
       the `kubectl` CLI
     - [User FAQ](https://github.com/kubernetes/kubernetes/wiki/User-FAQ)
   - **Cluster administrator documentation**
     - for people who want to create a Kubernetes cluster and administer it
-    - in the [Kubernetes Cluster Admin Guide](docs/admin/README.md)
+    - in the [Kubernetes Cluster Admin Guide](http://kubernetes.io/docs/admin/)
   - **Developer and API documentation**
     - for people who want to write programs that access the Kubernetes API, write plugins
       or extensions, or modify the core Kubernetes code
@@ -90,7 +90,7 @@ Kubernetes documentation is organized into several categories.
       detailed description of all fields found in the core API objects
   - **Walkthroughs and examples**
     - hands-on introduction and example config files
-    - in the [user guide](docs/user-guide/README.md#quick-walkthrough)
+    - in the [user guide](http://kubernetes.github.io/docs/user-guide/)
     - in the [docs/examples directory](examples/)
   - **Contributions from the Kubernetes community**
     - in the [docs/contrib directory](contrib/)
@@ -100,7 +100,7 @@ Kubernetes documentation is organized into several categories.
     - proposals in the [docs/proposals directory](docs/proposals/)
   - **Wiki/FAQ**
     - in the [wiki](https://github.com/kubernetes/kubernetes/wiki)
-    - troubleshooting information in the [troubleshooting guide](docs/troubleshooting.md)
+    - troubleshooting information in the [troubleshooting guide](http://kubernetes.io/docs/troubleshooting/)
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION

A majority of the links in the README tell you to go to another link on
kubernetes.io. Fix up all of the ones I could find.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36595)
<!-- Reviewable:end -->
