### PR TITLE
Modify GCI mounter to enable NFSv3

### DIFF
--- a/cluster/gce/gci/mounter/Makefile
+++ b/cluster/gce/gci/mounter/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v2
+TAG=v3
 REGISTRY=gcr.io/google_containers
 IMAGE=gci-mounter
 

--- a/cluster/gce/gci/mounter/mounter
+++ b/cluster/gce/gci/mounter/mounter
@@ -18,7 +18,7 @@ set -e
 set -o pipefail
 
 MOUNTER_DOCKER_IMAGE=gcr.io/google_containers/gci-mounter
-MOUNTER_DOCKER_VERSION=v2
+MOUNTER_DOCKER_VERSION=v3
 MOUNTER_USER=root
 RKT_BINARY=/home/kubernetes/bin/rkt
 
@@ -33,4 +33,4 @@ ${RKT_BINARY} run --stage1-name="coreos.com/rkt/stage1-fly:1.18.0" \
 	--insecure-options=image \
 	--volume=rootfs,kind=host,source=/,readOnly=false,recursive=true \
 	--mount volume=rootfs,target=/media/root \
-	docker://${MOUNTER_DOCKER_IMAGE}:${MOUNTER_DOCKER_VERSION} --user=${MOUNTER_USER} --exec /bin/mount -- "$@"
+	docker://${MOUNTER_DOCKER_IMAGE}:${MOUNTER_DOCKER_VERSION} --user=${MOUNTER_USER} --exec /startmounter.sh -- "$@"

--- a/cluster/gce/gci/mounter/startmounter.sh
+++ b/cluster/gce/gci/mounter/startmounter.sh
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-MAINTAINER vishh@google.com
+#!/bin/bash
 
-RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
-ADD startmounter.sh /startmounter.sh
-ENTRYPOINT ["/bin/mount"]
+# start rpcbind if it is not started yet
+s=`/etc/init.d/rpcbind status`
+if [[ $s == *"not running"* ]]; then
+   echo "Starting rpcbind"
+   /sbin/rpcbind -w
+fi
+s=`/etc/init.d/rpcbind status`
+echo "$s"
+s=`ps aux | grep rpc`
+/bin/mount "${@}"


### PR DESCRIPTION
In order to make NFSv3 work, mounter needs to start rpcbind daemon. This
change modify mounter's Dockerfile and mounter script to start the
rpcbind daemon if it is not running on the host.

After this change, need to make push the image and update the sha number in Changelog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36609)
<!-- Reviewable:end -->
