### PR TITLE
Modify GCI mounter to enable NFSv3

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -100,10 +100,10 @@ function split-commas {
 
 function install-gci-mounter-tools {
     local -r rkt_version="v1.18.0"
-    local -r gci_mounter_version="v2"
+    local -r gci_mounter_version="v3"
     local -r rkt_binary_sha1="75fc8f29c79bc9e505f3e7f6e8fadf2425c21967"
     local -r rkt_stage1_fly_sha1="474df5a1f934960ba669b360ab713d0a54283091"
-    local -r gci_mounter_sha1="851e841d8640d6a05e64e22c493f5ac3c4cba561"
+    local -r gci_mounter_sha1="6ae71998bf9deba06468b036c2ba126626e0050d"
     download-or-bust "${rkt_binary_sha1}" "https://storage.googleapis.com/kubernetes-release/rkt/${rkt_version}/rkt"
     download-or-bust "${rkt_stage1_fly_sha1}" "https://storage.googleapis.com/kubernetes-release/rkt/${rkt_version}/stage1-fly.aci"
     download-or-bust "${gci_mounter_sha1}" "https://storage.googleapis.com/kubernetes-release/gci-mounter/gci-mounter-${gci_mounter_version}.aci"

--- a/cluster/gce/gci/mounter/Changelog
+++ b/cluster/gce/gci/mounter/Changelog
@@ -5,3 +5,8 @@
 ## v2 (Fri Oct 28 2016 Vishnu Kannan <vishh@google.com>)
   - Adding netbase package.
   - Digest: sha256:c7dfe059fbbf976fc4284a87eb18adf0f8e0c4cf30a30f5a852842c772a64c2d
+
+## v3 (Fri Nov 11 2016 Jing Xu <jingxu@google.com>)
+  - Add startmounter.sh script to start rpcbind before mounting for NFSv3
+  - Digest: sha256:35bc48a1ca97c3971611dc4662d08d131869daa692acb281c7e9e052924e38b1
+  

--- a/cluster/gce/gci/mounter/Makefile
+++ b/cluster/gce/gci/mounter/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v2
+TAG=v3
 REGISTRY=gcr.io/google_containers
 IMAGE=gci-mounter
 

--- a/cluster/gce/gci/mounter/mounter
+++ b/cluster/gce/gci/mounter/mounter
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-MOUNTER_VERSION=v2
+MOUNTER_VERSION=v3
 MOUNTER_USER=root
 ROOT_DIR=/home/kubernetes/bin
 RKT_BINARY=${ROOT_DIR}/rkt
@@ -31,9 +31,9 @@ function gc {
     # Rkt pods end up creating new copies of mounts on the host. Hence it is ideal to clean them up right away.
     attempt=0
     until [ $attempt -ge 5 ]; do
-	${RKT_BINARY} gc --grace-period=0s &> /dev/null && break
-	attempt=$[$attempt+1]
-	sleep 1
+      ${RKT_BINARY} gc --grace-period=0s &> /dev/null && break
+      attempt=$[$attempt+1]
+      sleep 1
     done
 }
 
@@ -45,11 +45,17 @@ if [[ ! $(${RKT_BINARY} image list | grep ${MOUNTER_IMAGE}) ]]; then
 fi
 
 echo "Running mount using a rkt fly container"
-
-${RKT_BINARY} run --stage1-path=${STAGE1_ACI} \
-	--insecure-options=image \
-	--volume=kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
-	--mount volume=kubelet,target=/var/lib/kubelet \
-	${MOUNTER_IMAGE} --user=${MOUNTER_USER} --exec /bin/mount -- "$@"
-
+if ["$#" -eq 0 ]; then
+  ${RKT_BINARY} run --stage1-path=${STAGE1_ACI} \
+    --insecure-options=image \
+    --volume=kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
+    --mount volume=kubelet,target=/var/lib/kubelet \
+    ${MOUNTER_IMAGE} --user=${MOUNTER_USER} --exec /bin/mount
+else
+  ${RKT_BINARY} run --stage1-path=${STAGE1_ACI} \
+    --insecure-options=image \
+    --volume=kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
+    --mount volume=kubelet,target=/var/lib/kubelet \
+    ${MOUNTER_IMAGE} --user=${MOUNTER_USER} --exec /startmounter.sh -- "$@"
+fi
 echo "Successfully ran mount using a rkt fly container"

--- a/cluster/gce/gci/mounter/startmounter.sh
+++ b/cluster/gce/gci/mounter/startmounter.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-MAINTAINER vishh@google.com
+# start rpcbind if it is not started yet
+s=`/etc/init.d/rpcbind status`
+if [[ $s == *"not running"* ]]; then
+   echo "Starting rpcbind: /sbin/rpcbind -w"
+   /sbin/rpcbind -w
+fi
+echo `/etc/init.d/rpcbind status`
 
-RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
-ADD startmounter.sh /startmounter.sh
-ENTRYPOINT ["/startmounter.sh"]
+# mount with passing paramaters
+/bin/mount "${@}"

--- a/test/e2e/common/volumes.go
+++ b/test/e2e/common/volumes.go
@@ -360,7 +360,7 @@ var _ = framework.KubeDescribe("GCP Volumes", func() {
 	})
 
 	////////////////////////////////////////////////////////////////////////
-	// NFS
+	// NFSv4
 	////////////////////////////////////////////////////////////////////////
 
 	framework.KubeDescribe("NFSv4", func() {
@@ -385,6 +385,40 @@ var _ = framework.KubeDescribe("GCP Volumes", func() {
 				NFS: &api.NFSVolumeSource{
 					Server:   serverIP,
 					Path:     "/",
+					ReadOnly: true,
+				},
+			}
+			// Must match content of test/images/volumes-tester/nfs/index.html
+			testVolumeClient(f, config, volume, nil, "Hello from NFS!")
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// NFSv3
+	////////////////////////////////////////////////////////////////////////
+
+	framework.KubeDescribe("NFSv3", func() {
+		It("should be mountable for NFSv3", func() {
+			config := VolumeTestConfig{
+				namespace:   namespace.Name,
+				prefix:      "nfs",
+				serverImage: "gcr.io/google_containers/volume-nfs:0.8",
+				serverPorts: []int{2049, 20048},
+			}
+
+			defer func() {
+				if clean {
+					volumeTestCleanup(f, config)
+				}
+			}()
+			pod := startVolumeServer(f, config)
+			serverIP := pod.Status.PodIP
+			framework.Logf("NFS server IP address: %v", serverIP)
+
+			volume := api.VolumeSource{
+				NFS: &api.NFSVolumeSource{
+					Server:   serverIP,
+					Path:     "/exports",
 					ReadOnly: true,
 				},
 			}

--- a/test/e2e_node/jenkins/gci-init.yaml
+++ b/test/e2e_node/jenkins/gci-init.yaml
@@ -8,5 +8,5 @@ runcmd:
   - mount -B -o remount,exec /home/kubernetes/bin 
   - wget https://storage.googleapis.com/kubernetes-release/rkt/v1.18.0/rkt -O /home/kubernetes/bin/rkt
   - wget https://storage.googleapis.com/kubernetes-release/rkt/v1.18.0/stage1-fly.aci -O /home/kubernetes/bin/stage1-fly.aci
-  - wget https://storage.googleapis.com/kubernetes-release/gci-mounter/gci-mounter-v2.aci -O /home/kubernetes/bin/gci-mounter-v2.aci
+  - wget https://storage.googleapis.com/kubernetes-release/gci-mounter/gci-mounter-v3.aci -O /home/kubernetes/bin/gci-mounter-v3.aci
   - chmod a+x /home/kubernetes/bin/rkt


### PR DESCRIPTION
In order to make NFSv3 work, mounter needs to start rpcbind daemon. This
change modify mounter's Dockerfile and mounter script to start the
rpcbind daemon if it is not running on the host.

After this change, need to make push the image and update the sha number in Changelog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36610)
<!-- Reviewable:end -->
