### PR TITLE
Federation test util fix - 1

### DIFF
--- a/federation/pkg/federation-controller/util/meta.go
+++ b/federation/pkg/federation-controller/util/meta.go
@@ -65,10 +65,10 @@ func ObjectMetaEquivalent(a, b api_v1.ObjectMeta) bool {
 	if a.Namespace != b.Namespace {
 		return false
 	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
+	if !reflect.DeepEqual(a.Labels, b.Labels) && (len(a.Labels) != 0 || len(b.Labels) != 0) {
 		return false
 	}
-	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) && (len(a.Annotations) != 0 || len(b.Annotations) != 0) {
 		return false
 	}
 	return true

--- a/federation/pkg/federation-controller/util/meta_test.go
+++ b/federation/pkg/federation-controller/util/meta_test.go
@@ -56,6 +56,18 @@ func TestObjectMeta(t *testing.T) {
 		ResourceVersion: "1231255531412",
 		Annotations:     map[string]string{"A": "B"},
 	}
+	o7 := api_v1.ObjectMeta{
+		Namespace:       "ns1",
+		Name:            "s1",
+		ResourceVersion: "1231255531412",
+		Annotations:     map[string]string{},
+		Labels:          map[string]string{},
+	}
+	o8 := api_v1.ObjectMeta{
+		Namespace:       "ns1",
+		Name:            "s1",
+		ResourceVersion: "1231255531412",
+	}
 	assert.Equal(t, 0, len(o2.UID))
 	assert.Equal(t, 0, len(o2.ResourceVersion))
 	assert.Equal(t, o1.Name, o2.Name)
@@ -64,6 +76,8 @@ func TestObjectMeta(t *testing.T) {
 	assert.True(t, ObjectMetaEquivalent(o3, o4))
 	assert.True(t, ObjectMetaEquivalent(o5, o6))
 	assert.True(t, ObjectMetaEquivalent(o3, o5))
+	assert.True(t, ObjectMetaEquivalent(o7, o8))
+	assert.True(t, ObjectMetaEquivalent(o8, o7))
 }
 
 func TestObjectMetaAndSpec(t *testing.T) {

--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -280,3 +280,30 @@ func WaitForStoreUpdate(store util.FederatedReadOnlyStore, clusterName, key stri
 	})
 	return err
 }
+
+// Ensure a key is in the store before returning (or timeout w/ error)
+func WaitForStoreUpdateChecking(store util.FederatedReadOnlyStore, clusterName, key string, timeout time.Duration,
+	checkFunction CheckingFunction) error {
+	retryInterval := 500 * time.Millisecond
+	var lastError error
+	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		item, found, err := store.GetByKey(clusterName, key)
+		if err != nil || !found {
+			return found, err
+		}
+		runtimeObj := item.(runtime.Object)
+		lastError = checkFunction(runtimeObj)
+		glog.V(2).Infof("Check function failed for %s %v %v", key, runtimeObj, lastError)
+		return lastError == nil, nil
+	})
+	return err
+}
+
+func MetaAndSpecCheckingFunction(expected runtime.Object) CheckingFunction {
+	return func(obj runtime.Object) error {
+		if util.ObjectMetaAndSpecEquivalent(obj, expected) {
+			return nil
+		}
+		return fmt.Errorf("Object different expected=%#v  received=%#v", expected, obj)
+	}
+}

--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -242,11 +242,11 @@ func CompareObjectMeta(a, b api_v1.ObjectMeta) error {
 	if a.Name != b.Name {
 		return fmt.Errorf("Different name expected:%s observed:%s", a.Namespace, b.Namespace)
 	}
-	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
-		return fmt.Errorf("Annotations are different expected:%v observerd:%v", a.Annotations, b.Annotations)
+	if !reflect.DeepEqual(a.Labels, b.Labels) && (len(a.Labels) != 0 || len(b.Labels) != 0) {
+		return fmt.Errorf("Labels are different expected:%v observerd:%v", a.Labels, b.Labels)
 	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
-		return fmt.Errorf("Annotations are different expected:%v observerd:%v", a.Labels, b.Labels)
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) && (len(a.Annotations) != 0 || len(b.Annotations) != 0) {
+		return fmt.Errorf("Annotations are different expected:%v observerd:%v", a.Annotations, b.Annotations)
 	}
 	return nil
 }


### PR DESCRIPTION
* Make nil and empty map equivalent when testing ObjectMeta equivalence
* Add a function that waits for a particular content inside federated store

cc: @nikhiljindal @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36605)
<!-- Reviewable:end -->
